### PR TITLE
Suppress "normal" build output from ghc et al.

### DIFF
--- a/haskell/actions.bzl
+++ b/haskell/actions.bzl
@@ -588,6 +588,7 @@ def create_ghc_package(ctx, interfaces_dir, static_library, dynamic_library, exp
     executable = tools(ctx).ghc_pkg,
     arguments = [
       "register", "--package-db={0}".format(pkg_db_dir.path),
+      "-v0",
       "--no-expand-pkgroot",
       registration_file.path
     ]
@@ -626,12 +627,14 @@ def _compilation_defaults(ctx):
 
   # Common flags
   args.add([
+    "-v0",
     "-c",
     "--make",
     "-fPIC",
     "-hide-all-packages",
   ])
   haddock_args.add(["-hide-all-packages"], before_each="--optghc")
+  haddock_args.add(["-v0"])
 
   args.add([
     "-odir", objects_dir,

--- a/haskell/lint.bzl
+++ b/haskell/lint.bzl
@@ -48,6 +48,7 @@ def _haskell_lint_aspect_impl(target, ctx):
 
   args.add([
     "-O0",
+    "-v0",
     "-fno-code",
     "-Wall",
     "-Werror",


### PR DESCRIPTION
Passes `-v0` so that only warnings and errors are emitted, not normal status
messages.

Previously the rules were fairly noisy; for example:
```
INFO: From Compiling lib [for host]:
[1 of 1] Compiling Lib              ( tests/binary-with-lib/src/Lib.hs,
bazel-out/host/bin/tests/binary-with-lib/objects-lib-1.0.0/Lib.o )
INFO: From Building binary-custom-main:
[1 of 1] Compiling Main             ( tests/binary-custom-main/foo.hs,
bazel-out/darwin-fastbuild/bin/tests/binary-custom-main/objects-binary-custom-main-1.0.0/Main.o
)
INFO: From Compiling hs-lib:
[1 of 1] Compiling Foo              ( tests/haskell_repl/Foo.hs,
bazel-out/darwin-fastbuild/bin/tests/haskell_repl/objects-hs-lib-1.0.0/Foo.o )
```

This follows the behavior of other build rules (e.g., C++, Java, rust) which
don't emit any output for a successful build.

See also the "General Advice" section from the Bazel docs:
https://docs.bazel.build/versions/master/be/general.html#general-advice
> Do not write informational messages to stdout or stderr. While useful for
> debugging, this can easily become noise; a successful genrule should be
> silent. On the other hand, a failing genrule should emit good error messages.