### PR TITLE
Move the doc generating rule into a separate package

### DIFF
--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -15,11 +15,12 @@ RUN apt-get update && apt-get install -y curl \
 
 COPY WORKSPACE /bazel/
 COPY haskell /bazel/haskell/
+COPY docs /bazel/docs/
 COPY tests /bazel/tests/
 COPY third_party /bazel/third_party/
 
-RUN cd /bazel; bazel build //haskell:docs
+RUN cd /bazel; bazel build //docs:docs
 RUN cp /bazel/site/start /site \
-    && unzip -d /site /bazel/bazel-bin/haskell/docs-skydoc.zip
+    && unzip -d /site /bazel/bazel-bin/docs/docs-skydoc.zip
 
 CMD cd /site; python -m SimpleHTTPServer $PORT

--- a/docs/BUILD
+++ b/docs/BUILD
@@ -1,0 +1,15 @@
+load(
+    "@io_bazel_skydoc//skylark:skylark.bzl",
+    "skylark_doc",
+)
+
+skylark_doc(
+  name = "docs",
+  srcs = [
+    "//haskell:haskell.bzl",
+    "//haskell:cc.bzl",
+    "//haskell:haddock.bzl",
+    "//haskell:toolchain.bzl"
+  ],
+  format = "html",
+)

--- a/haskell/BUILD
+++ b/haskell/BUILD
@@ -1,23 +1,9 @@
 package(default_visibility = ["//visibility:public"])
 
 exports_files([
-  "haskell.bzl",
+  "cc.bzl",
   "ghc-version-check.sh",
+  "haddock.bzl",
+  "haskell.bzl",
+  "toolchain.bzl",
 ])
-
-load(
-    "@io_bazel_skydoc//skylark:skylark.bzl",
-    "skylark_doc",
-)
-
-skylark_doc(
-  name = "docs",
-  srcs = [
-    "haskell.bzl",
-    "cc.bzl",
-    "haddock.bzl",
-    "toolchain.bzl",
-    "ghc_bindist.bzl",
-  ],
-  format = "html",
-)

--- a/serve-docs.sh
+++ b/serve-docs.sh
@@ -16,7 +16,7 @@ function finish {
 
 trap finish EXIT
 
-bazel build //haskell:docs
-unzip -d $SCRATCH bazel-bin/haskell/docs-skydoc.zip
+bazel build //docs:docs
+unzip -d $SCRATCH bazel-bin/docs/docs-skydoc.zip
 cd $SCRATCH
 python -m SimpleHTTPServer $PORT


### PR DESCRIPTION
With current placement, the following happens when user requires `haskell.bzl`:

```
[mark@arch test-bindist]$ bazel build //...
ERROR: /home/mark/projects/tweag/test-bindist/BUILD:9:1: every rule of type _haskell_toolchain implicitly depends upon the target '@io_tweag_rules_haskell//haskell:ghc-version-check.sh', but this target could not be found because of: error loading package '@io_tweag_rules_haskell//haskell': Extension file not found. Unable to load package for '@io_bazel_skydoc//skylark:skylark.bzl': The repository could not be resolved
ERROR: Analysis of target '//:ghc-impl' failed; build aborted: error loading package '@io_tweag_rules_haskell//haskell': Extension file not found. Unable to load package for '@io_bazel_skydoc//skylark:skylark.bzl': The repository could not be resolved
INFO: Elapsed time: 5.917s
FAILED: Build did NOT complete successfully (6 packages loaded)
    currently loading: @io_tweag_rules_haskell//haskell
```

Bazel is confused about the skydoc repo.