### PR TITLE
Resolve the “file name does not match module name” issue

### DIFF
--- a/haskell/actions.bzl
+++ b/haskell/actions.bzl
@@ -4,6 +4,7 @@ load(":path_utils.bzl",
      "declare_compiled",
      "target_unique_name",
      "module_name",
+     "import_hierarchy_root",
 )
 
 load(":set.bzl", "set")
@@ -505,10 +506,9 @@ def compilation_defaults(ctx):
 
   _add_mode_options(ctx, args)
 
-  for idir in set.to_list(set.from_list([f.dirname for f in sources])):
-    items = ["-i{0}".format(idir)]
-    args.add(items)
-    haddock_args.add(items, before_each="--optghc")
+  ih_root_arg = ["-i{0}".format(import_hierarchy_root(ctx))]
+  args.add(ih_root_arg)
+  haddock_args.add(ih_root_arg, before_each="--optghc")
 
   dep_info = gather_dependency_information(ctx)
 


### PR DESCRIPTION
Close #145, close #139.

This resolves the issue for the `jvm-streaming` package but I could not reproduce the problem in isolation in our test suite. It makes sense to assume that the problem should have to do with directory structure/file names/module names. I re-created all of this in my test and upon inspection of actual calls to `ghc`, they were virtually identical (sans concrete module names). Yet in the case of `jvm-streaming` we get the error message complaining about the mismatch, while in the other case the test passes.

I further attempted to bring the two cases closer by commenting out `deps` and `prebuilt_dependencies` in the BUILD file of `jvm-streaming`, thinking that since these fields are present in `jvm-steraming` and not in my test, they may somehow make the difference, but that also did not help. `jvm-streaming` fails and my test passes.

I'm out of ideas, it looks like an inconsistent behavior of GHC.