### PR TITLE
Adding ghc_link_flags attribute to haskell_binary rule.

### DIFF
--- a/haskell/actions.bzl
+++ b/haskell/actions.bzl
@@ -114,6 +114,7 @@ def link_haskell_bin(ctx, object_files):
   # function yet, and need to construct full shell command below as
   # a string.
   link_args = []
+  link_args.extend(ctx.attr.ghc_link_flags)
   link_args.extend(["-o", ctx.outputs.executable.path, dummy_static_lib.path])
 
   for o in object_files:

--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -65,6 +65,7 @@ def _mk_binary_rule(**kwargs):
     attrs = dict(
       _haskell_common_attrs,
       main = attr.string(default="Main.main"),
+      ghc_link_flags = attr.string_list()
     ),
     host_fragments = ["cpp"],
     toolchains = ["@io_tweag_rules_haskell//haskell:toolchain"],


### PR DESCRIPTION
The main motivation for this PR is to compile binaries with linking-only options such as `-threaded` or `-with-rtsopts=...`.
  