### PR TITLE
Add .so to default outputs, drop pointless directories

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -22,6 +22,25 @@ load("@io_tweag_rules_nixpkgs//nixpkgs:nixpkgs.bzl", "nixpkgs_package")
 nixpkgs_package(
   name = "ghc",
   attribute_path = "haskell.compiler.ghc822",
+  build_file_content = """
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+  name = "bin",
+  srcs = glob(["nix/bin/*"]),
+)
+
+filegroup(
+  name = "lib",
+  srcs = glob(["nix/lib/**/*.so"]),
+)
+
+cc_library(
+  name = "headers",
+  hdrs = glob(["nix/lib/ghc-*/include/**/*.h"]),
+  strip_include_prefix = glob(["nix/lib/ghc-*/include"], exclude_directories=0)[0],
+)
+""",
 )
 
 # For tests

--- a/haskell/actions.bzl
+++ b/haskell/actions.bzl
@@ -32,8 +32,6 @@ HaskellPackageInfo = provider(
     "static_libraries": "Compiled library archives.",
     "dynamic_libraries": "Dynamic libraries.",
     "interface_files": "Interface files belonging to the packages.",
-    "static_library_dirs": "Library file directories",
-    "dynamic_library_dirs": "Dynamic library file directories",
     "prebuilt_dependencies": "Transitive collection of all wired-in Haskell dependencies.",
     "external_libraries": "Non-Haskell libraries needed for linking. List of shared libs.",
   }
@@ -217,10 +215,9 @@ def create_static_library(ctx, object_files):
     object_files: All object files to include in the library.
 
   Returns:
-    (File, File): Directory containing the static library and the library itself.
+    File: Produced static library.
   """
-  static_library_dir = ctx.actions.declare_directory(mk_name(ctx, "lib"))
-  static_library = ctx.actions.declare_file(paths.join(static_library_dir.basename, "lib{0}.a".format(get_library_name(ctx))))
+  static_library = ctx.actions.declare_file("lib{0}.a".format(get_library_name(ctx)))
 
   args = ctx.actions.args()
   args.add(["qc", static_library])
@@ -228,11 +225,11 @@ def create_static_library(ctx, object_files):
 
   ctx.actions.run(
     inputs = object_files,
-    outputs = [static_library, static_library_dir],
+    outputs = [static_library],
     executable = ctx.host_fragments.cpp.ar_executable,
     arguments = [args],
   )
-  return static_library_dir, static_library
+  return static_library
 
 def create_dynamic_library(ctx, object_files):
   """Create a dynamic library for the package using given object files.
@@ -242,17 +239,14 @@ def create_dynamic_library(ctx, object_files):
     object_files: Object files to use for linking.
 
   Returns:
-    (File, File): Directory containing the dynamic library and the library itself.
+    File: Produced dynamic library.
   """
 
   # Make shared library
   version = get_compiler_version(ctx)
-  dynamic_library_dir = ctx.actions.declare_directory(mk_name(ctx, "dynlib"))
   dynamic_library = ctx.actions.declare_file(
-    paths.join(dynamic_library_dir.basename,
-               "lib{0}-ghc{1}.so".format(get_library_name(ctx), version))
+    "lib{0}-ghc{1}.so".format(get_library_name(ctx), version)
   )
-
   args = ["-shared", "-dynamic", "-o", dynamic_library.path]
 
   dep_info = gather_dependency_information(ctx)
@@ -284,16 +278,16 @@ def create_dynamic_library(ctx, object_files):
                                   dep_info.dynamic_libraries,
                                   dep_info.external_libraries,
                                   get_build_tools(ctx)]),
-    outputs = [dynamic_library_dir, dynamic_library],
+    outputs = [dynamic_library],
     env = {
       "PATH": get_build_tools_path(ctx),
     },
     command = " ".join([get_compiler(ctx).path] + args)
   )
 
-  return dynamic_library_dir, dynamic_library
+  return dynamic_library
 
-def create_ghc_package(ctx, interfaces_dir, static_library, dynamic_library, static_library_dir, dynamic_library_dir):
+def create_ghc_package(ctx, interfaces_dir, static_library, dynamic_library):
   """Create GHC package using ghc-pkg.
 
   Args:
