### PR TITLE
Add c related attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,10 @@ haskell_binary(
 | `compiler_flags` | `String list, optional` | Flags to pass to Haskell compiler |
 | `prebuilt_dependencies` | `String list, optional` | Non-Bazel supplied Cabal dependencies |
 | `main` | `String, optional` | Location of `main` function. Default: `"Main.main"` |
+| `include_dirs` | A list of include directories for C source files |
+| `c_srcs` | A list of C source files |
+| `extra_libraries` | A list of libraries to link against |
+| `c_options` | Options to pass to C compiler |
 
 ### haskell_library
 
@@ -176,7 +180,7 @@ haskell_library(
     name = 'hello_lib',
     srcs = glob(['hello_lib/**/*.hs']),
     deps = ["//hello_sublib:lib"],
-	prebuilt_dependencies = ["base", "bytestring"],
+    prebuilt_dependencies = ["base", "bytestring"],
 )
 ```
 
@@ -190,6 +194,10 @@ haskell_library(
 | `src_strip_prefix` | `String, optional` | Directory in which module hierarchy starts |
 | `compiler_flags` | `String list, optional` | Flags to pass to Haskell compiler |
 | `prebuilt_dependencies` | `String list, optional` | Non-Bazel supplied Cabal dependencies |
+| `include_dirs` | A list of include directories for C source files |
+| `c_srcs` | A list of C source files |
+| `extra_libraries` | A list of libraries to link against |
+| `c_options` | Options to pass to C compiler |
 
 ### haskell_test
 

--- a/tests/c-compiles/BUILD
+++ b/tests/c-compiles/BUILD
@@ -6,16 +6,11 @@ load(
   "haskell_binary",
 )
 
-cc_library(
-  name = "c-lib",
-  srcs = ["c-compiles.c"],
-)
-
 haskell_library(
   name = "hs-lib",
   srcs = ["Lib.hs"],
-  deps = [":c-lib"],
   prebuilt_dependencies = ["base"],
+  c_srcs = ["c-compiles.c"],
 )
 
 haskell_binary(


### PR DESCRIPTION
Close #103. Please first see #115, because this branch starts there.

This PR adds the following new attributes to the `haskell_binary` and `haskell_library` rules:

* `include_dirs`
* `c_srcs`
* `extra_libraries`
* `c_options`

These ensure that the c bits are included in the resulting dynamic `.so` library and we don't create a separate `.so` library for c bits of every project. This allows to compile Aeson library from the issue #103.