### PR TITLE
Add -Wnoncanonical-monad-instances to default warning set.

### DIFF
--- a/haskell/lint.bzl
+++ b/haskell/lint.bzl
@@ -56,6 +56,7 @@ def _haskell_lint_aspect_impl(target, ctx):
     "-Wincomplete-record-updates",
     "-Wincomplete-uni-patterns",
     "-Wredundant-constraints",
+    "-Wnoncanonical-monad-instances",
     "--make",
     "-hide-all-packages",
   ])


### PR DESCRIPTION
It's not part of -Wcompat apparently.

See
https://www.reddit.com/r/haskell/comments/8dtnax/code_quality_tools/dxq1kc4/
and https://www.reddit.com/r/haskell/comments/84p1wk/without_performance_tests_we_will_have_a_bad_time/dvrbtyl/.