### PR TITLE
Preserve ordering of static libraries to help the linker

### DIFF
--- a/haskell/actions.bzl
+++ b/haskell/actions.bzl
@@ -228,12 +228,11 @@ def link_haskell_bin(ctx, object_files):
   # directly rather than doing multiple reversals with temporary
   # lists.
   link_paths = {}
-  static_lib_list = set.to_list(dep_info.static_libraries)
 
-  for lib in static_lib_list:
+  for lib in dep_info.static_libraries:
     link_paths[lib] = link_paths.get(lib, 0) + 1
 
-  for lib in static_lib_list:
+  for lib in dep_info.static_libraries:
     occ = link_paths.get(lib, 0)
     # This is the last occurrence of the lib, insert it.
     if occ == 1:
@@ -249,7 +248,7 @@ def link_haskell_bin(ctx, object_files):
 
   ctx.actions.run(
     inputs = depset(transitive = [
-      set.to_depset(dep_info.static_libraries),
+      depset(dep_info.static_libraries),
       depset(object_files),
       depset([dummy_static_lib]),
       set.to_depset(dep_info.external_libraries),
@@ -647,7 +646,7 @@ def gather_dependency_information(ctx):
     names = depset(),
     confs = depset(),
     caches = depset(),
-    static_libraries = set.empty(),
+    static_libraries = [],
     dynamic_libraries = set.empty(),
     interface_files = set.empty(),
     prebuilt_dependencies = set.from_list(ctx.attr.prebuilt_dependencies),
@@ -663,7 +662,7 @@ def gather_dependency_information(ctx):
         names = hpi.names + [pkg.name],
         confs = hpi.confs + pkg.confs,
         caches = hpi.caches + pkg.caches,
-        static_libraries = set.mutable_union(hpi.static_libraries, pkg.static_libraries),
+        static_libraries = hpi.static_libraries + pkg.static_libraries,
         dynamic_libraries = set.mutable_union(hpi.dynamic_libraries, pkg.dynamic_libraries),
         interface_files = set.mutable_union(hpi.interface_files, pkg.interface_files),
         prebuilt_dependencies = set.mutable_union(hpi.prebuilt_dependencies, pkg.prebuilt_dependencies),

--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -155,7 +155,11 @@ def _haskell_library_impl(ctx):
     names = depset(transitive = [dep_info.names, depset([get_pkg_id(ctx)])]),
     confs = depset(transitive = [dep_info.confs, depset([conf_file])]),
     caches = depset(transitive = [dep_info.caches, depset([cache_file])]),
-    static_libraries = set.insert(dep_info.static_libraries, static_library),
+    # We have to use lists for static libraries because the order is
+    # important for linker. Linker searches for unresolved symbols to the
+    # left, i.e. you first feed a library which has unresolved symbols and
+    # then you feed the library which resolves the symbols.
+    static_libraries = [static_library] + dep_info.static_libraries,
     dynamic_libraries = set.insert(dep_info.dynamic_libraries, dynamic_library),
     interface_files = set.union(dep_info.interface_files, set.from_list(interface_files)),
     prebuilt_dependencies = set.union(

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -167,13 +167,20 @@ rule_test(
 rule_test(
   name = "test-hs-boot",
   generates = ["hs-boot"],
-  rule = "//tests/hs-boot",
+  rule = "//tests/hs-boot:hs-boot",
   size = "small",
 )
 
 rule_test(
   name = "test-textual-hdrs",
   generates = ["textual-hdrs"],
-  rule = "//tests/textual-hdrs",
+  rule = "//tests/textual-hdrs:textual-hdrs",
+  size = "small",
+)
+
+rule_test(
+  name = "test-two-libs",
+  generates = ["two-libs"],
+  rule = "//tests/two-libs:two-libs",
   size = "small",
 )

--- a/tests/two-libs/BUILD
+++ b/tests/two-libs/BUILD
@@ -6,16 +6,6 @@ load(
   "haskell_binary",
 )
 
-haskell_binary(
-  name = "two-libs",
-  srcs = ["Main.hs"],
-  deps = [
-    "one",
-    "two"
-  ],
-  prebuilt_dependencies = ["base"],
-)
-
 haskell_library(
   name = 'one',
   srcs = [ 'One.hs' ],
@@ -30,4 +20,12 @@ haskell_library(
   prebuilt_dependencies = [
     "base"
   ],
+  deps = [":one"],
+)
+
+haskell_binary(
+  name = "two-libs",
+  srcs = ["Main.hs"],
+  deps = [":two"],
+  prebuilt_dependencies = ["base"],
 )

--- a/tests/two-libs/Main.hs
+++ b/tests/two-libs/Main.hs
@@ -1,7 +1,6 @@
 module Main where
 
-import One (one)
 import Two (two)
 
 main :: IO ()
-main = putStrLn $ "One and Two makes " ++ show (one + two)
+main = putStrLn ("Two: " ++ show two)

--- a/tests/two-libs/Two.hs
+++ b/tests/two-libs/Two.hs
@@ -1,4 +1,6 @@
 module Two (two) where
 
+import One (one)
+
 two :: Int
-two = 2
+two = one + one


### PR DESCRIPTION
Close #140.

Apparently this is a regression introduced in #109. I noticed that the test `two-libs` is not in the test `BUILD` files and so it was essentially redundant because it was not run on `bazel test //...`. I adjusted the test to catch this issue and added it to the test suite.