### PR TITLE
Deploy to haskell.build using Heroku.

### DIFF
--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -1,0 +1,25 @@
+# Container for https://haskell.build.
+
+FROM ubuntu:xenial
+
+RUN apt-get update && apt-get install -y curl \
+    && echo "deb [arch=amd64] http://storage.googleapis.com/bazel-apt stable jdk1.8" \
+    | tee /etc/apt/sources.list.d/bazel.list \
+    && curl https://bazel.build/bazel-release.pub.gpg | apt-key add - \
+    && apt-get update \
+    && apt-get install -y \
+         bazel \
+	 openjdk-8-jdk \
+	 python \
+	 unzip
+
+COPY WORKSPACE /bazel/
+COPY haskell /bazel/haskell/
+COPY tests /bazel/tests/
+COPY third_party /bazel/third_party/
+
+RUN cd /bazel; bazel build //haskell:docs
+RUN cp /bazel/site/start /site \
+    && unzip -d /site /bazel/bazel-bin/haskell/docs-skydoc.zip
+
+CMD cd /site; python -m SimpleHTTPServer $PORT

--- a/heroku.yml
+++ b/heroku.yml
@@ -1,0 +1,3 @@
+build:
+  docker:
+    web: Dockerfile.web

--- a/start
+++ b/start
@@ -1,0 +1,78 @@
+#!/bin/sh
+
+MIN_BAZEL_VERSION=0.8.0
+
+set -e
+
+expected=$MIN_BAZEL_VERSION
+actual=$(bazel version | egrep '^Build label:' | egrep -o '[0-9.]+')
+cmp=$expected'\n'$actual
+
+if [ "$(echo -e ${cmp})" != "$(echo -e ${cmp} | sort -n -t. -k1 -k2)" ]
+then
+    echo Need at least Bazel v${expected}. v${actual} detected. >/dev/stderr
+    exit 1
+fi
+
+if [ -e WORKSPACE ] || [ -e BUILD ]
+then
+    echo Current directory already has WORKSPACE and/or BUILD files. >/dev/stderr
+    exit 1
+fi
+
+cat > WORKSPACE <<EOF
+workspace(name = "YOUR_PROJECT_NAME_HERE")
+
+http_archive(
+  name = "io_tweag_rules_haskell",
+  strip_prefix = "rules_haskell-0.2",
+  urls = ["https://github.com/tweag/rules_haskell/archive/v0.2.tar.gz"]
+)
+
+load("@io_tweag_rules_haskell//haskell:repositories.bzl", "haskell_repositories")
+haskell_repositories()
+
+http_archive(
+  name = "io_tweag_rules_nixpkgs",
+  strip_prefix = "rules_nixpkgs-0.1",
+  urls = ["https://github.com/tweag/rules_nixpkgs/archive/v0.1.tar.gz"],
+)
+
+load("@io_tweag_rules_nixpkgs//nixpkgs:nixpkgs.bzl", "nixpkgs_package")
+
+nixpkgs_package(
+  name = "ghc",
+  attribute_path = "haskell.compiler.ghc822",
+)
+
+register_toolchains("//:ghc")
+EOF
+
+cat > BUILD <<EOF
+package(default_visibility = ["//visibility:public"])
+
+load(
+  "@io_tweag_rules_haskell//haskell:haskell.bzl",
+  "haskell_library",
+  "haskell_toolchain",
+)
+
+haskell_toolchain(
+  name = "ghc",
+  version = "8.2.2",
+  tools = "@ghc//:bin",
+)
+
+haskell_library(
+  name = "MY_LIBRARY_NAME",
+  src_strip_prefix = "src",
+  srcs = glob(['src/**/*.hs']),
+  prebuilt_dependencies = ["base"],
+)
+EOF
+
+cat <<EOF
+WORKSPACE and initial BUILD files created. To run Bazel:
+
+    $ bazel build //...
+EOF


### PR DESCRIPTION
We use Heroku's new heroku.yml manifest to deploy containers,
eschewing buildpacks, which are just a pain to deal with.

Merge after #126.