### PR TITLE
Add support for running doctests

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -34,6 +34,19 @@ cc_library(
 """,
 )
 
+nixpkgs_package(
+  name = "doctest",
+  attribute_path = "haskell.packages.ghc822.doctest",
+  build_file_content = """
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+  name = "bin",
+  srcs = ["bin/doctest"],
+)
+  """
+)
+
 register_toolchains("//tests:ghc")
 
 nixpkgs_package(name = "zlib", build_file_content = """

--- a/haskell/actions.bzl
+++ b/haskell/actions.bzl
@@ -707,6 +707,9 @@ def _compilation_defaults(ctx):
         interface_files.append(
           declare_compiled(ctx, s, ".hi", directory=interfaces_dir)
         )
+        interface_files.append(
+          declare_compiled(ctx, s, ".dyn_hi", directory=interfaces_dir)
+        )
       else:
         if s.extension == "hsc":
           s0 = _process_hsc_file(ctx, ghc_defs_dump, s)
@@ -722,6 +725,9 @@ def _compilation_defaults(ctx):
         )
         interface_files.append(
           ctx.actions.declare_file(paths.join(interfaces_dir_raw, "Main.hi"))
+        )
+        interface_files.append(
+          ctx.actions.declare_file(paths.join(interfaces_dir_raw, "Main.dyn_hi"))
         )
 
   hdrs, include_args = cc_headers(ctx)

--- a/haskell/cc.bzl
+++ b/haskell/cc.bzl
@@ -135,6 +135,17 @@ def _cc_haskell_import(ctx):
     )
   ]
 
