### PR TITLE
Add build tools to path when linking, otherwise ghc can't find gcc + friends

### DIFF
--- a/haskell/actions.bzl
+++ b/haskell/actions.bzl
@@ -154,6 +154,8 @@ def link_haskell_bin(ctx, object_files):
       get_build_tools(ctx),
     ]),
     outputs = [ctx.outputs.executable],
+    env = {"PATH": get_build_tools_path(ctx)},
+
     progress_message = "Linking {0}".format(ctx.outputs.executable.basename),
     command = " ".join([get_compiler(ctx).path] + rpaths + link_args),
   )

--- a/haskell/actions.bzl
+++ b/haskell/actions.bzl
@@ -155,7 +155,6 @@ def link_haskell_bin(ctx, object_files):
     ]),
     outputs = [ctx.outputs.executable],
     env = {"PATH": get_build_tools_path(ctx)},
-
     progress_message = "Linking {0}".format(ctx.outputs.executable.basename),
     command = " ".join([get_compiler(ctx).path] + rpaths + link_args),
   )


### PR DESCRIPTION
I'm guessing this is only happens when you use a local ghc?

It would be nice to add tests for builds using a locally installed ghc, I think this could be done with a different docker image in the circleci config.

## Example build failure
WORKSPACE:
```
workspace(name = "hello")
http_archive(
  name = "io_tweag_rules_haskell",
  strip_prefix = "rules_haskell-master",
  urls = ["https://github.com/tweag/rules_haskell/archive/master.tar.gz"]
)
load("@io_tweag_rules_haskell//haskell:repositories.bzl", "haskell_repositories")
haskell_repositories()

new_local_repository(
  name = "ghc",
  path = "/usr/",
  build_file_content = """
package(default_visibility = ["//visibility:public"])
filegroup(
  name = "bin",
  srcs = glob([
    "bin/ghc*",
    "bin/hsc2hs",
    "bin/gcc",
    "bin/as",
    "bin/ld.gold",
    "bin/dirname",
    "bin/realpath",
  ])
)
""")
register_toolchains(
  "//:ghc_toolchain",
)
```
BUILD:
```
package(default_visibility = ["//visibility:public"])

load(
  "@io_tweag_rules_haskell//haskell:haskell.bzl",
  "haskell_binary",
  "haskell_toolchain",
)

haskell_toolchain(
  name = "ghc_toolchain",
  version = "8.2.2",
  tools = "@ghc//:bin",
)

haskell_binary(
  name = "hello",
  srcs = ['Main.hs'],
  prebuilt_dependencies = ["base"]
)
```


