### PR TITLE
Fix crash where an extra character is removed from the .o filename.

### DIFF
--- a/haskell/toolchain.bzl
+++ b/haskell/toolchain.bzl
@@ -117,8 +117,11 @@ def take_haskell_module(ctx, f):
   pkgDirLen = len(pkgDir)
   # TODO: hack; depending on circumstance, workspace_root can have a
   # leading / which f.path does not have: if that's the case, drop one
-  # less character
-  if pkgDirLen > 0 and pkgDir[0] == '/':
+  # less character. If workspace_root and package are both empty, drop
+  # two characters.
+  if pkgDir == "//":
+    pkgDirLen -= 2
+  elif pkgDirLen > 0 and pkgDir[0] == '/':
     pkgDirLen -= 1
   return f.path[pkgDirLen:f.path.rfind(".")]
 


### PR DESCRIPTION
`Main.o` becomes `ain.o` if `Main.hs` is the workspace root. This is because `ctx.label.workspace_root` and `ctx.label.package` are both blank and the `pkgLen` reduction doesn't account for that.

Fixes:
```
→ bazel build :main
INFO: Found 1 target...
INFO: From Building main:
[1 of 1] Compiling Main             ( Main.hs, bazel-out/darwin_x86_64-opt/bin/objects/Main.o )
ERROR: /Users/jin/Code/rules_haskell_conflict_error/BUILD:3:1: output 'objects/ain.o' was not created.
ERROR: /Users/jin/Code/rules_haskell_conflict_error/BUILD:3:1: not all outputs were created or valid.
Target //:main failed to build
Use --verbose_failures to see the command lines of failed build steps.
INFO: Elapsed time: 0.393s, Critical Path: 0.25s
```