### PR TITLE
Add ‘haskell_repl’ rule

### DIFF
--- a/docs/BUILD
+++ b/docs/BUILD
@@ -12,6 +12,7 @@ skylark_doc(
 
     "//haskell:haskell.bzl",
     "//haskell:haddock.bzl",
+    "//haskell:ghci-repl.bzl",
     "//haskell:toolchain.bzl",
     "//haskell:cc.bzl",
     "//haskell:repositories.bzl",

--- a/haskell/BUILD
+++ b/haskell/BUILD
@@ -8,8 +8,11 @@ exports_files([
   "haddock.bzl",
   "toolchain.bzl",
   "ghc_bindist.bzl",
+  "ghci-repl.bzl",
 
   "ghc-defs-cleanup.sh",
   "ghc-version-check.sh",
+  "ghci-repl-wrapper.sh",
+  "ghci-script",
 
 ])

--- a/haskell/ghc-defs-cleanup.sh
+++ b/haskell/ghc-defs-cleanup.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Usage: ghc-defs-cleanup.SH <ORIGINAL-FILE> <OUTPUT-FILE>
+# Usage: ghc-defs-cleanup.sh <ORIGINAL_FILE> <OUTPUT_FILE>
 
 # This is what Cabal sets:
 #

--- a/haskell/ghci-repl-wrapper.sh
+++ b/haskell/ghci-repl-wrapper.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+#
+# Usage: ghci-repl-wrapper.sh <ARGS>
+
+# First test if ghci can be found where we expect it to be. If not, it's
+# likely that the script is invoked incorrectly, so we need to output a
+# warning with instructions how to invoke it.
+
+GHCI_LOCATION="bazel-$(basename $PWD)/{GHCi}"
+SCRIPT_LOCATION="{SCRIPT_LOCATION}"
+
+if ! [ -e "$GHCI_LOCATION" ]
+then
+    cat <<EOF
+It looks like you are trying to invoke the REPL incorrectly.
+Due to limitations in Bazel, "bazel run" should not be used
+for that (because it closes stdin).
+
+Instead please execute the following from workspace root:
+
+$ $SCRIPT_LOCATION
+EOF
+    exit 1
+fi
+
+export LD_LIBRARY_PATH={LDLIBPATH}
+$GHCI_LOCATION {ARGS} "$@"

--- a/haskell/ghci-repl.bzl
+++ b/haskell/ghci-repl.bzl
@@ -1,0 +1,153 @@
+"""GHCi REPL support"""
+
+load(":tools.bzl",
+     "get_ghci",
+)
+
+load("@bazel_skylib//:lib.bzl",
+     "paths",
+     "shell",
+)
+
+load(":providers.bzl",
+     "HaskellPackageInfo",
+)
+
+load(":path_utils.bzl",
+     "target_unique_name",
+     "get_external_libs_path",
+     "import_hierarchy_root",
+)
+
+load(":set.bzl",
+     "set",
+)
+
+load(":utils.bzl",
+     "get_lib_name",
+)
+
+def _haskell_repl_impl(ctx):
+
+  target = ctx.attr.target[HaskellPackageInfo]
+
+  # Bring packages in scope.
+  args = ["-hide-all-packages"]
+  for dep in set.to_list(target.prebuilt_dependencies):
+    args += ["-package ", dep]
+  for name in target.names.to_list():
+    if not (ctx.attr.interpreted and name == target.name):
+      args += ["-package", name]
+  for cache in target.caches.to_list():
+    args += ["-package-db", cache.dirname]
+
+  # Import dirs in interpreted mode.
+  if ctx.attr.interpreted:
+    for idir in set.to_list(target.import_dirs):
+      args += ["-i{0}".format(idir)]
+
+  # External libraries.
+  seen_libs = set.empty()
+  for lib in set.to_list(target.external_libraries):
+    lib_name = get_lib_name(lib)
+    if not set.is_member(seen_libs, lib_name):
+      set.mutable_insert(seen_libs, lib_name)
+      args += [
+        "-l{0}".format(lib_name),
+        "-L{0}".format(paths.dirname(lib.path)),
+      ]
+
+  ghci_script = ctx.actions.declare_file(target_unique_name(ctx, "ghci-repl-script"))
+
+  interpreted_modules = set.to_list(target.exposed_modules if ctx.attr.interpreted else set.empty())
+  visible_modules = set.to_list(target.exposed_modules)
+
+  ctx.actions.expand_template(
+    template = ctx.file._ghci_script,
+    output = ghci_script,
+    substitutions = {
+      "{INTERPRETED_MODULES}": " ".join(interpreted_modules),
+      "{VISIBLE_MODULES}": " ".join(visible_modules),
+    },
+  )
+
+  args += ["-ghci-script", ghci_script.path]
+
+  # Extra arguments.
+  args += ctx.attr.ghci_args
+
+  ctx.actions.expand_template(
+    template = ctx.file._ghci_repl_wrapper,
+    output = ctx.outputs.executable,
+    substitutions = {
+      # XXX I'm not 100% sure if this is necessary, I think it may be
+      # necessary for dynamic Haskell libraries to see other dynamic Haskell
+      # libraries they are linked with.
+      "{LDLIBPATH}": get_external_libs_path(
+        set.union(
+          target.dynamic_libraries,
+          target.external_libraries,
+        )
+      ),
+      "{GHCi}": get_ghci(ctx).path,
+      "{SCRIPT_LOCATION}": ctx.outputs.executable.path,
+      "{ARGS}": " ".join([shell.quote(a) for a in args]),
+    },
+    is_executable = True,
+  )
+
+  return [DefaultInfo(
+    executable = ctx.outputs.executable,
+    files = depset([
+      ctx.outputs.executable,
+      ghci_script,
+    ]),
+    # This "forces" compilation of target:
+    runfiles = ctx.runfiles(ctx.files.target),
+  )]
+
+haskell_repl = rule(
+  _haskell_repl_impl,
+  executable = True,
+  attrs = {
+    "target": attr.label(
+      mandatory = True,
+      doc = "Target that should be available in the REPL.",
+    ),
+    "interpreted": attr.bool(
+      default = True,
+      doc = """
+Whether source files of `target` should interpreted rather than compiled.
+This allows for e.g. reloading of sources on editing, but in this case we
+don't handle boot files and hsc preprocessing.
+"""
+    ),
+    "ghci_args": attr.string_list(
+      doc = "Arbitrary extra arguments to pass to GHCi.",
+    ),
+    # XXX Consider making this private. Blocked on
+    # https://github.com/bazelbuild/bazel/issues/4366.
+    "version": attr.string(
+      default = "1.0.0",
+      doc = "Library/binary version. Internal - do not use."
+    ),
+    "_ghci_script": attr.label(
+      allow_single_file = True,
+      default = Label("@io_tweag_rules_haskell//haskell:ghci-script"),
+    ),
+    "_ghci_repl_wrapper": attr.label(
+      allow_single_file = True,
+      default = Label("@io_tweag_rules_haskell//haskell:ghci-repl-wrapper.sh"),
+    ),
+  },
+  toolchains = ["@io_tweag_rules_haskell//haskell:toolchain"],
+)
+"""Produce a script that calls GHCi for working with `target`.
+
+Example of use:
+
+```
+$ bazel build //test:my-repl
+$ bazel-bin/test/my-repl
+```
+"""

--- a/haskell/ghci-script
+++ b/haskell/ghci-script
@@ -1,0 +1,2 @@
+:add {INTERPRETED_MODULES}
+:module + {VISIBLE_MODULES}

--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -30,6 +30,10 @@ load (":ghc_bindist.bzl",
   _ghc_bindist = "ghc_bindist",
 )
 
+load(":ghci-repl.bzl",
+  _haskell_repl = "haskell_repl",
+)
+
 load(":cc.bzl",
   _haskell_cc_import = "haskell_cc_import",
   _cc_haskell_import = "cc_haskell_import",
@@ -171,6 +175,9 @@ def _haskell_library_impl(ctx):
       set.from_list(ctx.attr.prebuilt_dependencies)
     ),
     external_libraries = dep_info.external_libraries,
+    import_dirs = dep_info.import_dirs,
+    exposed_modules = dep_info.exposed_modules,
+    hidden_modules = dep_info.hidden_modules,
     haddock_ghc_args = haddock_args,
   ),
   DefaultInfo(
@@ -210,6 +217,8 @@ haskell_doc = _haskell_doc
 haskell_toolchain = _haskell_toolchain
 
 ghc_bindist = _ghc_bindist
+
+haskell_repl = _haskell_repl
 
 haskell_cc_import = _haskell_cc_import
 

--- a/haskell/path_utils.bzl
+++ b/haskell/path_utils.bzl
@@ -1,6 +1,7 @@
 """Utilities for module and path manipulations."""
 
-load("@bazel_skylib//:lib.bzl", "paths")
+load(":set.bzl", "set")
+load("@bazel_skylib//:lib.bzl", "paths", "shell")
 
 def module_name(ctx, f):
   """Given Haskell source file path, turn it into a dot-separated module name.
@@ -102,6 +103,20 @@ def import_hierarchy_root(ctx):
     ctx.attr.src_strip_prefix if hasattr(ctx.attr, "src_strip_prefix")
                               else ctx.rule.attr.src_strip_prefix
   )
+
+def get_external_libs_path(libs):
+  """Return a String value for using as LD_LIBRARY_PATH or similar.
+
+  Args:
+    libs: Set of File: the libs that should be available.
+
+  Returns:
+    String: paths to the given libs separated by \":\".
+  """
+  return ":".join(set.to_list(set.map(libs, _get_external_lib_path)))
+
+def _get_external_lib_path(lib):
+  return paths.dirname(lib.path)
 
 def _rel_path_to_module(ctx, f):
   """Make given file name relative to the directory where the module hierarchy

--- a/haskell/providers.bzl
+++ b/haskell/providers.bzl
@@ -10,6 +10,9 @@ HaskellPackageInfo = provider(
     "interface_files": "Interface files belonging to the packages.",
     "prebuilt_dependencies": "Transitive collection of all wired-in Haskell dependencies.",
     "external_libraries": "Dynamic shared libraries needed for linking. List of .so files.",
+    "import_dirs": "A set of import directories (useful with GHCi for example)",
+    "exposed_modules": "A set of exposed module names.",
+    "hidden_modules": "A set of hidden module names.",
     "haddock_ghc_args": "Arguments that were used to compile the package, suitable for Haddock."
   }
 )

