### PR TITLE
Use Skylib.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -12,6 +12,12 @@ http_archive(
   urls = ["https://github.com/tweag/rules_nixpkgs/archive/a300f574885c50430147e457d21ec22a9fe015f4.tar.gz"],
 )
 
+http_archive(
+  name = "bazel_skylib",
+  strip_prefix = "bazel-skylib-0.2.0",
+  urls = ["https://github.com/bazelbuild/bazel-skylib/archive/0.2.0.tar.gz"]
+)
+
 load("@io_tweag_rules_nixpkgs//nixpkgs:nixpkgs.bzl", "nixpkgs_package")
 
 # Default toolchain

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -6,10 +6,10 @@ local_repository(
 )
 
 http_archive(
-    name = "io_tweag_rules_nixpkgs",
-    # Commit hash is current latest master.
-    strip_prefix = "rules_nixpkgs-a300f574885c50430147e457d21ec22a9fe015f4",
-    urls = ["https://github.com/tweag/rules_nixpkgs/archive/a300f574885c50430147e457d21ec22a9fe015f4.tar.gz"],
+  name = "io_tweag_rules_nixpkgs",
+  # Commit hash is current latest master.
+  strip_prefix = "rules_nixpkgs-a300f574885c50430147e457d21ec22a9fe015f4",
+  urls = ["https://github.com/tweag/rules_nixpkgs/archive/a300f574885c50430147e457d21ec22a9fe015f4.tar.gz"],
 )
 
 load("@io_tweag_rules_nixpkgs//nixpkgs:nixpkgs.bzl", "nixpkgs_package")

--- a/haskell/c_compile.bzl
+++ b/haskell/c_compile.bzl
@@ -2,7 +2,6 @@
 
 load(":path_utils.bzl",
      "path_append",
-     "replace_ext",
      "get_dyn_object_suffix",
 )
 
