### PR TITLE
Fix build breakage on macOS when XCode is not installed.

### DIFF
--- a/haskell/toolchain.bzl
+++ b/haskell/toolchain.bzl
@@ -74,8 +74,9 @@ def _haskell_toolchain_impl(ctx):
 
   # If running on darwin but XCode is not installed (i.e., only the Command
   # Line Tools are available), then Bazel will make ar_executable point to
-  # "/usr/bin/libtool".  Since we call ar directly, override it.
+  # "/usr/bin/libtool". Since we call ar directly, override it.
   # TODO: remove this if Bazel fixes its behavior.
+  # Upstream ticket: https://github.com/bazelbuild/bazel/issues/5127.
   if targets_r["ar"].find("libtool") >= 0:
     targets_r["ar"] = "/usr/bin/ar"
 

--- a/haskell/toolchain.bzl
+++ b/haskell/toolchain.bzl
@@ -76,7 +76,7 @@ def _haskell_toolchain_impl(ctx):
   # Line Tools are available), then Bazel will make ar_executable point to
   # "/usr/bin/libtool".  Since we call ar directly, override it.
   # TODO: remove this if Bazel fixes its behavior.
-  if targets_r["ar"].find("libtool"):
+  if targets_r["ar"].find("libtool") >= 0:
     targets_r["ar"] = "/usr/bin/ar"
 
   ar_runfiles = []

--- a/haskell/toolchain.bzl
+++ b/haskell/toolchain.bzl
@@ -72,6 +72,13 @@ def _haskell_toolchain_impl(ctx):
       "strip": ctx.host_fragments.cpp.strip_executable,
   } + ghc_binaries
 
+  # If running on darwin but XCode is not installed (i.e., only the Command
+  # Line Tools are available), then Bazel will make ar_executable point to
+  # "/usr/bin/libtool".  Since we call ar directly, override it.
+  # TODO: remove this if Bazel fixes its behavior.
+  if targets_r["ar"].find("libtool"):
+    targets_r["ar"] = "/usr/bin/ar"
+
   ar_runfiles = []
 
   # "xcrunwrapper.sh" is a Bazel-generated dependency of the `ar` program on macOS.


### PR DESCRIPTION
If the macOS "command-line developer tools" are installed, but XCode
is not, then Bazel will make `ar_executable` point to `/usr/bin/libtool`
(despite the fact that `ar` and `libtool` are not invoked the same way).
https://github.com/bazelbuild/bazel/blob/71932dd4e25d5e755cb8ce12f4dece438c4b5cb1/tools/cpp/unix_cc_configure.bzl#L101

Fix it by checking for that case and overriding it to point to `/usr/bin/ar`
(which is a path also hard-coded in the above code).  This is not ideal, but I don't
know a good way around it.

Note that `rules_rust` has done a similar workaround:
https://github.com/bazelbuild/rules_rust/blob/df95c3e3cd5afd87a69fa71dc9a56a0d0baa7823/rust/toolchain.bzl#L18

Filed an upstream bug: https://github.com/bazelbuild/bazel/issues/5127