### PR TITLE
Fix TemplateHaskell linking against cc_library targets on macOS.

### DIFF
--- a/tests/library-deps/TestLib.hs
+++ b/tests/library-deps/TestLib.hs
@@ -4,3 +4,6 @@ import TestSubLib (messageEnd)
 
 testMessage :: String
 testMessage = "hello " ++ messageEnd
+
+-- Force dynamic linking
+{-# ANN testMessage () #-}

--- a/tests/library-deps/sublib/BUILD
+++ b/tests/library-deps/sublib/BUILD
@@ -10,4 +10,10 @@ haskell_library(
   srcs = ["TestSubLib.hs"],
   prebuilt_dependencies = ["base"],
   visibility = ["//visibility:public"],
+  deps = [":sublib-c"],
+)
+
+cc_library(
+  name = "sublib-c",
+  srcs = ["sublib-c.c"],
 )

--- a/tests/library-deps/sublib/TestSubLib.hs
+++ b/tests/library-deps/sublib/TestSubLib.hs
@@ -1,4 +1,7 @@
+{-# LANGUAGE ForeignFunctionInterface #-}
 module TestSubLib (messageEnd) where
 
 messageEnd :: String
-messageEnd = "world"
+messageEnd = "world " ++ show (foo 10)
+
+foreign import ccall foo :: Int -> Int

--- a/tests/library-deps/sublib/sublib-c.c
+++ b/tests/library-deps/sublib/sublib-c.c
@@ -1,0 +1,3 @@
+int foo(int x) {
+  return x * 2;
+}


### PR DESCRIPTION
As with the binary, we need to use `install_name_tool` to correct
linker paths so they're relative to the file that references them.

Modifies a test to add a `cc_library` dependency.  Previously all
the tests only depended on Nix-supplied C libraries, which have
absolute paths and thus weren't triggering this bug.