### PR TITLE
Include extra deps during compilation, be explicit about C dyn object outputs.

### DIFF
--- a/haskell/toolchain.bzl
+++ b/haskell/toolchain.bzl
@@ -380,9 +380,12 @@ def compilation_defaults(ctx):
   interface_files = [declare_compiled(ctx, s, ".hi", directory=interfaces_dir)
                      for s in ctx.files.srcs]
 
+
   # Include any non-Haskell dependencies in inputs.
-  external_files = depset([f for dep in ctx.attr.external_deps
-                             for f in dep.files])
+  external_files = [f for dep in ctx.attr.external_deps for f in dep.files.to_list()]
+
+  for include_dir in depset([f.dirname for f in external_files]).to_list():
+    args.add("-I{0}".format(include_dir))
 
   # Lastly add all the processed sources.
   args.add(sources)
@@ -390,7 +393,7 @@ def compilation_defaults(ctx):
   return _DefaultCompileInfo(
     args = args,
     inputs = depset(transitive = [
-      depset(sources), external_files, dep_info.confs, dep_info.caches,
+      depset(sources), depset(external_files), dep_info.confs, dep_info.caches,
       dep_info.interface_files, dep_info.dynamic_libraries,
       get_build_tools(ctx),
       dep_info.external_libraries,

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -108,3 +108,10 @@ rule_test(
   rule = "//tests/haskell_test",
   size = "small",
 )
+
+rule_test(
+  name = "test-extras-included-during-comp",
+  generates = ["extras-included-during-comp"],
+  rule = "//tests/extras-included-during-comp",
+  size = "small",
+)

--- a/tests/c-compiles.c
+++ b/tests/c-compiles.c
@@ -1,0 +1,1 @@
+int add_five(int x) { return 5 + x; }

--- a/tests/c-compiles/BUILD
+++ b/tests/c-compiles/BUILD
@@ -1,0 +1,22 @@
+package(default_testonly = 1)
+
+load(
+  "@io_tweag_rules_haskell//haskell:haskell.bzl",
+  "haskell_library",
+  "haskell_binary",
+)
+
+haskell_library(
+  name = "c-compiles-lib",
+  srcs = ["Lib.hs"],
+  c_sources = ["c-compiles.c"],
+  prebuilt_dependencies = ["base"],
+)
+
+haskell_binary(
+  name = "c-compiles",
+  srcs = ["Main.hs",],
+  prebuilt_dependencies = ["base"],
+  deps = [":c-compiles-lib"],
+  visibility = ["//visibility:public"],
+)

--- a/tests/c-compiles/Lib.hs
+++ b/tests/c-compiles/Lib.hs
@@ -1,0 +1,10 @@
+{-# LANGUAGE ForeignFunctionInterface #-}
+module Lib (ten) where
+
+import Foreign.C.Types (CInt(..))
+
+foreign import ccall "add_five"
+  c_add_five :: CInt -> CInt
+
+ten :: Int
+ten = fromIntegral (c_add_five 5)

--- a/tests/c-compiles/Main.hs
+++ b/tests/c-compiles/Main.hs
@@ -1,0 +1,8 @@
+module Main (main) where
+
+import Lib (ten)
+
+main :: IO ()
+main = if ten == 10
+       then putStrLn "c-compiles"
+       else error $ "Unexpected result from Lib.ten: " ++ show ten

--- a/tests/c-compiles/c-compiles.c
+++ b/tests/c-compiles/c-compiles.c
@@ -1,0 +1,1 @@
+int add_five(int x) { return x + 5; }

--- a/tests/extras-included-during-comp/BUILD
+++ b/tests/extras-included-during-comp/BUILD
@@ -1,0 +1,14 @@
+package(default_testonly = 1)
+
+load(
+  "@io_tweag_rules_haskell//haskell:haskell.bzl",
+  "haskell_binary",
+)
+
+haskell_binary(
+  name = "extras-included-during-comp",
+  srcs = ["Main.hs"],
+  external_deps = ["includes/main_definition"],
+  prebuilt_dependencies = ["base"],
+  visibility = ["//visibility:public"],
+)

--- a/tests/extras-included-during-comp/Main.hs
+++ b/tests/extras-included-during-comp/Main.hs
@@ -1,0 +1,6 @@
+{-# LANGUAGE CPP #-}
+module Main (main) where
+
+-- This lives under "includes" so we're testing that bazel passes in
+-- the appropriate include flag.
+#include "main_definition"

--- a/tests/extras-included-during-comp/includes/main_definition
+++ b/tests/extras-included-during-comp/includes/main_definition
@@ -1,0 +1,2 @@
+main :: IO ()
+main = putStrLn "extras-included-during-comp"

--- a/tests/hsc/BUILD
+++ b/tests/hsc/BUILD
@@ -12,7 +12,6 @@ haskell_library(
   prebuilt_dependencies = ["base"],
 )
 
-# https://github.com/tweag/rules_haskell/issues/13
 haskell_binary(
   name = "hsc",
   srcs = ["Main.hs", "BinHsc.hsc"],


### PR DESCRIPTION
Here are a couple of C-related fixes found when updating inline-java BUILD files.