Build Log:
```
 bazel build  --show_task_finish --sandbox_debug --subcommands --verbose_failures hello 
INFO: Analysed target //:hello (8 packages loaded).
INFO: Found 1 target...
SUBCOMMAND: # //:hello [action 'Building hello']
(cd /home/redacted/.cache/bazel/_bazel_redacted/edd3a784d297362531c972f3f37a31cc/execroot/hello && \
  exec env - \
    PATH=external/ghc/bin:external/ghc/lib/gcc/x86_64-pc-linux-gnu/7.2.1 \
  external/ghc/bin/ghc -no-link -hide-all-packages -odir bazel-out/k8-fastbuild/bin/objects-hello-1.0.0 -hidir bazel-out/k8-fastbuild/bin/interfaces-hello-1.0.0 -package base Main.hs -main-is Main.main)
SUBCOMMAND: # //:hello [action 'SkylarkAction BazelDummy.o']
(cd /home/redacted/.cache/bazel/_bazel_redacted/edd3a784d297362531c972f3f37a31cc/execroot/hello && \
  exec env - \
  external/ghc/bin/ghc -no-link bazel-out/k8-fastbuild/bin/BazelDummy.hs)
SUBCOMMAND: # //:hello [action 'Creating runfiles tree bazel-out/k8-fastbuild/bin/hello.runfiles']
(cd /home/redacted/.cache/bazel/_bazel_redacted/edd3a784d297362531c972f3f37a31cc/execroot/hello && \
  exec env - \
    PATH=/usr/local/bin:/usr/local/sbin:/opt/google-cloud-sdk/bin:/usr/bin:/usr/lib/jvm/default/bin:/usr/bin/site_perl:/usr/bin/vendor_perl:/usr/bin/core_perl:/home/redacted/.local/bin:/home/redacted/.gem/ruby/2.3.0/bin:/home/redacted/.cargo/bin:/opt/google-cloud-sdk/bin:/home/redacted/.fzf/bin:/home/redacted/.gem/ruby/2.3.0/bin:/home/redacted/.cargo/bin:/opt/google-cloud-sdk/bin \
    TMPDIR=/tmp/tmp.bNodH6EdSO \
  _bin/build-runfiles bazel-out/k8-fastbuild/bin/hello.runfiles_manifest bazel-out/k8-fastbuild/bin/hello.runfiles)
INFO: From SkylarkAction BazelDummy.o:
[1 of 1] Compiling BazelDummy       ( bazel-out/k8-fastbuild/bin/BazelDummy.hs, bazel-out/k8-fastbuild/bin/BazelDummy.o )
SUBCOMMAND: # //:hello [action 'SkylarkAction libempty.a']
(cd /home/redacted/.cache/bazel/_bazel_redacted/edd3a784d297362531c972f3f37a31cc/execroot/hello && \
  exec env - \
  /usr/bin/ar qc bazel-out/k8-fastbuild/bin/libempty.a bazel-out/k8-fastbuild/bin/BazelDummy.o)
INFO: From Building hello:
[1 of 1] Compiling Main             ( Main.hs, bazel-out/k8-fastbuild/bin/objects-hello-1.0.0/Main.o )
SUBCOMMAND: # //:hello [action 'Linking hello']
(cd /home/redacted/.cache/bazel/_bazel_redacted/edd3a784d297362531c972f3f37a31cc/execroot/hello && \
  exec env - \
  /bin/bash -c 'external/ghc/bin/ghc -o bazel-out/k8-fastbuild/bin/hello bazel-out/k8-fastbuild/bin/libempty.a -optl bazel-out/k8-fastbuild/bin/objects-hello-1.0.0/Main.o -package base')
ERROR: /home/redacted/tmp/btest/BUILD:15:1: error executing shell command: 'external/ghc/bin/ghc -o bazel-out/k8-fastbuild/bin/hello bazel-out/k8-fastbuild/bin/libempty.a -optl bazel-out/k8-fastbuild/bin/objects-hello-1.0.0/Main.o -package base' failed (Exit 1): process-wrapper failed: error executing command 
  (cd /home/redacted/.cache/bazel/_bazel_redacted/edd3a784d297362531c972f3f37a31cc/execroot/hello && \
  exec env - \
    TMPDIR=/home/redacted/.cache/bazel/_bazel_redacted/edd3a784d297362531c972f3f37a31cc/bazel-sandbox/2457777586235817310/execroot/hello/tmp \
  /home/redacted/.cache/bazel/_bazel_redacted/edd3a784d297362531c972f3f37a31cc/execroot/hello/_bin/process-wrapper '--timeout=0' '--kill_delay=15' /bin/bash -c 'external/ghc/bin/ghc -o bazel-out/k8-fastbuild/bin/hello bazel-out/k8-fastbuild/bin/libempty.a -optl bazel-out/k8-fastbuild/bin/objects-hello-1.0.0/Main.o -package base')
gcc: error trying to exec 'cc1': execvp: No such file or directory
`gcc' failed in phase `C Compiler'. (Exit code: 1)
Target //:hello failed to build
INFO: Elapsed time: 1.143s, Critical Path: 0.37s
FAILED: Build did NOT complete successfully
```
