### PR TITLE
Add ‘hidden_modules’ attribute to ‘haskell_library’ rule

### DIFF
--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -43,7 +43,7 @@ _haskell_common_attrs = {
   ),
   "srcs": attr.label_list(
     allow_files = FileType([".hs", ".hsc", ".lhs", ".hs-boot", ".lhs-boot", ".h"]),
-    doc = "Haskell source files",
+    doc = "Haskell source files.",
   ),
   "deps": attr.label_list(
     doc = "List of other Haskell libraries to be linked to this target.",
@@ -177,7 +177,11 @@ def _haskell_library_impl(ctx):
 
 haskell_library = rule(
   _haskell_library_impl,
-  attrs = _haskell_common_attrs,
+  attrs = dict(
+    _haskell_common_attrs,
+    hidden_modules = attr.string_list(
+      doc = "Modules that should be made unavailable for import by dependencies."
+    )),
   host_fragments = ["cpp"],
   toolchains = ["@io_tweag_rules_haskell//haskell:toolchain"],
 )

--- a/haskell/set.bzl
+++ b/haskell/set.bzl
@@ -20,7 +20,7 @@ def _is_member(s, e):
   Result:
     Bool, true if `e` is in `s`, false otherwise.
   """
-  e in s._set_items
+  return e in s._set_items
 
 def _insert(s, e):
   """Insert an element into the set.

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -111,7 +111,17 @@ rule_test(
 rule_test(
   name = "test-haskell_test",
   generates = ["haskell_test"],
-  rule = "//tests/haskell_test",
+  rule = "//tests/haskell_test:haskell_test",
+  size = "small",
+)
+
+rule_test(
+  name = "test-hidden-modules",
+  generates = [
+    "lib-c-1.0.0/lib-c-1.0.0.conf",
+    "lib-c-1.0.0/package.cache"
+  ],
+  rule = "//tests/hidden-modules:lib-c",
   size = "small",
 )
 

--- a/tests/hidden-modules/BUILD
+++ b/tests/hidden-modules/BUILD
@@ -1,0 +1,28 @@
+package(default_testonly = 1, default_visibility = ["//visibility:public"])
+
+load("@io_tweag_rules_haskell//haskell:haskell.bzl",
+     "haskell_library",
+)
+
+haskell_library(
+  name = "lib-a",
+  src_strip_prefix = "lib-a",
+  srcs = glob(["lib-a/*.hs"]),
+  hidden_modules = ["Foo"],
+  prebuilt_dependencies = ["base"],
+)
+
+haskell_library(
+  name = "lib-b",
+  src_strip_prefix = "lib-b",
+  srcs = glob(["lib-b/*.hs"]),
+  prebuilt_dependencies = ["base"],
+)
+
+haskell_library(
+  name = "lib-c",
+  src_strip_prefix = "lib-c",
+  srcs = glob(["lib-c/*.hs"]),
+  prebuilt_dependencies = ["base"],
+  deps = [":lib-a", ":lib-b"],
+)

--- a/tests/hidden-modules/lib-a/Bar.hs
+++ b/tests/hidden-modules/lib-a/Bar.hs
@@ -1,0 +1,6 @@
+module Bar (bar) where
+
+import Foo (foo)
+
+bar :: Int
+bar = foo * 2

--- a/tests/hidden-modules/lib-a/Foo.hs
+++ b/tests/hidden-modules/lib-a/Foo.hs
@@ -1,0 +1,4 @@
+module Foo (foo) where
+
+foo :: Int
+foo = 15

--- a/tests/hidden-modules/lib-b/Foo.hs
+++ b/tests/hidden-modules/lib-b/Foo.hs
@@ -1,0 +1,4 @@
+module Foo (foo) where
+
+foo :: Int
+foo = 16

--- a/tests/hidden-modules/lib-c/Baz.hs
+++ b/tests/hidden-modules/lib-c/Baz.hs
@@ -1,0 +1,7 @@
+module Baz (bar) where
+
+import Foo (foo)
+import Bar (bar)
+
+baz :: Int
+baz = foo + bar


### PR DESCRIPTION
Close #152.

This allows to selectively hide modules, which is necessary in order to compile some existing code from Hackage.