### PR TITLE
Improve ‘.gitignore’

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,8 +18,4 @@ cabal.sandbox.config
 .stack-work/
 cabal.project.local
 .HTF/
-/bazel-bin
-/bazel-genfiles
-/bazel-out
-/bazel-rules_haskell
-/bazel-testlogs
+/bazel-*


### PR DESCRIPTION
More concise and allows to blindly copy the `.gitignore` to other Bazel projects because it does not hardcode the project name.