### PR TITLE
Allow main modules with custom file names

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,8 @@ haskell_binary(
 | `src_strip_prefix` | `String, optional` | Directory in which module hierarchy starts |
 | `compiler_flags` | `String list, optional` | Flags to pass to Haskell compiler |
 | `prebuilt_dependencies` | `String list, optional` | Non-Bazel supplied Cabal dependencies |
-| `main` | `String, optional` | Location of `main` function. Default: `"Main.main"` |
+| `main_function` | `String, optional` | Location of `main` function. Default: `"Main.main"` |
+| `main_file` | `Label, optional` | File containing `Main` module. Default: `Main.hs` |
 
 ### haskell_library
 
@@ -176,7 +177,7 @@ haskell_library(
     name = 'hello_lib',
     srcs = glob(['hello_lib/**/*.hs']),
     deps = ["//hello_sublib:lib"],
-	prebuilt_dependencies = ["base", "bytestring"],
+    prebuilt_dependencies = ["base", "bytestring"],
 )
 ```
 

--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -66,7 +66,10 @@ def _mk_binary_rule(**kwargs):
     executable = True,
     attrs = dict(
       _haskell_common_attrs,
-      main = attr.string(default="Main.main"),
+      main_function = attr.string(default="Main.main"),
+      main_file = attr.label(
+        allow_single_file=FileType([".hs", ".hsc", ".lhs"]),
+      )
     ),
     host_fragments = ["cpp"],
     toolchains = ["@io_tweag_rules_haskell//haskell:toolchain"],

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -27,6 +27,13 @@ rule_test(
 )
 
 rule_test(
+  name = "test-binary-custom-main",
+  generates = ["binary-custom-main"],
+  rule = "//tests/binary-custom-main",
+  size = "small",
+)
+
+rule_test(
   name = "test-binary-with-lib",
   generates = ["binary-with-lib"],
   rule = "//tests/binary-with-lib",

--- a/tests/binary-custom-main/BUILD
+++ b/tests/binary-custom-main/BUILD
@@ -5,9 +5,9 @@ load("@io_tweag_rules_haskell//haskell:haskell.bzl",
 )
 
 haskell_binary(
-  name = "binary-with-main",
-  srcs = ["MainIsHere.hs"],
-  main_function = "MainIsHere.this",
+  name = "binary-custom-main",
+  srcs = ["foo.hs"],
   prebuilt_dependencies = ["base"],
-  visibility = ["//visibility:public"]
+  visibility = ["//visibility:public"],
+  main_file = "foo.hs"
 )

--- a/tests/binary-custom-main/foo.hs
+++ b/tests/binary-custom-main/foo.hs
@@ -1,0 +1,4 @@
+module Main (main) where
+
+main :: IO ()
+main = return ()

--- a/tests/haskell_test/BUILD
+++ b/tests/haskell_test/BUILD
@@ -7,7 +7,7 @@ load("@io_tweag_rules_haskell//haskell:haskell.bzl",
 haskell_test(
   name = "haskell_test",
   srcs = ["Test.hs"],
-  main = "Test.test",
+  main_function = "Test.test",
   prebuilt_dependencies = ["base"],
   visibility = ["//visibility:public"],
   # Use some parameters that only test rules have.


### PR DESCRIPTION
Add a new attribute to the `haskell_binary` rule: `main_file`. The attribute allows to specify which file contains the `Main` module of the program. Since there is already `main` attribute, I renamed it to `main_function` for
clarity.

Close #100.