### PR TITLE
Fix location of shared libraries by test executables

### DIFF
--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -68,7 +68,7 @@ _haskell_common_attrs = {
 
 def _haskell_binary_impl(ctx):
   object_files = compile_haskell_bin(ctx)
-  link_haskell_bin(ctx, object_files)
+  return link_haskell_bin(ctx, object_files)
 
 def _mk_binary_rule(**kwargs):
   """Generate a rule that compiles a binary.

--- a/tests/haskell_test/BUILD
+++ b/tests/haskell_test/BUILD
@@ -4,11 +4,17 @@ load("@io_tweag_rules_haskell//haskell:haskell.bzl",
   "haskell_test",
 )
 
+cc_library(
+  name = "cbits",
+  srcs = ["cbits.c"],
+)
+
 haskell_test(
   name = "haskell_test",
   srcs = ["Test.hs"],
   main_function = "Test.test",
   prebuilt_dependencies = ["base"],
+  deps = [":cbits"],
   visibility = ["//visibility:public"],
   # Use some parameters that only test rules have.
   size = "small",

--- a/tests/haskell_test/cbits.c
+++ b/tests/haskell_test/cbits.c
@@ -1,0 +1,1 @@
+int add_six(int x) { return x + 6; }


### PR DESCRIPTION
Close #151.

This PR makes test executables locate shared libraries (of cbits in particular) correctly so tests can be run. Also we adjust the test suite to catch the issue.