### PR TITLE
Factor out common build elements of lib/bin components.

### DIFF
--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -12,10 +12,6 @@ load(":toolchain.bzl",
      "link_haskell_bin",
 )
 
-load(":hsc2hs.bzl",
-     "hsc_to_hs",
-)
-
 load(":c_compile.bzl",
      "c_compile_dynamic",
      "c_compile_static",
@@ -26,12 +22,7 @@ def _haskell_binary_impl(ctx):
   link_haskell_bin(ctx, object_files)
 
 def _haskell_library_impl(ctx):
-  # Process hsc files
-  processed_hsc_files = hsc_to_hs(ctx)
-
-  interfaces_dir, interface_files, object_files, object_dyn_files = compile_haskell_lib(
-    ctx, processed_hsc_files
-  )
+  interfaces_dir, interface_files, object_files, object_dyn_files = compile_haskell_lib(ctx)
 
   c_object_files = c_compile_static(ctx)
   static_library_dir, static_library = create_static_library(

--- a/haskell/hsc2hs.bzl
+++ b/haskell/hsc2hs.bzl
@@ -16,10 +16,15 @@ def hsc_to_hs(ctx):
     ctx: Rule context.
 
   Returns:
-    list of File: Produced Haskell source files.
+    list of File: New Haskell source files to use.
   """
-  return [_process_hsc_file(ctx, f)
-          for f in ctx.files.srcs if f.extension == "hsc"]
+  sources = []
+  for f in ctx.files.srcs:
+    if f.extension == "hsc":
+      sources.append(_process_hsc_file(ctx, f))
+    else:
+      sources.append(f)
+  return sources
 
 def _process_hsc_file(ctx, hsc_file):
   """Process a single hsc file.

--- a/tests/binary-simple/BUILD
+++ b/tests/binary-simple/BUILD
@@ -7,5 +7,6 @@ load("@io_tweag_rules_haskell//haskell:haskell.bzl",
 haskell_binary(
   name = "binary-simple",
   srcs = ["Main.hs"],
+  prebuilt_dependencies = ["base"],
   visibility = ["//visibility:public"]
 )

--- a/tests/binary-with-lib/BUILD
+++ b/tests/binary-with-lib/BUILD
@@ -15,5 +15,6 @@ haskell_binary(
   name = "binary-with-lib",
   srcs = ["Main.hs"],
   deps = ["lib"],
+  prebuilt_dependencies = ["base"],
   visibility = ["//visibility:public"],
 )

--- a/tests/binary-with-main/BUILD
+++ b/tests/binary-with-main/BUILD
@@ -8,5 +8,6 @@ haskell_binary(
   name = "binary-with-main",
   srcs = ["MainIsHere.hs"],
   main = "MainIsHere.this",
+  prebuilt_dependencies = ["base"],
   visibility = ["//visibility:public"]
 )

--- a/tests/hsc/BUILD
+++ b/tests/hsc/BUILD
@@ -15,7 +15,7 @@ haskell_library(
 # https://github.com/tweag/rules_haskell/issues/13
 haskell_binary(
   name = "hsc",
-  srcs = ["Main.hs"],
+  srcs = ["Main.hs", "BinHsc.hsc"],
   prebuilt_dependencies = ["base"],
   deps = [":hsc-lib"],
   visibility = ["//visibility:public"],

--- a/tests/hsc/BinHsc.hsc
+++ b/tests/hsc/BinHsc.hsc
@@ -1,0 +1,1 @@
+module BinHsc () where

--- a/tests/hsc/Main.hs
+++ b/tests/hsc/Main.hs
@@ -1,5 +1,6 @@
 module Main (main) where
 
+import BinHsc ()
 import Test (hscFired)
 
 main :: IO ()

--- a/tests/two-libs/BUILD
+++ b/tests/two-libs/BUILD
@@ -12,7 +12,8 @@ haskell_binary(
   deps = [
     "one",
     "two"
-  ]
+  ],
+  prebuilt_dependencies = ["base"],
 )
 
 haskell_library(


### PR DESCRIPTION
This lets us share default build logic between
haskell_library/haskell_binary: this is desirable as we now can't
forget to process some files in one or the other or apply flags in one
or the other &c. Both still do have their own behaviour but it's a
much smaller surface to maintain.

Fixes #20, fixes #13.