### PR TITLE
Initial roadmap.

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,46 @@
+# Feature roadmap
+
+In the following list, each feature is associated with a corresponding
+milestone. The convention for the priorities are:
+
+* P0 feature will block the milestone; we will delay the milestone
+  date until the feature is shipped.
+* P1 feature can delay the milestone if the feature can be shipped
+  with a reasonable delay.
+* P2 feature will be dropped and rescheduled for later rather than
+  delaying the milestone.
+
+We will update this list when reaching each milestone. Some milestones
+may also be refined if appropriate.
+
+## Planned feature list
+
+### Build and test inline-java
+
+### Build and test sparkle
+
+### Build and test Agda
+
+### 1.0
+
+* P0. Support passing compiler flags on command-line.
+* P1. GHC server to amortize cost of invoking `ghc` command.
+* P1. Make object cache available to server to achieve incremental
+  rebuild of `haskell_library` targets.
+* P1. Import toolchains from `rules_nixpkgs`.
+* P2. Define official GHC bindists as toolchains for each Tier-1
+  platform.
+* P2. Define cross-compiler toolchains.
+* P2. Support multiple build flavours: fastbuild, opt, dbg/profiling.
+
+## Previous milestones
+
+### Initial support
+
+* P0. Ensure legalese is in place from the beginning to make project
+  upstreamable to official `bazelbuild` org eventually.
+* P0. `haskell_library` able to compile single file library.
+* P0. `haskell_binary` able to compile single file binary.
+* P1. Basic binary build with a library dependency.
+* P2. Transitive library dependencies.
+* P2. Basic documentation with rule descriptions.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -23,15 +23,13 @@ may also be refined if appropriate.
 
 ### 1.0
 
-* P0. Support passing compiler flags on command-line.
-* P1. GHC server to amortize cost of invoking `ghc` command.
-* P1. Make object cache available to server to achieve incremental
-  rebuild of `haskell_library` targets.
+* P1. Maximally incremental rebuilds.
 * P1. Import toolchains from `rules_nixpkgs`.
 * P2. Define official GHC bindists as toolchains for each Tier-1
   platform.
 * P2. Define cross-compiler toolchains.
 * P2. Support multiple build flavours: fastbuild, opt, dbg/profiling.
+* P2. Support passing compiler flags on command-line.
 
 ## Previous milestones
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -17,9 +17,18 @@ may also be refined if appropriate.
 
 ### Build and test inline-java
 
+* P0. Can build and run inline-java spec and jvm-streaming spec.
+* P0. Can use inline-java packages as dependencies in bigger product
+  (sparkle).
+
 ### Build and test sparkle
 
+* P0. Able to build sparkle executable. This includes building all
+  relevant Java.
+
 ### Build and test Agda
+
+* P0. Produces working `agda` and `agda-mode` executables.
 
 ### 1.0
 


### PR DESCRIPTION
Modeled like the [Bazel roadmap][roadmap].

I omitted for now items that are still speculative and therefore
haven't been scheduled yet. Two in particular come to mind:

* #17 Auto generation of `BUILD` files. Makes sense. But need to
  discuss: whether a Gazelle-like approach makes sense for Haskell,
  whether we want something more fine grained or more coarse grained.
* Hackage dependencies: at the moment we delegate building what
  Stackage would call "snapshots" to other tools (namely Nix). It's
  unclear whether Bazel build rules want to be getting into that
  business and for what gain.

[roadmap]: https://raw.githubusercontent.com/bazelbuild/bazel-website/master/roadmap.md