@@ -301,8 +295,6 @@ def create_ghc_package(ctx, interfaces_dir, static_library, dynamic_library, sta
     interfaces_dir: Directory containing interface files.
     static_library: Static library of the package.
     dynamic_library: Dynamic library of the package.
-    static_library_dir: Directory containing static library.
-    dynamic_library_dir: Directory containing dynamic library.
 
   Returns:
     (File, File): GHC package conf file, GHC package cache file
@@ -322,9 +314,8 @@ def create_ghc_package(ctx, interfaces_dir, static_library, dynamic_library, sta
     "exposed-modules":
       " ".join([path_to_module(ctx, f) for f in _hs_srcs(ctx)]),
     "import-dirs": paths.join("${pkgroot}", interfaces_dir.basename),
-    "library-dirs": paths.join("${pkgroot}", static_library_dir.basename),
-    "dynamic-library-dirs":
-      paths.join("${pkgroot}", dynamic_library_dir.basename),
+    "library-dirs": "${pkgroot}",
+    "dynamic-library-dirs": "${pkgroot}",
     "hs-libraries": get_library_name(ctx),
     "depends":
       ", ".join([ d[HaskellPackageInfo].name for d in ctx.attr.deps if HaskellPackageInfo in d])
@@ -480,8 +471,6 @@ def gather_dependency_information(ctx):
     static_libraries = [],
     dynamic_libraries = depset(),
     interface_files = depset(),
-    static_library_dirs = depset(),
-    dynamic_library_dirs = depset(),
     prebuilt_dependencies = depset(ctx.attr.prebuilt_dependencies),
     external_libraries = depset(),
   )
@@ -499,8 +488,6 @@ def gather_dependency_information(ctx):
         static_libraries = hpi.static_libraries + pkg.static_libraries,
         dynamic_libraries = hpi.dynamic_libraries + pkg.dynamic_libraries,
         interface_files = hpi.interface_files + pkg.interface_files,
-        static_library_dirs = hpi.static_library_dirs + pkg.static_library_dirs,
-        dynamic_library_dirs = hpi.dynamic_library_dirs + pkg.dynamic_library_dirs,
         prebuilt_dependencies = hpi.prebuilt_dependencies + pkg.prebuilt_dependencies,
         external_libraries = new_external_libraries,
       )
@@ -515,8 +502,6 @@ def gather_dependency_information(ctx):
         static_libraries = hpi.static_libraries,
         dynamic_libraries = hpi.dynamic_libraries,
         interface_files = hpi.interface_files,
-        static_library_dirs = hpi.static_library_dirs,
-        dynamic_library_dirs = hpi.dynamic_library_dirs,
         prebuilt_dependencies = hpi.prebuilt_dependencies,
         external_libraries = hpi.external_libraries.union(depset(dep.files)),
       )

--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -93,11 +93,11 @@ haskell_binary = _mk_binary_rule()
 def _haskell_library_impl(ctx):
   interfaces_dir, interface_files, object_files, object_dyn_files = compile_haskell_lib(ctx)
 
-  static_library_dir, static_library = create_static_library(
+  static_library = create_static_library(
     ctx, object_files
   )
 
-  dynamic_library_dir, dynamic_library = create_dynamic_library(
+  dynamic_library = create_dynamic_library(
     ctx, object_dyn_files
   )
 
@@ -107,8 +107,6 @@ def _haskell_library_impl(ctx):
     interfaces_dir,
     static_library,
     dynamic_library,
-    static_library_dir,
-    dynamic_library_dir,
   )
 
   dep_info = gather_dependency_information(ctx)
@@ -124,12 +122,6 @@ def _haskell_library_impl(ctx):
     ),
     interface_files = depset(
       transitive = [dep_info.interface_files, depset(interface_files)]
-    ),
-    static_library_dirs = depset(
-      transitive = [dep_info.static_library_dirs, depset([static_library_dir])]
-    ),
-    dynamic_library_dirs = depset(
-      transitive = [dep_info.dynamic_library_dirs, depset([dynamic_library_dir])]
     ),
     prebuilt_dependencies = depset(
       transitive = [

--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -138,14 +138,16 @@ def _haskell_library_impl(ctx):
       ]
     ),
     external_libraries = dep_info.external_libraries
