### PR TITLE
Make --compilation_mode opt mean -O2.

### DIFF
--- a/haskell/toolchain.bzl
+++ b/haskell/toolchain.bzl
@@ -352,7 +352,7 @@ def compilation_defaults(ctx):
   interfaces_dir = ctx.actions.declare_directory(mk_name(ctx, "interfaces"))
 
   # Compilation mode and explicit user flags
-  if ctx.var["COMPILATION_MODE"] == "opt": args.add("-O")
+  if ctx.var["COMPILATION_MODE"] == "opt": args.add("-O2")
   args.add(ctx.attr.compiler_flags)
 
   # Common flags


### PR DESCRIPTION
Relevant discussion supporting using `-O2` as the blanket optimization level, even though Cabal is still sticking to `-O1`:

* https://mail.haskell.org/pipermail/glasgow-haskell-users/2010-May/018834.html
* https://stackoverflow.com/questions/11108746/difference-between-ghcs-o-and-o2