### PR TITLE
Initial Haddock support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ run tests, you'll furthermore need [Nix][nix] installed.
 * [haskell_binary](#haskell_binary)
 * [haskell_library](#haskell_library)
 * [haskell_import](#haskell_import)
+* [haskell_haddock](#haskell_haddock)
 
 ## Setup
 
@@ -190,6 +191,54 @@ haskell_binary(
       <td>
         <p><code>Label, required</code></p>
         <p>A single precompiled shared library.</p>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+### haskell_haddock
+
+Builds [Haddock](http://haskell-haddock.readthedocs.io/en/latest/)
+documentation for given Haskell libraries. It will automatically
+build documentation for any transitive dependencies to allow for
+cross-package documentation linking. Currently linking to
+`prebuilt_deps` is not supported.
+
+```bzl
+haskell_library(
+  name = "my-lib",
+  …
+)
+
+haskell_haddock(
+  name = "my-lib-haddock",
+  deps = [":my-lib"],
+)
+```
+
+<table class="table table-condensed table-bordered table-params">
+  <colgroup>
+    <col class="col-param" />
+    <col class="param-description" />
+  </colgroup>
+  <thead>
+    <tr>
+      <th colspan="2">Attributes</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>name</code></td>
+      <td>
+        <p><code>Name, required</code></p>
+        <p>A unique name for this target</p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>deps</code></td>
+      <td>
+        <p><code>List of labels, required</code></p>
+        <p>List of Haskell libraries to generate documentation for.</p>
       </td>
     </tr>
   </tbody>

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -26,6 +26,13 @@ nixpkgs_package(
 
 # For tests
 
-nixpkgs_package(name = "zlib")
+nixpkgs_package(name = "zlib", build_file_content = """
+filegroup (
+  name = "lib",
+  srcs = glob(["nix/lib/**/*.so"]),
+  visibility = ["//visibility:public"],
+  testonly = 1,
+)""",
+)
 
 register_toolchains("//tests:toolchain")

--- a/haskell/haddock.bzl
+++ b/haskell/haddock.bzl
@@ -1,0 +1,165 @@
+"""Haddock suppport."""
+
+load (":path_utils.bzl",
+      "path_to_module",
+)
+
+load(":tools.bzl",
+     "get_haddock",
+     "get_build_tools_path",
+)
+
+load(":toolchain.bzl",
+     "HaskellPackageInfo"
+)
+
+load("@bazel_skylib//:lib.bzl", "paths")
+
+HaddockInfo = provider(
+  doc = "Haddock information.",
+  fields = {
+    "outputs": "All interesting outputs produced by Haddock.",
+    "interface_file": "Haddock interface file.",
+    "doc_dir": "Directory where all the documentation files live.",
+  }
+)
+
+def _haskell_haddock_aspect_impl(target, ctx):
+  if HaskellPackageInfo not in target:
+    return []
+
+  pkg_id = "{0}-{1}".format(ctx.rule.attr.name, ctx.rule.attr.version)
+
+  doc_dir = ctx.actions.declare_directory("doc-{0}".format(pkg_id))
+  haddock_interface = ctx.actions.declare_file(
+    paths.join(doc_dir.basename, "{0}.haddock".format(pkg_id)),
+
+  )
+  hoogle_file = ctx.actions.declare_file(
+    paths.replace_extension(ctx.rule.attr.name, ".txt"),
+    sibling = haddock_interface
+  )
+  input_sources = [ f for t in ctx.rule.attr.srcs for f in t.files.to_list() ]
+
+  args = ctx.actions.args()
+  args.add([
+    "-D", haddock_interface,
+    "--package-name={0}".format(ctx.rule.attr.name),
+    "--package-version={0}".format(ctx.rule.attr.version),
+    "-o", doc_dir,
+    "--html", "--hoogle",
+    # TODO: We shouldn't have to remember this, I think haskell
+    # targets should expose all GHC flags they were ultimately built
+    # with. That way we can pass exactly the same stuff. Having said
+    # that, it's not that easy: only some flags are relevant and only
+    # in some contexts.
+    "--optghc=-hide-all-packages",
+    "--title={0}".format(pkg_id),
+    # This is absolutely required otherwise GHC doesn't what package
+    # it's creating `Name`s for to put them in Haddock interface files
+    # which then results in Haddock not being able to find names for
+    # linking in environment after reading its interface file later.
+    "--optghc=-this-unit-id", "--optghc={0}".format(pkg_id)
+    # TODO: --hyperlinked-source or make a ticket
+  ])
+
+  dep_interfaces = depset()
+  for dep in ctx.rule.attr.deps:
+    if HaddockInfo in dep:
+      args.add("--read-interface={0},{1}".format(
+        # Is this the best we can do? We have to tell haddock where the
+        # docs for the given interface are and it has to be relative
+        # because bazel moves these things around but is relying on
+        # these always being in the same directory for the target the
+        # right thing to do? Feels too hacky.
+        paths.join("..", dep[HaddockInfo].doc_dir.basename),
+        dep[HaddockInfo].interface_file.path
+      ))
+      dep_interfaces = depset(transitive = [
+        dep_interfaces, depset([dep[HaddockInfo].interface_file])
+      ])
+
+  # Expose all prebuilt packages
+  for prebuilt_dep in ctx.rule.attr.prebuilt_dependencies:
+    args.add("--optghc=-package {0}".format(prebuilt_dep))
+
+  # Expose all bazel dependencies
+  for pkg_name in target[HaskellPackageInfo].names.to_list():
+    # Don't try to tell GHC to include the target itself.
+    if target[HaskellPackageInfo].name != pkg_name:
+      args.add("--optghc=-package {0}".format(pkg_name))
+
+  # Include all package DBs we know of. Technically we shouldn't
+  # include the one for target but it shouldn't hurt us.
+  for pkg_cache in target[HaskellPackageInfo].caches.to_list():
+    args.add("--optghc=-package-db {0}".format(pkg_cache.dirname))
+
+  # Pass same flags the user set for the build.
+  for ghc_flag in ctx.rule.attr.compiler_flags:
+    args.add("--optghc={0}".format(ghc_flag))
+
+  args.add(input_sources)
+
+  static_haddock_outputs = [
+    ctx.actions.declare_file(f, sibling=haddock_interface)
+    for f in ["doc-index.html", "haddock-util.js",
+              "hslogo-16.png",
+              "index.html", "minus.gif", "ocean.css", "plus.gif",
+              "synopsis.png"]
+  ]
+
+  module_htmls = [
+    ctx.actions.declare_file(
+      paths.replace_extension(
+        path_to_module(ctx, f, sep='-', prefix=ctx.rule.attr.src_strip_prefix),
+        ".html"
+      ),
+      sibling=haddock_interface
+    )
+    for f in input_sources
+  ]
+
+  self_outputs = [doc_dir, haddock_interface, hoogle_file] + static_haddock_outputs + module_htmls
+
+  ctx.actions.run(
+    inputs = depset(transitive = [
+      target[HaskellPackageInfo].caches,
+      target[HaskellPackageInfo].interface_files,
+      dep_interfaces,
+      depset(input_sources),
+    ]),
+    outputs = self_outputs,
+    progress_message = "Haddock {0}".format(ctx.rule.attr.name),
+    env = {
+      "PATH": get_build_tools_path(ctx),
+    },
+    executable = get_haddock(ctx),
+    arguments = [args],
+  )
+
+  return [HaddockInfo(
+    outputs = depset(self_outputs),
+    interface_file = haddock_interface,
+    doc_dir = doc_dir,
+  )]
+
+haskell_haddock_aspect = aspect(
+  implementation = _haskell_haddock_aspect_impl,
+  attr_aspects = ['deps'],
+  toolchains = ["@io_tweag_rules_haskell//haskell:toolchain"],
+)
+
+def _haskell_haddock_rule_impl(ctx):
+  interface_files = depset()
+  for dep in ctx.attr.deps:
+    if HaddockInfo in dep:
+      interface_files = depset(transitive = [interface_files, dep[HaddockInfo].outputs])
+
+  return [DefaultInfo(files = interface_files)]
+
+haskell_haddock = rule(
+  implementation  = _haskell_haddock_rule_impl,
+  attrs = {
+    "deps": attr.label_list(aspects = [haskell_haddock_aspect]),
+  },
+)

--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -17,6 +17,11 @@ load(":c_compile.bzl",
      "c_compile_static",
 )
 
+# Re-export haskell_haddock
+load (":haddock.bzl",
+      _haskell_haddock = "haskell_haddock",
+)
+
 def _haskell_binary_impl(ctx):
   object_files = compile_haskell_bin(ctx)
   link_haskell_bin(ctx, object_files)
@@ -129,6 +134,8 @@ haskell_binary = rule(
   host_fragments = ["cpp"],
   toolchains = ["@io_tweag_rules_haskell//haskell:toolchain"],
 )
+
+haskell_haddock = _haskell_haddock
 
 def haskell_import(name, shared_library, visibility = None):
   native.alias(name = name, actual = shared_library, visibility = visibility)

--- a/haskell/path_utils.bzl
+++ b/haskell/path_utils.bzl
@@ -2,7 +2,7 @@
 
 load("@bazel_skylib//:lib.bzl", "paths")
 
-def path_to_module_path(ctx, hs_file):
+def path_to_module_path(ctx, hs_file, prefix=None):
   """Map a source file to a module name.
 
   some-workspace/some-package/src/Foo/Bar/Baz.hs => Foo/Bar/Baz
@@ -10,21 +10,24 @@ def path_to_module_path(ctx, hs_file):
   Args:
     ctx: Rule context.
     hs_file: Haskell source file.
+    prefix: Prefix to strip. ctx.attr.src_strip_prefix used if not set.
 
   Returns:
     string: Module part of hs_file. See example above.
   """
+  strip_prefix = prefix if prefix != None else ctx.attr.src_strip_prefix
+
   # Directory under which module hierarchy starts.
   pkg_dir = paths.join(ctx.label.workspace_root,
                        ctx.label.package,
-                       ctx.attr.src_strip_prefix)
+                       strip_prefix)
   # Module path without the workspace and source directories, just
   # relevant hierarchy.
   path_no_prefix = paths.relativize(hs_file.path, pkg_dir)
   # Drop extension.
   return path_no_prefix[:path_no_prefix.rfind(".")]
 
-def path_to_module(ctx, hs_file):
+def path_to_module(ctx, hs_file, sep='.', prefix=None):
   """Given Haskell source file path, turn it to a module name.
 
   some-workspace/some-package/src/Foo/Bar/Baz.hs => Foo.Bar.Baz
@@ -32,11 +35,13 @@ def path_to_module(ctx, hs_file):
   Args:
     ctx: Rule context.
     hs_file: Haskell source file.
+    sep: Separator to use. By default `.`.
+    prefix: Prefix to strip. ctx.attr.src_strip_prefix used if not set.
 
   Returns:
     string: Haskell module name. See example above.
   """
-  return path_to_module_path(ctx, hs_file).replace('/', '.')
+  return path_to_module_path(ctx, hs_file, prefix = prefix).replace('/', sep)
 
 def declare_compiled(ctx, src, ext, directory=None):
   """Given a Haskell-ish source file, declare its output.

--- a/haskell/tools.bzl
+++ b/haskell/tools.bzl
@@ -77,3 +77,15 @@ def get_hsc2hs(ctx):
     File: hsc2hs to use.
   """
   return get_build_tool(ctx, "hsc2hs")
+
+
+def get_haddock(ctx):
+  """Get the haddock tool.
+
+  Args:
+    ctx: Rule context.
+
+  Returns:
+    File: haddock to use.
+  """
+  return get_build_tool(ctx, "haddock")

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -80,3 +80,23 @@ rule_test(
   rule = "//tests/hsc",
   size = "small",
 )
+
+rule_test(
+  name = "test-haddock",
+  generates =
+    ["doc-haddock-lib-b-1.0.0",
+     "doc-haddock-lib-b-1.0.0/LibB.html",
+     "doc-haddock-lib-b-1.0.0/doc-index.html",
+     "doc-haddock-lib-b-1.0.0/haddock-lib-b-1.0.0.haddock",
+     "doc-haddock-lib-b-1.0.0/haddock-lib-b.txt",
+     "doc-haddock-lib-b-1.0.0/haddock-util.js",
+     "doc-haddock-lib-b-1.0.0/hslogo-16.png",
+     "doc-haddock-lib-b-1.0.0/index.html",
+     "doc-haddock-lib-b-1.0.0/minus.gif",
+     "doc-haddock-lib-b-1.0.0/ocean.css",
+     "doc-haddock-lib-b-1.0.0/plus.gif",
+     "doc-haddock-lib-b-1.0.0/synopsis.png"
+    ],
+  rule = "//tests/haddock",
+  size = "small",
+)

--- a/tests/haddock/BUILD
+++ b/tests/haddock/BUILD
@@ -2,9 +2,12 @@ package(default_testonly = 1, default_visibility = ["//visibility:public"])
 
 load(
   "@io_tweag_rules_haskell//haskell:haskell.bzl",
+  "haskell_import",
   "haskell_library",
   "haskell_haddock",
 )
+
+haskell_import(name = "zlib", shared_library = "@zlib//:lib")
 
 haskell_library(
   name = "haddock-lib-a",
@@ -12,14 +15,10 @@ haskell_library(
   prebuilt_dependencies = ["base"],
 )
 
-# TODO: Add system library to deps. I can't do it with something like
-# zlib because bazel freaks out that zlib is a non-test dependency
-# using test toolchain. I have checked once that it works by unsetting
-# testonly in tests/BUILD but it seems like a non-solution.
 haskell_library(
   name = "haddock-lib-b",
   srcs = ["LibB.hs"],
-  deps = [":haddock-lib-a"],
+  deps = [":haddock-lib-a", ":zlib"],
   prebuilt_dependencies = ["base"],
   visibility = ["//visibility:public"],
 )

--- a/tests/haddock/BUILD
+++ b/tests/haddock/BUILD
@@ -1,0 +1,30 @@
+package(default_testonly = 1, default_visibility = ["//visibility:public"])
+
+load(
+  "@io_tweag_rules_haskell//haskell:haskell.bzl",
+  "haskell_library",
+  "haskell_haddock",
+)
+
+haskell_library(
+  name = "haddock-lib-a",
+  srcs = ["LibA.hs", "LibA/A.hs"],
+  prebuilt_dependencies = ["base"],
+)
+
+# TODO: Add system library to deps. I can't do it with something like
+# zlib because bazel freaks out that zlib is a non-test dependency
+# using test toolchain. I have checked once that it works by unsetting
+# testonly in tests/BUILD but it seems like a non-solution.
+haskell_library(
+  name = "haddock-lib-b",
+  srcs = ["LibB.hs"],
+  deps = [":haddock-lib-a"],
+  prebuilt_dependencies = ["base"],
+  visibility = ["//visibility:public"],
+)
+
+haskell_haddock(
+  name = "haddock",
+  deps = [":haddock-lib-b"],
+)

--- a/tests/haddock/BUILD
+++ b/tests/haddock/BUILD
@@ -10,8 +10,15 @@ load(
 haskell_import(name = "zlib", shared_library = "@zlib//:lib")
 
 haskell_library(
+  name = "haddock-lib-deep",
+  srcs = ["Deep.hs"],
+  prebuilt_dependencies = ["base"],
+)
+
+haskell_library(
   name = "haddock-lib-a",
   srcs = ["LibA.hs", "LibA/A.hs"],
+  deps = [":haddock-lib-deep"],
   prebuilt_dependencies = ["base"],
 )
 
@@ -20,7 +27,6 @@ haskell_library(
   srcs = ["LibB.hs"],
   deps = [":haddock-lib-a", ":zlib"],
   prebuilt_dependencies = ["base"],
-  visibility = ["//visibility:public"],
 )
 
 haskell_haddock(

--- a/tests/haddock/Deep.hs
+++ b/tests/haddock/Deep.hs
@@ -1,0 +1,6 @@
+-- | "Deep" doc.
+module Deep (deep_lib) where
+
+-- | 'deep_lib' doc.
+deep_lib :: ()
+deep_lib = ()

--- a/tests/haddock/LibA.hs
+++ b/tests/haddock/LibA.hs
@@ -1,0 +1,13 @@
+-- | "Lib" header
+module LibA where
+
+import LibA.A (a)
+
+-- | 'A' declaration.
+data A =
+  -- | 'A' constructor.
+  A
+
+-- | Doc for 'f' using 'a'.
+f :: ()
+f = a

--- a/tests/haddock/LibA.hs
+++ b/tests/haddock/LibA.hs
@@ -2,12 +2,13 @@
 module LibA where
 
 import LibA.A (a)
+import Deep (deep_lib)
 
 -- | 'A' declaration.
 data A =
   -- | 'A' constructor.
   A
 
--- | Doc for 'f' using 'a'.
+-- | Doc for 'f' using 'a' and 'deep_lib'.
 f :: ()
-f = a
+f = const a deep_lib

--- a/tests/haddock/LibA/A.hs
+++ b/tests/haddock/LibA/A.hs
@@ -1,0 +1,6 @@
+-- | "Lib.A" header
+module LibA.A where
+
+-- | 'a' doc
+a :: ()
+a = ()

--- a/tests/haddock/LibB.hs
+++ b/tests/haddock/LibB.hs
@@ -1,0 +1,9 @@
+-- | "LibB" doc
+module LibB where
+
+import LibA.A (a)
+import LibA (f)
+
+-- | Doc for 'x' using 'f' and 'a' and 'Int'.
+x :: ()
+x = const f a


### PR DESCRIPTION
I'm able to generate documentation for existing
library (`haddock-lib-b` in tests) that depends on another. They both
automagically get their docs generated. Some notes:

* Linking to direct dependencies seems to work. I'm unsure that we
  need transitive interface file inclusion: I don't think so.
* It's able to skip non-Haskell dependencies so it doesn't try to do
  something weird on system deps for example but see comment in tests.
* Linking to `prebuilt_dependencies` documentation is not solved: we'd
  need to find out the actual paths to these to pass to Haddock. A
  possibility is to get it from GHC itself, basically a little script
  that calls `ghc-pkg`, finds out where packages live and gets the
  paths that way. Possibly we don't care about providing this with
  "you should be defining dependencies in bazel". I think we should
  provide this if it's not too hard though.
* We only output default files for the direct dependencies mentioned
  in `haskell_haddock`. This seems to work OK though I'm not 100% on
  whether we can rely no other docs always being neighbours. See
  comment in code on `--read-interface`. FWIW we could output them all
  if we wanted but it doesn't change the assumption.
* I haven't added `haddock` to the tool check toolchain does but
  I'm relying on it being there. This is because it's there normally
  but it's not inconceivable the user might not care about haddock and
  user's toolchain doesn't actually provide it.
* Various versions of Haddock behave in different ways: for example
  Haddock master doesn't output `haddock-util.js` anymore. Unsure how
  to deal with this except letting the user to specify what Haddock
  version they are using (and getting this info from toolchain
  somehow by default somehow).
* There is a lot of repetition of logic when it comes to GHC flags and
  we risk the same situation that we had with
  `haskell_library/haskell_binary`. This sucks but I'm unsure how to
  deal with this nicely: ideally we'd want some sort of "OK let's just
  use the same flags as the package used" with a caveat that not all
  those flags are relevant: we don't care about `-odir` or `-no-link`
  for example. I suspect we could ‘register’ flags we potentially care
  about at build time and propagate them in `HaskellPackageInfo` for
  Haddock's use later (if any). I don't see an elegant way to do this
  except straight up mutating some builder object throughout the
  program though... Nevertheless this needs to be addressed unless we
  want to re-implement a lot of build logic for Haddock.

Closes #34. If we merge this in its current state, I'll create tickets
for some of the above points. May want to address that last one before
even initial merge.