### PR TITLE
Do not mangle system-level solibs

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -43,7 +43,10 @@ package(default_visibility = ["//visibility:public"])
 
 filegroup (
   name = "lib",
-  srcs = glob(["nix/lib/*.so"]),
+  srcs = glob([
+    "nix/lib/*.so",
+    "nix/lib/*.so.*",
+  ]),
   testonly = 1,
 )
 """,

--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -1,7 +1,11 @@
 """Core Haskell rules"""
 
-load(":actions.bzl",
+load(":providers.bzl",
   "HaskellPackageInfo",
+  "CcSkylarkApiProviderHacked",
+)
+
+load(":actions.bzl",
   "compile_haskell_bin",
   "compile_haskell_lib",
   "create_dynamic_library",
@@ -27,7 +31,6 @@ load (":ghc_bindist.bzl",
 )
 
 load(":cc.bzl",
-  "CcSkylarkApiProviderHacked",
   _haskell_cc_import = "haskell_cc_import",
   _cc_haskell_import = "cc_haskell_import",
 )

--- a/haskell/providers.bzl
+++ b/haskell/providers.bzl
@@ -22,3 +22,18 @@ HaddockInfo = provider(
     "doc_dir": "Directory where all the documentation files live.",
   }
 )
+
+# XXX this provider shouldn't be necessary. But since Skylark rules
+# can neither return CcSkylarkApiProvider nor properly test for its
+# existence in a dependency, we're forced to introduce this hack for
+# now. See https://github.com/bazelbuild/bazel/issues/4370.
+CcSkylarkApiProviderHacked = provider(
+  doc = "Skylark emulation of CcSkylarkApiProvider. Temporary hack.",
+  fields = {
+    "transitive_headers": """
+
+Returns a depset of headers that have been declared in the src or
+headers attribute(possibly empty but never None).
+"""
+  },
+)

--- a/tests/library-with-sysincludes/BUILD
+++ b/tests/library-with-sysincludes/BUILD
@@ -13,9 +13,22 @@ haskell_cc_import(
 )
 
 haskell_library(
-  name = "library-with-sysincludes",
-  srcs = ["Lib.hsc"],
+  name = "intermediate-library",
+  srcs = ["IntLib.hsc"],
   deps = [":zlib"],
   prebuilt_dependencies = ["base"],
+)
+
+haskell_library(
+  name = "library-with-sysincludes",
+  srcs = [
+      "Lib.hs",
+      "TH.hs",
+  ],
+  deps = [":intermediate-library"],
+  prebuilt_dependencies = [
+      "base",
+      "template-haskell",
+  ],
   visibility = ["//visibility:public"],
 )

--- a/tests/library-with-sysincludes/IntLib.hsc
+++ b/tests/library-with-sysincludes/IntLib.hsc
@@ -1,4 +1,4 @@
-module Lib (crc) where
+module IntLib (crc) where
 
 import Foreign.Ptr
 import Foreign.C.Types

--- a/tests/library-with-sysincludes/Lib.hs
+++ b/tests/library-with-sysincludes/Lib.hs
@@ -1,0 +1,8 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+module Lib (bar) where
+
+import TH (foo)
+
+bar :: IO ()
+bar = $foo

--- a/tests/library-with-sysincludes/TH.hs
+++ b/tests/library-with-sysincludes/TH.hs
@@ -1,0 +1,9 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+module TH (foo) where
+
+import IntLib (crc)
+import Language.Haskell.TH
+
+foo :: Q Exp
+foo = [| crc |]


### PR DESCRIPTION
Close #142.

The PR makes it so system-level shared libraries, provided by `haskell_cc_import` rules are not mangled. In addition to that their SONAME field, if set, does not break the build. We also allow shared libraries with numeric suffixes now.