### PR TITLE
Take Bazel package names into account when generating GHC package names

### DIFF
--- a/haskell/actions.bzl
+++ b/haskell/actions.bzl
@@ -846,7 +846,7 @@ def _compilation_defaults(ctx):
     ),
   )
 
-def _zero_escape(s):
+def _zencode(s):
   """Zero-escape a given string.
 
   Args:
@@ -855,7 +855,7 @@ def _zero_escape(s):
   Returns:
     string: zero-escaped string.
   """
-  return s.replace("0", "00").replace("_", "0U").replace("/", "0S")
+  return s.replace("Z", "ZZ").replace("_", "ZU").replace("/", "ZS")
 
 def get_pkg_name(ctx):
   """Get package name. Package name includes Bazel package and name of the
@@ -868,10 +868,11 @@ def get_pkg_name(ctx):
   Returns:
     string: GHC package name to use.
   """
-  return "{0}0R{1}0D{2}".format(
-    _zero_escape(ctx.label.workspace_root),
-    _zero_escape(ctx.label.package),
-    ctx.attr.name,
+  return _zencode("%s/%s/%s" %
+                  [ctx.label.workspace_root,
+                   ctx.label.package,
+                   ctx.attr.name,
+                  ]
   )
 
 def get_pkg_id(ctx):

--- a/haskell/actions.bzl
+++ b/haskell/actions.bzl
@@ -868,12 +868,11 @@ def get_pkg_name(ctx):
   Returns:
     string: GHC package name to use.
   """
-  return _zencode("%s/%s/%s" %
-                  [ctx.label.workspace_root,
-                   ctx.label.package,
-                   ctx.attr.name,
-                  ]
-  )
+  return _zencode("/".join([i for i in [
+    ctx.label.workspace_root,
+    ctx.label.package,
+    ctx.attr.name,
+  ] if i != ""]))
 
 def get_pkg_id(ctx):
   """Get package identifier of the form `name-version`.

--- a/haskell/actions.bzl
+++ b/haskell/actions.bzl
@@ -624,7 +624,7 @@ def create_ghc_package(ctx, interfaces_dir, static_library, dynamic_library, exp
   # Create a file from which ghc-pkg will create the actual package from.
   registration_file = ctx.actions.declare_file(target_unique_name(ctx, "registration-file"))
   registration_file_entries = {
-    "name": ctx.attr.name,
+    "name": get_pkg_name(ctx),
     "version": ctx.attr.version,
     "id": get_pkg_id(ctx),
     "key": get_pkg_id(ctx),
@@ -846,8 +846,36 @@ def _compilation_defaults(ctx):
     ),
   )
 
+def _zero_escape(s):
+  """Zero-escape a given string.
+
+  Args:
+    s: inputs string.
+
+  Returns:
+    string: zero-escaped string.
+  """
+  return s.replace("0", "00").replace("_", "0U").replace("/", "0S")
+
+def get_pkg_name(ctx):
+  """Get package name. Package name includes Bazel package and name of the
+  component. We can't use just the latter because then two components with
+  the same names in different packages would clash.
+
+  Args:
+    ctx: Rule context
+
+  Returns:
+    string: GHC package name to use.
+  """
+  return "{0}0R{1}0D{2}".format(
+    _zero_escape(ctx.label.workspace_root),
+    _zero_escape(ctx.label.package),
+    ctx.attr.name,
+  )
+
 def get_pkg_id(ctx):
-  """Get package identifier. This is name-version.
+  """Get package identifier of the form `name-version`.
 
   Args:
     ctx: Rule context
@@ -855,7 +883,10 @@ def get_pkg_id(ctx):
   Returns:
     string: GHC package ID to use.
   """
-  return "{0}-{1}".format(ctx.attr.name, ctx.attr.version)
+  return "{0}-{1}".format(
+    get_pkg_name(ctx),
+    ctx.attr.version,
+  )
 
 def _get_library_name(ctx):
   """Get core library name for this package. This is "HS" followed by package ID.

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -73,8 +73,8 @@ sh_test(
 rule_test(
   name = "test-library-deps",
   generates =
-    ["library-deps-1.0.0/library-deps-1.0.0.conf",
-     "library-deps-1.0.0/package.cache",
+    ["0Rtests0Slibrary-deps0Dlibrary-deps-1.0.0/0Rtests0Slibrary-deps0Dlibrary-deps-1.0.0.conf",
+     "0Rtests0Slibrary-deps0Dlibrary-deps-1.0.0/package.cache",
     ],
   rule = "//tests/library-deps",
   size = "small",
@@ -83,8 +83,8 @@ rule_test(
 rule_test(
   name = "test-library-with-sysdeps",
   generates =
-    ["library-with-sysdeps-1.0.0/library-with-sysdeps-1.0.0.conf",
-     "library-with-sysdeps-1.0.0/package.cache",
+    ["0Rtests0Slibrary-with-sysdeps0Dlibrary-with-sysdeps-1.0.0/0Rtests0Slibrary-with-sysdeps0Dlibrary-with-sysdeps-1.0.0.conf",
+     "0Rtests0Slibrary-with-sysdeps0Dlibrary-with-sysdeps-1.0.0/package.cache",
     ],
   rule = "//tests/library-with-sysdeps",
   size = "small",
@@ -100,18 +100,18 @@ rule_test(
 rule_test(
   name = "test-haddock",
   generates = [
-    "doc-haddock-lib-b-1.0.0",
-    "doc-haddock-lib-b-1.0.0/LibB.html",
-    "doc-haddock-lib-b-1.0.0/doc-index.html",
-    "doc-haddock-lib-b-1.0.0/haddock-lib-b-1.0.0.haddock",
-    "doc-haddock-lib-b-1.0.0/haddock-lib-b.txt",
-    "doc-haddock-lib-b-1.0.0/haddock-util.js",
-    "doc-haddock-lib-b-1.0.0/hslogo-16.png",
-    "doc-haddock-lib-b-1.0.0/index.html",
-    "doc-haddock-lib-b-1.0.0/minus.gif",
-    "doc-haddock-lib-b-1.0.0/ocean.css",
-    "doc-haddock-lib-b-1.0.0/plus.gif",
-    "doc-haddock-lib-b-1.0.0/synopsis.png",
+    "doc-0Rtests0Shaddock0Dhaddock-lib-b-1.0.0",
+    "doc-0Rtests0Shaddock0Dhaddock-lib-b-1.0.0/LibB.html",
+    "doc-0Rtests0Shaddock0Dhaddock-lib-b-1.0.0/doc-index.html",
+    "doc-0Rtests0Shaddock0Dhaddock-lib-b-1.0.0/0Rtests0Shaddock0Dhaddock-lib-b-1.0.0.haddock",
+    "doc-0Rtests0Shaddock0Dhaddock-lib-b-1.0.0/0Rtests0Shaddock0Dhaddock-lib-b-1.0.0.txt",
+    "doc-0Rtests0Shaddock0Dhaddock-lib-b-1.0.0/haddock-util.js",
+    "doc-0Rtests0Shaddock0Dhaddock-lib-b-1.0.0/hslogo-16.png",
+    "doc-0Rtests0Shaddock0Dhaddock-lib-b-1.0.0/index.html",
+    "doc-0Rtests0Shaddock0Dhaddock-lib-b-1.0.0/minus.gif",
+    "doc-0Rtests0Shaddock0Dhaddock-lib-b-1.0.0/ocean.css",
+    "doc-0Rtests0Shaddock0Dhaddock-lib-b-1.0.0/plus.gif",
+    "doc-0Rtests0Shaddock0Dhaddock-lib-b-1.0.0/synopsis.png",
     ],
   rule = "//tests/haddock",
   size = "small",
@@ -177,8 +177,8 @@ rule_test(
 rule_test(
   name = "test-hidden-modules",
   generates = [
-    "lib-c-1.0.0/lib-c-1.0.0.conf",
-    "lib-c-1.0.0/package.cache"
+    "0Rtests0Shidden-modules0Dlib-c-1.0.0/0Rtests0Shidden-modules0Dlib-c-1.0.0.conf",
+    "0Rtests0Shidden-modules0Dlib-c-1.0.0/package.cache"
   ],
   rule = "//tests/hidden-modules:lib-c",
   size = "small",
@@ -187,10 +187,20 @@ rule_test(
 rule_test(
   name = "test-library-with-sysincludes",
   generates =
-    ["library-with-sysincludes-1.0.0/library-with-sysincludes-1.0.0.conf",
-     "library-with-sysincludes-1.0.0/package.cache",
+    ["0Rtests0Slibrary-with-sysincludes0Dlibrary-with-sysincludes-1.0.0/0Rtests0Slibrary-with-sysincludes0Dlibrary-with-sysincludes-1.0.0.conf",
+     "0Rtests0Slibrary-with-sysincludes0Dlibrary-with-sysincludes-1.0.0/package.cache",
     ],
   rule = "//tests/library-with-sysincludes",
+  size = "small",
+)
+
+rule_test(
+  name = "test-package-id-clash",
+  generates =
+    ["0Rtests0Spackage-id-clash0Dlib-1.0.0/0Rtests0Spackage-id-clash0Dlib-1.0.0.conf",
+     "0Rtests0Spackage-id-clash0Dlib-1.0.0/package.cache",
+    ],
+  rule = "//tests/package-id-clash:lib",
   size = "small",
 )
 
@@ -205,13 +215,13 @@ rule_test(
   name = "test-cc_haskell_import-output",
   generates = select({
       "@bazel_tools//src/conditions:darwin":
-          [ "libHShs-lib-a-1.0.0-ghc8.2.2.dylib",
-          "libHShs-lib-b-1.0.0-ghc8.2.2.dylib",
-        ],
+          ["libHS0Rtests0Scc0Uhaskell0Uimport0Dhs-lib-a-1.0.0-ghc8.2.2.dylib",
+           "libHS0Rtests0Scc0Uhaskell0Uimport0Dhs-lib-b-1.0.0-ghc8.2.2.dylib",
+          ],
       "//conditions:default":
-          [ "libHShs-lib-a-1.0.0-ghc8.2.2.so",
-          "libHShs-lib-b-1.0.0-ghc8.2.2.so",
-        ]}),
+          ["libHS0Rtests0Scc0Uhaskell0Uimport0Dhs-lib-a-1.0.0-ghc8.2.2.so",
+           "libHS0Rtests0Scc0Uhaskell0Uimport0Dhs-lib-b-1.0.0-ghc8.2.2.so",
+          ]}),
   rule = "//tests/cc_haskell_import:hs-lib-b-so",
   size = "small",
 )

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -73,8 +73,8 @@ sh_test(
 rule_test(
   name = "test-library-deps",
   generates =
-    ["0Rtests0Slibrary-deps0Dlibrary-deps-1.0.0/0Rtests0Slibrary-deps0Dlibrary-deps-1.0.0.conf",
-     "0Rtests0Slibrary-deps0Dlibrary-deps-1.0.0/package.cache",
+    ["ZStestsZSlibrary-depsZSlibrary-deps-1.0.0/ZStestsZSlibrary-depsZSlibrary-deps-1.0.0.conf",
+     "ZStestsZSlibrary-depsZSlibrary-deps-1.0.0/package.cache",
     ],
   rule = "//tests/library-deps",
   size = "small",
@@ -83,8 +83,8 @@ rule_test(
 rule_test(
   name = "test-library-with-sysdeps",
   generates =
-    ["0Rtests0Slibrary-with-sysdeps0Dlibrary-with-sysdeps-1.0.0/0Rtests0Slibrary-with-sysdeps0Dlibrary-with-sysdeps-1.0.0.conf",
-     "0Rtests0Slibrary-with-sysdeps0Dlibrary-with-sysdeps-1.0.0/package.cache",
+    ["ZStestsZSlibrary-with-sysdepsZSlibrary-with-sysdeps-1.0.0/ZStestsZSlibrary-with-sysdepsZSlibrary-with-sysdeps-1.0.0.conf",
+     "ZStestsZSlibrary-with-sysdepsZSlibrary-with-sysdeps-1.0.0/package.cache",
     ],
   rule = "//tests/library-with-sysdeps",
   size = "small",
@@ -100,18 +100,18 @@ rule_test(
 rule_test(
   name = "test-haddock",
   generates = [
-    "doc-0Rtests0Shaddock0Dhaddock-lib-b-1.0.0",
-    "doc-0Rtests0Shaddock0Dhaddock-lib-b-1.0.0/LibB.html",
-    "doc-0Rtests0Shaddock0Dhaddock-lib-b-1.0.0/doc-index.html",
-    "doc-0Rtests0Shaddock0Dhaddock-lib-b-1.0.0/0Rtests0Shaddock0Dhaddock-lib-b-1.0.0.haddock",
-    "doc-0Rtests0Shaddock0Dhaddock-lib-b-1.0.0/0Rtests0Shaddock0Dhaddock-lib-b-1.0.0.txt",
-    "doc-0Rtests0Shaddock0Dhaddock-lib-b-1.0.0/haddock-util.js",
-    "doc-0Rtests0Shaddock0Dhaddock-lib-b-1.0.0/hslogo-16.png",
-    "doc-0Rtests0Shaddock0Dhaddock-lib-b-1.0.0/index.html",
-    "doc-0Rtests0Shaddock0Dhaddock-lib-b-1.0.0/minus.gif",
-    "doc-0Rtests0Shaddock0Dhaddock-lib-b-1.0.0/ocean.css",
-    "doc-0Rtests0Shaddock0Dhaddock-lib-b-1.0.0/plus.gif",
-    "doc-0Rtests0Shaddock0Dhaddock-lib-b-1.0.0/synopsis.png",
+    "doc-ZStestsZShaddockZShaddock-lib-b-1.0.0",
+    "doc-ZStestsZShaddockZShaddock-lib-b-1.0.0/LibB.html",
+    "doc-ZStestsZShaddockZShaddock-lib-b-1.0.0/doc-index.html",
+    "doc-ZStestsZShaddockZShaddock-lib-b-1.0.0/ZStestsZShaddockZShaddock-lib-b-1.0.0.haddock",
+    "doc-ZStestsZShaddockZShaddock-lib-b-1.0.0/ZStestsZShaddockZShaddock-lib-b-1.0.0.txt",
+    "doc-ZStestsZShaddockZShaddock-lib-b-1.0.0/haddock-util.js",
+    "doc-ZStestsZShaddockZShaddock-lib-b-1.0.0/hslogo-16.png",
+    "doc-ZStestsZShaddockZShaddock-lib-b-1.0.0/index.html",
+    "doc-ZStestsZShaddockZShaddock-lib-b-1.0.0/minus.gif",
+    "doc-ZStestsZShaddockZShaddock-lib-b-1.0.0/ocean.css",
+    "doc-ZStestsZShaddockZShaddock-lib-b-1.0.0/plus.gif",
+    "doc-ZStestsZShaddockZShaddock-lib-b-1.0.0/synopsis.png",
     ],
   rule = "//tests/haddock",
   size = "small",
@@ -177,8 +177,8 @@ rule_test(
 rule_test(
   name = "test-hidden-modules",
   generates = [
-    "0Rtests0Shidden-modules0Dlib-c-1.0.0/0Rtests0Shidden-modules0Dlib-c-1.0.0.conf",
-    "0Rtests0Shidden-modules0Dlib-c-1.0.0/package.cache"
+    "ZStestsZShidden-modulesZSlib-c-1.0.0/ZStestsZShidden-modulesZSlib-c-1.0.0.conf",
+    "ZStestsZShidden-modulesZSlib-c-1.0.0/package.cache"
   ],
   rule = "//tests/hidden-modules:lib-c",
   size = "small",
@@ -187,8 +187,8 @@ rule_test(
 rule_test(
   name = "test-library-with-sysincludes",
   generates =
-    ["0Rtests0Slibrary-with-sysincludes0Dlibrary-with-sysincludes-1.0.0/0Rtests0Slibrary-with-sysincludes0Dlibrary-with-sysincludes-1.0.0.conf",
-     "0Rtests0Slibrary-with-sysincludes0Dlibrary-with-sysincludes-1.0.0/package.cache",
+    ["ZStestsZSlibrary-with-sysincludesZSlibrary-with-sysincludes-1.0.0/ZStestsZSlibrary-with-sysincludesZSlibrary-with-sysincludes-1.0.0.conf",
+     "ZStestsZSlibrary-with-sysincludesZSlibrary-with-sysincludes-1.0.0/package.cache",
     ],
   rule = "//tests/library-with-sysincludes",
   size = "small",
@@ -197,8 +197,8 @@ rule_test(
 rule_test(
   name = "test-package-id-clash",
   generates =
-    ["0Rtests0Spackage-id-clash0Dlib-1.0.0/0Rtests0Spackage-id-clash0Dlib-1.0.0.conf",
-     "0Rtests0Spackage-id-clash0Dlib-1.0.0/package.cache",
+    ["ZStestsZSpackage-id-clashZSlib-1.0.0/ZStestsZSpackage-id-clashZSlib-1.0.0.conf",
+     "ZStestsZSpackage-id-clashZSlib-1.0.0/package.cache",
     ],
   rule = "//tests/package-id-clash:lib",
   size = "small",
@@ -215,12 +215,12 @@ rule_test(
   name = "test-cc_haskell_import-output",
   generates = select({
       "@bazel_tools//src/conditions:darwin":
-          ["libHS0Rtests0Scc0Uhaskell0Uimport0Dhs-lib-a-1.0.0-ghc8.2.2.dylib",
-           "libHS0Rtests0Scc0Uhaskell0Uimport0Dhs-lib-b-1.0.0-ghc8.2.2.dylib",
+          ["libHSZStestsZSccZUhaskellZUimportZShs-lib-a-1.0.0-ghc8.2.2.dylib",
+           "libHSZStestsZSccZUhaskellZUimportZShs-lib-b-1.0.0-ghc8.2.2.dylib",
           ],
       "//conditions:default":
-          ["libHS0Rtests0Scc0Uhaskell0Uimport0Dhs-lib-a-1.0.0-ghc8.2.2.so",
-           "libHS0Rtests0Scc0Uhaskell0Uimport0Dhs-lib-b-1.0.0-ghc8.2.2.so",
+          ["libHSZStestsZSccZUhaskellZUimportZShs-lib-a-1.0.0-ghc8.2.2.so",
+           "libHSZStestsZSccZUhaskellZUimportZShs-lib-b-1.0.0-ghc8.2.2.so",
           ]}),
   rule = "//tests/cc_haskell_import:hs-lib-b-so",
   size = "small",

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -73,8 +73,8 @@ sh_test(
 rule_test(
   name = "test-library-deps",
   generates =
-    ["ZStestsZSlibrary-depsZSlibrary-deps-1.0.0/ZStestsZSlibrary-depsZSlibrary-deps-1.0.0.conf",
-     "ZStestsZSlibrary-depsZSlibrary-deps-1.0.0/package.cache",
+    ["testsZSlibrary-depsZSlibrary-deps-1.0.0/testsZSlibrary-depsZSlibrary-deps-1.0.0.conf",
+     "testsZSlibrary-depsZSlibrary-deps-1.0.0/package.cache",
     ],
   rule = "//tests/library-deps",
   size = "small",
@@ -83,8 +83,8 @@ rule_test(
 rule_test(
   name = "test-library-with-sysdeps",
   generates =
-    ["ZStestsZSlibrary-with-sysdepsZSlibrary-with-sysdeps-1.0.0/ZStestsZSlibrary-with-sysdepsZSlibrary-with-sysdeps-1.0.0.conf",
-     "ZStestsZSlibrary-with-sysdepsZSlibrary-with-sysdeps-1.0.0/package.cache",
+    ["testsZSlibrary-with-sysdepsZSlibrary-with-sysdeps-1.0.0/testsZSlibrary-with-sysdepsZSlibrary-with-sysdeps-1.0.0.conf",
+     "testsZSlibrary-with-sysdepsZSlibrary-with-sysdeps-1.0.0/package.cache",
     ],
   rule = "//tests/library-with-sysdeps",
   size = "small",
@@ -100,18 +100,18 @@ rule_test(
 rule_test(
   name = "test-haddock",
   generates = [
-    "doc-ZStestsZShaddockZShaddock-lib-b-1.0.0",
-    "doc-ZStestsZShaddockZShaddock-lib-b-1.0.0/LibB.html",
-    "doc-ZStestsZShaddockZShaddock-lib-b-1.0.0/doc-index.html",
-    "doc-ZStestsZShaddockZShaddock-lib-b-1.0.0/ZStestsZShaddockZShaddock-lib-b-1.0.0.haddock",
-    "doc-ZStestsZShaddockZShaddock-lib-b-1.0.0/ZStestsZShaddockZShaddock-lib-b-1.0.0.txt",
-    "doc-ZStestsZShaddockZShaddock-lib-b-1.0.0/haddock-util.js",
-    "doc-ZStestsZShaddockZShaddock-lib-b-1.0.0/hslogo-16.png",
-    "doc-ZStestsZShaddockZShaddock-lib-b-1.0.0/index.html",
-    "doc-ZStestsZShaddockZShaddock-lib-b-1.0.0/minus.gif",
-    "doc-ZStestsZShaddockZShaddock-lib-b-1.0.0/ocean.css",
-    "doc-ZStestsZShaddockZShaddock-lib-b-1.0.0/plus.gif",
-    "doc-ZStestsZShaddockZShaddock-lib-b-1.0.0/synopsis.png",
+    "doc-testsZShaddockZShaddock-lib-b-1.0.0",
+    "doc-testsZShaddockZShaddock-lib-b-1.0.0/LibB.html",
+    "doc-testsZShaddockZShaddock-lib-b-1.0.0/doc-index.html",
+    "doc-testsZShaddockZShaddock-lib-b-1.0.0/testsZShaddockZShaddock-lib-b-1.0.0.haddock",
+    "doc-testsZShaddockZShaddock-lib-b-1.0.0/testsZShaddockZShaddock-lib-b-1.0.0.txt",
+    "doc-testsZShaddockZShaddock-lib-b-1.0.0/haddock-util.js",
+    "doc-testsZShaddockZShaddock-lib-b-1.0.0/hslogo-16.png",
+    "doc-testsZShaddockZShaddock-lib-b-1.0.0/index.html",
+    "doc-testsZShaddockZShaddock-lib-b-1.0.0/minus.gif",
+    "doc-testsZShaddockZShaddock-lib-b-1.0.0/ocean.css",
+    "doc-testsZShaddockZShaddock-lib-b-1.0.0/plus.gif",
+    "doc-testsZShaddockZShaddock-lib-b-1.0.0/synopsis.png",
     ],
   rule = "//tests/haddock",
   size = "small",
@@ -177,8 +177,8 @@ rule_test(
 rule_test(
   name = "test-hidden-modules",
   generates = [
-    "ZStestsZShidden-modulesZSlib-c-1.0.0/ZStestsZShidden-modulesZSlib-c-1.0.0.conf",
-    "ZStestsZShidden-modulesZSlib-c-1.0.0/package.cache"
+    "testsZShidden-modulesZSlib-c-1.0.0/testsZShidden-modulesZSlib-c-1.0.0.conf",
+    "testsZShidden-modulesZSlib-c-1.0.0/package.cache"
   ],
   rule = "//tests/hidden-modules:lib-c",
   size = "small",
@@ -187,8 +187,8 @@ rule_test(
 rule_test(
   name = "test-library-with-sysincludes",
   generates =
-    ["ZStestsZSlibrary-with-sysincludesZSlibrary-with-sysincludes-1.0.0/ZStestsZSlibrary-with-sysincludesZSlibrary-with-sysincludes-1.0.0.conf",
-     "ZStestsZSlibrary-with-sysincludesZSlibrary-with-sysincludes-1.0.0/package.cache",
+    ["testsZSlibrary-with-sysincludesZSlibrary-with-sysincludes-1.0.0/testsZSlibrary-with-sysincludesZSlibrary-with-sysincludes-1.0.0.conf",
+     "testsZSlibrary-with-sysincludesZSlibrary-with-sysincludes-1.0.0/package.cache",
     ],
   rule = "//tests/library-with-sysincludes",
   size = "small",
@@ -197,8 +197,8 @@ rule_test(
 rule_test(
   name = "test-package-id-clash",
   generates =
-    ["ZStestsZSpackage-id-clashZSlib-1.0.0/ZStestsZSpackage-id-clashZSlib-1.0.0.conf",
-     "ZStestsZSpackage-id-clashZSlib-1.0.0/package.cache",
+    ["testsZSpackage-id-clashZSlib-1.0.0/testsZSpackage-id-clashZSlib-1.0.0.conf",
+     "testsZSpackage-id-clashZSlib-1.0.0/package.cache",
     ],
   rule = "//tests/package-id-clash:lib",
   size = "small",
@@ -215,12 +215,12 @@ rule_test(
   name = "test-cc_haskell_import-output",
   generates = select({
       "@bazel_tools//src/conditions:darwin":
-          ["libHSZStestsZSccZUhaskellZUimportZShs-lib-a-1.0.0-ghc8.2.2.dylib",
-           "libHSZStestsZSccZUhaskellZUimportZShs-lib-b-1.0.0-ghc8.2.2.dylib",
+          ["libHStestsZSccZUhaskellZUimportZShs-lib-a-1.0.0-ghc8.2.2.dylib",
+           "libHStestsZSccZUhaskellZUimportZShs-lib-b-1.0.0-ghc8.2.2.dylib",
           ],
       "//conditions:default":
-          ["libHSZStestsZSccZUhaskellZUimportZShs-lib-a-1.0.0-ghc8.2.2.so",
-           "libHSZStestsZSccZUhaskellZUimportZShs-lib-b-1.0.0-ghc8.2.2.so",
+          ["libHStestsZSccZUhaskellZUimportZShs-lib-a-1.0.0-ghc8.2.2.so",
+           "libHStestsZSccZUhaskellZUimportZShs-lib-b-1.0.0-ghc8.2.2.so",
           ]}),
   rule = "//tests/cc_haskell_import:hs-lib-b-so",
   size = "small",

--- a/tests/generated-modules/BUILD
+++ b/tests/generated-modules/BUILD
@@ -45,5 +45,5 @@ haskell_test(
     src_strip_prefix = "src",
     prebuilt_dependencies = ["base"],
     deps = [":GenModule", ":BinModule"],
+    size = "small",
 )
-

--- a/tests/package-id-clash/BUILD
+++ b/tests/package-id-clash/BUILD
@@ -1,0 +1,24 @@
+package(default_testonly = 1)
+
+load(
+  "@io_tweag_rules_haskell//haskell:haskell.bzl",
+  "haskell_library",
+)
+
+haskell_library(
+  name = "sublib",
+  srcs = ["Foo.hs"],
+  prebuilt_dependencies = ["base"],
+  visibility = ["//visibility:public"],
+)
+
+haskell_library(
+  name = "lib",
+  srcs = ["Baz.hs"],
+  deps = [
+    ":sublib",
+    "//tests/package-id-clash/sublib:sublib",
+  ],
+  prebuilt_dependencies = ["base"],
+  visibility = ["//visibility:public"],
+)

--- a/tests/package-id-clash/Baz.hs
+++ b/tests/package-id-clash/Baz.hs
@@ -1,0 +1,7 @@
+module Baz (baz) where
+
+import Foo (foo)
+import Bar (bar)
+
+baz :: Int
+baz = foo + bar

--- a/tests/package-id-clash/Foo.hs
+++ b/tests/package-id-clash/Foo.hs
@@ -1,0 +1,4 @@
+module Foo (foo) where
+
+foo :: Int
+foo = 5

--- a/tests/package-id-clash/sublib/BUILD
+++ b/tests/package-id-clash/sublib/BUILD
@@ -1,0 +1,13 @@
+package(default_testonly = 1)
+
+load(
+  "@io_tweag_rules_haskell//haskell:haskell.bzl",
+  "haskell_library",
+)
+
+haskell_library(
+  name = "sublib",
+  srcs = ["Bar.hs"],
+  prebuilt_dependencies = ["base"],
+  visibility = ["//visibility:public"],
+)

--- a/tests/package-id-clash/sublib/Bar.hs
+++ b/tests/package-id-clash/sublib/Bar.hs
@@ -1,0 +1,4 @@
+module Bar (bar) where
+
+bar :: Int
+bar = 6


### PR DESCRIPTION
Close #219.

In short, there are many possible approaches to do encoding. The key, it seems, is to take a rare character and use it as escape character remembering to escape the escape character itself to achieve injectivity. With @mboes We discussed several possibilities and I implemented an encoding scheme where escaping character is zero `0`.

So we use `0R` to separate workspace root from (Bazel) package name and `0D` to separate package name from target name. In addition to that we escape zero `0` as `00`, underscore `_` as `0U` and slash `/` as `0S`. This should work.

We also discussed using dash, perhaps something symmetric like `-U-`, but then two underscores in a row would result in an invalid package name, because GHC does not like underscores or more than one dash in a row.

@mboes also proposed to prefix all digits with `0` because this is less-surprising (i.e. we escape 0, and so we should escape all digits for consistency).

@judah What do you think?