--- a/haskell/set.bzl
+++ b/haskell/set.bzl
@@ -10,6 +10,19 @@ def _empty():
   """
   return struct(_set_items = dict())
 
+def _singleton(e):
+  """Create a set with single element `e` inside.
+
+  Args:
+    e: The element to put in the set.
+
+  Returns:
+    set, new set.
+  """
+  r = dict()
+  r[e] = None
+  return struct(_set_items = r)
+
 def _is_member(s, e):
   """Return true if `e` is in the set `s`.
 
@@ -124,6 +137,7 @@ def _to_depset(s):
 
 set = struct(
   empty     = _empty,
+  singleton = _singleton,
   is_member = _is_member,
   insert    = _insert,
   mutable_insert = _mutable_insert,

--- a/haskell/toolchain.bzl
+++ b/haskell/toolchain.bzl
@@ -1,7 +1,7 @@
 """Rules for defining toolchains"""
 
 def _haskell_toolchain_impl(ctx):
-  for tool in ["ghc", "ghc-pkg", "hsc2hs", "haddock"]:
+  for tool in ["ghc", "ghc-pkg", "hsc2hs", "haddock", "ghci"]:
     if tool not in [t.basename for t in ctx.files.tools]:
       fail("Cannot find {} in {}".format(tool, ctx.attr.tools.label))
 

--- a/haskell/tools.bzl
+++ b/haskell/tools.bzl
@@ -1,7 +1,7 @@
 """Tools used during build."""
 
 load(":set.bzl", "set")
-load("@bazel_skylib//:lib.bzl", "paths")
+load("@bazel_skylib//:lib.bzl", "paths", "shell")
 
 def get_build_tools(ctx):
   """Get the set of all build tools we have available.
@@ -120,3 +120,8 @@ def get_haddock(ctx):
     File: haddock to use.
   """
   return _get_build_tool(ctx, "haddock")
+
+def get_ghci(ctx):
+  """Get the GHCi tool.
+  """
+  return _get_build_tool(ctx, "ghci")

--- a/haskell/utils.bzl
+++ b/haskell/utils.bzl
@@ -1,0 +1,20 @@
+"""Misc utils."""
+
+load("@bazel_skylib//:lib.bzl",
+     "paths",
+)
+
+def get_lib_name(lib):
+  """Return name of library by dropping extension and \"lib\" prefix.
+
+  Args:
+    lib: The library File.
+
+  Returns:
+    String: name of library.
+  """
+
+  base = lib.basename[3:] if lib.basename[:3] == "lib" else lib.basename
+  n = base.find(".so.")
+  end = paths.replace_extension(base, "") if n == -1 else base[:n]
+  return end

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -117,6 +117,16 @@ rule_test(
 )
 
 rule_test(
+  name = "test-haskell_repl",
+  generates = [
+    "haskell_repl",
+    "ghci-repl-script-haskell_repl-1.0.0",
+  ],
+  rule = "//tests/haskell_repl:haskell_repl",
+  size = "small",
+)
+
+rule_test(
   name = "test-haskell_test",
   generates = ["haskell_test"],
   rule = "//tests/haskell_test:haskell_test",

--- a/tests/haskell_repl/BUILD
+++ b/tests/haskell_repl/BUILD
@@ -1,0 +1,26 @@
+package(default_testonly = 1)
+
+load("@io_tweag_rules_haskell//haskell:haskell.bzl",
+     "haskell_library",
+     "haskell_repl",
+)
+
+cc_library(
+  name = "cbits",
+  srcs = ["cbits/Lib.c"],
+)
+
+haskell_library(
+  name = "hs-lib",
+  srcs = ["Foo.hs"],
+  prebuilt_dependencies = ["base", "array"],
+  deps = [":cbits"],
+  visibility = ["//visibility:public"],
+)
+
+haskell_repl(
+  name = "haskell_repl",
+  target = ":hs-lib",
+  # interpreted = False,
+  visibility = ["//visibility:public"],
+)

--- a/tests/haskell_repl/Foo.hs
+++ b/tests/haskell_repl/Foo.hs
@@ -1,0 +1,9 @@
+{-# LANGUAGE ForeignFunctionInterface #-}
+
+module Foo (foo) where
+
+foreign import ccall "add_seven"
+  c_add_seven :: Int -> Int
+
+foo :: Int -> Int
+foo = (+ 5) . c_add_seven

--- a/tests/haskell_repl/cbits/Lib.c
+++ b/tests/haskell_repl/cbits/Lib.c
@@ -1,0 +1,1 @@
+int add_seven(int x) { return x + 7; }

--- a/tests/haskell_repl/src/Bar.hs
+++ b/tests/haskell_repl/src/Bar.hs
@@ -1,0 +1,4 @@
+module Bar (bar) where
+
+bar :: Int
+bar = 4

--- a/tests/haskell_repl/src/Baz.hsc
+++ b/tests/haskell_repl/src/Baz.hsc
@@ -1,0 +1,4 @@
+module Baz (baz) where
+
+baz :: Int
+baz = 8


### PR DESCRIPTION
Close #82.

The rule allows to create a script that runs GHCi with all explicit dependencies in scope, similar to `scala_repl` from `rules_scala`.