### PR TITLE
Personalize api documentation appearance

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -77,8 +77,8 @@ sass_repositories()
 
 http_archive(
     name = "io_bazel_skydoc",
-    strip_prefix = "skydoc-deef7e7ae262417e7f2633bea6a1246460cd1e7b",
-    urls = ["https://github.com/mboes/skydoc/archive/deef7e7ae262417e7f2633bea6a1246460cd1e7b.tar.gz"],
+    strip_prefix = "skydoc-b374449408e759e32e010fa6a20585fe9fabd523",
+    urls = ["https://github.com/mrkkrp/skydoc/archive/b374449408e759e32e010fa6a20585fe9fabd523.tar.gz"],
 )
 load("@io_bazel_skydoc//skylark:skylark.bzl", "skydoc_repositories")
 skydoc_repositories()


### PR DESCRIPTION
Close #130. Ready, but first merge #133.

The idea with putting skydoc in `third_party` was not going to work because this way you need to adjust all the rules from e.g. `//skydoc` to `//third_party/skydoc/skydoc` and after that names of modules in python part. And after that tempting starts to break. They make things so move-able at Google, good luck to them.

Here I attach an image as a demo of the new look:

![new-doc-style](https://user-images.githubusercontent.com/8165792/36146264-a7fe7bd4-10e6-11e8-8ddc-4f1fcf006c2a.png)

Also, there was a bug with anchors on the overview page, I fixed that too. Going to submit a PR upstream.