### PR TITLE
Fix another macOS linking issue.

### DIFF
--- a/tests/library-deps/BUILD
+++ b/tests/library-deps/BUILD
@@ -3,6 +3,7 @@ package(default_testonly = 1)
 load(
   "@io_tweag_rules_haskell//haskell:haskell.bzl",
   "haskell_library",
+  "haskell_test",
 )
 
 haskell_library(
@@ -11,4 +12,13 @@ haskell_library(
   deps = ["//tests/library-deps/sublib"],
   prebuilt_dependencies = ["base"],
   visibility = ["//visibility:public"],
+)
+
+haskell_test(
+    name = "bin-deps",
+    srcs = ["Bin.hs"],
+    main_file = "Bin.hs",
+    deps = ["//tests/library-deps/sublib"],
+    prebuilt_dependencies = ["base"],
+    visibility = ["//visibility:public"],
 )

--- a/tests/library-deps/Bin.hs
+++ b/tests/library-deps/Bin.hs
@@ -1,0 +1,6 @@
+module Main (main) where
+
+import TestSubLib (messageEnd)
+
+main :: IO ()
+main = putStrLn $ messageEnd


### PR DESCRIPTION
Previously, a `haskell_test` that dependend transitively on a C library would fail to
run:

```
$ bazel test //tests/library-deps:bin-deps

Abort trap: 6
dyld: Library not loaded:
@executable_path/libtests_Slibrary-deps_Ssublib_Ssublib-c_libsublib-c.so
  Referenced from:
  /private/var/tmp/_bazel_judah.jacobson/82cbe265677c431f236ecc47b43dfa0d/bazel-sandbox/2543326136945263834/execroot/io_tweag_rules_haskell/bazel-out/darwin-fastbuild/bin/tests/library-deps/bin-deps.runfiles/io_tweag_rules_haskell/tests/library-deps/bin-deps
    Reason: image not found
```

Fixed by making the executable linking logic use the same approach as for
Haskell dynamic libraries.  (And splitting the common logic into a helper
function.)

The cause was that the original macOS executable linking logic pointed to the
`solib` symlinks, which are not made available at runtime.  Now, both
executables and libraries point directly at the original solib.