### PR TITLE
Expose and fix a bug with missing .so libraries when running Haddock

### DIFF
--- a/haskell/haddock.bzl
+++ b/haskell/haddock.bzl
@@ -100,6 +100,7 @@ def _haskell_doc_aspect_impl(target, ctx):
     inputs = depset(transitive = [
       set.to_depset(target[HaskellBuildInfo].package_caches),
       set.to_depset(target[HaskellBuildInfo].interface_files),
+      set.to_depset(target[HaskellBuildInfo].dynamic_libraries),
       set.to_depset(dep_interfaces),
       depset(input_sources),
     ]),

--- a/tests/haddock/BUILD
+++ b/tests/haddock/BUILD
@@ -19,7 +19,7 @@ haskell_library(
   name = "haddock-lib-a",
   srcs = ["LibA.hs", "LibA/A.hs"],
   deps = [":haddock-lib-deep"],
-  prebuilt_dependencies = ["base"],
+  prebuilt_dependencies = ["base", "template-haskell"],
 )
 
 haskell_library(

--- a/tests/haddock/Deep.hs
+++ b/tests/haddock/Deep.hs
@@ -2,5 +2,5 @@
 module Deep (deep_lib) where
 
 -- | 'deep_lib' doc.
-deep_lib :: ()
-deep_lib = ()
+deep_lib :: Int
+deep_lib = 100

--- a/tests/haddock/LibA.hs
+++ b/tests/haddock/LibA.hs
@@ -1,4 +1,6 @@
 -- | "Lib" header
+{-# LANGUAGE TemplateHaskell #-}
+
 module LibA where
 
 import LibA.A (a)
@@ -10,5 +12,5 @@ data A =
   A
 
 -- | Doc for 'f' using 'a' and 'deep_lib'.
-f :: ()
-f = const a deep_lib
+f :: Int
+f = const $a deep_lib

--- a/tests/haddock/LibA/A.hs
+++ b/tests/haddock/LibA/A.hs
@@ -1,6 +1,10 @@
 -- | "Lib.A" header
+{-# LANGUAGE TemplateHaskell #-}
+
 module LibA.A where
 
+import Language.Haskell.TH
+
 -- | 'a' doc
-a :: ()
-a = ()
+a :: Q Exp
+a = [| 5 |]

--- a/tests/haddock/LibB.hs
+++ b/tests/haddock/LibB.hs
@@ -5,5 +5,5 @@ import LibA.A (a)
 import LibA (f)
 
 -- | Doc for 'x' using 'f' and 'a' and 'Int'.
-x :: ()
+x :: Int
 x = const f a


### PR DESCRIPTION
@gdeest reported this when he was trying to use `haskell_doc` rule with numero. I don't know what caused this with numero, but my idea is that TH may be the culprit and I was indeed able to reproduce it this way in our test suite.