### PR TITLE
Suppress a Clang warning on macOS during linking.

### DIFF
--- a/haskell/actions.bzl
+++ b/haskell/actions.bzl
@@ -406,7 +406,15 @@ def link_haskell_bin(ctx, object_files):
     dep_info.dynamic_libraries,
   )
 
-  if not is_darwin(ctx):
+  if is_darwin(ctx):
+    # Suppress a warning that Clang prints due to GHC automatically passing
+    # "-pie" or "-no-pie" to the C compiler.
+    # This particular invocation of GHC is a little unusual; e.g., we're
+    # passing an empty archive so that GHC has some input files to work on
+    # during linking.
+    args.add(["-optc-Wno-unused-command-line-argument",
+              "-optl-Wno-unused-command-line-argument"])
+  else:
     for rpath in set.to_list(_infer_rpaths(ctx.outputs.executable, solibs)):
       args.add(["-optl-Wl,-rpath," + rpath])
 


### PR DESCRIPTION
Example previous output:
```
$ bazel build tests/binary-with-link-flags
INFO: Analysed target //tests/binary-with-link-flags:binary-with-link-flags (2
packages loaded).
INFO: Found 1 target...
INFO: From Linking binary-with-link-flags:
clang-5.0: warning: argument unused during compilation: '-nopie'
[-Wunused-command-line-argument]
clang-5.0: warning: argument unused during compilation: '-nopie'
[-Wunused-command-line-argument]
Target //tests/binary-with-link-flags:binary-with-link-flags up-to-date:
  bazel-bin/tests/binary-with-link-flags/binary-with-link-flags
```
(Passing `-pie` to GHC causes it to complain about *that* flag being unused;
you can't win either way.)