### PR TITLE
Don't filter out new static link paths when merging dependencies.

### DIFF
--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -123,12 +123,8 @@ def _haskell_library_impl(ctx):
     names = depset(transitive = [dep_info.names, depset([get_pkg_id(ctx)])]),
     confs = depset(transitive = [dep_info.confs, depset([conf_file])]),
     caches = depset(transitive = [dep_info.caches, depset([cache_file])]),
-    # Keep package libraries in preorder (naive_link) order: this
-    # gives us the valid linking order at binary linking time.
-    static_libraries = depset(
-      transitive = [depset([static_library]), dep_info.static_libraries],
-      order = "preorder"
-    ),
+    # Do _not_ use a depset.
+    static_libraries = [static_library] + dep_info.static_libraries,
     dynamic_libraries = depset(
       transitive = [depset([dynamic_library]), dep_info.dynamic_libraries]
     ),


### PR DESCRIPTION
There's ordering required to link things together. First you specify
the user then the library providing the needed function. If we have a
library `foo` providing `foo_func` and we have a library `bar` that
calls `foo_func`, order should be `-l bar -l foo` (written as `[bar,
foo]` from now.

Now consider what happens in case of shared dependencies. Suppose we
now also have `baz` that also depends on `foo`. We have two orderings
to include:

* `[baz, foo]`
* `[bar, foo]`

However we have been using a depset to hold onto static libraries.
This means that depending on the order in which things are gathered,
we would end up with either `[baz, foo, bar]` or `[bar, foo, baz]`,
both undesirable. The correct way we would like is `[baz, bar, foo]`.

One way to achieve it is be holding onto all the information `[baz,
foo, bar, foo]`. We can now process "from the back": if we only keep
the last occurence of a term, we know nothing to the right of it is
going to depend on it. This is doable in few ways: we can either
enforce this invariant when collapsing dependencies and therefore
always keeping the minimal list with a correct ordering or we can
correct it in the very end.

In this commit I have picked nothing (but do include sample
inefficient code for the latter way at below): modern linkers are
actually happy to accept `[baz, foo, bar, foo]` so this is what we
pass. This does hold onto more memory (we store more than needed) and
results in larger linking commands (bazel can use response files if
needed) but is simple. If needed we can implement any optimisation
easily.

Lastly I have failed to implement a test case for this that could
replicate the behaviour before I fixed it. I have only noticed it on a
private project and that's how I was able to verify it. While you can
reproduce the conditions described above quite easily, triggering the
behaviour seems to depend on the content of the files being linked
too: possibly depending on content, stuff just gets fully inlined and
therefore doesn't need to look into a library &c.

```
lib_used = dict()
uniq_static_libs = []
for lib in reversed(dep_info.static_libraries):
  if lib not in lib_used:
    lib_used[lib] = None
    uniq_static_libs.append(lib)

for lib in reversed(uniq_static_libs):
  link_args.extend(["-optl", lib.path])
```