### PR TITLE
Do not -package transitive dependencies.

### DIFF
--- a/haskell/actions.bzl
+++ b/haskell/actions.bzl
@@ -503,7 +503,7 @@ def gather_dependency_information(ctx):
       new_external_libraries = new_external_libraries.union(pkg.external_libraries)
       hpi = HaskellPackageInfo(
         name = hpi.name,
-        names = hpi.names + pkg.names,
+        names = hpi.names + [pkg.name],
         confs = hpi.confs + pkg.confs,
         caches = hpi.caches + pkg.caches,
         static_libraries = hpi.static_libraries + pkg.static_libraries,

--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -98,6 +98,11 @@ def _haskell_library_impl(ctx):
   dep_info = gather_dependency_information(ctx)
   return [HaskellPackageInfo(
     name = dep_info.name,
+    # TODO this is somewhat useless now, we shouldn't be abusing
+    # HaskellPackageInfo to carry information only relevant during
+    # build just to throw it away later as upstream doesn't need this.
+    # Technically Haddock rule relies on this but it should gather its
+    # own info.
     names = depset(transitive = [dep_info.names, depset([get_pkg_id(ctx)])]),
     confs = depset(transitive = [dep_info.confs, depset([conf_file])]),
     caches = depset(transitive = [dep_info.caches, depset([cache_file])]),


### PR DESCRIPTION
If A depends on B and B depends on C, previously A could import
directly from C without listing C in dependencies. It should not.

Fixes #72.