### PR TITLE
Fix grep not found error

### DIFF
--- a/haskell/hsc2hs.bzl
+++ b/haskell/hsc2hs.bzl
@@ -62,6 +62,7 @@ def _make_ghc_defs_dump(ctx):
     inputs     = [ghc_defs_dump_raw],
     outputs    = [ghc_defs_dump],
     executable = ctx.file._ghc_defs_cleanup,
+    use_default_shell_env = True,
     arguments  = [
       ghc_defs_dump_raw.path,
       ghc_defs_dump.path,


### PR DESCRIPTION
At least in sandbox mode, the ghc-defs-cleanup.sh script fails with
a `grep: command not found` error, because `PATH` is sanitized by
Bazel. We set `use_default_shell` to reuse the host shell environment.
This is an impurity, because it makes the build result depend on
what's on the host's PATH. But we already borrow up `/bin/sh` from the
host. Arguably it's also reasonable to borrow `grep`.