### PR TITLE
Add support for boot files

### DIFF
--- a/haskell/actions.bzl
+++ b/haskell/actions.bzl
@@ -379,12 +379,15 @@ def compilation_defaults(ctx):
 
   # Common flags
   args.add([
-    "-no-link",
+    "-c",
+    "--make",
     "-fPIC",
     "-hide-all-packages",
     "-odir", objects_dir,
     "-hidir", interfaces_dir,
   ])
+
+  args.add(["-i{0}".format(idir) for idir in set.to_list(set.from_list([f.dirname for f in sources]))])
 
   dep_info = gather_dependency_information(ctx)
   for n in depset(transitive = [dep_info.names, depset(ctx.attr.prebuilt_dependencies)]).to_list():
@@ -428,7 +431,7 @@ def compilation_defaults(ctx):
   args.add(include_args)
 
   # Lastly add all the processed sources.
-  args.add(sources)
+  args.add([f for f in sources if f.extension not in ["hs-boot", "lhs-boot"]])
 
   # Add any interop info for other languages.
   java = java_interop_info(ctx)

--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -32,7 +32,9 @@ load(":set.bzl", "set")
 
 _haskell_common_attrs = {
   "src_strip_prefix": attr.string(default="",mandatory=False),
-  "srcs": attr.label_list(allow_files=FileType([".hs", ".hsc", ".lhs"])),
+  "srcs": attr.label_list(allow_files=FileType(
+    [".hs", ".hsc", ".lhs", ".hs-boot", ".lhs-boot"]
+  )),
   "copts": attr.string_list(),
   "deps": attr.label_list(),
   "compiler_flags": attr.string_list(),

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -163,3 +163,10 @@ rule_test(
   rule = "//tests/lhs:lhs-bin",
   size = "small",
 )
+
+rule_test(
+  name = "test-hs-boot",
+  generates = ["hs-boot"],
+  rule = "//tests/hs-boot",
+  size = "small",
+)

--- a/tests/hs-boot/A.hs
+++ b/tests/hs-boot/A.hs
@@ -1,0 +1,8 @@
+module A where
+
+import B (TB (..))
+
+newtype TA = MkTA Int
+
+f :: TB -> TA
+f (MkTB x) = MkTA x

--- a/tests/hs-boot/A.hs-boot
+++ b/tests/hs-boot/A.hs-boot
@@ -1,0 +1,2 @@
+module A where
+  newtype TA = MkTA Int

--- a/tests/hs-boot/B.hs
+++ b/tests/hs-boot/B.hs
@@ -1,0 +1,8 @@
+module B where
+
+import {-# SOURCE #-} A (TA (..))
+
+data TB = MkTB !Int
+
+g :: TA -> TB
+g (MkTA x) = MkTB x

--- a/tests/hs-boot/BUILD
+++ b/tests/hs-boot/BUILD
@@ -1,0 +1,21 @@
+package(default_testonly = 1)
+
+load("@io_tweag_rules_haskell//haskell:haskell.bzl",
+  "haskell_library",
+  "haskell_binary",
+)
+
+haskell_library(
+  name = "hs-boot-lib",
+  srcs = ["A.hs", "A.hs-boot", "B.hs"],
+  prebuilt_dependencies = ["base"],
+  visibility = ["//visibility:public"],
+)
+
+haskell_binary(
+  name = "hs-boot",
+  srcs = ["MA.hs", "MA.hs-boot", "MB.hs", "Main.hs"],
+  deps = [":hs-boot-lib"],
+  prebuilt_dependencies = ["base"],
+  visibility = ["//visibility:public"],
+)

--- a/tests/hs-boot/MA.hs
+++ b/tests/hs-boot/MA.hs
@@ -1,0 +1,8 @@
+module MA where
+
+import MB (TB (..))
+
+newtype TA = MkTA Int
+
+f :: TB -> TA
+f (MkTB x) = MkTA x

--- a/tests/hs-boot/MA.hs-boot
+++ b/tests/hs-boot/MA.hs-boot
@@ -1,0 +1,2 @@
+module MA where
+  newtype TA = MkTA Int

--- a/tests/hs-boot/MB.hs
+++ b/tests/hs-boot/MB.hs
@@ -1,0 +1,8 @@
+module MB where
+
+import {-# SOURCE #-} MA (TA (..))
+
+data TB = MkTB !Int
+
+g :: TA -> TB
+g (MkTA x) = MkTB x

--- a/tests/hs-boot/Main.hs
+++ b/tests/hs-boot/Main.hs
@@ -1,0 +1,9 @@
+module Main (main) where
+
+import A ()
+import B ()
+import MA ()
+import MB ()
+
+main :: IO ()
+main = putStrLn "hsboot"


### PR DESCRIPTION
This PR adds support for compiling mutually recursive modules using `.hs-boot` and `.lhs-boot` files.

Close #30.
