### PR TITLE
Specify compiler version in haskell_toolchain

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ run tests, you'll furthermore need [Nix][nix] installed.
 
 * [haskell_binary](#haskell_binary)
 * [haskell_library](#haskell_library)
+* [haskell_toolchain](#haskell_import)
 * [haskell_import](#haskell_import)
 
 ## Setup
@@ -136,6 +137,69 @@ haskell_library(
       <td>
         <p><code>List of labels, required</code></p>
         <p>List of other Haskell libraries to be linked to this target</p>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+### haskell_library
+
+Generates a Haskell library.
+
+```bzl
+haskell_library(name, srcs, deps)
+```
+
+#### Example
+
+```bzl
+haskell_toolchain(
+    name = 'ghc',
+    version = '1.2.3'
+    tools = ["@ghc//:bin"]
+)
+```
+
+where `@ghc` is an external repository defined in the `WORKSPACE`,
+e.g. using:
+
+```bzl
+nixpkgs_package(
+    name = 'ghc',
+    attribute_path = 'haskell.compiler.ghc123'
+)
+```
+
+<table class="table table-condensed table-bordered table-params">
+  <colgroup>
+    <col class="col-param" />
+    <col class="param-description" />
+  </colgroup>
+  <thead>
+    <tr>
+      <th colspan="2">Attributes</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>name</code></td>
+      <td>
+        <p><code>Name, required</code></p>
+        <p>A unique name for this toolchain</p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>version</code></td>
+      <td>
+        <p><code>String, required</code></p>
+        <p>Version of the compiler.</p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>tools</code></td>
+      <td>
+        <p><code>Label, required</code></p>
+        <p>A target providing GHC commands (`ghc`, `ghc-pkg`, etc).</p>
       </td>
     </tr>
   </tbody>

--- a/README.md
+++ b/README.md
@@ -31,7 +31,12 @@ http_archive(
 and this to your BUILD files.
 
 ```bzl
-load("@io_tweag_rules_haskell//haskell:haskell.bzl", "haskell_binary", "haskell_library")
+load("@io_tweag_rules_haskell//haskell:haskell.bzl",
+  "haskell_binary",
+  "haskell_library",
+  "haskell_toolchain",
+  "haskell_import",
+)
 ```
 
 ## Rules
@@ -142,13 +147,15 @@ haskell_library(
   </tbody>
 </table>
 
-### haskell_library
+### haskell_toolchain
 
 Generates a Haskell library.
 
 ```bzl
-haskell_library(name, srcs, deps)
+haskell_toolchain(name, version, tools, ...)
 ```
+
+Extra arguments forwarded to `toolchain` rule.
 
 #### Example
 

--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -93,15 +93,6 @@ _haskell_common_attrs = {
     default="1.0.0",
     doc="Package/binary version"
   ),
-  "ghc_version": attr.string(
-    default="8.2.2",
-    # TODO (fuuzetsu): We need this because we have to generate
-    # correct suffix for shared libraries that GHC expects for
-    # dynamic-library-dirs content. As currently we're using GHC from
-    # nix, there's not really a way to do this. In future we need to
-    # expose toolchains that expose a version and use that. I think.
-    doc="Version of GHC being used."
-  ),
 }
 
 haskell_library = rule(
@@ -138,19 +129,22 @@ def _haskell_toolchain_impl(ctx):
   return [platform_common.ToolchainInfo(
     name = ctx.label.name,
     tools = ctx.files.tools,
+    version = ctx.attr.version,
   )]
 
 _haskell_toolchain = rule(
   _haskell_toolchain_impl,
   attrs = {
     "tools": attr.label(mandatory = True),
+    "version": attr.string(mandatory = True),
   }
 )
 
-def haskell_toolchain(name, tools, **kwargs):
+def haskell_toolchain(name, version, tools, **kwargs):
   impl_name = name + "-impl"
   _haskell_toolchain(
     name = impl_name,
+    version = version,
     tools = tools,
     visibility = ["//visibility:public"],
     **kwargs

--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -143,7 +143,7 @@ def _haskell_toolchain_impl(ctx):
 _haskell_toolchain = rule(
   _haskell_toolchain_impl,
   attrs = {
-    "tools": attr.label(),
+    "tools": attr.label(mandatory = True),
   }
 )
 

--- a/haskell/toolchain.bzl
+++ b/haskell/toolchain.bzl
@@ -8,6 +8,7 @@ load(":path_utils.bzl",
 
 load(":tools.bzl",
      "get_compiler",
+     "get_compiler_version",
      "get_ghc_pkg",
      "get_build_tools",
      "get_build_tools_path",
@@ -218,10 +219,11 @@ def create_dynamic_library(ctx, object_files):
   """
 
   # Make shared library
+  version = get_compiler_version(ctx)
   dynamic_library_dir = ctx.actions.declare_directory(mk_name(ctx, "dynlib"))
   dynamic_library = ctx.actions.declare_file(
     paths.join(dynamic_library_dir.basename,
-               "lib{0}-ghc{1}.so".format(get_library_name(ctx), ctx.attr.ghc_version))
+               "lib{0}-ghc{1}.so".format(get_library_name(ctx), version))
   )
 
   args = ["-shared", "-dynamic", "-o", dynamic_library.path]

--- a/haskell/tools.bzl
+++ b/haskell/tools.bzl
@@ -56,6 +56,17 @@ def get_compiler(ctx):
   """
   return get_build_tool(ctx, "ghc")
 
+def get_compiler_version(ctx):
+  """Get the compiler version.
+
+  Args:
+    ctx: Rule context.
+
+  Returns:
+    String: Version string.
+  """
+  return ctx.toolchains["@io_tweag_rules_haskell//haskell:toolchain"].version
+
 def get_ghc_pkg(ctx):
   """Get the compiler path.
 

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -16,6 +16,7 @@ load("//haskell:haskell.bzl", "haskell_toolchain")
 
 haskell_toolchain(
   name = "toolchain",
+  version = "8.2.2",
   tools = "@ghc//:bin",
 )
 


### PR DESCRIPTION
Instead of in `haskell_library` / `haskell_binary` rules. Also,
document `haskell_toolchain`.

Resolves #24 and #11.