### PR TITLE
Define haskell_test.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ run tests, you'll furthermore need [Nix][nix] installed.
 * [haskell_toolchain](#haskell_import)
 * [haskell_import](#haskell_import)
 * [haskell_haddock](#haskell_haddock)
+* [haskell_test](#haskell_test)
 
 ## Setup
 
@@ -342,3 +343,12 @@ haskell_haddock(
     </tr>
   </tbody>
 </table>
+
+### haskell_test
+
+This is currently a handy alias for [haskell_binary](#haskell_binary)
+so please refer to that for documentation of fields. Additionally, it
+accepts [all common bazel test rule
+fields](https://docs.bazel.build/versions/master/be/common-definitions.html#common-attributes-tests).
+This allows you to influence things like timeout and resource
+allocation for the test.

--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -113,18 +113,35 @@ haskell_library = rule(
   toolchains = ["@io_tweag_rules_haskell//haskell:toolchain"],
 )
 
-haskell_binary = rule(
-  _haskell_binary_impl,
-  executable = True,
-  attrs = dict(_haskell_common_attrs,
-    main = attr.string(
-      default="Main.main",
-      doc="Main function location."
-    )
-  ),
-  host_fragments = ["cpp"],
-  toolchains = ["@io_tweag_rules_haskell//haskell:toolchain"],
-)
+def _mk_binary_rule(**kwargs):
+  """Generate a rule that compiles a binary.
+
+  This is useful to create variations of a Haskell binary compilation
+  rule without having to copy and paste the actual `rule` invocation.
+
+  Args:
+    **kwargs: Any additional keyword arguments to pass to `rule`.
+
+  Returns:
+    Rule: Haskell binary compilation rule.
+  """
+  return rule(
+    _haskell_binary_impl,
+    executable = True,
+    attrs = dict(_haskell_common_attrs,
+                 main = attr.string(
+                   default="Main.main",
+                   doc="Main function location."
+                 )
+    ),
+    host_fragments = ["cpp"],
+    toolchains = ["@io_tweag_rules_haskell//haskell:toolchain"],
+    **kwargs
+  )
+
+haskell_binary = _mk_binary_rule()
+
+haskell_test = _mk_binary_rule(test = True)
 
 haskell_haddock = _haskell_haddock
 

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -101,3 +101,10 @@ rule_test(
   rule = "//tests/haddock",
   size = "small",
 )
+
+rule_test(
+  name = "test-haskell_test",
+  generates = ["haskell_test"],
+  rule = "//tests/haskell_test",
+  size = "small",
+)

--- a/tests/haskell_test/BUILD
+++ b/tests/haskell_test/BUILD
@@ -1,0 +1,17 @@
+package(default_testonly = 1)
+
+load("@io_tweag_rules_haskell//haskell:haskell.bzl",
+  "haskell_test",
+)
+
+haskell_test(
+  name = "haskell_test",
+  srcs = ["Test.hs"],
+  main = "Test.test",
+  prebuilt_dependencies = ["base"],
+  visibility = ["//visibility:public"],
+  # Use some parameters that only test rules have.
+  size = "small",
+  timeout = "short",
+  flaky = False
+)

--- a/tests/haskell_test/Test.hs
+++ b/tests/haskell_test/Test.hs
@@ -1,0 +1,4 @@
+module Test (test) where
+
+test :: IO ()
+test = putStrLn "haskell_test fired"


### PR DESCRIPTION
This effectively aliases `haskell_binary` and exposes common Bazel
test rule fields. In the future we may want to do more (integrate with
test runners directly for example). This basically lets the user say
`bazel test`, use `test_suites` and few other useful things.

Closes #28.