-  )]
+  ),
+  DefaultInfo(files = depset([
+      conf_file,
+      cache_file,
+      dynamic_library,
+  ])),
+  ]
 
 haskell_library = rule(
   _haskell_library_impl,
-  outputs = {
-    "conf": "%{name}-%{version}/%{name}-%{version}.conf",
-    "package_cache": "%{name}-%{version}/package.cache"
-  },
   attrs = _haskell_common_attrs,
   host_fragments = ["cpp"],
   toolchains = ["@io_tweag_rules_haskell//haskell:toolchain"],

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -59,6 +59,7 @@ rule_test(
   generates =
     ["library-deps-1.0.0/library-deps-1.0.0.conf",
      "library-deps-1.0.0/package.cache",
+     "dynlib-library-deps-1.0.0/libHSlibrary-deps-1.0.0-ghc8.2.2.so",
     ],
   rule = "//tests/library-deps",
   size = "small",
@@ -69,6 +70,7 @@ rule_test(
   generates =
     ["library-with-sysdeps-1.0.0/library-with-sysdeps-1.0.0.conf",
      "library-with-sysdeps-1.0.0/package.cache",
+     "dynlib-library-with-sysdeps-1.0.0/libHSlibrary-with-sysdeps-1.0.0-ghc8.2.2.so",
     ],
   rule = "//tests/library-with-sysdeps",
   size = "small",
@@ -113,6 +115,7 @@ rule_test(
   generates =
     ["library-with-sysincludes-1.0.0/library-with-sysincludes-1.0.0.conf",
      "library-with-sysincludes-1.0.0/package.cache",
+     "dynlib-library-with-sysincludes-1.0.0/libHSlibrary-with-sysincludes-1.0.0-ghc8.2.2.so",
     ],
   rule = "//tests/library-with-sysincludes",
   size = "small",

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -59,7 +59,7 @@ rule_test(
   generates =
     ["library-deps-1.0.0/library-deps-1.0.0.conf",
      "library-deps-1.0.0/package.cache",
-     "dynlib-library-deps-1.0.0/libHSlibrary-deps-1.0.0-ghc8.2.2.so",
+     "libHSlibrary-deps-1.0.0-ghc8.2.2.so",
     ],
   rule = "//tests/library-deps",
   size = "small",
@@ -70,7 +70,7 @@ rule_test(
   generates =
     ["library-with-sysdeps-1.0.0/library-with-sysdeps-1.0.0.conf",
      "library-with-sysdeps-1.0.0/package.cache",
-     "dynlib-library-with-sysdeps-1.0.0/libHSlibrary-with-sysdeps-1.0.0-ghc8.2.2.so",
+     "libHSlibrary-with-sysdeps-1.0.0-ghc8.2.2.so",
     ],
   rule = "//tests/library-with-sysdeps",
   size = "small",
@@ -115,7 +115,7 @@ rule_test(
   generates =
     ["library-with-sysincludes-1.0.0/library-with-sysincludes-1.0.0.conf",
      "library-with-sysincludes-1.0.0/package.cache",
-     "dynlib-library-with-sysincludes-1.0.0/libHSlibrary-with-sysincludes-1.0.0-ghc8.2.2.so",
+     "libHSlibrary-with-sysincludes-1.0.0-ghc8.2.2.so",
     ],
   rule = "//tests/library-with-sysincludes",
   size = "small",


### PR DESCRIPTION
Adding produced .so to default outputs allows us to use `haskell_library` rules directly in `srcs` on `cc_library` rules which allows the cc rule to use the shared object. There is an alternative solution where we have `haskell_so` rule that just takes the shared object from the provider and forwards it. This _may_ be still be needed for linking purposes.

Additionally in separate commit I drop static_library_dir and dynamic_library_dir: they are not needed because the library names are already unique enough and they were just pointless noise.