### PR TITLE
Haddock improvements

### DIFF
--- a/haskell/haddock.bzl
+++ b/haskell/haddock.bzl
@@ -39,7 +39,7 @@ def _haskell_doc_aspect_impl(target, ctx):
     "-o", doc_dir,
     "--html", "--hoogle",
     "--title={0}".format(pkg_id),
-    # TODO: --hyperlinked-source or make a ticket
+    "--hyperlinked-source",
   ])
 
   dep_interfaces = set.empty()

--- a/haskell/haddock.bzl
+++ b/haskell/haddock.bzl
@@ -166,4 +166,5 @@ haskell_doc = rule(
   attrs = {
     "deps": attr.label_list(aspects = [haskell_doc_aspect]),
   },
+  toolchains = ["@io_tweag_rules_haskell//haskell:toolchain"],
 )

--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -83,7 +83,7 @@ haskell_test = _mk_binary_rule(test = True)
 haskell_binary = _mk_binary_rule()
 
 def _haskell_library_impl(ctx):
-  interfaces_dir, interface_files, object_files, object_dyn_files = compile_haskell_lib(ctx)
+  interfaces_dir, interface_files, object_files, object_dyn_files, haddock_args = compile_haskell_lib(ctx)
 
   static_library = create_static_library(
     ctx, object_files
@@ -120,7 +120,8 @@ def _haskell_library_impl(ctx):
       dep_info.prebuilt_dependencies,
       set.from_list(ctx.attr.prebuilt_dependencies)
     ),
-    external_libraries = dep_info.external_libraries
+    external_libraries = dep_info.external_libraries,
+    haddock_ghc_args = haddock_args,
   ),
   DefaultInfo(files = depset([
       conf_file,

--- a/haskell/providers.bzl
+++ b/haskell/providers.bzl
@@ -9,6 +9,16 @@ HaskellPackageInfo = provider(
     "dynamic_libraries": "Dynamic libraries.",
     "interface_files": "Interface files belonging to the packages.",
     "prebuilt_dependencies": "Transitive collection of all wired-in Haskell dependencies.",
-    "external_libraries": "Dynamic shared libraries needed for linking. List of .so files."
+    "external_libraries": "Dynamic shared libraries needed for linking. List of .so files.",
+    "haddock_ghc_args": "Arguments that were used to compile the package, suitable for Haddock."
+  }
+)
+
+HaddockInfo = provider(
+  doc = "Haddock information.",
+  fields = {
+    "outputs": "All interesting outputs produced by Haddock.",
+    "interface_file": "Haddock interface file.",
+    "doc_dir": "Directory where all the documentation files live.",
   }
 )

--- a/haskell/toolchain.bzl
+++ b/haskell/toolchain.bzl
@@ -1,7 +1,7 @@
 """Rules for defining toolchains."""
 
 def _haskell_toolchain_impl(ctx):
-  for tool in ["ghc", "ghc-pkg", "hsc2hs"]:
+  for tool in ["ghc", "ghc-pkg", "hsc2hs", "haddock"]:
     if tool not in [t.basename for t in ctx.files.tools]:
       fail("Cannot find {} in {}".format(tool, ctx.attr.tools.label))
 


### PR DESCRIPTION
Close #55.

Although #55 mentions the term "toolchain constraint", I could not find anything with this name in the docs. I think what is meant is [platform constraints](https://docs.bazel.build/versions/master/platforms.html). I evaluated these and they look inapplicable.

Platform constraint is essentially a named enumeration of values (or indeed tags of a sort). One can create a new enumeration with `constraint_setting` and add values to it with `constraint_value`. After that it's possible to group several values (we can even include other platforms) and call it a "platform". Platforms indeed influence toolchain selection, but the current platform is either detected automatically or manually specified by user.

So what do we want to achieve? We want to select toolchains which provide `haddock` executable in `haskell_doc` and otherwise we are OK with using toolchains which don't have it. Platforms and platform constraints just select toolchains that work on particular platform, they don't know anything about whether we have haddock or not (we could of course define a new enumeration that would represent something about haddock, but then the user will have to state things like "I think I have haddock on this platform" by adding something to default detected platforms somehow).

In fact if we think about it, `haddock` is a separate toolchain, so if we want the separation we should have two toolchains: `toolchain_ghc` and `toolchain_haddock`. Then rules like `haskell_binary` and `haskell_library` would require just `toolchain_ghc` and `haskell_doc` would require both `toolchain_ghc` and `toolchain_haddock`.

This is the correct way to handle this, afaiak. But I don't like it because it makes end user experience more verbose (he/she needs to define/register one more toolchain), and it does not solve a common, real problem. I'd argue that there is no problem with demanding that `haddock` executable be in our default current `toolchain`. Haddock comes with GHC, and that's true for official binary distributions as well as various Linux repos.

In the end I'd just close #55 and add `haddock` to the list of necessary tools. This is done in d5674fb. Feel free to reject the idea.

----

Close #57.

The situation is somewhat better now, see 459aa73.

----

Close #53.

After some thinking I believe that the current approach to with relative HTML directories is the best:

* With current code docs for targets in the same package will always be in neighboring directories.
* The first value in the comma-separated pair passed to `--read-interface` is just a prefix to add to every link. Since relative prefix makes sense and makes the whole thing relocatable.
* Absolute path is impossible to obtain anyway without the `$(realpath ...)` hack, which I'm very hesitant to employ anywhere.

----

Close #58.

Just adding `--hyperlinked-source` adds links to sources. You can't yet click on entities in the source files. This is nice but not so necessary, I'll try to add it this evening though.