+  if HaskellBinaryInfo in ctx.attr.dep:
+    dbin = ctx.attr.dep[HaskellBinaryInfo].dynamic_bin
+    if dbin != None:
+      set.mutable_insert(dyn_libs, dbin)
+
+  return [
+    DefaultInfo(
+      files = set.to_depset(dyn_libs)
+    )
+  ]
+
 cc_haskell_import = rule(
   _cc_haskell_import,
   attrs = {

--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -31,6 +31,7 @@ load(":haddock.bzl",
 )
 load(":lint.bzl",
   _haskell_lint = "haskell_lint",
+  _haskell_doctest = "haskell_doctest",
 )
 load(":toolchain.bzl",
   _haskell_toolchain = "haskell_toolchain",
@@ -242,6 +243,8 @@ Example:
 haskell_doc = _haskell_doc
 
 haskell_lint = _haskell_lint
+
+haskell_doctest  = _haskell_doctest
 
 haskell_toolchain = _haskell_toolchain
 

--- a/haskell/lint.bzl
+++ b/haskell/lint.bzl
@@ -24,6 +24,18 @@ load(":java_interop.bzl",
 
 load(":cc.bzl", "cc_headers")
 
+def _collect_lint_logs(deps):
+  lint_logs = set.empty()
+  for dep in deps:
+    if HaskellLintInfo in dep:
+      set.mutable_union(lint_logs, dep[HaskellLintInfo].outputs)
+  return lint_logs
+
+def _haskell_lint_rule_impl(ctx):
+  return [DefaultInfo(
+    files = set.to_depset(_collect_lint_logs(ctx.attr.deps)),
+  )]
+
 def _haskell_lint_aspect_impl(target, ctx):
   if HaskellBuildInfo not in target:
     return []
@@ -114,23 +126,103 @@ haskell_lint_aspect = aspect(
   }
 )
 
-def _haskell_lint_rule_impl(ctx):
-  return [DefaultInfo(
-    files = set.to_depset(_collect_lint_logs(ctx.attr.deps)),
-  )]
-
-def _collect_lint_logs(deps):
-  lint_logs = set.empty()
-  for dep in deps:
-    if HaskellLintInfo in dep:
-      set.mutable_union(lint_logs, dep[HaskellLintInfo].outputs)
-  return lint_logs
-
 haskell_lint = rule(
   _haskell_lint_rule_impl,
   attrs = {
     "deps": attr.label_list(
       aspects = [haskell_lint_aspect],
+      doc = "List of Haskell targets to lint.",
+    ),
+  },
+  toolchains = ["@io_tweag_rules_haskell//haskell:toolchain"],
+)
+
+def _haskell_doctest_aspect_impl(target, ctx):
+  if HaskellBuildInfo not in target:
+    return []
+
+  build_info = target[HaskellBuildInfo]
+  lib_info = target[HaskellLibraryInfo] if HaskellLibraryInfo in target else None
+  bin_info = target[HaskellBinaryInfo] if HaskellBinaryInfo in target else None
+
+  args = ctx.actions.args()
+
+  args.add([
+    "--no-magic",
+    "-hide-all-packages",
+  ])
+
+  # Expose all prebuilt dependencies
+  for prebuilt_dep in set.to_list(build_info.prebuilt_dependencies):
+    args.add(["-package", prebuilt_dep])
+
+  # Expose all bazel dependencies
+  for package in set.to_list(build_info.package_names):
+    if lib_info != None or package != lib_info.package_name:
+      args.add(["-package", package])
+
+  for cache in set.to_list(build_info.package_caches):
+    args.add(["-package-db", cache.dirname])
+
+  sources = set.to_list(
+    lib_info.source_files if lib_info != None else bin_info.source_files
+  )
+
+  args.add(sources)
+
+  lint_log = ctx.actions.declare_file(
+    target_unique_name(ctx.rule, "doctest-log")
+  )
+
+  lint_logs = _collect_lint_logs(
+    ctx.rule.attr.deps
+  )
+
+  ctx.actions.run(
+    inputs = depset(transitive = [
+      depset(sources),
+      set.to_depset(build_info.package_confs),
+      set.to_depset(build_info.package_caches),
+      set.to_depset(build_info.interface_files),
+      set.to_depset(build_info.dynamic_libraries),
+      set.to_depset(build_info.external_libraries),
+      depset([
+        tools(ctx).doctest,
+        tools(ctx).tee,
+      ]),
+    ]),
+    outputs = [lint_log],
+    progress_message = "Doctesting {0}".format(ctx.rule.attr.name),
+    executable = ctx.file._ghc_lint_wrapper,
+    env = {
+      "RULES_HASKELL_GHC": tools(ctx).doctest.path,
+      "RULES_HASKELL_TEE": tools(ctx).tee.path,
+      "RULES_HASKELL_LINT_OUTPUT": lint_log.path,
+    },
+    arguments = [args],
+  )
+
+  return [HaskellLintInfo(
+    outputs = set.mutable_insert(lint_logs, lint_log)
+  )]
+
+haskell_doctest_aspect = aspect(
+  _haskell_doctest_aspect_impl,
+  attr_aspects = ["deps"],
+  toolchains = ["@io_tweag_rules_haskell//haskell:toolchain"],
+  attrs = {
+    "_ghc_lint_wrapper": attr.label(
+      allow_single_file = True,
+      default = Label("@io_tweag_rules_haskell//haskell:ghc-lint-wrapper.sh"),
+    ),
+  }
+)
+
+haskell_doctest = rule(
+  _haskell_lint_rule_impl,
+  attrs = {
+    "deps": attr.label_list(
+      aspects = [haskell_doctest_aspect],
       doc = "List of Haskell targets to lint.",
     ),
   },

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -17,6 +17,7 @@ haskell_toolchain(
   name = "ghc",
   version = "8.2.2",
   tools = "@ghc//:bin",
+  doctest = "@doctest//:bin",
 )
 
 rule_test(
@@ -153,6 +154,16 @@ rule_test(
     "lint-log-bin-1.0.0",
   ],
   rule = "//tests/haskell_lint:lint-bin",
+  size = "small",
+)
+
+rule_test(
+  name = "test-haskell_doctest",
+  generates = [
+    "doctest-log-lib-a-1.0.0",
+    "doctest-log-lib-b-1.0.0",
+  ],
+  rule = "//tests/haskell_doctest:haskell_doctest",
   size = "small",
 )
 

--- a/tests/cc_haskell_import/BUILD
+++ b/tests/cc_haskell_import/BUILD
@@ -2,6 +2,7 @@ package(default_testonly = 1)
 
 load("@io_tweag_rules_haskell//haskell:haskell.bzl",
    "haskell_library",
+   "haskell_binary",
    "cc_haskell_import",
 )
 

--- a/tests/haskell_doctest/BUILD
+++ b/tests/haskell_doctest/BUILD
@@ -1,0 +1,27 @@
+package(default_testonly = 1)
+
+load("@io_tweag_rules_haskell//haskell:haskell.bzl",
+     "haskell_library",
+     "haskell_doctest",
+)
+
+haskell_library(
+  name = "lib-a",
+  srcs = ["Foo.hs"],
+  prebuilt_dependencies = ["base"],
+  visibility = ["//visibility:public"],
+)
+
+haskell_library(
+  name = "lib-b",
+  srcs = ["Bar.hs"],
+  prebuilt_dependencies = ["base"],
+  deps = [":lib-a"],
+  visibility = ["//visibility:public"],
+)
+
+haskell_doctest(
+  name = "haskell_doctest",
+  deps = [":lib-b"],
+  visibility = ["//visibility:public"],
+)

--- a/tests/haskell_doctest/Bar.hs
+++ b/tests/haskell_doctest/Bar.hs
@@ -1,0 +1,10 @@
+module Bar (bar) where
+
+import Foo (foo)
+
+-- |
+-- >>> bar
+-- 9
+
+bar :: Int
+bar = 4 + foo :: Int

--- a/tests/haskell_doctest/Foo.hs
+++ b/tests/haskell_doctest/Foo.hs
@@ -1,0 +1,8 @@
+module Foo (foo) where
+
+-- |
+-- >>> foo
+-- 5
+
+foo :: Int
+foo = 5 :: Int


### PR DESCRIPTION
Close #194.

This PR adds `haskell_doctest` rule which allows us to run doctests. Again, we first need to merge #196 because this builds on the code developed in that PR.