### PR TITLE
Fix linting of ‘haskell_binary’ targets

### DIFF
--- a/haskell/lint.bzl
+++ b/haskell/lint.bzl
@@ -53,7 +53,7 @@ def _haskell_lint_aspect_impl(target, ctx):
 
   # Expose all bazel dependencies
   for package in set.to_list(build_info.package_names):
-    if lib_info != None or package != lib_info.package_name:
+    if lib_info == None or package != lib_info.package_name:
       args.add(["-package", package])
 
   for cache in set.to_list(build_info.package_caches):

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -137,12 +137,22 @@ rule_test(
 )
 
 rule_test(
-  name = "test-haskell_lint",
+  name = "test-haskell_lint-library",
   generates = [
     "lint-log-lib-a-1.0.0",
     "lint-log-lib-b-1.0.0",
   ],
-  rule = "//tests/haskell_lint:haskell_lint",
+  rule = "//tests/haskell_lint:lint-lib-b",
+  size = "small",
+)
+
+rule_test(
+  name = "test-haskell_lint-binary",
+  generates = [
+    "lint-log-lib-a-1.0.0",
+    "lint-log-bin-1.0.0",
+  ],
+  rule = "//tests/haskell_lint:lint-bin",
   size = "small",
 )
 

--- a/tests/haskell_lint/BUILD
+++ b/tests/haskell_lint/BUILD
@@ -1,12 +1,9 @@
 package(default_testonly = 1)
 
-# XXX This package is for manual testing. I could not find a way to
-# automatically test the fact that a rule must fail (must be not a very
-# common use case for Bazel) and that files produced by a failing rule have
-# certain contents.
-
 load("@io_tweag_rules_haskell//haskell:haskell.bzl",
      "haskell_library",
+     "haskell_binary",
+     "haskell_test",
      "haskell_lint",
 )
 
@@ -26,7 +23,21 @@ haskell_library(
 )
 
 haskell_lint(
-  name = "haskell_lint",
+  name = "lint-lib-b",
   deps = [":lib-b"],
+  visibility = ["//visibility:public"],
+)
+
+haskell_binary(
+  name = "bin",
+  srcs = ["Main.hs"],
+  prebuilt_dependencies = ["base"],
+  deps = [":lib-a"],
+  visibility = ["//visibility:public"],
+)
+
+haskell_lint(
+  name = "lint-bin",
+  deps = [":bin"],
   visibility = ["//visibility:public"],
 )

--- a/tests/haskell_lint/Main.hs
+++ b/tests/haskell_lint/Main.hs
@@ -1,0 +1,6 @@
+module Main (main) where
+
+import Foo (foo)
+
+main :: IO ()
+main = print foo


### PR DESCRIPTION
This PR fixes a bug that prevented using `haskell_lint` with `haskell_binary` and `haskell_test` targets.