### PR TITLE
Make ‘cc_haskell_import’ work with ‘haskell_binary’ targets

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -24,7 +24,10 @@ filegroup(
 
 cc_library(
   name = "threaded-rts",
-  srcs = glob(["lib/ghc-*/rts/libHSrts_thr-ghc*.so"]),
+  srcs = glob([
+    "lib/ghc-*/rts/libHSrts_thr-ghc*.so",
+    "lib/ghc-*/rts/libffi.so.6",
+  ]),
   hdrs = glob(["lib/ghc-*/include/**/*.h"]),
   strip_include_prefix = glob(["lib/ghc-*/include"], exclude_directories=0)[0],
 )

--- a/haskell/providers.bzl
+++ b/haskell/providers.bzl
@@ -19,7 +19,7 @@ HaskellLibraryInfo = provider(
     "import_dir": "Import hierarchy root.",
     "exposed_modules": "Set of exposed module names.",
     "other_modules": "Set of non-public module names.",
-    "haddock_args": "Arguments that were used to compile the package suitable for Haddock."
+    "haddock_args": "Arguments that were used to compile the package suitable for Haddock.",
   },
 )
 
@@ -28,6 +28,7 @@ HaskellBinaryInfo = provider(
   fields = {
     "source_files": "Set of source files.",
     "modules": "Set of module names.",
+    "binary": "File, compiled binary.",
   },
 )
 


### PR DESCRIPTION
Close #179.

This PR allows to generate `.so` files from object files of executables, not just executables themselves. This way it's possible to use them with `cc_haskell_import`. Generation of `.so` version in conditional though, and disabled by default. The reasons:

* Some existing `sh_test`s run outputs of targets, and so if executable target produces more than one file they get confused. This could be avoided, if they just used `executable` from `DefaultInfo`, which always be a single file, but somehow this is not what `sh_test` does. We use our own copy of it, so we could patch it and submit the changes upstream.

* Usually such `.so` versions of binaries are not needed, so why do extra work.

The both reasons are not very strong IMO, so I'm open to alternative decisions.