### PR TITLE
Make Haddock link to docs of prebuilt dependencies

### DIFF
--- a/haskell/BUILD
+++ b/haskell/BUILD
@@ -16,6 +16,7 @@ exports_files([
   "ghc-version-check.sh",
   "ghci-repl-wrapper.sh",
   "ghci-script",
+  "haddock-wrapper.sh",
   "make-bin-symlink-which.sh",
 
 ])

--- a/haskell/haddock-wrapper.sh
+++ b/haskell/haddock-wrapper.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+#
+# Usage: haddock-wrapper.sh <HADDOCK_ARGS>
+#
+# Environment variables:
+#   * RULES_HASKELL_GHC_PKG -- location of ghc-pkg
+#   * RULES_HASKELL_HADDOCK -- location of haddock
+#   * RULES_HASKELL_PREBUILT_DEPS -- pre-built dependencies
+
+set -o pipefail
+
+extra_args=()
+
+for pkg in $RULES_HASKELL_PREBUILT_DEPS
+do
+    haddock_interfaces=$($RULES_HASKELL_GHC_PKG --simple-output field $pkg haddock-interfaces)
+    haddock_html=$($RULES_HASKELL_GHC_PKG --simple-output field $pkg haddock-html)
+    extra_args+=("--read-interface=$haddock_html,$haddock_interfaces")
+done
+
+"$RULES_HASKELL_HADDOCK" "${extra_args[@]}" "$@"

--- a/haskell/haddock.bzl
+++ b/haskell/haddock.bzl
@@ -103,14 +103,25 @@ def _haskell_doc_aspect_impl(target, ctx):
       set.to_depset(target[HaskellBuildInfo].dynamic_libraries),
       set.to_depset(dep_interfaces),
       depset(input_sources),
+      depset([
+        tools(ctx).ghc_pkg,
+        tools(ctx).haddock,
+      ]),
     ]),
     outputs = self_outputs,
     progress_message = "Haddock {0}".format(ctx.rule.attr.name),
-    executable = tools(ctx).haddock,
+    executable = ctx.file._haddock_wrapper,
     arguments = [
       args,
       target[HaskellLibraryInfo].haddock_args,
     ],
+    env = {
+      "RULES_HASKELL_GHC_PKG": tools(ctx).ghc_pkg.path,
+      "RULES_HASKELL_HADDOCK": tools(ctx).haddock.path,
+      "RULES_HASKELL_PREBUILT_DEPS": " ".join(
+        set.to_list(target[HaskellBuildInfo].prebuilt_dependencies)
+      ),
+    },
   )
 
   return [HaddockInfo(
@@ -121,6 +132,12 @@ def _haskell_doc_aspect_impl(target, ctx):
 
 haskell_doc_aspect = aspect(
   _haskell_doc_aspect_impl,
+  attrs = {
+    "_haddock_wrapper": attr.label(
+      allow_single_file = True,
+      default = Label("@io_tweag_rules_haskell//haskell:haddock-wrapper.sh"),
+    ),
+  },
   attr_aspects = ['deps'],
   toolchains = ["@io_tweag_rules_haskell//haskell:toolchain"],
 )


### PR DESCRIPTION
Close #52, close #230.

This makes the `haskell_doc` rule actually produce haddock with links to pre-built packages such as `base`.