### PR TITLE
Introduce interop with Java rules.

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ haskell_binary(
       <td><code>deps</code></td>
       <td>
         <p><code>List of labels, required</code></p>
-        <p>List of other Haskell libraries to be linked to this target</p>
+        <p>List of dependencies to of this target</p>
       </td>
     </tr>
   </tbody>
@@ -166,7 +166,7 @@ haskell_library(
       <td><code>deps</code></td>
       <td>
         <p><code>List of labels, required</code></p>
-        <p>List of other Haskell libraries to be linked to this target</p>
+        <p>List of dependencies to of this target</p>
       </td>
     </tr>
   </tbody>
@@ -360,3 +360,17 @@ accepts [all common bazel test rule
 fields](https://docs.bazel.build/versions/master/be/common-definitions.html#common-attributes-tests).
 This allows you to influence things like timeout and resource
 allocation for the test.
+
+## Language interop
+
+We may be supporting interop with other languages in one way or
+another. Please see languages listed below about how.
+
+### Java
+
+You can supply `java_*` rule targets in `deps` of
+[haskell_binary](#haskell_binary) and
+[haskell_library](#haskell_library). This will make jars produced by
+those dependencies available during Haskell source compilation phase
+(i.e. not during linking &c. but it's subject to change) and set the
+CLASSPATH for that phase as well.

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -49,3 +49,8 @@ filegroup (
 )
 """,
 )
+
+maven_jar(
+  name = "org_apache_spark_spark_core_2_10",
+  artifact = "org.apache.spark:spark-core_2.10:1.6.0",
+)

--- a/haskell/java_interop.bzl
+++ b/haskell/java_interop.bzl
@@ -1,0 +1,43 @@
+"""Interop with Java."""
+
+load("@bazel_skylib//:lib.bzl", "collections")
+
+JavaInteropInfo = provider(
+  doc = "Information needed for interop with Java rules.",
+  fields = {
+    "inputs": "Files needed during build.",
+    "env": "Dict with env variables that should be set during build."
+  },
+)
+
+def java_interop_info(ctx):
+  """Gather information from any Java dependencies.
+
+  Args:
+    ctx: Rule context.
+
+  Returns:
+    JavaInteropInfo: Information needed for Java interop.
+  """
+
+  inputs = []
+  for dep in ctx.attr.deps:
+    if JavaInfo in dep:
+      for f in dep.files.to_list():
+        # Crashes!
+        # print(dep[JavaInfo].transitive_compile_time_jars)
+        if f.extension == "jar":
+          inputs.append(f)
+
+  env_dict = dict()
+  uniq_classpath = collections.uniq([
+    f.path for f in inputs
+  ])
+
+  if len(uniq_classpath) > 0:
+    env_dict["CLASSPATH"] = ":".join(uniq_classpath)
+
+  return JavaInteropInfo(
+    inputs = depset(inputs),
+    env = env_dict,
+  )

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -117,3 +117,10 @@ rule_test(
   rule = "//tests/library-with-sysincludes",
   size = "small",
 )
+
+rule_test(
+  name = "test-java_classpath",
+  generates = ["java_classpath"],
+  rule = "//tests/java_classpath",
+  size = "small",
+)

--- a/tests/java_classpath/BUILD
+++ b/tests/java_classpath/BUILD
@@ -1,0 +1,13 @@
+package(default_testonly = 1)
+
+load("@io_tweag_rules_haskell//haskell:haskell.bzl",
+  "haskell_binary",
+)
+
+haskell_binary(
+  name = "java_classpath",
+  srcs = ["Main.hs"],
+  deps = ["@org_apache_spark_spark_core_2_10//jar"],
+  prebuilt_dependencies = ["base", "template-haskell"],
+  visibility = ["//visibility:public"],
+)

--- a/tests/java_classpath/Main.hs
+++ b/tests/java_classpath/Main.hs
@@ -1,0 +1,17 @@
+{-# LANGUAGE LambdaCase      #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Main (main) where
+
+import qualified Language.Haskell.TH as TH (runIO)
+import qualified Language.Haskell.TH.Syntax as TH (lift)
+import           System.Environment (lookupEnv)
+
+main :: IO ()
+main = putStrLn $(
+  let ensureClassPath :: IO String
+      ensureClassPath = lookupEnv "CLASSPATH" >>= \case
+        Nothing -> error "CLASSPATH not set when it was expected to be."
+        Just "" -> error "CLASSPATH empty when it was expected to have content."
+        Just cpath -> pure $ "java-classpath at compile time: " ++ cpath
+  in TH.runIO ensureClassPath >>= TH.lift
+  )


### PR DESCRIPTION
This allows us to list Java dependencies in `deps` of Haskell rules
and have appropriate inputs and CLASSPATH be available during compile
time if for example `javac` is called during build.

Relates to #80 but does not close it: we ideally want transitive
classpath (I think? cc @mboes , maybe we're OK with how things are
now) but accessing the necessary attribute crashes bazel in some
cases. I'll be creating an upstream ticket shortly.