### PR TITLE
Allow arbitrary inputs during GHC's compilation.

### DIFF
--- a/haskell/actions.bzl
+++ b/haskell/actions.bzl
@@ -414,6 +414,7 @@ def compilation_defaults(ctx):
       dep_info.dynamic_libraries,
       get_build_tools(ctx),
       dep_info.external_libraries,
+      depset([ f for data_dep in ctx.attr.data for f in data_dep.files ]),
     ]),
     outputs = [objects_dir, interfaces_dir] + object_files + interface_files,
     objects_dir = objects_dir,

--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -54,6 +54,19 @@ _haskell_common_attrs = {
     default="1.0.0",
     doc="Package/binary version"
   ),
+  # Allows us to inject arbitrary files that may be needed at GHC's
+  # runtime.
+  #
+  # TODO: This is not very nice, things just get dumped into the env:
+  # you have to know exactly what you're passing in to make any real
+  # use of it. Apparently java rules &c. manage to put things from
+  # their data fields into tidy data directories. We should do that if
+  # we stick with this.
+  "data": attr.label_list(
+    mandatory=False,
+    default=[],
+    doc="Any additional data needed at compilation time."
+  ),
 }
 
 def _haskell_binary_impl(ctx):


### PR DESCRIPTION
This is necessary to accomodate a hack in sparkle without particularly
poluting rules_haskell.