### PR TITLE
Pass compiler_flags to GHC during linking of Haskell binaries

### DIFF
--- a/haskell/actions.bzl
+++ b/haskell/actions.bzl
@@ -114,6 +114,7 @@ def link_haskell_bin(ctx, object_files):
   # function yet, and need to construct full shell command below as
   # a string.
   link_args = []
+  link_args.extend(ctx.attr.compiler_flags)
   link_args.extend(["-o", ctx.outputs.executable.path, dummy_static_lib.path])
 
   for o in object_files:

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -41,6 +41,13 @@ rule_test(
 )
 
 rule_test(
+  name = "test-binary-with-link-flags",
+  generates = ["binary-with-link-flags"],
+  rule = "//tests/binary-with-link-flags",
+  size = "small",
+)
+
+rule_test(
   name = "test-binary-with-main",
   generates = ["binary-with-main"],
   rule = "//tests/binary-with-main",
@@ -140,4 +147,10 @@ rule_test(
   generates = ["cc-bin"],
   rule = "//tests/cc_haskell_import:cc-bin",
   size = "small",
+)
+
+sh_test(
+  name = "test-haskell_binary-with-link-flags",
+  size = "small",
+  srcs = ["//tests/binary-with-link-flags:test-sh"],
 )

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -41,13 +41,6 @@ rule_test(
 )
 
 rule_test(
-  name = "test-binary-with-link-flags",
-  generates = ["binary-with-link-flags"],
-  rule = "//tests/binary-with-link-flags",
-  size = "small",
-)
-
-rule_test(
   name = "test-binary-with-main",
   generates = ["binary-with-main"],
   rule = "//tests/binary-with-main",
@@ -152,5 +145,7 @@ rule_test(
 sh_test(
   name = "test-haskell_binary-with-link-flags",
   size = "small",
-  srcs = ["//tests/binary-with-link-flags:test-sh"],
+  srcs = ["scripts/test-threaded.sh"],
+  data = ["//tests/binary-with-link-flags:binary-with-link-flags"],
+  args = ["$(location //tests/binary-with-link-flags:binary-with-link-flags)"]
 )

--- a/tests/binary-with-link-flags/BUILD
+++ b/tests/binary-with-link-flags/BUILD
@@ -14,9 +14,3 @@ haskell_binary(
   prebuilt_dependencies = ["base"],
   visibility = ["//visibility:public"]
 )
-
-sh_binary(
-  name = "test-sh",
-  srcs = ["test.sh"],
-  data = [":binary-with-link-flags"]
-)

--- a/tests/binary-with-link-flags/BUILD
+++ b/tests/binary-with-link-flags/BUILD
@@ -1,0 +1,22 @@
+package(
+  default_visibility = ["//visibility:public"],
+  default_testonly = 1
+)
+
+load("@io_tweag_rules_haskell//haskell:haskell.bzl",
+  "haskell_binary",
+)
+
+haskell_binary(
+  name = "binary-with-link-flags",
+  srcs = ["Main.hs"],
+  compiler_flags = ["-threaded"],
+  prebuilt_dependencies = ["base"],
+  visibility = ["//visibility:public"]
+)
+
+sh_binary(
+  name = "test-sh",
+  srcs = ["test.sh"],
+  data = [":binary-with-link-flags"]
+)

--- a/tests/binary-with-link-flags/Main.hs
+++ b/tests/binary-with-link-flags/Main.hs
@@ -1,0 +1,3 @@
+module Main where
+
+main = return ()

--- a/tests/binary-with-link-flags/test.sh
+++ b/tests/binary-with-link-flags/test.sh
@@ -1,0 +1,6 @@
+#/usr/bin/env sh
+
+set -e
+
+# Fails if executable was linked without -threaded flags.
+binary-with-link-flags +RTS -N

--- a/tests/scripts/test-threaded.sh
+++ b/tests/scripts/test-threaded.sh
@@ -3,4 +3,4 @@
 set -e
 
 # Fails if executable was linked without -threaded flags.
-binary-with-link-flags +RTS -N
+$1 +RTS -N

--- a/tests/scripts/test-threaded.sh
+++ b/tests/scripts/test-threaded.sh
@@ -2,5 +2,5 @@
 
 set -e
 
-# Fails if executable was linked without -threaded flags.
+# Fails if executable was linked without -threaded flag.
 $1 +RTS -N


### PR DESCRIPTION
As discussed in #91 , some compiler flags such as `-threaded` MUST be passed during the linking phase. This PR solves this problem by passing `compiler_flags` to GHC during linking.

Do we want to add a test for this change ?