### PR TITLE
Toolchain support.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -25,7 +25,5 @@ nixpkgs_package(
   attribute_path = "haskell.packages.ghc822.ghc"
 )
 
-nixpkgs_package(name = "binutils")
-
 # For tests
 nixpkgs_package(name = "zlib")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -7,9 +7,8 @@ local_repository(
 
 http_archive(
   name = "io_tweag_rules_nixpkgs",
-  # Commit hash is current latest master.
-  strip_prefix = "rules_nixpkgs-a300f574885c50430147e457d21ec22a9fe015f4",
-  urls = ["https://github.com/tweag/rules_nixpkgs/archive/a300f574885c50430147e457d21ec22a9fe015f4.tar.gz"],
+  strip_prefix = "rules_nixpkgs-0.1",
+  urls = ["https://github.com/tweag/rules_nixpkgs/archive/v0.1.tar.gz"],
 )
 
 http_archive(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -19,11 +19,13 @@ http_archive(
 
 load("@io_tweag_rules_nixpkgs//nixpkgs:nixpkgs.bzl", "nixpkgs_package")
 
-# Default toolchain
 nixpkgs_package(
   name = "ghc",
   attribute_path = "haskell.packages.ghc822.ghc"
 )
 
 # For tests
+
 nixpkgs_package(name = "zlib")
+
+register_toolchains("//tests:toolchain")

--- a/haskell/toolchain.bzl
+++ b/haskell/toolchain.bzl
@@ -7,7 +7,6 @@ load(":path_utils.bzl",
 )
 
 load(":tools.bzl",
-     "get_ar",
      "get_compiler",
      "get_ghc_pkg",
      "get_build_tools",
@@ -109,7 +108,7 @@ def link_haskell_bin(ctx, object_files):
   ctx.actions.run(
     inputs = [dummy_object],
     outputs = [dummy_static_lib],
-    executable = get_ar(ctx),
+    executable = ctx.host_fragments.cpp.ar_executable,
     arguments = [ar_args]
   )
 
@@ -241,7 +240,7 @@ def create_static_library(ctx, object_files):
   ctx.actions.run(
     inputs = object_files,
     outputs = [static_library, static_library_dir],
-    executable = get_ar(ctx),
+    executable = ctx.host_fragments.cpp.ar_executable,
     arguments = [args],
   )
   return static_library_dir, static_library

--- a/haskell/tools.bzl
+++ b/haskell/tools.bzl
@@ -10,8 +10,7 @@ def get_build_tools(ctx):
     depset of File: All build tools provided to the rule.
   """
   return depset([
-    f for bt in ctx.attr.build_tools
-      for f in bt.files.to_list()
+    t for t in ctx.toolchains["@io_tweag_rules_haskell//haskell:toolchain"].tools
   ])
 
 def get_build_tools_path(ctx):

--- a/haskell/tools.bzl
+++ b/haskell/tools.bzl
@@ -89,14 +89,3 @@ def get_cpphs(ctx):
     File: cpphs to use.
   """
   return get_build_tool(ctx, "cpphs")
-
-def get_ar(ctx):
-  """Get the ar tool.
-
-  Args:
-    ctx: Rule context.
-
-  Returns:
-    File: ar to use.
-  """
-  return ctx.host_fragments.cpp.ar_executable

--- a/haskell/tools.bzl
+++ b/haskell/tools.bzl
@@ -17,9 +17,9 @@ def get_build_tools(ctx):
 def get_build_tools_path(ctx):
   """Get list of build tools suited for PATH.
 
-  Useful to make sure that GHC can find hsc2hs or cpphs at runtime:
-  even if those files aren't expected, user may just be using
-  OPTIONS_GHC to invoke them so they should be available.
+  Useful to make sure that GHC can find e.g. hsc2hs at runtime: even
+  if those files aren't expected, user may just be using OPTIONS_GHC
+  to invoke them so they should be available.
 
   Args:
     ctx: Rule context.
@@ -78,14 +78,3 @@ def get_hsc2hs(ctx):
     File: hsc2hs to use.
   """
   return get_build_tool(ctx, "hsc2hs")
-
-def get_cpphs(ctx):
-  """Get the cpphs tool.
-
-  Args:
-    ctx: Rule context.
-
-  Returns:
-    File: cpphs to use.
-  """
-  return get_build_tool(ctx, "cpphs")

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -12,6 +12,13 @@ load("@io_tweag_rules_haskell//haskell:haskell.bzl",
 # load("@bazel_tools//tools/build_rules:test_rules.bzl", "rule_test")
 load("//third_party:test_rules.bzl", "rule_test")
 
+load("//haskell:haskell.bzl", "haskell_toolchain")
+
+haskell_toolchain(
+  name = "toolchain",
+  tools = "@ghc//:bin",
+)
+
 rule_test(
   name = "test-binary-simple",
   generates = ["binary-simple"],

--- a/tests/binary-simple/BUILD
+++ b/tests/binary-simple/BUILD
@@ -1,3 +1,5 @@
+package(default_testonly = 1)
+
 load("@io_tweag_rules_haskell//haskell:haskell.bzl",
   "haskell_binary",
 )

--- a/tests/binary-with-lib/BUILD
+++ b/tests/binary-with-lib/BUILD
@@ -1,3 +1,5 @@
+package(default_testonly = 1)
+
 load("@io_tweag_rules_haskell//haskell:haskell.bzl",
   "haskell_binary",
   "haskell_library",

--- a/tests/binary-with-main/BUILD
+++ b/tests/binary-with-main/BUILD
@@ -1,3 +1,5 @@
+package(default_testonly = 1)
+
 load("@io_tweag_rules_haskell//haskell:haskell.bzl",
   "haskell_binary",
 )

--- a/tests/binary-with-prebuilt/BUILD
+++ b/tests/binary-with-prebuilt/BUILD
@@ -1,3 +1,5 @@
+package(default_testonly = 1)
+
 load("@io_tweag_rules_haskell//haskell:haskell.bzl",
   "haskell_binary",
 )

--- a/tests/binary-with-sysdeps/BUILD
+++ b/tests/binary-with-sysdeps/BUILD
@@ -1,3 +1,5 @@
+package(default_testonly = 1)
+
 load("@io_tweag_rules_haskell//haskell:haskell.bzl",
   "haskell_binary",
   "haskell_import",

--- a/tests/hsc/BUILD
+++ b/tests/hsc/BUILD
@@ -1,3 +1,5 @@
+package(default_testonly = 1)
+
 load(
   "@io_tweag_rules_haskell//haskell:haskell.bzl",
   "haskell_library",

--- a/tests/library-deps/BUILD
+++ b/tests/library-deps/BUILD
@@ -1,3 +1,5 @@
+package(default_testonly = 1)
+
 load(
   "@io_tweag_rules_haskell//haskell:haskell.bzl",
   "haskell_library",

--- a/tests/library-deps/sublib/BUILD
+++ b/tests/library-deps/sublib/BUILD
@@ -1,3 +1,5 @@
+package(default_testonly = 1)
+
 load(
   "@io_tweag_rules_haskell//haskell:haskell.bzl",
   "haskell_library",

--- a/tests/library-with-sysdeps/BUILD
+++ b/tests/library-with-sysdeps/BUILD
@@ -1,3 +1,5 @@
+package(default_testonly = 1)
+
 load("@io_tweag_rules_haskell//haskell:haskell.bzl",
   "haskell_binary",
   "haskell_import",

--- a/tests/two-libs/BUILD
+++ b/tests/two-libs/BUILD
@@ -1,4 +1,4 @@
-package(default_visibility = ["//visibility:public"])
+package(default_testonly = 1, default_visibility = ["//visibility:public"])
 
 load(
   "@io_tweag_rules_haskell//haskell:haskell.bzl",


### PR DESCRIPTION
Instead of a build_tools attribute in rules, we use the standard
toolchains attribute for the same purpose: finding the commands to use
for building.

Resolves #36.