### PR TITLE
Fix ghc-pkg warnings.

### DIFF
--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -44,6 +44,7 @@ def _haskell_library_impl(ctx):
     ctx,
     interfaces_dir,
     static_library,
+    dynamic_library,
     static_library_dir,
     dynamic_library_dir,
   )


### PR DESCRIPTION
While these were non-fatal (the files in question did exist when they
were actually needed), they may have been disconcerning to the user.
Technically this does have an impact on the rule dependency graph in
that we may have to register more often but it should have no impact
past that point: registration file output will stay the same and bazel
won't need to re-run anything more upstream.

```
[nix-shell:~/programming/rules_haskell]$ bazel clean && bazel build -s //tests/... 2>&1 | grep -i warning
INFO: Starting clean (this may take a while). Consider using --async if the clean takes more than several minutes.
Warning: LibB: could not find link destinations for:
```

Fixes #48.