### PR TITLE
Introduce haskell_import. Replaces external_libraries field.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,18 @@
 
 [![CircleCI](https://circleci.com/gh/tweag/rules_haskell.svg?style=svg)](https://circleci.com/gh/tweag/rules_haskell)
 
+To use these rules, you'll need [Bazel >= 0.8.1][bazel-install]. To
+run tests, you'll furthermore need [Nix][nix] installed.
+
 [bazel]: https://bazel.build/
+[bazel-install]: https://docs.bazel.build/versions/master/install.html
+[nix]: https://nixos.org/nix
 
 ## Rules
 
 * [haskell_binary](#haskell_binary)
 * [haskell_library](#haskell_library)
+* [haskell_import](#haskell_import)
 
 ## Setup
 
@@ -130,6 +136,55 @@ haskell_library(
       <td>
         <p><code>List of labels, required</code></p>
         <p>List of other Haskell libraries to be linked to this target</p>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+### haskell_binary
+
+Imports a prebuilt shared library.
+
+```bzl
+haskell_import(name, shared_library, visibility = None)
+```
+
+#### Example
+
+```bzl
+haskell_import(name = "zlib", shared_library = "@zlib//:lib")
+
+haskell_binary(
+  name = "crc32sum",
+  srcs = ["Main.hs"],
+  deps = [":zlib"],
+  prebuilt_dependencies = ["base"],
+)
+```
+
+<table class="table table-condensed table-bordered table-params">
+  <colgroup>
+    <col class="col-param" />
+    <col class="param-description" />
+  </colgroup>
+  <thead>
+    <tr>
+      <th colspan="2">Attributes</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>name</code></td>
+      <td>
+        <p><code>Name, required</code></p>
+        <p>A unique name for this target</p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>shared_library</code></td>
+      <td>
+        <p><code>Label, required</code></p>
+        <p>A single precompiled shared library.</p>
       </td>
     </tr>
   </tbody>

--- a/README.md
+++ b/README.md
@@ -141,13 +141,18 @@ haskell_library(
   </tbody>
 </table>
 
-### haskell_binary
+### haskell_import
 
-Imports a prebuilt shared library.
+Imports a prebuilt shared library. Use this to make `.so`, `.dll`,
+`.dylib` files residing in
+external [external repositories][bazel-ext-repos] available to Haskell
+rules.
 
 ```bzl
 haskell_import(name, shared_library, visibility = None)
 ```
+
+[bazel-ext-repos]: https://docs.bazel.build/versions/master/external.html
 
 #### Example
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -7,6 +7,7 @@ local_repository(
 
 http_archive(
     name = "io_tweag_rules_nixpkgs",
+    # Commit hash is current latest master.
     strip_prefix = "rules_nixpkgs-a300f574885c50430147e457d21ec22a9fe015f4",
     urls = ["https://github.com/tweag/rules_nixpkgs/archive/a300f574885c50430147e457d21ec22a9fe015f4.tar.gz"],
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -4,3 +4,14 @@ local_repository(
   name = "examples",
   path = "examples"
 )
+
+http_archive(
+    name = "io_tweag_rules_nixpkgs",
+    strip_prefix = "rules_nixpkgs-a300f574885c50430147e457d21ec22a9fe015f4",
+    urls = ["https://github.com/tweag/rules_nixpkgs/archive/a300f574885c50430147e457d21ec22a9fe015f4.tar.gz"],
+)
+
+load("@io_tweag_rules_nixpkgs//nixpkgs:nixpkgs.bzl", "nixpkgs_package")
+
+# For tests
+nixpkgs_package(name = "zlib")

--- a/haskell/c_compile.bzl
+++ b/haskell/c_compile.bzl
@@ -65,8 +65,9 @@ def __generic_c_compile(ctx, output_dir_template, output_ext, user_args):
   pkg_caches = depset()
   pkg_names = depset()
   for d in ctx.attr.deps:
-    pkg_caches += d[HaskellPackageInfo].caches
-    pkg_names += d[HaskellPackageInfo].names
+    if HaskellPackageInfo in d:
+      pkg_caches += d[HaskellPackageInfo].caches
+      pkg_names += d[HaskellPackageInfo].names
 
   # Expose every dependency and every prebuilt dependency.
   for n in pkg_names + depset(ctx.attr.prebuilt_dependencies):

--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -98,10 +98,6 @@ _haskell_common_attrs = {
     allow_files=True,
     doc="Non-Haskell dependencies",
   ),
-  # Only supports one per lib for now
-  "external_libraries": attr.string_dict(
-    doc="Non-Haskell libraries that we should link",
-  ),
   "prebuilt_dependencies": attr.string_list(
     doc="Haskell packages which are magically available such as wired-in packages."
   ),
@@ -139,3 +135,6 @@ haskell_binary = rule(
     )
   }
 )
+
+def haskell_import(name, shared_library, visibility = None):
+  native.alias(name = name, actual = shared_library, visibility = visibility)

--- a/haskell/toolchain.bzl
+++ b/haskell/toolchain.bzl
@@ -121,6 +121,8 @@ def link_haskell_bin(ctx, object_files):
     if HaskellPackageInfo in dep:
       external_libraries = external_libraries.union(dep[HaskellPackageInfo].external_libraries)
     else:
+      # If not a Haskell dependency, collect list of files to be
+      # passed as-is to the linking command.
       external_libraries = external_libraries.union(depset(dep.files))
 
   for lib in external_libraries:

--- a/haskell/toolchain.bzl
+++ b/haskell/toolchain.bzl
@@ -103,39 +103,43 @@ def link_haskell_bin(ctx, object_files):
     arguments = [ar_args]
   )
 
-  link_args = ctx.actions.args()
-  link_args.add(["-o", ctx.outputs.executable, dummy_static_lib])
+  # XXX Use list instead of Args, because no Args -> string conversion
+  # function yet, and need to construct full shell command below as
+  # a string.
+  link_args = []
+  link_args.extend(["-o", ctx.outputs.executable.path, dummy_static_lib.path])
 
   for o in object_files:
-    link_args.add(["-optl", o])
+    link_args.extend(["-optl", o.path])
 
   dep_info = gather_dependency_information(ctx)
   for l in dep_info.static_libraries:
-    link_args.add(["-optl", l])
+    link_args.extend(["-optl", l.path])
 
-  external_libraries = {}
+  external_libraries = depset()
   for dep in ctx.attr.deps:
-    external_libraries.update(
-      dep[HaskellPackageInfo].external_libraries
-    )
+    if HaskellPackageInfo in dep:
+      external_libraries = external_libraries.union(dep[HaskellPackageInfo].external_libraries)
+    else:
+      external_libraries = external_libraries.union(depset(dep.files))
 
-  for dep_name, dep_dirs in external_libraries.items():
-    link_args.add("-l{0}".format(dep_name))
-    for d in dep_dirs:
-      link_args.add("-L{0}".format(d))
+  for lib in external_libraries:
+    link_args.append(lib.path)
 
   # We have to remember to specify all (transitive) wired-in
   # dependencies or we can't find objects for linking.
   for p in dep_info.prebuilt_dependencies:
-    link_args.add(["-package", p])
+    link_args.extend(["-package", p])
 
-  ctx.actions.run(
-    inputs = dep_info.static_libraries + object_files + [dummy_static_lib],
+  # Resolve symlinks to system libraries to their absolute location.
+  # Otherwise we'd end up with meaningless relative rpath.
+  rpaths = ["$(realpath {0})".format(lib.path) for lib in external_libraries]
+  ctx.actions.run_shell(
+    inputs = dep_info.static_libraries + object_files + [dummy_static_lib] + external_libraries,
     outputs = [ctx.outputs.executable],
     use_default_shell_env = True,
     progress_message = "Linking {0}".format(ctx.outputs.executable.basename),
-    executable = "ghc",
-    arguments = [link_args],
+    command = " ".join(["ghc"] + rpaths + link_args),
   )
 
 def compile_haskell_lib(ctx, generated_hs_sources):
@@ -247,21 +251,17 @@ def create_dynamic_library(ctx, object_files):
 
   dep_info = gather_dependency_information(ctx)
 
-  # We do not add anything to inputs from these as these are supposed
-  # to be absolute paths outside of bazel's control such as system
-  # libraries.
-  for dep_name, dep_dirs in dep_info.external_libraries.items():
-    args.add("-l{0}".format(dep_name))
-    for d in dep_dirs:
-      args.add("-L{0}".format(d))
+  for libs in dep_info.external_libraries:
+    args.add(libs)
 
   pkg_caches = depset()
   pkg_names = depset()
   dep_dyn_lib_dirs = depset()
   for d in ctx.attr.deps:
-    pkg_caches += d[HaskellPackageInfo].caches
-    pkg_names += d[HaskellPackageInfo].names
-    dep_dyn_lib_dirs += d[HaskellPackageInfo].dynamic_libraries
+    if HaskellPackageInfo in d:
+      pkg_caches += d[HaskellPackageInfo].caches
+      pkg_names += d[HaskellPackageInfo].names
+      dep_dyn_lib_dirs += d[HaskellPackageInfo].dynamic_libraries
 
   for n in dep_info.names + depset(ctx.attr.prebuilt_dependencies):
     args.add(["-package", n])
@@ -275,7 +275,8 @@ def create_dynamic_library(ctx, object_files):
     inputs =
       depset(object_files) +
       pkg_caches +
-      dep_dyn_lib_dirs,
+      dep_dyn_lib_dirs +
+      dep_info.external_libraries,
     outputs = [dynamic_library_dir, dynamic_library],
     use_default_shell_env = True,
     executable = "ghc",
@@ -316,7 +317,7 @@ def create_ghc_package(ctx, interface_files, interfaces_dir, static_library, sta
       path_append("${pkgroot}", dynamic_library_dir.basename),
     "hs-libraries": get_library_name(ctx),
     "depends":
-      ", ".join([ d[HaskellPackageInfo].name for d in ctx.attr.deps ])
+      ", ".join([ d[HaskellPackageInfo].name for d in ctx.attr.deps if HaskellPackageInfo in d])
   }
   ctx.actions.write(
     output=registration_file,
@@ -326,6 +327,7 @@ def create_ghc_package(ctx, interface_files, interfaces_dir, static_library, sta
 
   pkg_confs = depset([
     c for dep in ctx.attr.deps
+      if HaskellPackageInfo in dep
       for c in dep[HaskellPackageInfo].confs
   ])
 
@@ -394,31 +396,43 @@ def gather_dependency_information(ctx):
     static_library_dirs = depset(),
     dynamic_library_dirs = depset(),
     prebuilt_dependencies = depset(ctx.attr.prebuilt_dependencies),
-    external_libraries = {}
+    external_libraries = depset(),
   )
 
   for dep in ctx.attr.deps:
-    pkg = dep[HaskellPackageInfo]
-    new_external_libraries = {}
-    new_external_libraries.update(hpi.external_libraries)
-    new_external_libraries.update(pkg.external_libraries)
-    hpi = HaskellPackageInfo(
-      name = hpi.name,
-      names = hpi.names + pkg.names,
-      confs = hpi.confs + pkg.confs,
-      caches = hpi.caches + pkg.caches,
-      static_libraries = hpi.static_libraries + pkg.static_libraries,
-      dynamic_libraries = hpi.dynamic_libraries + pkg.dynamic_libraries,
-      interface_files = hpi.interface_files + pkg.interface_files,
-      static_library_dirs = hpi.static_library_dirs + pkg.static_library_dirs,
-      dynamic_library_dirs = hpi.dynamic_library_dirs + pkg.dynamic_library_dirs,
-      prebuilt_dependencies = hpi.prebuilt_dependencies + pkg.prebuilt_dependencies,
-      external_libraries = new_external_libraries
-    )
+    if HaskellPackageInfo in dep:
+      pkg = dep[HaskellPackageInfo]
+      new_external_libraries = hpi.external_libraries
+      new_external_libraries = new_external_libraries.union(pkg.external_libraries)
+      hpi = HaskellPackageInfo(
+        name = hpi.name,
+        names = hpi.names + pkg.names,
+        confs = hpi.confs + pkg.confs,
+        caches = hpi.caches + pkg.caches,
+        static_libraries = hpi.static_libraries + pkg.static_libraries,
+        dynamic_libraries = hpi.dynamic_libraries + pkg.dynamic_libraries,
+        interface_files = hpi.interface_files + pkg.interface_files,
+        static_library_dirs = hpi.static_library_dirs + pkg.static_library_dirs,
+        dynamic_library_dirs = hpi.dynamic_library_dirs + pkg.dynamic_library_dirs,
+        prebuilt_dependencies = hpi.prebuilt_dependencies + pkg.prebuilt_dependencies,
+        external_libraries = new_external_libraries,
+      )
+    else:
+      # If not a Haskell dependency, pass it through as-is to the
+      # linking phase.
+      hpi = HaskellPackageInfo(
+        name = hpi.name,
+        names = hpi.names,
+        confs = hpi.confs,
+        caches = hpi.caches,
+        static_libraries = hpi.static_libraries,
+        dynamic_libraries = hpi.dynamic_libraries,
+        interface_files = hpi.interface_files,
+        static_library_dirs = hpi.static_library_dirs,
+        dynamic_library_dirs = hpi.dynamic_library_dirs,
+        prebuilt_dependencies = hpi.prebuilt_dependencies,
+        external_libraries = hpi.external_libraries.union(depset(dep.files)),
+      )
 
-  # Add external_libraries from the user, formatting them in way code
-  # expects.
-  for name, f in ctx.attr.external_libraries.items():
-    hpi.external_libraries[name] = hpi.external_libraries.get(name, default=depset()) + [f]
 
   return hpi

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -2,6 +2,7 @@ package(default_testonly = 1)
 
 load("@io_tweag_rules_haskell//haskell:haskell.bzl",
      "haskell_binary",
+     "haskell_import",
      "haskell_library",
 )
 
@@ -36,12 +37,29 @@ rule_test(
 )
 
 rule_test(
+  name = "test-binary-with-sysdeps",
+  generates = ["binary-with-sysdeps"],
+  rule = "//tests/binary-with-sysdeps",
+  size = "small",
+)
+
+rule_test(
   name = "test-library-deps",
   generates =
     ["library-deps-1.0.0/library-deps-1.0.0.conf",
      "library-deps-1.0.0/package.cache",
     ],
   rule = "//tests/library-deps",
+  size = "small",
+)
+
+rule_test(
+  name = "test-library-with-sysdeps",
+  generates =
+    ["library-with-sysdeps-1.0.0/library-with-sysdeps-1.0.0.conf",
+     "library-with-sysdeps-1.0.0/package.cache",
+    ],
+  rule = "//tests/library-with-sysdeps",
   size = "small",
 )
 

--- a/tests/binary-with-sysdeps/BUILD
+++ b/tests/binary-with-sysdeps/BUILD
@@ -1,0 +1,14 @@
+load("@io_tweag_rules_haskell//haskell:haskell.bzl",
+  "haskell_binary",
+  "haskell_import",
+)
+
+haskell_import(name = "zlib", shared_library = "@zlib//:lib")
+
+haskell_binary(
+  name = "binary-with-sysdeps",
+  srcs = ["Main.hs"],
+  deps = [":zlib"],
+  prebuilt_dependencies = ["base"],
+  visibility = ["//visibility:public"],
+)

--- a/tests/binary-with-sysdeps/Main.hs
+++ b/tests/binary-with-sysdeps/Main.hs
@@ -1,0 +1,8 @@
+module Main where
+
+import Foreign.Ptr
+import Foreign.C.Types
+
+foreign import ccall crc32 :: CLong -> Ptr () -> CInt -> IO ()
+
+main = crc32 0 nullPtr 0

--- a/tests/library-with-sysdeps/BUILD
+++ b/tests/library-with-sysdeps/BUILD
@@ -1,0 +1,22 @@
+load("@io_tweag_rules_haskell//haskell:haskell.bzl",
+  "haskell_binary",
+  "haskell_import",
+  "haskell_library",
+)
+
+haskell_import(name = "zlib", shared_library = "@zlib//:lib")
+
+haskell_library(
+  name = "library-with-sysdeps",
+  srcs = ["Lib.hs"],
+  deps = [":zlib"],
+  prebuilt_dependencies = ["base"],
+  visibility = ["//visibility:public"],
+)
+
+haskell_binary(
+  name = "bin",
+  srcs = ["Main.hs"],
+  deps = [":library-with-sysdeps"],
+  prebuilt_dependencies = ["base"],
+)

--- a/tests/library-with-sysdeps/Lib.hs
+++ b/tests/library-with-sysdeps/Lib.hs
@@ -1,0 +1,8 @@
+module Lib (crc) where
+
+import Foreign.Ptr
+import Foreign.C.Types
+
+foreign import ccall crc32 :: CLong -> Ptr () -> CInt -> IO ()
+
+crc = crc32 0 nullPtr 0

--- a/tests/library-with-sysdeps/Main.hs
+++ b/tests/library-with-sysdeps/Main.hs
@@ -1,0 +1,5 @@
+module Main where
+
+import Lib (crc)
+
+main = crc


### PR DESCRIPTION
Prebuilt dynamic libraries, i.e. what Cabal calls `extra-libraries`,
are dependencies like any other. It's just that it's not a Haskell
dependency. The idiomatic way to express this in Bazel is to mix
dependencies of different types all in the `deps` field. So we move to
the content of `external_libraries` to `deps`. Further, for forward
compatibility, we introduce `haskell_import` to mirror `cc_import` and
`java_import`. It doesn't do much at the moment beyond reexport the
shared library it was given and do some sanity checking. But it may
need to do in the future.

This PR introduces two new tests for this functionality. They depend
on `rules_nixpkgs`, which in turn depends on Nix. Since repositories
are loaded lazily, it doesn't mean that Nix is required just to use
the rules, only to test them. We could perhaps conditionally disable
Nix in the future (using constraints?), but this is good enough for
now. And better than the alternative: hard coding absolute paths to
libraries in tests.

Fixes #15.