### PR TITLE
Allow hsc files in srcs, remove `hscs` rule attribute.

### DIFF
--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -75,7 +75,7 @@ _haskell_common_attrs = {
     doc="Directory in which module hierarchy starts."
   ),
   "srcs": attr.label_list(
-    allow_files=FileType([".hs"]),
+    allow_files=FileType([".hs", ".hsc"]),
     doc="A list of Haskell sources to be built by this rule."
   ),
   "c_sources": attr.label_list(
@@ -90,10 +90,6 @@ _haskell_common_attrs = {
   ),
   "compiler_flags": attr.string_list(
     doc="Flags to pass to Haskell compiler while compiling this rule's sources."
-  ),
-  "hscs": attr.label_list(
-    allow_files=FileType([".hsc"]),
-    doc=".hsc files to preprocess and link"
   ),
   "external_deps": attr.label_list(
     allow_files=True,

--- a/haskell/hsc2hs.bzl
+++ b/haskell/hsc2hs.bzl
@@ -19,7 +19,8 @@ def hsc_to_hs(ctx):
   Returns:
     list of File: Produced Haskell source files.
   """
-  return [_process_hsc_file(ctx, f) for f in ctx.files.hscs]
+  return [_process_hsc_file(ctx, f)
+          for f in ctx.files.srcs if f.extension == "hsc"]
 
 def _process_hsc_file(ctx, hsc_file):
   """Process a single hsc file.

--- a/haskell/toolchain.bzl
+++ b/haskell/toolchain.bzl
@@ -189,14 +189,14 @@ def compile_haskell_lib(ctx, generated_hs_sources):
 
   # We want object and dynamic objects from all inputs.
   object_files = [declare_compiled(ctx, s, ".o", directory=objects_dir)
-                  for s in get_input_files(ctx)]
+                  for s in ctx.files.srcs]
   object_dyn_files = [declare_compiled(ctx, s, ".dyn_o", directory=objects_dir)
-                      for s in get_input_files(ctx)]
+                      for s in ctx.files.srcs]
 
   # We need to keep interface files we produce so we can import
   # modules cross-package.
   interface_files = [declare_compiled(ctx, s, ".hi", directory=interfaces_dir)
-                     for s in get_input_files(ctx)]
+                     for s in ctx.files.srcs]
 
   ctx.actions.run(
     inputs =
@@ -330,7 +330,7 @@ def create_ghc_package(ctx, interfaces_dir, static_library, static_library_dir, 
     "key": get_pkg_id(ctx),
     "exposed": "True",
     "exposed-modules":
-      " ".join([path_to_module(ctx, f) for f in get_input_files(ctx)]),
+      " ".join([path_to_module(ctx, f) for f in ctx.files.srcs]),
     "import-dirs": paths.join("${pkgroot}", interfaces_dir.basename),
     "library-dirs": paths.join("${pkgroot}", static_library_dir.basename),
     "dynamic-library-dirs":
@@ -394,17 +394,6 @@ def get_library_name(ctx):
     string: Library name suitable for GHC package entry.
   """
   return "HS{0}".format(get_pkg_id(ctx))
-
-def get_input_files(ctx):
-  """Get all files we expect to project object files from.
-
-  Args:
-    ctx: Rule context.
-
-  Returns:
-    list of File: All input Haskell source files.
-  """
-  return ctx.files.srcs + ctx.files.hscs
 
 def gather_dependency_information(ctx):
   """Collapse dependencies into a single HaskellPackageInfo.

--- a/tests/hsc/BUILD
+++ b/tests/hsc/BUILD
@@ -6,7 +6,7 @@ load(
 
 haskell_library(
   name = "hsc-lib",
-  hscs = ["Test.hsc"],
+  srcs = ["Test.hsc"],
   prebuilt_dependencies = ["base"],
 )
 


### PR DESCRIPTION
We can uniquely identify these through an extension anyway.
Technically one could have an arbitrary extension and still want to
treat the file as `hsc` file but we weren't allowing that anyway is
`hscs` field already. This way is friendlier to the user and none of
the code really cared about the distinction anyway.

Fixes #26.