### PR TITLE
Introduce compilation modes

### DIFF
--- a/haskell/mode.bzl
+++ b/haskell/mode.bzl
@@ -1,0 +1,24 @@
+"""Compilation modes."""
+
+def _is_mode_enabled(ctx, mode):
+  """Check whether a compilation mode is enabled.
+
+  Args:
+    ctx: Rule context.
+    mode: Mode to check.
+
+  Returns:
+    bool: True if the mode is enabled, False otherwise.
+  """
+  return ctx.var["COMPILATION_MODE"] == mode;
+
+def is_profiling_enabled(ctx):
+  """Check whether profiling mode is enabled.
+
+  Args:
+    ctx: Rule context.
+
+  Returns:
+    bool: True if the mode is enabled, False otherwise.
+  """
+  return _is_mode_enabled(ctx, "dbg")


### PR DESCRIPTION
This introduces two compilation modes: `profiling` and `coverage`. The modes can be enabled either via setting the corresponding `haskell_binary`/`haskell_library` attributes, on the command line by passing `--features=profiling` and/or `--features=coverage`. Let me know what you think.

Close #29.