### PR TITLE
Use short_path instead of path when relativizing.

### DIFF
--- a/haskell/path_utils.bzl
+++ b/haskell/path_utils.bzl
@@ -23,7 +23,7 @@ def path_to_module_path(ctx, hs_file, prefix=None):
                        strip_prefix)
   # Module path without the workspace and source directories, just
   # relevant hierarchy.
-  path_no_prefix = paths.relativize(hs_file.path, pkg_dir)
+  path_no_prefix = paths.relativize(hs_file.short_path, pkg_dir)
   # Drop extension.
   return path_no_prefix[:path_no_prefix.rfind(".")]
 


### PR DESCRIPTION
in the case of generated files, the path can contain a lot more
components than short_path. This makes paths.relativize() fail.
I believe passing in short_path is the correct thing to do.