### PR TITLE
Rename c_options to copts

### DIFF
--- a/haskell/c_compile.bzl
+++ b/haskell/c_compile.bzl
@@ -66,7 +66,7 @@ def _generic_c_compile(ctx, output_dir_template, output_ext, user_args):
   ])
   args.add(user_args)
 
-  for opt in ctx.attr.c_options:
+  for opt in ctx.attr.copts:
     args.add("-optc{0}".format(opt))
 
   # TODO: use gather_dep_info instead, we don't need this. Even

--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -40,7 +40,7 @@ _haskell_common_attrs = {
     allow_files=FileType([".c"]),
     doc="A list of C source files to be built as part of the package."
   ),
-  "c_options": attr.string_list(
+  "copts": attr.string_list(
     doc="Options to pass to C compiler for any C source files."
   ),
   "deps": attr.label_list(


### PR DESCRIPTION
for consistency with `cc_*` rules.