### PR TITLE
Exposing bug with haskell_test and haskell_library

### DIFF
--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -88,7 +88,10 @@ def _haskell_binary_impl(ctx):
   so_symlinks = {}
 
   for lib in set.to_list(dep_info.external_libraries):
-    so_symlinks[paths.join(so_symlink_prefix, paths.basename(lib.path))] = lib
+    so_symlinks[paths.join(so_symlink_prefix, lib.basename)] = lib
+
+  for lib in set.to_list(dep_info.dynamic_libraries):
+    so_symlinks[paths.join(so_symlink_prefix, lib.basename)] = lib
 
   return [
     dep_info, # HaskellBuildInfo

--- a/tests/haskell_test/BUILD
+++ b/tests/haskell_test/BUILD
@@ -2,6 +2,7 @@ package(default_testonly = 1)
 
 load("@io_tweag_rules_haskell//haskell:haskell.bzl",
   "haskell_test",
+  "haskell_library",
 )
 
 cc_library(
@@ -9,12 +10,18 @@ cc_library(
   srcs = ["cbits.c"],
 )
 
+haskell_library(
+  name = "mylib",
+  srcs = ["Lib.hs"],
+  prebuilt_dependencies = ["base"],
+)
+
 haskell_test(
   name = "haskell_test",
   srcs = ["Test.hs"],
   main_function = "Test.test",
   prebuilt_dependencies = ["base"],
-  deps = [":cbits"],
+  deps = [":cbits", ":mylib"],
   visibility = ["//visibility:public"],
   # Use some parameters that only test rules have.
   size = "small",

--- a/tests/haskell_test/Lib.hs
+++ b/tests/haskell_test/Lib.hs
@@ -1,0 +1,4 @@
+module Lib where
+
+foo :: Int
+foo = 42


### PR DESCRIPTION
A haskell_test depending on a haskell_library would fail because the .so file cannot be found.

This PR modifies current `haskell_test` test to reproduce the issue.