### PR TITLE
Pin nixpkgs used in WORKSPACE

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -9,10 +9,19 @@ http_archive(
   urls = ["https://github.com/tweag/rules_nixpkgs/archive/v0.2.tar.gz"],
 )
 
-load("@io_tweag_rules_nixpkgs//nixpkgs:nixpkgs.bzl", "nixpkgs_package")
+load("@io_tweag_rules_nixpkgs//nixpkgs:nixpkgs.bzl",
+  "nixpkgs_git_repository",
+  "nixpkgs_package",
+)
+
+nixpkgs_git_repository(
+  name = "nixpkgs",
+  revision = "18.03",
+)
 
 nixpkgs_package(
   name = "ghc",
+  repository = "@nixpkgs",
   attribute_path = "haskell.compiler.ghc822",
   build_file_content = """
 package(default_visibility = ["//visibility:public"])
@@ -36,6 +45,7 @@ cc_library(
 
 nixpkgs_package(
   name = "doctest",
+  repository = "@nixpkgs",
   attribute_path = "haskell.packages.ghc822.doctest",
   build_file_content = """
 package(default_visibility = ["//visibility:public"])
@@ -49,7 +59,10 @@ filegroup(
 
 register_toolchains("//tests:ghc")
 
-nixpkgs_package(name = "zlib", build_file_content = """
+nixpkgs_package(
+  name = "zlib",
+  repository = "@nixpkgs",
+  build_file_content = """
 package(default_visibility = ["//visibility:public"])
 
 filegroup (
@@ -63,7 +76,10 @@ filegroup (
 """,
 )
 
-nixpkgs_package(name = "zlib.dev", build_file_content = """
+nixpkgs_package(
+  name = "zlib.dev",
+  repository = "@nixpkgs",
+  build_file_content = """
 package(default_visibility = ["//visibility:public"])
 
 filegroup (


### PR DESCRIPTION
Previously, we were using whatever nixpkgs was available in the
`NIX_PATH`. Now we use a specific version identified by a Git tag.

Tested with

```
$ NIX_PATH= bazel build //...
```