### PR TITLE
Rename haskell_haddock to haskell_doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ run tests, you'll furthermore need [Nix][nix] installed.
 | [`haskell_library`](#haskell_library) | Build a library from Haskell source. |
 | [`haskell_binary`](#haskell_binary) | Build an executable from Haskell source. |
 | [`haskell_test`](#haskell_test) | Run a test suite. |
-| [`haskell_haddock`](#haskell_haddock) | Create API documentation. |
+| [`haskell_doc`](#haskell_doc) | Create API documentation. |
 | [`haskell_toolchain`](#haskell_toolchain) | Declare a compiler toolchain. |
 | [`haskell_cc_import`](#haskell_cc_import) | Import a prebuilt shared library. |
 | [`cc_haskell_import`](#cc_haskell_import) | Expose all transitive shared object libraries for haskell dependency. |
@@ -180,13 +180,12 @@ accepts
 This allows you to influence things like timeout and resource
 allocation for the test.
 
-### haskell_haddock
+### haskell_doc
 
-Builds [Haddock](http://haskell-haddock.readthedocs.io/en/latest/)
-documentation for given Haskell libraries. It will automatically
-build documentation for any transitive dependencies to allow for
-cross-package documentation linking. Currently linking to
-`prebuilt_deps` is not supported.
+Builds API documentation (using [Haddock][haddock]) for the given
+Haskell libraries. It will automatically build documentation for any
+transitive dependencies to allow for cross-package documentation
+linking. Currently linking to `prebuilt_deps` is not supported.
 
 ```bzl
 haskell_library(
@@ -194,11 +193,13 @@ haskell_library(
   …
 )
 
-haskell_haddock(
-  name = "my-lib-haddock",
+haskell_doc(
+  name = "my-lib-doc",
   deps = [":my-lib"],
 )
 ```
+
+[haddock]: http://haskell-haddock.readthedocs.io/en/latest/
 
 #### Attributes
 

--- a/haskell/haddock.bzl
+++ b/haskell/haddock.bzl
@@ -20,7 +20,7 @@ HaddockInfo = provider(
   }
 )
 
-def _haskell_haddock_aspect_impl(target, ctx):
+def _haskell_doc_aspect_impl(target, ctx):
   if HaskellPackageInfo not in target:
     return []
 
@@ -145,13 +145,13 @@ def _haskell_haddock_aspect_impl(target, ctx):
     doc_dir = doc_dir,
   )]
 
-haskell_haddock_aspect = aspect(
-  implementation = _haskell_haddock_aspect_impl,
+haskell_doc_aspect = aspect(
+  implementation = _haskell_doc_aspect_impl,
   attr_aspects = ['deps'],
   toolchains = ["@io_tweag_rules_haskell//haskell:toolchain"],
 )
 
-def _haskell_haddock_rule_impl(ctx):
+def _haskell_doc_rule_impl(ctx):
   interface_files = depset()
   for dep in ctx.attr.deps:
     if HaddockInfo in dep:
@@ -159,9 +159,9 @@ def _haskell_haddock_rule_impl(ctx):
 
   return [DefaultInfo(files = interface_files)]
 
-haskell_haddock = rule(
-  implementation  = _haskell_haddock_rule_impl,
+haskell_doc = rule(
+  implementation  = _haskell_doc_rule_impl,
   attrs = {
-    "deps": attr.label_list(aspects = [haskell_haddock_aspect]),
+    "deps": attr.label_list(aspects = [haskell_doc_aspect]),
   },
 )

--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -12,9 +12,9 @@ load(":actions.bzl",
   "link_haskell_bin",
 )
 
-# Re-export haskell_haddock
+# Re-export haskell_doc
 load (":haddock.bzl",
-  _haskell_haddock = "haskell_haddock",
+  _haskell_doc = "haskell_doc",
 )
 
 # Re-export haskell_toolchain
@@ -134,7 +134,7 @@ haskell_library = rule(
   toolchains = ["@io_tweag_rules_haskell//haskell:toolchain"],
 )
 
-haskell_haddock = _haskell_haddock
+haskell_doc = _haskell_doc
 
 haskell_toolchain = _haskell_toolchain
 

--- a/tests/haddock/BUILD
+++ b/tests/haddock/BUILD
@@ -3,7 +3,7 @@ package(default_testonly = 1, default_visibility = ["//visibility:public"])
 load(
   "@io_tweag_rules_haskell//haskell:haskell.bzl",
   "haskell_library",
-  "haskell_haddock",
+  "haskell_doc",
   "haskell_cc_import",
 )
 
@@ -29,7 +29,7 @@ haskell_library(
   prebuilt_dependencies = ["base"],
 )
 
-haskell_haddock(
+haskell_doc(
   name = "haddock",
   deps = [":haddock-lib-b"],
 )


### PR DESCRIPTION
This is in keeping with two principles:

* following the precedent in other rule sets (e.g. `d_doc`,
  `rust_doc`, `skylark_doc`, which all refer to API documentation),
* bazel rules as best practices. The point of a Bazel rule is to let
  users declare *what* they want, not *how* they want it. It's the
  rule implementation that do the *how* according to the best
  practices that are current at the time of execution. Right now,
  generating API documentation via Haddock is the best practice. Maybe
  it'll be something else in the future.