### PR TITLE
Add GHC version check.

### DIFF
--- a/haskell/BUILD
+++ b/haskell/BUILD
@@ -2,5 +2,5 @@ package(default_visibility = ["//visibility:public"])
 
 exports_files([
     "haskell.bzl",
-    "toolchain.bzl",
+    "ghc-version-check.sh",
 ])

--- a/haskell/ghc-version-check.sh
+++ b/haskell/ghc-version-check.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+#
+# Usage: ghc-version-check.sh <COMPILER_PATH> <VERSION_FILE> <EXPECTED_VERSION>
+
+$1 --numeric-version > $2
+if [[ $3 != $(< $2) ]]
+then
+    echo GHC version $(< $2) does not match expected version $3.
+    exit 1
+fi


### PR DESCRIPTION
Better error message when GHC does not match the expected version.

Resolves #61.