### PR TITLE
Add support for macOS.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -24,10 +24,18 @@ filegroup(
 
 cc_library(
   name = "threaded-rts",
-  srcs = glob([
-    "lib/ghc-*/rts/libHSrts_thr-ghc*.so",
-    "lib/ghc-*/rts/libffi.so.6",
-  ]),
+  srcs = select({
+      "@bazel_tools//src/conditions:darwin":
+          glob([
+            "lib/ghc-*/rts/libHSrts_thr-ghc*.dylib",
+            "lib/ghc-*/rts/libffi.dylib",
+          ]),
+      "//conditions:default":
+          glob([
+            "lib/ghc-*/rts/libHSrts_thr-ghc*.so",
+            "lib/ghc-*/rts/libffi.so.6",
+          ]),
+  }),
   hdrs = glob(["lib/ghc-*/include/**/*.h"]),
   strip_include_prefix = glob(["lib/ghc-*/include"], exclude_directories=0)[0],
 )
@@ -57,6 +65,7 @@ filegroup (
   srcs = glob([
     "lib/*.so",
     "lib/*.so.*",
+    "lib/*.dylib",
   ]),
   testonly = 1,
 )

--- a/haskell/BUILD
+++ b/haskell/BUILD
@@ -16,7 +16,6 @@ exports_files([
   "ghc-version-check.sh",
   "ghci-repl-wrapper.sh",
   "ghci-script",
-  "make-bin-symlink-realpath.sh",
   "make-bin-symlink-which.sh",
 
 ])

--- a/haskell/actions.bzl
+++ b/haskell/actions.bzl
@@ -345,10 +345,10 @@ def link_haskell_bin(ctx, object_files):
 
   dep_info = gather_dep_info(ctx)
 
-  # On macOS, in order to simulate "relpath" behavior and make the binary load
-  # shared libaries from relative paths, we need to postprocess it with
-  # install_name_tool.  (This is what the Bazel-provided `cc_wrapper.sh` does
-  # for cc rules.)
+  # On macOS, in order to simulate the linker "rpath" behavior and make the
+  # binary load shared libaries from relative paths, we need to postprocess it
+  # with install_name_tool.  (This is what the Bazel-provided `cc_wrapper.sh`
+  # does for cc rules.)
   # For details: https://blogs.oracle.com/dipol/entry/dynamic_libraries_rpath_and_mac
   if not is_darwin(ctx):
     compile_output = ctx.outputs.executable
@@ -827,7 +827,6 @@ def _get_library_name(ctx):
     string: Library name suitable for GHC package entry.
   """
   return "HS{0}".format(get_pkg_id(ctx))
-
 
 def gather_dep_info(ctx):
   """Collapse dependencies into a single `HaskellBuildInfo`.

--- a/haskell/ghc.BUILD
+++ b/haskell/ghc.BUILD
@@ -9,7 +9,7 @@ filegroup(
 
 cc_library(
   name = "threaded-rts",
-  srcs = glob(["lib/ghc-*/rts/libHSrts_thr-ghc*.so"]),
+  srcs = glob(["lib/ghc-*/rts/libHSrts_thr-ghc*. + ext for ext in ["so", "dylib"]]),
   hdrs = glob(["lib/ghc-*/include/**/*.h"]),
   strip_include_prefix = glob(["lib/ghc-*/include"], exclude_directories=0)[0],
 )

--- a/haskell/ghci-repl.bzl
+++ b/haskell/ghci-repl.bzl
@@ -52,7 +52,7 @@ def _haskell_repl_impl(ctx):
 
   # External libraries.
   seen_libs = set.empty()
-  for lib in set.to_list(target.external_libraries):
+  for lib in target.external_libraries.values():
     lib_name = get_lib_name(lib)
     if not set.is_member(seen_libs, lib_name):
       set.mutable_insert(seen_libs, lib_name)
@@ -109,7 +109,7 @@ def _haskell_repl_impl(ctx):
       "{LDLIBPATH}": get_external_libs_path(
         set.union(
           target.dynamic_libraries,
-          target.external_libraries,
+          set.from_list(target.external_libraries.values()),
         )
       ),
       "{GHCi}": tools(ctx).ghci.path,

--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -136,7 +136,7 @@ def _mk_binary_rule(**kwargs):
       main_file = attr.label(
         allow_single_file = FileType([".hs", ".hsc", ".lhs"]),
         doc = "File containing `Main` module.",
-      ),
+      )
     ),
     toolchains = ["@io_tweag_rules_haskell//haskell:toolchain"],
     **kwargs
@@ -222,7 +222,6 @@ haskell_library = rule(
   _haskell_library_impl,
   attrs = dict(
     _haskell_common_attrs,
-
     hidden_modules = attr.string_list(
       doc = "Modules that should be unavailable for import by dependencies."
     )),

--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -87,7 +87,7 @@ def _haskell_binary_impl(ctx):
   dep_info = gather_dep_info(ctx)
 
   solibs = set.union(
-    dep_info.external_libraries,
+    set.from_list(dep_info.external_libraries.values()),
     dep_info.dynamic_libraries,
   )
 
@@ -136,7 +136,7 @@ def _mk_binary_rule(**kwargs):
       main_file = attr.label(
         allow_single_file = FileType([".hs", ".hsc", ".lhs"]),
         doc = "File containing `Main` module.",
-      )
+      ),
     ),
     toolchains = ["@io_tweag_rules_haskell//haskell:toolchain"],
     **kwargs
@@ -222,6 +222,7 @@ haskell_library = rule(
   _haskell_library_impl,
   attrs = dict(
     _haskell_common_attrs,
+
     hidden_modules = attr.string_list(
       doc = "Modules that should be unavailable for import by dependencies."
     )),

--- a/haskell/lint.bzl
+++ b/haskell/lint.bzl
@@ -92,7 +92,7 @@ def _haskell_lint_aspect_impl(target, ctx):
       set.to_depset(build_info.package_caches),
       set.to_depset(build_info.interface_files),
       set.to_depset(build_info.dynamic_libraries),
-      set.to_depset(build_info.external_libraries),
+      depset(build_info.external_libraries.values()),
       depset([
         tools(ctx).ghc,
         tools(ctx).gcc,
@@ -197,7 +197,7 @@ def _haskell_doctest_aspect_impl(target, ctx):
       set.to_depset(build_info.package_caches),
       set.to_depset(build_info.interface_files),
       set.to_depset(build_info.dynamic_libraries),
-      set.to_depset(build_info.external_libraries),
+      depset(build_info.external_libraries.values()),
       depset([
         tools(ctx).doctest,
         tools(ctx).tee,

--- a/haskell/make-bin-symlink-realpath.sh
+++ b/haskell/make-bin-symlink-realpath.sh
@@ -1,8 +1,0 @@
-#!/bin/sh
-#
-# Usage: make-bin-symlink-realpath.sh <TARGET> <SYMLINK>
-
-set -e # fail if any invocation below fails
-
-mkdir -p $(dirname "$2")
-ln -s $(realpath "$1") "$2"

--- a/haskell/tools.bzl
+++ b/haskell/tools.bzl
@@ -38,3 +38,25 @@ def tools(ctx):
     struct with Files inside.
   """
   return ctx.toolchains["@io_tweag_rules_haskell//haskell:toolchain"].tools
+
+def is_darwin(ctx):
+  """Returns whether the current build is using macOS.
+
+  Args:
+    ctx: Rule context.
+
+  Returns:
+    Boolean which is true when we're building on macOS.
+  """
+  return ctx.toolchains["@io_tweag_rules_haskell//haskell:toolchain"].is_darwin
+
+def so_extension(ctx):
+  """Returns the extension for shared libraries.
+
+  Args:
+    ctx: Rule context.
+
+  Returns:
+    string of extension.
+  """
+  return "dylib" if is_darwin(ctx) else "so"

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -203,10 +203,15 @@ rule_test(
 
 rule_test(
   name = "test-cc_haskell_import-output",
-  generates = [
-    "libHShs-lib-a-1.0.0-ghc8.2.2.so",
-    "libHShs-lib-b-1.0.0-ghc8.2.2.so",
-  ],
+  generates = select({
+      "@bazel_tools//src/conditions:darwin":
+          [ "libHShs-lib-a-1.0.0-ghc8.2.2.dylib",
+          "libHShs-lib-b-1.0.0-ghc8.2.2.dylib",
+        ],
+      "//conditions:default":
+          [ "libHShs-lib-a-1.0.0-ghc8.2.2.so",
+          "libHShs-lib-b-1.0.0-ghc8.2.2.so",
+        ]}),
   rule = "//tests/cc_haskell_import:hs-lib-b-so",
   size = "small",
 )

--- a/tests/cc_haskell_import/LibA.hs
+++ b/tests/cc_haskell_import/LibA.hs
@@ -1,4 +1,6 @@
 module LibA (add_one) where
 
-add_one :: Int -> Int
+import Data.Int (Int32)
+
+add_one :: Int32 -> Int32
 add_one x = x + 1

--- a/tests/cc_haskell_import/LibB.hs
+++ b/tests/cc_haskell_import/LibB.hs
@@ -1,9 +1,9 @@
 module LibB (add_one_hs) where
 
 import LibA (add_one)
-import Foreign.C.Types (CInt(..))
+import Data.Int (Int32)
 
-foreign export ccall add_one_hs :: Int -> IO Int
+foreign export ccall add_one_hs :: Int32 -> IO Int32
 
-add_one_hs :: Int -> IO Int
+add_one_hs :: Int32 -> IO Int32
 add_one_hs x = pure $! add_one x + 0

--- a/tests/cc_haskell_import/main.c
+++ b/tests/cc_haskell_import/main.c
@@ -1,7 +1,7 @@
 #include <stdio.h>
 #include "HsFFI.h"
 
-extern HsInt add_one_hs(HsInt a0);
+extern HsInt32 add_one_hs(HsInt32 a0);
 
 int main(int argc, char *argv[]) {
   hs_init(&argc, &argv);


### PR DESCRIPTION
This resolves #165, except that it statically links Haskell dependencies
on macOS (versus dynamically on Linux).  Since everything else seemed
to be working, I figured that was easier to do as a follow-up.

Summary of changes:
- Removed the Linux-specific toolchain constraint.  Not sure if that's the best
  approach; I'm not as familiar with toolchains.
- Don't use `realpath` in the toolchain definition since it's not available
  by default on macOS.
- macOS shared libraries have the externsion "dylib" rather than "so".
- The `cc_haskell_import` test assumed that `Int`/`HsInt` was 32-bit, via use of
  `printf("...%d...")`.  I changed the test to use `Int32` explicitly.
- Some of the binary dependencies (e.g.: ar, gcc) are wrapper scripts
  generated by `bazel` (`ar_wrapper.sh`, `cc_wrapper.sh`) and provided
  via `//tools/defaults:crosstool`.  Additionally,
  `ar_wrapper.sh` depends on another crosstool script, `xcwrapper.sh`.