### PR TITLE
Configurable tooling

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
             apk --no-progress update
             apk --no-progress add bash ca-certificates
             nix-channel --update
-            nix-env -iA nixpkgs.bazel
+            nix-env -iA nixpkgs.bazel nixpkgs.binutils
       - run:
           name: Run tests
           command: bazel test //...

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
             apk --no-progress update
             apk --no-progress add bash ca-certificates
             nix-channel --update
-            nix-env -iA nixpkgs.bazel nixpkgs.binutils nixpkgs.ghc
+            nix-env -iA nixpkgs.bazel
       - run:
           name: Run tests
           command: bazel test //...

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -14,5 +14,13 @@ http_archive(
 
 load("@io_tweag_rules_nixpkgs//nixpkgs:nixpkgs.bzl", "nixpkgs_package")
 
+# Default toolchain
+nixpkgs_package(
+  name = "ghc",
+  attribute_path = "haskell.packages.ghc822.ghc"
+)
+
+nixpkgs_package(name = "binutils")
+
 # For tests
 nixpkgs_package(name = "zlib")

--- a/haskell/c_compile.bzl
+++ b/haskell/c_compile.bzl
@@ -9,12 +9,14 @@ load(":path_utils.bzl",
      "get_dyn_object_suffix",
 )
 
-
 load(":toolchain.bzl",
      "HaskellPackageInfo",
      "mk_name",
 )
 
+load(":tools.bzl",
+     "get_compiler",
+)
 
 def c_compile_static(ctx):
   """Compile all C files to static object files.
@@ -92,7 +94,7 @@ def __generic_c_compile(ctx, output_dir_template, output_ext, user_args):
     outputs = [output_dir] + output_files,
     use_default_shell_env = True,
     progress_message = "Compiling C dynamic {0}".format(ctx.attr.name),
-    executable = "ghc",
+    executable = get_compiler(ctx),
     arguments = [user_args, args],
   )
   return output_files

--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -112,7 +112,15 @@ _haskell_common_attrs = {
     # dynamic-library-dirs content. As currently we're using GHC from
     # nix, there's not really a way to do this. In future we need to
     # expose toolchains that expose a version and use that. I think.
-    doc="Version of GHC used."
+    doc="Version of GHC being used."
+  ),
+  "build_tools": attr.label_list(
+    default= [
+      "@ghc//:bin",
+      "@binutils//:bin",
+    ],
+    allow_files=True,
+    doc="Build tools to use.",
   ),
 }
 

--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -117,7 +117,6 @@ _haskell_common_attrs = {
   "build_tools": attr.label_list(
     default= [
       "@ghc//:bin",
-      "@binutils//:bin",
     ],
     allow_files=True,
     doc="Build tools to use.",
@@ -131,6 +130,7 @@ haskell_library = rule(
     "package_cache": "%{name}-%{version}/package.cache"
   },
   attrs = _haskell_common_attrs,
+  host_fragments = ["cpp"],
 )
 
 haskell_binary = rule(
@@ -141,7 +141,8 @@ haskell_binary = rule(
       default="Main.main",
       doc="Main function location."
     )
-  }
+  },
+  host_fragments = ["cpp"],
 )
 
 def haskell_import(name, shared_library, visibility = None):

--- a/haskell/hsc2hs.bzl
+++ b/haskell/hsc2hs.bzl
@@ -6,6 +6,10 @@ load(":path_utils.bzl",
      "mk_name",
 )
 
+load(":tools.bzl",
+     "get_hsc2hs",
+)
+
 def hsc_to_hs(ctx):
   """Process all hsc files into Haskell source files.
 
@@ -41,7 +45,7 @@ def __process_hsc_file(ctx, hsc_file):
     outputs = [hs_out, hsc_output_dir],
     use_default_shell_env = True,
     progress_message = "hsc2hs {0}".format(hsc_file.basename),
-    executable = "hsc2hs",
+    executable = get_hsc2hs(ctx),
     arguments = [args],
   )
   return hs_out

--- a/haskell/tools.bzl
+++ b/haskell/tools.bzl
@@ -78,4 +78,4 @@ def get_ar(ctx):
   Args:
     ctx: Rule context.
   """
-  return get_build_tool(ctx, "ar")
+  return ctx.host_fragments.cpp.ar_executable

--- a/haskell/tools.bzl
+++ b/haskell/tools.bzl
@@ -1,0 +1,81 @@
+"""Tools used during build.
+"""
+def get_build_tools(ctx):
+  """Get the set of all build tools we have available.
+
+  Args:
+    ctx: Rule context.
+  """
+  return depset([
+    f for bt in ctx.attr.build_tools
+      for f in bt.files
+  ])
+
+def get_build_tools_path(ctx):
+  """Get list of build tools suited for PATH. Useful to make sure that
+  GHC can find hsc2hs or cpphs at runtime: even if those files aren't
+  expected, user may just be using OPTIONS_GHC to invoke them so they
+  should be available.
+
+  Args:
+    ctx: Rule context.
+  """
+  return ":".join(depset([bt.dirname for bt in get_build_tools(ctx)]).to_list())
+
+def get_build_tool(ctx, tool_name):
+
+  """Find the requested build tool from all the build tools we were given.
+
+  Args:
+    ctx: Rule context.
+    tool_name: Name of the binary we want to find.
+  """
+  for tool in get_build_tools(ctx):
+    if tool.basename == tool_name:
+      return tool
+
+  fail("Could not find the '{0}' tool.".format(tool_name))
+
+def get_compiler(ctx):
+  """Get the compiler path.
+
+  Args:
+    ctx: Rule context.
+  """
+  # We use allow_single_file with mandatory so this should always
+  # exist.
+  return get_build_tool(ctx, "ghc")
+
+def get_ghc_pkg(ctx):
+  """Get the compiler path.
+
+  Args:
+    ctx: Rule context.
+  """
+  # We use allow_single_file with mandatory so this should always
+  # exist.
+  return get_build_tool(ctx, "ghc-pkg")
+
+def get_hsc2hs(ctx):
+  """Get the hsc2hs tool.
+
+  Args:
+    ctx: Rule context.
+  """
+  return get_build_tool(ctx, "hsc2hs")
+
+def get_cpphs(ctx):
+  """Get the cpphs tool.
+
+  Args:
+    ctx: Rule context.
+  """
+  return get_build_tool(ctx, "cpphs")
+
+def get_ar(ctx):
+  """Get the ar tool.
+
+  Args:
+    ctx: Rule context.
+  """
+  return get_build_tool(ctx, "ar")


### PR DESCRIPTION
This allows us to provide tools to bazel rules to build with. By
default we use whatever `@ghc` and `@binutils` are available in the
workspace.

I'm unsure how to document/deal with this properly: right now it may
be surprising to the user to have to populate those. They are no
longer accepted from environment however which I suspect is what we
want to begin with.

Ideally we would provide some `compiler.bzl` with various GHC versions
out of rules_nixpkgs/official bindists. I'll have to look how to do
that and make it available to user just like we can say `@openjdk`
today without much extra work.