### PR TITLE
Test that REPL can be started on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,3 +20,9 @@ jobs:
       - run:
           name: Run tests
           command: bazel test //... --config=ci
+      - run:
+          name: Test REPL for libraries
+          command: bazel-bin/tests/haskell_repl/haskell_lib_repl -e ":quit"
+      - run:
+          name: Test REPL for binaries
+          command: bazel-bin/tests/haskell_repl/haskell_bin_repl -e ":quit"


### PR DESCRIPTION
The existing tests only test that REPLs can be built. This actually tests if they can be started without issues. Reminder: we cannot start them via `sh_test` or similar because in that case Bazel starts the scripts from a completely different directory and the scirpts cannot find `ghci`, source files, etc.