### PR TITLE
Build rules sufficient for building inline-java

### DIFF
--- a/examples/hello-lib/BUILD
+++ b/examples/hello-lib/BUILD
@@ -8,5 +8,6 @@ load(
 haskell_library(
   name = 'hello-lib',
   srcs = glob(['**/*.hs']),
-  deps = ["@examples//hello-sublib"]
+  deps = ["@examples//hello-sublib"],
+  prebuilt_dependencies = ["base"]
 )

--- a/examples/hello-sublib/BUILD
+++ b/examples/hello-sublib/BUILD
@@ -8,5 +8,6 @@ load(
 haskell_library(
   name = 'hello-sublib',
   srcs = glob(['**/*.hs']),
-  deps = ["@examples//hello-subsublib"]
+  deps = ["@examples//hello-subsublib"],
+  prebuilt_dependencies = ["base"]
 )

--- a/examples/hello-subsublib/BUILD
+++ b/examples/hello-subsublib/BUILD
@@ -8,4 +8,5 @@ load(
 haskell_library(
   name = 'hello-subsublib',
   srcs = glob(['**/*.hs']),
+  prebuilt_dependencies = ["base"]
 )

--- a/haskell/c_compile.bzl
+++ b/haskell/c_compile.bzl
@@ -1,0 +1,97 @@
+"""C file compilation.
+"""
+
+load(":path_utils.bzl",
+     "declare_compiled",
+     "path_append",
+     "replace_ext",
+     "get_object_suffix",
+     "get_dyn_object_suffix",
+)
+
+
+load(":toolchain.bzl",
+     "HaskellPackageInfo",
+     "mk_name",
+)
+
+
+def c_compile_static(ctx):
+  """Compile all C files to static object files.
+
+  TODO: We would like to compile these one at a time. This is somewhat
+  difficult as they all go into the same object directory and
+  therefore share prefix. Possibly we don't care about where in the
+  hierarchy they go though so we may be able to just put them in
+  separate directory each. Or something.
+
+  Args:
+    ctx: Rule context.
+  """
+  args = ctx.actions.args()
+  args.add("-c")
+  return __generic_c_compile(ctx, "objects_c", get_dyn_object_suffix(), args)
+
+def c_compile_dynamic(ctx):
+  """Compile all C files to dynamic object files.
+
+  TODO: We would like to compile these one at a time. This is somewhat
+  difficult as they all go into the same object directory and
+  therefore share prefix. Possibly we don't care about where in the
+  hierarchy they go though so we may be able to just put them in
+  separate directory each. Or something.
+
+  Args:
+    ctx: Rule context.
+  """
+  args = ctx.actions.args()
+  args.add(["-c", "-dynamic"])
+  return __generic_c_compile(ctx, "objects_c_dyn", get_dyn_object_suffix(), args)
+
+def __generic_c_compile(ctx, output_dir_template, output_ext, user_args):
+  # Directory for objects generated from C files.
+  output_dir = ctx.actions.declare_directory(mk_name(ctx, output_dir_template))
+
+  args = ctx.actions.args()
+  args.add([
+    "-fPIC",
+    "-osuf", output_ext,
+    "-odir", output_dir
+  ])
+
+  for opt in ctx.attr.c_options:
+    args.add("-optc{0}".format(opt))
+
+  pkg_caches = depset()
+  pkg_names = depset()
+  for d in ctx.attr.deps:
+    pkg_caches += d[HaskellPackageInfo].pkgCaches
+    pkg_names += d[HaskellPackageInfo].pkgNames
+
+  # Expose every dependency and every prebuilt dependency.
+  for n in pkg_names + depset(ctx.attr.prebuiltDeps):
+    args.add(["-package", n])
+
+  # Point at every package DB we depend on and know of explicitly.
+  for c in pkg_caches:
+    args.add(["-package-db", c.dirname])
+
+  # Make all external dependency files available.
+  external_files = depset([f for dep in ctx.attr.external_deps
+                             for f in dep.files])
+  for include_dir in depset([f.dirname for f in external_files]):
+    args.add("-I{0}".format(include_dir))
+
+  args.add(ctx.files.c_sources)
+
+  output_files = [ctx.actions.declare_file(path_append(output_dir.basename, replace_ext(s.path, output_ext)))
+                        for s in ctx.files.c_sources]
+  ctx.actions.run(
+    inputs = ctx.files.c_sources + (external_files + pkg_caches).to_list(),
+    outputs = [output_dir] + output_files,
+    use_default_shell_env = True,
+    progress_message = "Compiling C dynamic {0}".format(ctx.attr.name),
+    executable = "ghc",
+    arguments = [user_args, args],
+  )
+  return output_files

--- a/haskell/c_compile.bzl
+++ b/haskell/c_compile.bzl
@@ -65,11 +65,11 @@ def __generic_c_compile(ctx, output_dir_template, output_ext, user_args):
   pkg_caches = depset()
   pkg_names = depset()
   for d in ctx.attr.deps:
-    pkg_caches += d[HaskellPackageInfo].pkgCaches
-    pkg_names += d[HaskellPackageInfo].pkgNames
+    pkg_caches += d[HaskellPackageInfo].caches
+    pkg_names += d[HaskellPackageInfo].names
 
   # Expose every dependency and every prebuilt dependency.
-  for n in pkg_names + depset(ctx.attr.prebuiltDeps):
+  for n in pkg_names + depset(ctx.attr.prebuilt_dependencies):
     args.add(["-package", n])
 
   # Point at every package DB we depend on and know of explicitly.

--- a/haskell/cpphs.bzl
+++ b/haskell/cpphs.bzl
@@ -3,6 +3,7 @@
 
 load(":path_utils.bzl",
      "declare_compiled",
+     "mk_name",
 )
 
 def cpphs(ctx):
@@ -20,8 +21,9 @@ def __process_cpphs_file(ctx, cpphs_file):
     ctx: Rule context.
     cpphs_file: cpphs file to process.
   """
+  cpphs_output_dir = ctx.actions.declare_directory(mk_name(ctx, "cpphs_processed"))
   # Output a Haskell source file.
-  hs_out = declare_compiled(ctx, cpphs_file, "hs")
+  hs_out = declare_compiled(ctx, cpphs_file, "hs", directory=cpphs_output_dir)
   # Make all external dependency files available.
   external_files = depset([f for dep in ctx.attr.external_deps
                              for f in dep.files])
@@ -39,7 +41,7 @@ def __process_cpphs_file(ctx, cpphs_file):
 
   ctx.actions.run(
     inputs = external_files + depset([cpphs_file]),
-    outputs = [hs_out],
+    outputs = [hs_out, cpphs_output_dir],
     use_default_shell_env = True,
     progress_message = "cpphs {0}".format(cpphs_file.basename),
     executable = "ghc",

--- a/haskell/cpphs.bzl
+++ b/haskell/cpphs.bzl
@@ -1,0 +1,48 @@
+"""cpphs file handling.
+"""
+
+load(":path_utils.bzl",
+     "declare_compiled",
+)
+
+def cpphs(ctx):
+  """Process all cpphs files into Haskell source files.
+
+  Args:
+    ctx: Rule context.
+  """
+  return [__process_cpphs_file(ctx, f) for f in ctx.files.cpphs]
+
+def __process_cpphs_file(ctx, cpphs_file):
+  """Process a single cpphs file.
+
+  Args:
+    ctx: Rule context.
+    cpphs_file: cpphs file to process.
+  """
+  # Output a Haskell source file.
+  hs_out = declare_compiled(ctx, cpphs_file, "hs")
+  # Make all external dependency files available.
+  external_files = depset([f for dep in ctx.attr.external_deps
+                             for f in dep.files])
+  # Add all directories of external dependencies to include dirs.
+  include_directories = depset([f.dirname for f in external_files])
+
+  # Build args for GHC to use cpphs.
+  args = ctx.actions.args()
+  args.add([
+    "-E", "-cpp", "-pgmPcpphs", "-optP--cpp", "-x", "hs", "-o", hs_out,
+    cpphs_file
+  ])
+  for include_dir in include_directories:
+    args.add("-optP-I{0}".format(include_dir))
+
+  ctx.actions.run(
+    inputs = external_files + depset([cpphs_file]),
+    outputs = [hs_out],
+    use_default_shell_env = True,
+    progress_message = "cpphs {0}".format(cpphs_file.basename),
+    executable = "ghc",
+    arguments = [args],
+  )
+  return hs_out

--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -133,8 +133,16 @@ def _haskell_library_impl(ctx):
   )]
 
 _haskell_common_attrs = {
-  "srcs": attr.label_list(allow_files = FileType([".hs"])),
-  "deps": attr.label_list(),
+  "srcs": attr.label_list(
+    allow_files=FileType([".hs"]),
+    doc="A list of Haskell sources to be built by this rule."
+  ),
+  "deps": attr.label_list(
+    doc="haskell_library dependencies"
+  ),
+  "compilerFlags": attr.string_list(
+    doc="Flags to pass to Haskell compiler while compiling this rule's sources."
+  )
 }
 
 haskell_library = rule(
@@ -144,7 +152,10 @@ haskell_library = rule(
     "packageCache": "package.cache"
   },
   attrs = _haskell_common_attrs + {
-    "version": attr.string(default="1.0.0"),
+    "version": attr.string(
+      default="1.0.0",
+      doc="Library version"
+    ),
   }
 )
 

--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -131,12 +131,12 @@ def _haskell_library_impl(ctx):
   ctx.actions.run(
     inputs =
       ctx.files.srcs + genHsFiles +
-      (depPkgConfs + depPkgCaches + depInterfaceFiles).to_list(),
+      (exFiles + depPkgConfs + depPkgCaches + depInterfaceFiles).to_list(),
     outputs = [ifaceDir, objDir] + objectFiles + interfaceFiles,
     use_default_shell_env = True,
     progress_message = "Compiling {0}".format(ctx.attr.name),
     executable = "ghc",
-    arguments = [ghc_lib_args(ctx, objDir, ifaceDir, depPkgConfs, depPkgNames,
+    arguments = [ghc_lib_args(ctx, objDir, ifaceDir, depPkgConfs,
                               genHsFiles)]
   )
 
@@ -186,6 +186,10 @@ def _haskell_library_impl(ctx):
   )]
 
 _haskell_common_attrs = {
+  "sourceDir": attr.string(
+    mandatory=False,
+    doc="Directory in which module hierarchy starts."
+  ),
   "srcs": attr.label_list(
     allow_files=FileType([".hs"]),
     # TODO: Figure out how to deal with sources where module hierarchy

--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -174,5 +174,10 @@ haskell_library = rule(
 haskell_binary = rule(
   _haskell_binary_impl,
   executable = True,
-  attrs = _haskell_common_attrs,
+  attrs = _haskell_common_attrs + {
+    "main": attr.string(
+      default="Main.main",
+      doc="Main function location."
+    )
+  }
 )

--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -11,7 +11,6 @@ load(":toolchain.bzl",
      "ghc_bin_obj_args",
      "ghc_c_dyn_lib_args",
      "ghc_c_lib_args",
-     "ghc_cpphs_args",
      "ghc_dyn_link_args",
      "ghc_lib_args",
      "mk_name",
@@ -27,6 +26,10 @@ load(":path_utils.bzl",
 
 load(":hsc2hs.bzl",
      "hsc_to_hs",
+)
+
+load(":cpphs.bzl",
+     "cpphs",
 )
 
 def _haskell_binary_impl(ctx):
@@ -149,22 +152,9 @@ def _haskell_library_impl(ctx):
   # Process hsc files
   processed_hsc_files = hsc_to_hs(ctx)
   # Process cpphs files
-#  processed_cpphs_files = cpphs_to_hs(ctx)
+  processed_cpphs_files = cpphs(ctx)
 
-  cpphsFiles = []
-  for cpphsFile in ctx.files.cpphs:
-    hsOut = declare_compiled(ctx, cpphsFile, "hs")
-    ctx.actions.run(
-      inputs = exFiles + depset([cpphsFile]),
-      outputs = [hsOut],
-      use_default_shell_env = True,
-      progress_message = "Processing {0}".format(cpphsFile.basename),
-      executable = "ghc",
-      arguments = [ghc_cpphs_args(ctx, cpphsFile, hsOut, includeDirs)],
-    )
-    cpphsFiles.append(hsOut)
-
-  genHsFiles = processed_hsc_files + cpphsFiles
+  genHsFiles = processed_hsc_files + processed_cpphs_files
 
   # Compile C static objects
   ctx.actions.run(

--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -60,12 +60,13 @@ def _haskell_binary_impl(ctx):
 
 def _haskell_library_impl(ctx):
   objDir = ctx.actions.declare_directory(mk_name(ctx, "objects"))
+  inputFiles = ctx.files.srcs + ctx.files.hscs + ctx.files.cpphs
   objectFiles = [ctx.actions.declare_file(src_to_ext(ctx, s, get_object_suffix(ctx), directory=objDir))
-                 for s in ctx.files.srcs]
+                 for s in inputFiles]
 
   ifaceDir = ctx.actions.declare_directory(mk_name(ctx, "interfaces"))
   interfaceFiles = [ctx.actions.declare_file(src_to_ext(ctx, s, get_interface_suffix(ctx), directory=ifaceDir))
-                    for s in ctx.files.srcs ]
+                    for s in inputFiles]
 
   # Build transitive depsets
   depPkgConfs = depset()
@@ -158,7 +159,7 @@ def _haskell_library_impl(ctx):
   pkgDbDir = ctx.actions.declare_directory(pkgId)
   confFile = ctx.actions.declare_file("{0}/{1}.conf".format(pkgDbDir.basename, pkgId))
   cacheFile = ctx.actions.declare_file("package.cache", sibling=confFile)
-  registrationFile = mk_registration_file(ctx, pkgId, ifaceDir, libDir)
+  registrationFile = mk_registration_file(ctx, pkgId, ifaceDir, libDir, inputFiles)
 
   ctx.actions.run_shell(
     inputs =

--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -146,10 +146,8 @@ _haskell_common_attrs = {
     doc="Flags to pass to Haskell compiler while compiling this rule's sources."
   ),
   "profiling": attr.bool(
-    # Disabled because of linking errors against RTS. Buck has exactly
-    # the same problem.
     default=False,
-    doc="Build target profiled. You need to enable profiling for all the dependencies as well. Broken."
+    doc="Build target profiled. You need to enable profiling for all the dependencies as well."
   ),
   "PIC": attr.bool(
     default=False,

--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -1,22 +1,31 @@
 load(":toolchain.bzl",
      "HaskellPackageInfo",
      "ar_args",
+     "get_dyn_interface_suffix",
+     "get_dyn_object_suffix",
+     "get_interface_suffix",
+     "get_object_suffix",
      "ghc_bin_link_args",
      "ghc_bin_obj_args",
+     "ghc_c_dyn_lib_args",
+     "ghc_c_lib_args",
+     "ghc_cpphs_args",
+     "ghc_dyn_link_args",
      "ghc_lib_args",
-     "mk_registration_file",
-     "register_package",
-     "src_to_ext",
-     "get_object_suffix",
-     "get_interface_suffix",
      "hsc2hs_args",
      "mk_name",
-     "ghc_cpphs_args",
+     "mk_registration_file",
+     "path_append",
+     "register_package",
+     "replace_ext",
+     "src_to_ext",
 )
 
 def _haskell_binary_impl(ctx):
   depInputs = depset()
   depLibs = depset()
+  depDynLibs = depset()
+  externalLibs = {}
   for d in ctx.attr.deps:
     depInputs += d.files
     pkg = d[HaskellPackageInfo]
@@ -25,6 +34,8 @@ def _haskell_binary_impl(ctx):
     depInputs += pkg.pkgLibs
     depInputs += pkg.interfaceFiles
     depLibs += pkg.pkgLibs
+    depDynLibs += pkg.pkgDynLibs
+    externalLibs.update(pkg.externalLibs)
 
   depInputs += ctx.files.srcs
 
@@ -34,7 +45,7 @@ def _haskell_binary_impl(ctx):
 
   # Compile sources of the binary.
   ctx.actions.run(
-    inputs = depInputs + depLibs,
+    inputs = depInputs + depLibs + depDynLibs,
     outputs = binObjs + [objDir],
     # TODO: use env for GHC_PACKAGE_PATH when use_default_shell_env is removed
     use_default_shell_env = True,
@@ -48,7 +59,7 @@ def _haskell_binary_impl(ctx):
   for d in ctx.attr.deps:
     prebuiltDeps += d[HaskellPackageInfo].prebuiltDeps
 
-  linkTarget, linkArgs = ghc_bin_link_args(ctx, binObjs, depLibs, prebuiltDeps)
+  linkTarget, linkArgs = ghc_bin_link_args(ctx, binObjs, depLibs, prebuiltDeps, externalLibs)
   ctx.actions.run(
     inputs = binObjs + depLibs.to_list() + [linkTarget],
     outputs = [ctx.outputs.executable],
@@ -60,9 +71,22 @@ def _haskell_binary_impl(ctx):
 
 def _haskell_library_impl(ctx):
   objDir = ctx.actions.declare_directory(mk_name(ctx, "objects"))
+  # Directory for object files generated from C files. This can't be
+  # the same as objDir as we can have Foo/Bar.hs and Foo/Bar.c and we
+  # need to link objects from both without them generating the same
+  # file.
+  objDirC = ctx.actions.declare_directory(mk_name(ctx, "objects-c"))
+  objDirCDyn = ctx.actions.declare_directory(mk_name(ctx, "objects-c-dyn"))
   inputFiles = ctx.files.srcs + ctx.files.hscs + ctx.files.cpphs
   objectFiles = [ctx.actions.declare_file(src_to_ext(ctx, s, get_object_suffix(ctx), directory=objDir))
                  for s in inputFiles]
+  cObjectFiles = [ctx.actions.declare_file(path_append(objDirC.basename, replace_ext(s.path, get_object_suffix(ctx))))
+                  for s in ctx.files.c_sources]
+
+  dynObjectFiles = [ctx.actions.declare_file(src_to_ext(ctx, s, get_dyn_object_suffix(), directory=objDir))
+                    for s in inputFiles]
+  cDynObjectFiles = [ctx.actions.declare_file(path_append(objDirCDyn.basename, replace_ext(s.path, get_dyn_object_suffix())))
+                     for s in ctx.files.c_sources]
 
   ifaceDir = ctx.actions.declare_directory(mk_name(ctx, "interfaces"))
   interfaceFiles = [ctx.actions.declare_file(src_to_ext(ctx, s, get_interface_suffix(ctx), directory=ifaceDir))
@@ -73,10 +97,13 @@ def _haskell_library_impl(ctx):
   depPkgCaches = depset()
   depPkgNames = depset()
   depPkgLibs = depset()
+  depPkgDynLibs = depset()
   depInterfaceFiles = depset()
   depImportDirs = depset()
   depLibDirs = depset()
+  depDynLibDirs = depset()
   depPrebuiltDeps = depset()
+  allExternalLibs = {}
   for d in ctx.attr.deps:
     pkg = d[HaskellPackageInfo]
     depPkgConfs += pkg.pkgConfs
@@ -84,18 +111,24 @@ def _haskell_library_impl(ctx):
     depPkgNames += pkg.pkgNames
     depInterfaceFiles += pkg.interfaceFiles
     depPkgLibs += pkg.pkgLibs
+    depPkgDynLibs += pkg.pkgDynLibs
     depImportDirs += pkg.pkgImportDirs
     depLibDirs += pkg.pkgLibDirs
+    depDynLibDirs += pkg.pkgDynLibDirs
     depPrebuiltDeps += pkg.prebuiltDeps
+    allExternalLibs.update(pkg.externalLibs)
+
+  # Put external libraries for current target into the external lib
+  # dict.
+  for name, f in ctx.attr.external_libraries.items():
+    allExternalLibs[name] = allExternalLibs.get(name, default=depset()) + [f]
 
   exFiles = depset()
   for t in ctx.attr.external_deps:
     exFiles += t.files
 
   # Directories of external dependencies.
-  includeDirs = depset()
-  for exFile in exFiles:
-    includeDirs += depset([exFile.dirname])
+  includeDirs = depset([ d.dirname for d in exFiles ])
 
   # Process hsc files
   hscFiles = []
@@ -127,43 +160,84 @@ def _haskell_library_impl(ctx):
 
   genHsFiles = hscFiles + cpphsFiles
 
-  # Compile library files
+  # Compile C static objects
+  ctx.actions.run(
+    inputs =
+    ctx.files.c_sources +
+    (depPkgDynLibs + depDynLibDirs + exFiles + depPkgConfs + depPkgLibs +
+     depPkgCaches + depInterfaceFiles).to_list(),
+    outputs = [objDirC] + cObjectFiles,
+    use_default_shell_env = True,
+    progress_message = "Compiling C static {0}".format(ctx.attr.name),
+    executable = "ghc",
+    arguments = [ghc_c_lib_args(ctx, objDirC, depPkgConfs, depPkgNames, includeDirs)],
+  )
+
+  # Compile C dynamic objects
+  ctx.actions.run(
+    inputs =
+      ctx.files.c_sources +
+      (depPkgDynLibs + depDynLibDirs + exFiles + depPkgConfs + depPkgLibs +
+       depPkgCaches + depInterfaceFiles).to_list(),
+    outputs = [objDirCDyn] + cDynObjectFiles,
+    use_default_shell_env = True,
+    progress_message = "Compiling C dynamic {0}".format(ctx.attr.name),
+    executable = "ghc",
+    arguments = [ghc_c_dyn_lib_args(ctx, objDirCDyn, depPkgConfs, depPkgNames, includeDirs)]
+  )
+
   ctx.actions.run(
     inputs =
       ctx.files.srcs + genHsFiles +
-      (exFiles + depPkgConfs + depPkgCaches + depInterfaceFiles).to_list(),
-    outputs = [ifaceDir, objDir] + objectFiles + interfaceFiles,
+      (depPkgDynLibs + depDynLibDirs + exFiles + depPkgConfs + depPkgLibs +
+       depPkgCaches + depInterfaceFiles).to_list(),
+    outputs = [ifaceDir, objDir] + objectFiles + interfaceFiles +
+              dynObjectFiles,
     use_default_shell_env = True,
     progress_message = "Compiling {0}".format(ctx.attr.name),
     executable = "ghc",
-    arguments = [ghc_lib_args(ctx, objDir, ifaceDir, depPkgConfs,
-                              genHsFiles)]
+    arguments = [ghc_lib_args(ctx, objDir, ifaceDir, depPkgConfs, depPkgNames, genHsFiles)]
   )
 
-  # Make library archive; currently only static
-  #
-  # TODO: configurable shared &c. see various scenarios in buck
+  # Make static library archive
   pkgId = "{0}-{1}".format(ctx.attr.name, ctx.attr.version)
+  # Haskell lib names have to start with HS
+  # https://ghc.haskell.org/trac/ghc/ticket/9625
+  libName = "HS{0}".format(pkgId)
   libDir = ctx.actions.declare_directory(mk_name(ctx, "lib"))
   # We need libDir because ghc-pkg wants a directory for library-dirs.
-  pkgLib = ctx.actions.declare_file("{0}/lib{1}.a".format(libDir.basename, pkgId))
+  pkgLib = ctx.actions.declare_file(path_append(libDir.basename, "lib{0}.a".format(libName)))
+
   ctx.actions.run(
-    inputs = objectFiles,
+    inputs = objectFiles + cObjectFiles,
     outputs = [pkgLib, libDir],
     use_default_shell_env = True,
     executable = "ar",
-    arguments = [ar_args(ctx, pkgLib, objectFiles)],
+    arguments = [ar_args(ctx, pkgLib, objectFiles + cObjectFiles)],
+  )
+
+  # Make shared library
+  dynLibDir = ctx.actions.declare_directory(mk_name(ctx, "dynlib"))
+  pkgDynLib = ctx.actions.declare_file(path_append(dynLibDir.basename, "lib{0}-ghc{1}.so".format(libName, ctx.attr.ghcVersion)))
+
+  ctx.actions.run(
+    inputs = depPkgConfs + depPkgCaches + dynObjectFiles + cDynObjectFiles +
+             depDynLibDirs,
+    outputs = [pkgDynLib, dynLibDir],
+    use_default_shell_env = True,
+    executable = "ghc",
+    arguments = [ghc_dyn_link_args(ctx, dynObjectFiles + cDynObjectFiles, pkgDynLib, depPkgNames, depPkgConfs, allExternalLibs)]
   )
 
   # Create and register ghc package.
   pkgDbDir = ctx.actions.declare_directory(pkgId)
-  confFile = ctx.actions.declare_file("{0}/{1}.conf".format(pkgDbDir.basename, pkgId))
+  confFile = ctx.actions.declare_file(path_append(pkgDbDir.basename, "{0}.conf".format(pkgId)))
   cacheFile = ctx.actions.declare_file("package.cache", sibling=confFile)
-  registrationFile = mk_registration_file(ctx, pkgId, ifaceDir, libDir, inputFiles)
+  registrationFile = mk_registration_file(ctx, pkgId, ifaceDir, libDir, dynLibDir, inputFiles, libName)
 
   ctx.actions.run_shell(
     inputs =
-      [ pkgLib, ifaceDir, registrationFile ] +
+      [ pkgLib, pkgDynLib, ifaceDir, registrationFile ] +
       (depPkgConfs + depPkgCaches + depPkgLibs + depImportDirs + depLibDirs + interfaceFiles).to_list(),
     outputs = [pkgDbDir, confFile, cacheFile],
     # TODO: use env for GHC_PACKAGE_PATH when use_default_shell_env is removed
@@ -179,10 +253,13 @@ def _haskell_library_impl(ctx):
     # Keep package libraries in preorder (naive_link) order: this
     # gives us the valid linking order at binary linking time.
     pkgLibs = depset([pkgLib], order="preorder") + depPkgLibs,
+    pkgDynLibs = depset([pkgDynLib]) + depPkgDynLibs,
     interfaceFiles = depInterfaceFiles + depset(interfaceFiles),
     pkgImportDirs = depImportDirs + depset([ifaceDir]),
     pkgLibDirs = depLibDirs + depset([libDir]),
-    prebuiltDeps = depPrebuiltDeps + depset(ctx.attr.prebuiltDeps)
+    pkgDynLibDirs = depLibDirs + depset([dynLibDir]),
+    prebuiltDeps = depPrebuiltDeps + depset(ctx.attr.prebuiltDeps),
+    externalLibs = allExternalLibs
   )]
 
 _haskell_common_attrs = {
@@ -196,19 +273,18 @@ _haskell_common_attrs = {
     # doesn't start straight away.
     doc="A list of Haskell sources to be built by this rule."
   ),
+  "c_sources": attr.label_list(
+    allow_files=FileType([".c"]),
+    doc="A list of C source files to be built as part of the package."
+  ),
+  "c_options": attr.string_list(
+    doc="Options to pass to C compiler for any C source files."
+  ),
   "deps": attr.label_list(
     doc="haskell_library dependencies"
   ),
   "compilerFlags": attr.string_list(
     doc="Flags to pass to Haskell compiler while compiling this rule's sources."
-  ),
-  "profiling": attr.bool(
-    default=False,
-    doc="Build target profiled. You need to enable profiling for all the dependencies as well."
-  ),
-  "PIC": attr.bool(
-    default=False,
-    doc="Build as position independent code"
   ),
   "hscs": attr.label_list(
     allow_files=FileType([".hsc"]),
@@ -222,12 +298,25 @@ _haskell_common_attrs = {
     allow_files=True,
     doc="Non-Haskell dependencies",
   ),
+  # Only supports one per lib for now
+  "external_libraries": attr.string_dict(
+    doc="Non-Haskell libraries that we should link",
+  ),
   "prebuiltDeps": attr.string_list(
     doc="Haskell packages which are magically available such as wired-in packages."
   ),
   "version": attr.string(
     default="1.0.0",
     doc="Package/binary version"
+  ),
+  "ghcVersion": attr.string(
+    default="8.0.2",
+    # TODO (fuuzetsu): We need this because we have to generate
+    # correct suffix for shared libraries that GHC expects for
+    # dynamic-library-dirs content. As currently we're using GHC from
+    # nix, there's not really a way to do this. In future we need to
+    # expose toolchains that expose a version and use that. I think.
+    doc="Version of GHC used."
   ),
 }
 

--- a/haskell/hsc2hs.bzl
+++ b/haskell/hsc2hs.bzl
@@ -3,6 +3,7 @@
 
 load(":path_utils.bzl",
      "declare_compiled",
+     "mk_name",
 )
 
 def hsc_to_hs(ctx):
@@ -20,8 +21,10 @@ def __process_hsc_file(ctx, hsc_file):
     ctx: Rule context.
     hsc_file: hsc file to process.
   """
+  hsc_output_dir = ctx.actions.declare_directory(mk_name(ctx, "hsc_processed"))
+
   # Output a Haskell source file.
-  hs_out = declare_compiled(ctx, hsc_file, "hs")
+  hs_out = declare_compiled(ctx, hsc_file, "hs", directory=hsc_output_dir)
   # Make all external dependency files available.
   external_files = depset([f for dep in ctx.attr.external_deps
                              for f in dep.files])
@@ -35,7 +38,7 @@ def __process_hsc_file(ctx, hsc_file):
 
   ctx.actions.run(
     inputs = external_files + depset([hsc_file]),
-    outputs = [hs_out],
+    outputs = [hs_out, hsc_output_dir],
     use_default_shell_env = True,
     progress_message = "hsc2hs {0}".format(hsc_file.basename),
     executable = "hsc2hs",

--- a/haskell/hsc2hs.bzl
+++ b/haskell/hsc2hs.bzl
@@ -1,0 +1,44 @@
+"""hsc file handling.
+"""
+
+load(":path_utils.bzl",
+     "declare_compiled",
+)
+
+def hsc_to_hs(ctx):
+  """Process all hsc files into Haskell source files.
+
+  Args:
+    ctx: Rule context.
+  """
+  return [__process_hsc_file(ctx, f) for f in ctx.files.hscs]
+
+def __process_hsc_file(ctx, hsc_file):
+  """Process a single hsc file.
+
+  Args:
+    ctx: Rule context.
+    hsc_file: hsc file to process.
+  """
+  # Output a Haskell source file.
+  hs_out = declare_compiled(ctx, hsc_file, "hs")
+  # Make all external dependency files available.
+  external_files = depset([f for dep in ctx.attr.external_deps
+                             for f in dep.files])
+  # Add all directories of external dependencies to include dirs.
+  include_directories = depset([f.dirname for f in external_files])
+
+  args = ctx.actions.args()
+  args.add([hsc_file, "-o", hs_out])
+  for include_dir in include_directories:
+    args.add(["-I", include_dir])
+
+  ctx.actions.run(
+    inputs = external_files + depset([hsc_file]),
+    outputs = [hs_out],
+    use_default_shell_env = True,
+    progress_message = "hsc2hs {0}".format(hsc_file.basename),
+    executable = "hsc2hs",
+    arguments = [args],
+  )
+  return hs_out

--- a/haskell/path_utils.bzl
+++ b/haskell/path_utils.bzl
@@ -152,3 +152,11 @@ def declare_compiled(ctx, src, ext, directory=None):
   fp = replace_ext(path_to_module_path(ctx, src), ext)
   fp_with_dir = fp if directory == None else path_append(directory.basename, fp)
   return ctx.actions.declare_file(fp_with_dir)
+
+def mk_name(ctx, name_prefix):
+  """Make a target-unique name.
+
+  Args:
+    name_prefix: Template for the name.
+  """
+  return "{0}-{1}-{2}".format(name_prefix, ctx.attr.name, ctx.attr.version)

--- a/haskell/path_utils.bzl
+++ b/haskell/path_utils.bzl
@@ -1,0 +1,154 @@
+"""Utilities for module and path manipulations.
+"""
+
+def path_append(p1, p2):
+  """Append the two given paths with / separator but without creating
+  spurious separators if either path is empty or already has a
+  separator present. It does not try to normalise the path. None is
+  treated as empty path.
+
+  path_append("foo", "bar") => "foo/bar"
+  path_append("foo", "/bar") => "foo/bar"
+  path_append("foo/", "bar") => "foo/bar"
+  path_append("foo/", "/bar") => "foo//bar"
+  path_append("foo", "") => "foo"
+  path_append("foo/", "") => "foo/"
+  path_append("", "bar") => "bar"
+  path_append("", "/bar") => "/bar"
+  path_append("", "") => ""
+
+  Args:
+    p1: Left side of the path.
+    p2: Right side of the path.
+  """
+  # Front empty
+  if p1 == "" or p1 == None:
+    return p2
+  # Back empty
+  elif p2 == "" or p2 == None:
+    return p1
+  # Neither empty, but if there's a slash at either end of p1 or start
+  # of p2, just append. If there's one at both, too bad.
+  elif p1[:-1] == '/' or p2[0] == '/':
+    return p1 + p2
+  # No slash at join point add one.
+  else:
+    return "{0}/{1}".format(p1, p2)
+
+def drop_path_prefix(pathPrefix, fullPath):
+  """Drop pathPrefix path prefix from fullPath if it exists.
+
+  drop_path_prefix("foo/bar", "foo/bar/baz") => "baz"
+  drop_path_prefix("", "/foo") => "foo"
+  drop_path_prefix("foo/mid", "foo/middle/bar") => "dle/bar"
+  drop_path_prefix("nomatch", "some/path") => "some/path"
+  drop_path_prefix("nomatch", "/some/path") => "/some/path"
+
+  Args:
+    pathPrefix: Prefix to drop from fullPath.
+    fullPath: Path to drop pathPrefix from.
+
+  """
+  # Check if prefix matches
+  if pathPrefix == fullPath[:len(pathPrefix)]:
+    newPath = fullPath[len(pathPrefix):]
+    # We cut off the prefix and found a leading path separator, drop
+    # it as it was necessary with the prefix. Most likely.
+    if newPath[:1] == '/':
+      return newPath[1:]
+    else:
+      return newPath
+  else:
+    return fullPath
+
+def path_to_module_path(ctx, hsFile):
+  """Given Haskell source file path, get the module hierarchy without the
+    extension.
+
+  some-workspace/some-package/src/Foo/Bar/Baz.hs => Foo/Bar/Baz
+
+  Args:
+    ctx: Rule context.
+    hsFile: Haskell source file.
+  """
+  # Directory under which module hierarchy starts.
+  pkgDir = path_append(path_append(ctx.label.workspace_root, ctx.label.package),
+                       ctx.attr.sourceDir)
+  # Module path without the workspace and source directories, just
+  # relevant hierarchy.
+  noPrefixPath = drop_path_prefix(pkgDir, hsFile.path)
+  # Drop extension.
+  return noPrefixPath[:noPrefixPath.rfind(".")]
+
+def path_to_module(ctx, hsFile):
+  """Given Haskell source file path, turn it to a module name.
+
+  some-workspace/some-package/src/Foo/Bar/Baz.hs => Foo.Bar.Baz
+
+  Args:
+    ctx: Rule context.
+    hsFile: Haskell source file.
+  """
+  return path_to_module_path(ctx, hsFile).replace('/', '.')
+
+def get_object_suffix():
+  """Get the object file suffix that GHC expects for this mode of compilation.
+  """
+  return "o"
+
+def get_dyn_object_suffix():
+  """Get the dynamic object file suffix.
+  """
+  return "dyn_o"
+
+def get_interface_suffix():
+  """Get the interface file suffix that GHC expects for this mode of
+  compilation.
+  """
+  return "hi"
+
+def get_dyn_interface_suffix():
+  """Get the dynamic interface file suffix that GHC expects for this
+  mode of compilation.
+  """
+  return "dyn_hi"
+
+
+def replace_ext(filePath, newExt):
+  """Replace an extension in a path with the given one.
+
+  replace_ext("foo/bar.hs", "o") => "foo/bar.o"
+  replace_ext("foo/bar.hs", "") => "foo/bar"
+  replace_ext("foo/bar", "") => "foo/bar"
+  replace_ext("foo/bar", "hs") => "foo/bar.hs"
+  replace_ext("foo/bar.hs", ".o") => "foo/bar.o"
+
+  Args:
+    filePath: Path to replace extension in.
+    newExt: Extension give to the new path.
+  """
+
+  dotPos = filePath.rfind(".")
+  noExt = filePath if dotPos < 0 else filePath[:dotPos]
+  if newExt != None and newExt != "":
+    if newExt[:1] == ".":
+      # If user passed ext with dot, don't add one ourselves.
+      return "{0}{1}".format(noExt, newExt)
+    else:
+      return "{0}.{1}".format(noExt, newExt)
+  else:
+    return noExt
+
+def declare_compiled(ctx, src, ext, directory=None):
+  """Given a Haskell-ish source file, declare its output.
+
+  Args:
+    ctx: Rule context.
+    src: Haskell source file.
+    ext: New extension.
+    directory: Directory the new file should live in.
+
+  """
+  fp = replace_ext(path_to_module_path(ctx, src), ext)
+  fp_with_dir = fp if directory == None else path_append(directory.basename, fp)
+  return ctx.actions.declare_file(fp_with_dir)

--- a/haskell/toolchain.bzl
+++ b/haskell/toolchain.bzl
@@ -239,16 +239,6 @@ def ghc_dyn_link_args(ctx, dynObjectFiles, pkgDynLib, pkgNames, pkgConfs, allExt
   args.add(dynObjectFiles)
   return args
 
-def ghc_cpphs_args(ctx, cpphsFile, hsOut, includeDirs):
-  args = ctx.actions.args()
-  args.add(["-E", "-cpp", "-pgmPcpphs", "-optP--cpp", "-x", "hs"])
-  for includeDir in includeDirs:
-    args.add("-optP-I{0}".format(includeDir))
-
-  args.add(["-o", hsOut])
-  args.add(cpphsFile)
-  return args
-
 def mk_registration_file(ctx, pkgId, interfaceDir, libDir, dynLibDir, inputFiles, libName):
   """Prepare a file we'll use to register a package with.
 

--- a/haskell/toolchain.bzl
+++ b/haskell/toolchain.bzl
@@ -13,6 +13,14 @@ HaskellPackageInfo = provider(
   }
 )
 
+def mk_name(ctx, namePrefix):
+  """Make a target-unique name.
+
+  Args:
+    namePrefix: Template for the name.
+  """
+  return "{0}-{1}-{2}".format(namePrefix, ctx.attr.name, ctx.attr.version)
+
 def ghc_bin_obj_args(ctx, objDir):
   """Build arguments for Haskell binary object building.
 
@@ -173,7 +181,7 @@ def mk_registration_file(ctx, pkgId, interfaceDir, libDir):
     interfaceDir: Directory with interface files.
     libDir: Directory containing library archive(s).
   """
-  registrationFile = ctx.actions.declare_file("registration-file")
+  registrationFile = ctx.actions.declare_file(mk_name(ctx, "registration-file"))
   registrationFileDict = {
     "name": ctx.attr.name,
     "version": ctx.attr.version,
@@ -186,7 +194,7 @@ def mk_registration_file(ctx, pkgId, interfaceDir, libDir):
                                  for f in ctx.files.srcs]),
     "import-dirs": "${{pkgroot}}/{0}".format(interfaceDir.basename),
     "library-dirs": "${{pkgroot}}/{0}".format(libDir.basename),
-    "hs-libraries": ctx.attr.name,
+    "hs-libraries": pkgId,
     "depends": ", ".join([ d[HaskellPackageInfo].pkgName for d in ctx.attr.deps ])
   }
   ctx.actions.write(

--- a/haskell/toolchain.bzl
+++ b/haskell/toolchain.bzl
@@ -4,6 +4,7 @@ load(":path_utils.bzl",
      "get_dyn_object_suffix",
      "get_interface_suffix",
      "get_object_suffix",
+     "mk_name",
      "path_append",
      "path_to_module",
      "replace_ext",
@@ -25,14 +26,6 @@ HaskellPackageInfo = provider(
     "external_libraries": "Non-Haskell libraries needed for linking. Dict of Name:LinkDir.",
   }
 )
-
-def mk_name(ctx, name_prefix):
-  """Make a target-unique name.
-
-  Args:
-    name_prefix: Template for the name.
-  """
-  return "{0}-{1}-{2}".format(name_prefix, ctx.attr.name, ctx.attr.version)
 
 def compile_haskell_bin(ctx):
   """Build arguments for Haskell binary object building.

--- a/haskell/toolchain.bzl
+++ b/haskell/toolchain.bzl
@@ -195,6 +195,32 @@ def compile_haskell_lib(ctx, generated_hs_sources):
 
   return interfaces_dir, interface_files, object_files, object_dyn_files
 
+def create_static_library(ctx, library_name, object_files):
+  """Create a static library for the package using given object files.
+
+  Args:
+    ctx: Rule context.
+    object_files: All object files to include in the library.
+  """
+  args = ctx.actions.args()
+  static_library_dir = ctx.actions.declare_directory(mk_name(ctx, "lib"))
+  static_library = ctx.actions.declare_file(path_append(static_library_dir.basename, "lib{0}.a".format(library_name)))
+
+
+  args = ctx.actions.args()
+  args.add(["qc", static_library])
+  args.add(object_files)
+
+  ctx.actions.run(
+    inputs = object_files,
+    outputs = [static_library, static_library_dir],
+    use_default_shell_env = True,
+    executable = "ar",
+    arguments = [args],
+  )
+  return static_library_dir, static_library
+
+
 def get_input_files(ctx):
   """Get all files we expect to project object files from.
 

--- a/haskell/toolchain.bzl
+++ b/haskell/toolchain.bzl
@@ -120,58 +120,6 @@ def ghc_bin_link_args(ctx, binObjs, depLibs, prebuiltDeps, externalLibs):
 
   return dummyLib, args
 
-def ghc_c_lib_args(ctx, objDir, pkgConfs, pkgNames, includeDirs):
-  args = ctx.actions.args()
-  args.add([
-    "-c", "-fPIC",
-    "-osuf", get_object_suffix(),
-    "-odir", objDir
-  ])
-
-  args.add("-optc-O2")
-  for opt in ctx.attr.c_options:
-    args.add("-optc{0}".format(opt))
-
-  # Expose every dependency and every prebuilt dependency.
-  packages = pkgNames + depset(ctx.attr.prebuiltDeps)
-  for n in packages:
-    args.add(["-package", n])
-
-  for c in pkgConfs:
-    args.add(["-package-db", c.dirname])
-
-  for d in includeDirs:
-    args.add("-I{0}".format(d))
-
-  args.add(ctx.files.c_sources)
-  return args
-
-def ghc_c_dyn_lib_args(ctx, objDir, pkgConfs, pkgNames, includeDirs):
-  args = ctx.actions.args()
-  args.add([
-    "-c", "-dynamic", "-fPIC",
-    "-osuf", get_dyn_object_suffix(),
-    "-odir", objDir
-  ])
-
-  args.add("-optc-O2")
-  for opt in ctx.attr.c_options:
-    args.add("-optc{0}".format(opt))
-
-  # Expose every dependency and every prebuilt dependency.
-  packages = pkgNames + depset(ctx.attr.prebuiltDeps)
-  for n in packages:
-    args.add(["-package", n])
-
-  for c in pkgConfs:
-    args.add(["-package-db", c.dirname])
-
-  for d in includeDirs:
-    args.add("-I{0}".format(d))
-
-  args.add(ctx.files.c_sources)
-  return args
-
 def ghc_lib_args(ctx, objDir, ifaceDir, pkgConfs, pkgNames, genHsFiles):
   """Build arguments for Haskell package build.
 

--- a/haskell/toolchain.bzl
+++ b/haskell/toolchain.bzl
@@ -20,6 +20,7 @@ def ghc_bin_obj_args(ctx, objDir):
     objDir: Output directory for object files.
   """
   args = ctx.actions.args()
+  args.add(ctx.attr.compilerFlags)
   args.add("-no-link")
   args.add(ctx.files.srcs)
   args.add(["-odir", objDir])
@@ -93,6 +94,7 @@ def ghc_lib_args(ctx, objDir, ifaceDir, pkgConfs, pkgNames):
     pkgNames: Package names of dependencies.
   """
   args = ctx.actions.args()
+  args.add(ctx.attr.compilerFlags)
   args.add(["-no-link"])
   args.add(["-package-name", "{0}-{1}".format(ctx.attr.name, ctx.attr.version)])
   args.add(["-odir", objDir, "-hidir", ifaceDir])

--- a/haskell/toolchain.bzl
+++ b/haskell/toolchain.bzl
@@ -239,14 +239,6 @@ def ghc_dyn_link_args(ctx, dynObjectFiles, pkgDynLib, pkgNames, pkgConfs, allExt
   args.add(dynObjectFiles)
   return args
 
-def hsc2hs_args(ctx, hscFile, hsOut, includeDirs):
-  args = ctx.actions.args()
-  args.add(hscFile)
-  args.add(["-o", hsOut])
-  for includeDir in includeDirs:
-    args.add(["-I", includeDir])
-  return args
-
 def ghc_cpphs_args(ctx, cpphsFile, hsOut, includeDirs):
   args = ctx.actions.args()
   args.add(["-E", "-cpp", "-pgmPcpphs", "-optP--cpp", "-x", "hs"])

--- a/haskell/toolchain.bzl
+++ b/haskell/toolchain.bzl
@@ -24,6 +24,7 @@ def ghc_bin_obj_args(ctx, objDir):
   args.add("-no-link")
   args.add(ctx.files.srcs)
   args.add(["-odir", objDir])
+  args.add(["-main-is", ctx.attr.main])
 
   if ctx.attr.profiling:
     args.add("-prof")

--- a/haskell/toolchain.bzl
+++ b/haskell/toolchain.bzl
@@ -82,6 +82,8 @@ def ghc_bin_link_args(ctx, binObjs, depLibs):
   )
 
   args = ctx.actions.args()
+  if ctx.attr.profiling:
+    args.add("-prof")
   args.add(["-o", ctx.outputs.executable])
   args.add(dummyLib)
   for o in binObjs:

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -10,6 +10,16 @@ haskell_binary(
     deps = ["//tests/test-lib"]
 )
 
+haskell_binary(
+  name = "two-libs-one-BUILD",
+  main = "TogetherTest.main",
+  srcs = ["TogetherTest.hs"],
+  deps = [
+    "//tests/together-lib:one",
+    "//tests/together-lib:two"
+  ]
+)
+
 [sh_test(
     name = "Run" + binary,
     srcs = ["test_binary.sh"],
@@ -18,4 +28,5 @@ haskell_binary(
     timeout="short",
 ) for binary in [
     "hello",
+    "two-libs-one-BUILD",
 ]]

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -20,6 +20,16 @@ haskell_binary(
   ]
 )
 
+haskell_binary(
+  name = "non-top-srcs",
+  sourceDir = "non-top-srcs",
+  srcs = [
+    "non-top-srcs/Test.hs",
+    "non-top-srcs/Main.hs"
+  ],
+  prebuiltDeps = ["base"]
+)
+
 [sh_test(
     name = "Run" + binary,
     srcs = ["test_binary.sh"],
@@ -29,4 +39,5 @@ haskell_binary(
 ) for binary in [
     "hello",
     "two-libs-one-BUILD",
+    "non-top-srcs",
 ]]

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -56,6 +56,23 @@ haskell_binary(
   deps = [":hsc-lib"],
 )
 
+haskell_library(
+  name = "cpphs-lib",
+  sourceDir = "cpphs",
+  srcs = [],
+  cpphs = ["cpphs/Test.cpphs"],
+  prebuiltDeps = ["base"]
+)
+
+# https://github.com/tweag/rules_haskell/issues/13
+haskell_binary(
+  name = "cpphs",
+  sourceDir = "cpphs",
+  srcs = ["cpphs/Main.hs"],
+  prebuiltDeps = ["base"],
+  deps = [":cpphs-lib"],
+)
+
 [sh_test(
     name = "Run" + binary,
     srcs = ["test_binary.sh"],
@@ -68,4 +85,5 @@ haskell_binary(
     "non-top-srcs",
     "main-is",
     "hsc",
+    "cpphs",
 ]]

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -1,7 +1,8 @@
 package(default_testonly = 1)
 
 load("@io_tweag_rules_haskell//haskell:haskell.bzl",
-    "haskell_binary",
+     "haskell_binary",
+     "haskell_library",
 )
 
 haskell_binary(
@@ -37,6 +38,24 @@ haskell_binary(
   prebuiltDeps = ["base"],
 )
 
+
+haskell_library(
+  name = "hsc-lib",
+  sourceDir = "hsc",
+  srcs = [],
+  hscs = ["hsc/Test.hsc"],
+  prebuiltDeps = ["base"]
+)
+
+# https://github.com/tweag/rules_haskell/issues/13
+haskell_binary(
+  name = "hsc",
+  sourceDir = "hsc",
+  srcs = ["hsc/Main.hs"],
+  prebuiltDeps = ["base"],
+  deps = [":hsc-lib"],
+)
+
 [sh_test(
     name = "Run" + binary,
     srcs = ["test_binary.sh"],
@@ -48,4 +67,5 @@ haskell_binary(
     "two-libs-one-BUILD",
     "non-top-srcs",
     "main-is",
+    "hsc",
 ]]

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -30,6 +30,13 @@ haskell_binary(
   prebuiltDeps = ["base"]
 )
 
+haskell_binary(
+  name = "main-is",
+  main = "MainIs.mainIs",
+  srcs = [ "MainIs.hs" ],
+  prebuiltDeps = ["base"],
+)
+
 [sh_test(
     name = "Run" + binary,
     srcs = ["test_binary.sh"],
@@ -40,4 +47,5 @@ haskell_binary(
     "hello",
     "two-libs-one-BUILD",
     "non-top-srcs",
+    "main-is",
 ]]

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -28,14 +28,14 @@ haskell_binary(
     "non-top-srcs/Test.hs",
     "non-top-srcs/Main.hs"
   ],
-  prebuiltDeps = ["base"]
+  prebuilt_dependencies = ["base"]
 )
 
 haskell_binary(
   name = "main-is",
   main = "MainIs.mainIs",
   srcs = [ "MainIs.hs" ],
-  prebuiltDeps = ["base"],
+  prebuilt_dependencies = ["base"],
 )
 
 
@@ -44,7 +44,7 @@ haskell_library(
   sourceDir = "hsc",
   srcs = [],
   hscs = ["hsc/Test.hsc"],
-  prebuiltDeps = ["base"]
+  prebuilt_dependencies = ["base"]
 )
 
 # https://github.com/tweag/rules_haskell/issues/13
@@ -52,7 +52,7 @@ haskell_binary(
   name = "hsc",
   sourceDir = "hsc",
   srcs = ["hsc/Main.hs"],
-  prebuiltDeps = ["base"],
+  prebuilt_dependencies = ["base"],
   deps = [":hsc-lib"],
 )
 
@@ -61,7 +61,7 @@ haskell_library(
   sourceDir = "cpphs",
   srcs = [],
   cpphs = ["cpphs/Test.cpphs"],
-  prebuiltDeps = ["base"]
+  prebuilt_dependencies = ["base"]
 )
 
 # https://github.com/tweag/rules_haskell/issues/13
@@ -69,7 +69,7 @@ haskell_binary(
   name = "cpphs",
   sourceDir = "cpphs",
   srcs = ["cpphs/Main.hs"],
-  prebuiltDeps = ["base"],
+  prebuilt_dependencies = ["base"],
   deps = [":cpphs-lib"],
 )
 

--- a/tests/MainIs.hs
+++ b/tests/MainIs.hs
@@ -1,0 +1,4 @@
+module MainIs (mainIs) where
+
+mainIs :: IO ()
+mainIs = putStrLn "mainIs"

--- a/tests/TogetherTest.hs
+++ b/tests/TogetherTest.hs
@@ -1,0 +1,7 @@
+module TogetherTest (main) where
+
+import One (one)
+import Two (two)
+
+main :: IO ()
+main = putStrLn $ "One and Two makes " ++ show (one + two)

--- a/tests/cpphs/Main.hs
+++ b/tests/cpphs/Main.hs
@@ -1,0 +1,6 @@
+module Main (main) where
+
+import Test (cpphsFired)
+
+main :: IO ()
+main = putStrLn cpphsFired

--- a/tests/cpphs/Test.cpphs
+++ b/tests/cpphs/Test.cpphs
@@ -1,0 +1,6 @@
+module Test (cpphsFired) where
+
+#ifndef _INTERNAL_CPPHS_DO_NOT_DEFINE_ME
+cpphsFired :: String
+cpphsFired = "cpphsFired"
+#endif

--- a/tests/hsc/Main.hs
+++ b/tests/hsc/Main.hs
@@ -1,0 +1,6 @@
+module Main (main) where
+
+import Test (hscFired)
+
+main :: IO ()
+main = putStrLn hscFired

--- a/tests/hsc/Test.hsc
+++ b/tests/hsc/Test.hsc
@@ -1,0 +1,6 @@
+module Test (hscFired) where
+
+#ifndef _INTERNAL_HSC_DO_NOT_DEFINE_ME
+hscFired :: String
+hscFired = "hscFired"
+#endif

--- a/tests/non-top-srcs/Main.hs
+++ b/tests/non-top-srcs/Main.hs
@@ -1,0 +1,6 @@
+module Main (main) where
+
+import Test ()
+
+main :: IO ()
+main = putStrLn "non-top-srcs"

--- a/tests/non-top-srcs/Test.hs
+++ b/tests/non-top-srcs/Test.hs
@@ -1,0 +1,2 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+module Test () where

--- a/tests/test-lib/BUILD
+++ b/tests/test-lib/BUILD
@@ -10,5 +10,8 @@ haskell_library(
   srcs = [
     'TestLib.hs',
   ],
-  deps = ["//tests/test-sublib"]
+  deps = ["//tests/test-sublib"],
+  prebuiltDeps = [
+    "base",
+  ],
 )

--- a/tests/test-lib/BUILD
+++ b/tests/test-lib/BUILD
@@ -11,7 +11,7 @@ haskell_library(
     'TestLib.hs',
   ],
   deps = ["//tests/test-sublib"],
-  prebuiltDeps = [
+  prebuilt_dependencies = [
     "base",
   ],
 )

--- a/tests/test-sublib/BUILD
+++ b/tests/test-sublib/BUILD
@@ -10,7 +10,7 @@ haskell_library(
   srcs = [
     'TestSubLib.hs',
   ],
-  prebuiltDeps = [
+  prebuilt_dependencies = [
     "base"
   ],
 )

--- a/tests/test-sublib/BUILD
+++ b/tests/test-sublib/BUILD
@@ -9,5 +9,8 @@ haskell_library(
   name = 'test-sublib',
   srcs = [
     'TestSubLib.hs',
-  ]
+  ],
+  prebuiltDeps = [
+    "base"
+  ],
 )

--- a/tests/together-lib/BUILD
+++ b/tests/together-lib/BUILD
@@ -1,0 +1,16 @@
+package(default_visibility = ["//visibility:public"])
+
+load(
+  "@io_tweag_rules_haskell//haskell:haskell.bzl",
+  "haskell_library",
+)
+
+haskell_library(
+  name = 'one',
+  srcs = [ 'One.hs' ]
+)
+
+haskell_library(
+  name = 'two',
+  srcs = [ 'Two.hs' ]
+)

--- a/tests/together-lib/BUILD
+++ b/tests/together-lib/BUILD
@@ -8,7 +8,7 @@ load(
 haskell_library(
   name = 'one',
   srcs = [ 'One.hs' ],
-  prebuiltDeps = [
+  prebuilt_dependencies = [
     "base"
   ],
 )
@@ -16,7 +16,7 @@ haskell_library(
 haskell_library(
   name = 'two',
   srcs = [ 'Two.hs' ],
-  prebuiltDeps = [
+  prebuilt_dependencies = [
     "base"
   ],
 )

--- a/tests/together-lib/BUILD
+++ b/tests/together-lib/BUILD
@@ -7,10 +7,16 @@ load(
 
 haskell_library(
   name = 'one',
-  srcs = [ 'One.hs' ]
+  srcs = [ 'One.hs' ],
+  prebuiltDeps = [
+    "base"
+  ],
 )
 
 haskell_library(
   name = 'two',
-  srcs = [ 'Two.hs' ]
+  srcs = [ 'Two.hs' ],
+  prebuiltDeps = [
+    "base"
+  ],
 )

--- a/tests/together-lib/One.hs
+++ b/tests/together-lib/One.hs
@@ -1,0 +1,4 @@
+module One (one) where
+
+one :: Int
+one = 1

--- a/tests/together-lib/Two.hs
+++ b/tests/together-lib/Two.hs
@@ -1,0 +1,4 @@
+module Two (two) where
+
+two :: Int
+two = 2


### PR DESCRIPTION
This large PR multiple features. Sadly it's far too sequential to easily split up without wasting whole day as each feature depends on changes in last. This is also the reason why couple of tests are tacked on in the end: discarding all work on top, writing the tests, reapplying work and updating the tests to use new needed features is time better spent on actually getting things to work.

Most commits are self-explanatory w.r.t. what they add.

Code itself is quite messy. I want to spend some time tomorrow on fixing that and adding more tests once that's done.

There's a test missing for C-related things as I could not come up with one on the spot.

I'm attaching a `git diff` from `inline-java` repository with BUILD files that work with this version. My nixpkgs is `6f8601288b1292726188d2600cfeaa6c5be658ce` FWIW.

[inline-java.txt](https://github.com/tweag/rules_haskell/files/1544942/inline-java.txt)
