### PR TITLE
start: Fix rules_haskell strip_prefix for 0.4

### DIFF
--- a/start
+++ b/start
@@ -33,7 +33,7 @@ workspace(name = "YOUR_PROJECT_NAME_HERE")
 
 http_archive(
   name = "io_tweag_rules_haskell",
-  strip_prefix = "rules_haskell-0.3",
+  strip_prefix = "rules_haskell-0.4",
   urls = ["https://github.com/tweag/rules_haskell/archive/v0.4.tar.gz"]
 )
 


### PR DESCRIPTION
`bazel build` would previously fail with

`ERROR: error loading package '': Encountered error while reading extension file 'haskell/repositories.bzl': no such package '@io_tweag_rules_haskell//haskell': Prefix rules_haskell-0.3 was given, but not found in the archive`