### PR TITLE
Introduce textual_hdrs.

### DIFF
--- a/haskell/actions.bzl
+++ b/haskell/actions.bzl
@@ -435,6 +435,8 @@ def compilation_defaults(ctx):
   # modules cross-package.
   interface_files = []
 
+  textual_headers = []
+
   # Output object files are named after modules, not after input file names.
   # The difference is only visible in the case of Main module because it may
   # be placed in a file with a name different from "Main.hs". In that case
@@ -442,7 +444,9 @@ def compilation_defaults(ctx):
 
   for s in _hs_srcs(ctx):
 
-    if not hasattr(ctx.file, "main_file") or (s != ctx.file.main_file):
+    if s.extension == "h":
+      textual_headers.append(s)
+    elif not hasattr(ctx.file, "main_file") or (s != ctx.file.main_file):
       object_files.append(
         declare_compiled(ctx, s, ".o", directory=objects_dir)
       )
@@ -478,6 +482,7 @@ def compilation_defaults(ctx):
       set.to_depset(get_build_tools(ctx)),
       set.to_depset(dep_info.external_libraries),
       java.inputs,
+      depset(textual_headers),
     ]),
     outputs = [objects_dir, interfaces_dir] + object_files + interface_files,
     objects_dir = objects_dir,

--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -33,7 +33,7 @@ load(":set.bzl", "set")
 _haskell_common_attrs = {
   "src_strip_prefix": attr.string(default="",mandatory=False),
   "srcs": attr.label_list(allow_files=FileType(
-    [".hs", ".hsc", ".lhs", ".hs-boot", ".lhs-boot"]
+    [".hs", ".hsc", ".lhs", ".hs-boot", ".lhs-boot", ".h"]
   )),
   "copts": attr.string_list(),
   "deps": attr.label_list(),

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -170,3 +170,10 @@ rule_test(
   rule = "//tests/hs-boot",
   size = "small",
 )
+
+rule_test(
+  name = "test-textual-hdrs",
+  generates = ["textual-hdrs"],
+  rule = "//tests/textual-hdrs",
+  size = "small",
+)

--- a/tests/textual-hdrs/BUILD
+++ b/tests/textual-hdrs/BUILD
@@ -1,0 +1,14 @@
+package(default_testonly = 1)
+
+load(
+  "@io_tweag_rules_haskell//haskell:haskell.bzl",
+  "haskell_binary",
+)
+
+haskell_binary(
+  name = "textual-hdrs",
+  srcs = ["Main.hs", "include/main_definition.h"],
+  compiler_flags = ["-Itests/textual-hdrs/include"],
+  prebuilt_dependencies = ["base"],
+  visibility = ["//visibility:public"],
+)

--- a/tests/textual-hdrs/Main.hs
+++ b/tests/textual-hdrs/Main.hs
@@ -1,0 +1,5 @@
+{-# LANGUAGE CPP #-}
+
+module Main (main) where
+
+#include "main_definition.h"

--- a/tests/textual-hdrs/include/main_definition.h
+++ b/tests/textual-hdrs/include/main_definition.h
@@ -1,0 +1,2 @@
+main :: IO ()
+main = putStrLn "extras-included-during-comp"


### PR DESCRIPTION
We already had this, in the form of `external_deps`, which
5d1a179c0463c182766af1603b38ad04dadef4fb removed. As noted there, we
removed it for lack of a good use case. We just found a use case:
compile aeson without making modifications to the code organization of
that package. The new name for this is consistent with
https://docs.bazel.build/versions/master/be/c-cpp.html#cc_library.textual_hdrs.

Tested with bazel-protolude aeson, but needs a minimal test case.

Together with #117, this makes aeson buildable.