### PR TITLE
Make ‘haskell_repl’ work with ‘haskell_binary’ targets as well

### DIFF
--- a/haskell/ghci-repl.bzl
+++ b/haskell/ghci-repl.bzl
@@ -35,10 +35,10 @@ def _haskell_repl_impl(ctx):
   args = ["-hide-all-packages"]
   for dep in set.to_list(target.prebuilt_dependencies):
     args += ["-package ", dep]
-  for name in target.names.to_list():
+  for name in set.to_list(target.names):
     if not (ctx.attr.interpreted and name == target.name):
       args += ["-package", name]
-  for cache in target.caches.to_list():
+  for cache in set.to_list(target.caches):
     args += ["-package-db", cache.dirname]
 
   # Import dirs in interpreted mode.
@@ -120,6 +120,9 @@ haskell_repl = rule(
 Whether source files of `target` should interpreted rather than compiled.
 This allows for e.g. reloading of sources on editing, but in this case we
 don't handle boot files and hsc preprocessing.
+
+Note that if you would like to use REPL with a `haskell_binary` target,
+`interpreted` must be set to `True`.
 """
     ),
     "ghci_args": attr.string_list(

--- a/haskell/haddock.bzl
+++ b/haskell/haddock.bzl
@@ -90,7 +90,7 @@ def _haskell_doc_aspect_impl(target, ctx):
 
   ctx.actions.run(
     inputs = depset(transitive = [
-      target[HaskellPackageInfo].caches,
+      set.to_depset(target[HaskellPackageInfo].caches),
       set.to_depset(target[HaskellPackageInfo].interface_files),
       set.to_depset(dep_interfaces),
       depset(input_sources),

--- a/haskell/providers.bzl
+++ b/haskell/providers.bzl
@@ -2,9 +2,9 @@ HaskellPackageInfo = provider(
   doc = "Package information exposed by Haskell libraries.",
   fields = {
     "name": "Package name, usually of the form name-version.",
-    "names": "All package names of transitive dependencies. Includes own name.",
-    "confs": "Package conf files.",
-    "caches": "Package cache files.",
+    "names": "A set of all package names of transitive dependencies. Includes own name.",
+    "confs": "A set of package conf files.",
+    "caches": "A set of package cache files.",
     "static_libraries": "Compiled library archives.",
     "dynamic_libraries": "Dynamic libraries.",
     "interface_files": "Interface files belonging to the packages.",

--- a/haskell/tools.bzl
+++ b/haskell/tools.bzl
@@ -123,5 +123,11 @@ def get_haddock(ctx):
 
 def get_ghci(ctx):
   """Get the GHCi tool.
+
+  Args:
+    ctx: Rule context.
+
+  Returns:
+    File: ghci to use.
   """
   return _get_build_tool(ctx, "ghci")

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -117,12 +117,22 @@ rule_test(
 )
 
 rule_test(
-  name = "test-haskell_repl",
+  name = "test-haskell_lib_repl",
   generates = [
-    "haskell_repl",
-    "ghci-repl-script-haskell_repl-1.0.0",
+    "haskell_lib_repl",
+    "ghci-repl-script-haskell_lib_repl-1.0.0",
   ],
-  rule = "//tests/haskell_repl:haskell_repl",
+  rule = "//tests/haskell_repl:haskell_lib_repl",
+  size = "small",
+)
+
+rule_test(
+  name = "test-haskell_bin_repl",
+  generates = [
+    "haskell_bin_repl",
+    "ghci-repl-script-haskell_bin_repl-1.0.0",
+  ],
+  rule = "//tests/haskell_repl:haskell_bin_repl",
   size = "small",
 )
 

--- a/tests/haskell_repl/BUILD
+++ b/tests/haskell_repl/BUILD
@@ -2,6 +2,7 @@ package(default_testonly = 1)
 
 load("@io_tweag_rules_haskell//haskell:haskell.bzl",
      "haskell_library",
+     "haskell_binary",
      "haskell_repl",
 )
 
@@ -19,8 +20,20 @@ haskell_library(
 )
 
 haskell_repl(
-  name = "haskell_repl",
+  name = "haskell_lib_repl",
   target = ":hs-lib",
-  # interpreted = False,
+  visibility = ["//visibility:public"],
+)
+
+haskell_binary(
+  name = "hs-bin",
+  srcs = ["Main.hs"],
+  prebuilt_dependencies = ["base"],
+  visibility = ["//visibility:public"],
+)
+
+haskell_repl(
+  name = "haskell_bin_repl",
+  target = ":hs-bin",
   visibility = ["//visibility:public"],
 )

--- a/tests/haskell_repl/Main.hs
+++ b/tests/haskell_repl/Main.hs
@@ -1,0 +1,4 @@
+module Main (main) where
+
+main :: IO ()
+main = putStrLn "Hello GHCi!"


### PR DESCRIPTION
Close #176.

Also includes a minor refactoring that switches `names`, `caches` and `confs` fields of `HaskellPackageInfo` to sets (no reason not to use sets here, I should have switched these in that earlier refactoring PR).