@@ -14,6 +13,8 @@ load(":toolchain.bzl",
 load(":tools.bzl",
      "get_compiler",
 )
+
+load("@bazel_skylib//:lib.bzl", "paths")
 
 def c_compile_static(ctx):
   """Compile all C files to static object files.
@@ -84,7 +85,7 @@ def _generic_c_compile(ctx, output_dir_template, output_ext, user_args):
 
   args.add(ctx.files.c_sources)
 
-  output_files = [ctx.actions.declare_file(path_append(output_dir.basename, replace_ext(s.path, output_ext)))
+  output_files = [ctx.actions.declare_file(path_append(output_dir.basename, paths.replace_extension(s.path, "." + output_ext)))
                         for s in ctx.files.c_sources]
   ctx.actions.run(
     inputs = ctx.files.c_sources + external_files.to_list() + pkg_caches.to_list(),

--- a/haskell/c_compile.bzl
+++ b/haskell/c_compile.bzl
@@ -1,9 +1,5 @@
 """C file compilation."""
 
-load(":path_utils.bzl",
-     "get_dyn_object_suffix",
-)
-
 load(":toolchain.bzl",
      "HaskellPackageInfo",
      "mk_name",
@@ -29,7 +25,7 @@ def c_compile_static(ctx):
   """
   args = ctx.actions.args()
   args.add("-c")
-  return _generic_c_compile(ctx, "objects_c", get_dyn_object_suffix(), args)
+  return _generic_c_compile(ctx, "objects_c", ".o", args)
 
 def c_compile_dynamic(ctx):
   """Compile all C files to dynamic object files.
@@ -45,7 +41,7 @@ def c_compile_dynamic(ctx):
   """
   args = ctx.actions.args()
   args.add(["-c", "-dynamic"])
-  return _generic_c_compile(ctx, "objects_c_dyn", get_dyn_object_suffix(), args)
+  return _generic_c_compile(ctx, "objects_c_dyn", ".dyn_o", args)
 
 def _generic_c_compile(ctx, output_dir_template, output_ext, user_args):
   # Directory for objects generated from C files.
@@ -54,7 +50,6 @@ def _generic_c_compile(ctx, output_dir_template, output_ext, user_args):
   args = ctx.actions.args()
   args.add([
     "-fPIC",
-    "-osuf", output_ext,
     "-odir", output_dir
   ])
 
@@ -84,7 +79,7 @@ def _generic_c_compile(ctx, output_dir_template, output_ext, user_args):
 
   args.add(ctx.files.c_sources)
 
-  output_files = [ctx.actions.declare_file(paths.join(output_dir.basename, paths.replace_extension(s.path, "." + output_ext)))
+  output_files = [ctx.actions.declare_file(paths.join(output_dir.basename, paths.replace_extension(s.path, output_ext)))
                         for s in ctx.files.c_sources]
   ctx.actions.run(
     inputs = ctx.files.c_sources + external_files.to_list() + pkg_caches.to_list(),

--- a/haskell/c_compile.bzl
+++ b/haskell/c_compile.bzl
@@ -1,7 +1,6 @@
 """C file compilation."""
 
 load(":path_utils.bzl",
-     "path_append",
      "get_dyn_object_suffix",
 )
 
@@ -85,7 +84,7 @@ def _generic_c_compile(ctx, output_dir_template, output_ext, user_args):
 
   args.add(ctx.files.c_sources)
 
-  output_files = [ctx.actions.declare_file(path_append(output_dir.basename, paths.replace_extension(s.path, "." + output_ext)))
+  output_files = [ctx.actions.declare_file(paths.join(output_dir.basename, paths.replace_extension(s.path, "." + output_ext)))
                         for s in ctx.files.c_sources]
   ctx.actions.run(
     inputs = ctx.files.c_sources + external_files.to_list() + pkg_caches.to_list(),

--- a/haskell/hsc2hs.bzl
+++ b/haskell/hsc2hs.bzl
@@ -28,7 +28,7 @@ def _process_hsc_file(ctx, hsc_file):
   hsc_output_dir = ctx.actions.declare_directory(mk_name(ctx, "hsc_processed"))
 
   # Output a Haskell source file.
-  hs_out = declare_compiled(ctx, hsc_file, "hs", directory=hsc_output_dir)
+  hs_out = declare_compiled(ctx, hsc_file, ".hs", directory=hsc_output_dir)
   # Make all external dependency files available.
   external_files = depset([f for dep in ctx.attr.external_deps
                              for f in dep.files])

--- a/haskell/path_utils.bzl
+++ b/haskell/path_utils.bzl
@@ -1,5 +1,4 @@
-"""Utilities for module and path manipulations.
-"""
+"""Utilities for module and path manipulations."""
 
 load("@bazel_skylib//:lib.bzl", "paths")
 
@@ -33,22 +32,6 @@ def path_to_module(ctx, hs_file):
   """
   return path_to_module_path(ctx, hs_file).replace('/', '.')
 
-def get_object_suffix():
-  """Get the object file suffix that GHC expects for this mode of compilation."""
-  return "o"
-
-def get_dyn_object_suffix():
-  """Get the dynamic object file suffix."""
-  return "dyn_o"
-
-def get_interface_suffix():
-  """Get the interface file suffix that GHC expects for this mode of compilation."""
-  return "hi"
-
-def get_dyn_interface_suffix():
-  """Same as get_interface_suffix(), but for dynamic linking."""
-  return "dyn_hi"
-
 def declare_compiled(ctx, src, ext, directory=None):
   """Given a Haskell-ish source file, declare its output.
 
@@ -58,7 +41,7 @@ def declare_compiled(ctx, src, ext, directory=None):
     ext: New extension.
     directory: Directory the new file should live in.
   """
-  fp = paths.replace_extension(path_to_module_path(ctx, src), "." + ext)
+  fp = paths.replace_extension(path_to_module_path(ctx, src), ext)
   fp_with_dir = fp if directory == None else paths.join(directory.basename, fp)
   return ctx.actions.declare_file(fp_with_dir)
 

--- a/haskell/path_utils.bzl
+++ b/haskell/path_utils.bzl
@@ -1,6 +1,8 @@
 """Utilities for module and path manipulations.
 """
 
+load("@bazel_skylib//:lib.bzl", "paths")
+
 def path_append(p1, p2):
   """Concatenate two paths without creating spurious separators.
 
@@ -35,32 +37,6 @@ def path_append(p1, p2):
   else:
     return "{0}/{1}".format(p1, p2)
 
-def drop_path_prefix(path_prefix, full_path):
-  """Drop path_prefix path prefix from full_path if it exists.
-
-  drop_path_prefix("foo/bar", "foo/bar/baz") => "baz"
-  drop_path_prefix("", "/foo") => "foo"
-  drop_path_prefix("foo/mid", "foo/middle/bar") => "dle/bar"
-  drop_path_prefix("nomatch", "some/path") => "some/path"
-  drop_path_prefix("nomatch", "/some/path") => "/some/path"
-
-  Args:
-    path_prefix: Prefix to drop from full_path.
-    full_path: Path to drop path_prefix from.
-
-  """
-  # Check if prefix matches
-  if path_prefix == full_path[:len(path_prefix)]:
-    new_path = full_path[len(path_prefix):]
-    # We cut off the prefix and found a leading path separator, drop
-    # it as it was necessary with the prefix. Most likely.
-    if new_path[:1] == '/':
-      return new_path[1:]
-    else:
-      return new_path
-  else:
-    return full_path
-
 def path_to_module_path(ctx, hs_file):
   """Map a source file to a module name.
 
@@ -75,7 +51,7 @@ def path_to_module_path(ctx, hs_file):
                         ctx.attr.src_strip_prefix)
   # Module path without the workspace and source directories, just
   # relevant hierarchy.
-  path_no_prefix = drop_path_prefix(pkg_dir, hs_file.path)
+  path_no_prefix = paths.relativize(hs_file.path, pkg_dir)
   # Drop extension.
   return path_no_prefix[:path_no_prefix.rfind(".")]
 
@@ -106,31 +82,6 @@ def get_dyn_interface_suffix():
   """Same as get_interface_suffix(), but for dynamic linking."""
   return "dyn_hi"
 
-def replace_ext(file_path, new_ext):
-  """Replace an extension in a path with the given one.
-
-  replace_ext("foo/bar.hs", "o") => "foo/bar.o"
-  replace_ext("foo/bar.hs", "") => "foo/bar"
-  replace_ext("foo/bar", "") => "foo/bar"
-  replace_ext("foo/bar", "hs") => "foo/bar.hs"
-  replace_ext("foo/bar.hs", ".o") => "foo/bar.o"
-
-  Args:
-    file_path: Path to replace extension in.
-    new_ext: Extension give to the new path.
-  """
-
-  dot_pos = file_path.rfind(".")
-  file_path_no_ext = file_path if dot_pos < 0 else file_path[:dot_pos]
-  if new_ext != None and new_ext != "":
-    if new_ext[:1] == ".":
-      # If user passed ext with dot, don't add one ourselves.
-      return "{0}{1}".format(file_path_no_ext, new_ext)
-    else:
-      return "{0}.{1}".format(file_path_no_ext, new_ext)
-  else:
-    return file_path_no_ext
-
 def declare_compiled(ctx, src, ext, directory=None):
   """Given a Haskell-ish source file, declare its output.
 
@@ -140,7 +91,7 @@ def declare_compiled(ctx, src, ext, directory=None):
     ext: New extension.
     directory: Directory the new file should live in.
   """
-  fp = replace_ext(path_to_module_path(ctx, src), ext)
+  fp = paths.replace_extension(path_to_module_path(ctx, src), "." + ext)
   fp_with_dir = fp if directory == None else path_append(directory.basename, fp)
   return ctx.actions.declare_file(fp_with_dir)
 

--- a/haskell/toolchain.bzl
+++ b/haskell/toolchain.bzl
@@ -7,7 +7,6 @@ load(":path_utils.bzl",
      "get_interface_suffix",
      "get_object_suffix",
      "mk_name",
-     "path_append",
      "path_to_module",
 )
 
@@ -223,7 +222,7 @@ def create_static_library(ctx, object_files):
     object_files: All object files to include in the library.
   """
   static_library_dir = ctx.actions.declare_directory(mk_name(ctx, "lib"))
-  static_library = ctx.actions.declare_file(path_append(static_library_dir.basename, "lib{0}.a".format(get_library_name(ctx))))
+  static_library = ctx.actions.declare_file(paths.join(static_library_dir.basename, "lib{0}.a".format(get_library_name(ctx))))
 
   args = ctx.actions.args()
   args.add(["qc", static_library])
@@ -248,8 +247,8 @@ def create_dynamic_library(ctx, object_files):
   # Make shared library
   dynamic_library_dir = ctx.actions.declare_directory(mk_name(ctx, "dynlib"))
   dynamic_library = ctx.actions.declare_file(
-    path_append(dynamic_library_dir.basename,
-                "lib{0}-ghc{1}.so".format(get_library_name(ctx), ctx.attr.ghc_version))
+    paths.join(dynamic_library_dir.basename,
+               "lib{0}-ghc{1}.so".format(get_library_name(ctx), ctx.attr.ghc_version))
   )
 
   args = ["-shared", "-dynamic", "-o", dynamic_library.path]
@@ -304,7 +303,7 @@ def create_ghc_package(ctx, interfaces_dir, static_library, static_library_dir, 
     dynamic_library_dir: Directory containing dynamic library.
   """
   pkg_db_dir = ctx.actions.declare_directory(get_pkg_id(ctx))
-  conf_file = ctx.actions.declare_file(path_append(pkg_db_dir.basename, "{0}.conf".format(get_pkg_id(ctx))))
+  conf_file = ctx.actions.declare_file(paths.join(pkg_db_dir.basename, "{0}.conf".format(get_pkg_id(ctx))))
   cache_file = ctx.actions.declare_file("package.cache", sibling=conf_file)
 
   # Create a file from which ghc-pkg will create the actual package from.
@@ -317,10 +316,10 @@ def create_ghc_package(ctx, interfaces_dir, static_library, static_library_dir, 
     "exposed": "True",
     "exposed-modules":
       " ".join([path_to_module(ctx, f) for f in get_input_files(ctx)]),
-    "import-dirs": path_append("${pkgroot}", interfaces_dir.basename),
-    "library-dirs": path_append("${pkgroot}", static_library_dir.basename),
+    "import-dirs": paths.join("${pkgroot}", interfaces_dir.basename),
+    "library-dirs": paths.join("${pkgroot}", static_library_dir.basename),
     "dynamic-library-dirs":
-      path_append("${pkgroot}", dynamic_library_dir.basename),
+      paths.join("${pkgroot}", dynamic_library_dir.basename),
     "hs-libraries": get_library_name(ctx),
     "depends":
       ", ".join([ d[HaskellPackageInfo].name for d in ctx.attr.deps if HaskellPackageInfo in d])


### PR DESCRIPTION
Skylib is located at https://github.com/bazelbuild/bazel-skylib. It
turns out that it already contained functions that replace
`drop_path_prefix()`, `replace_ext()` and `path_append()`. So we have
less code to maintain ourselves. In fact the stats on this PR are -100
lines net.

Also includes a related refactor that removes getter functions that
were adding needless indirection.