### PR TITLE
Implement protobuf integration using proto-lens

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -5,8 +5,8 @@ haskell_repositories()
 
 http_archive(
   name = "io_tweag_rules_nixpkgs",
-  strip_prefix = "rules_nixpkgs-0.2",
-  urls = ["https://github.com/tweag/rules_nixpkgs/archive/v0.2.tar.gz"],
+  strip_prefix = "rules_nixpkgs-0.2.2",
+  urls = ["https://github.com/tweag/rules_nixpkgs/archive/v0.2.2.tar.gz"],
 )
 
 load("@io_tweag_rules_nixpkgs//nixpkgs:nixpkgs.bzl",
@@ -16,13 +16,16 @@ load("@io_tweag_rules_nixpkgs//nixpkgs:nixpkgs.bzl",
 
 nixpkgs_git_repository(
   name = "nixpkgs",
-  revision = "18.03",
+  # To make protobuf support work we need packages such as
+  # lens-labels_0_2_0_0 to be available in nixpkgs. This means we need to
+  # use a version of nixpkgs that is newer than 18.03.
+  revision = "7c3dc2f53fc837be79426f11c9133f73d15a05c4",
 )
 
 nixpkgs_package(
   name = "ghc",
   repository = "@nixpkgs",
-  attribute_path = "haskell.compiler.ghc822",
+  nix_file = "//tests:ghc.nix",
   build_file_content = """
 package(default_visibility = ["//visibility:public"])
 
@@ -51,6 +54,19 @@ cc_library(
 """,
 )
 
+http_archive(
+  name = "com_google_protobuf",
+  sha256 = "cef7f1b5a7c5fba672bec2a319246e8feba471f04dcebfe362d55930ee7c1c30",
+  strip_prefix = "protobuf-3.5.0",
+  urls = ["https://github.com/google/protobuf/archive/v3.5.0.zip"],
+)
+
+nixpkgs_package(
+  name = "protoc_gen_haskell",
+  repository = "@nixpkgs",
+  nix_file = "//tests:protoc_gen_haskell.nix",
+)
+
 nixpkgs_package(
   name = "doctest",
   repository = "@nixpkgs",
@@ -65,7 +81,10 @@ filegroup(
   """
 )
 
-register_toolchains("//tests:ghc")
+register_toolchains(
+  "//tests:ghc",
+  "//tests:protobuf-toolchain",
+)
 
 nixpkgs_package(
   name = "zlib",

--- a/docs/BUILD
+++ b/docs/BUILD
@@ -15,6 +15,7 @@ skylark_doc(
     "//haskell:lint.bzl",
     "//haskell:ghci-repl.bzl",
     "//haskell:toolchain.bzl",
+    "//haskell:protobuf.bzl",
     "//haskell:cc.bzl",
     "//haskell:repositories.bzl",
     "//haskell:ghc_bindist.bzl",

--- a/haskell/BUILD
+++ b/haskell/BUILD
@@ -3,6 +3,7 @@ package(default_visibility = ["//visibility:public"])
 exports_files([
 
   "haskell.bzl",
+  "protobuf.bzl",
   "repositories.bzl",
   "cc.bzl",
   "haddock.bzl",

--- a/haskell/actions.bzl
+++ b/haskell/actions.bzl
@@ -562,7 +562,7 @@ def link_dynamic_lib(ctx, object_files):
   for package in set.to_list(
       set.union(
         dep_info.package_names,
-        set.from_list(ctx.attr.prebuilt_dependencies)
+        set.from_list(ctx.attr.prebuilt_dependencies),
       )):
     args.add(["-package", package])
 
@@ -636,7 +636,8 @@ def create_ghc_package(ctx, interfaces_dir, static_library, dynamic_library, exp
     "dynamic-library-dirs": "${pkgroot}",
     "hs-libraries": _get_library_name(ctx),
     "depends":
-      ", ".join([ d[HaskellLibraryInfo].package_name for d in ctx.attr.deps if HaskellLibraryInfo in d])
+      ", ".join([ d[HaskellLibraryInfo].package_name for d in
+                  ctx.attr.deps if HaskellLibraryInfo in d])
   }
   ctx.actions.write(
     output=registration_file,
@@ -672,7 +673,6 @@ def _compilation_defaults(ctx):
 
   Args:
     ctx: Rule context.
-    for_binary: We're compiling a binary target.
 
   Returns:
     _DefaultCompileInfo: Populated default compilation settings.
@@ -721,10 +721,10 @@ def _compilation_defaults(ctx):
   # to be in the same directory as the corresponding .hs file.  Thus
   # the two must both have the same root; i.e., both plain files,
   # both in bin_dir, or both in genfiles_dir.
-  root = import_hierarchy_root(ctx)
-  ih_root_arg = ["-i{0}".format(root),
-                 "-i{0}".format(paths.join(ctx.bin_dir.path, root)),
-                 "-i{0}".format(paths.join(ctx.genfiles_dir.path, root))]
+  import_root = import_hierarchy_root(ctx)
+  ih_root_arg = ["-i{0}".format(import_root),
+                 "-i{0}".format(paths.join(ctx.bin_dir.path, import_root)),
+                 "-i{0}".format(paths.join(ctx.genfiles_dir.path, import_root))]
   args.add(ih_root_arg)
   haddock_args.add(ih_root_arg, before_each="--optghc")
 
@@ -758,7 +758,7 @@ def _compilation_defaults(ctx):
   other_sources = []
   modules = set.empty()
   source_files = set.empty()
-  import_dirs = set.singleton(import_hierarchy_root(ctx))
+  import_dirs = set.singleton(import_root)
 
   # Output object files are named after modules, not after input file names.
   # The difference is only visible in the case of Main module because it may
@@ -968,6 +968,7 @@ def gather_dep_info(ctx):
             # files come from haskell_cc_import.
             _mangle_solib(ctx, dep.label, f, CcSkylarkApiProviderHacked in dep)
             for f in dep.files.to_list() if _is_shared_library(f)}
+
           ),
       )
 

--- a/haskell/haskell-impl.bzl
+++ b/haskell/haskell-impl.bzl
@@ -1,0 +1,192 @@
+"""Implementation of core Haskell rules"""
+
+load(":actions.bzl",
+  "compile_haskell_bin",
+  "link_haskell_bin",
+  "compile_haskell_lib",
+  "link_static_lib",
+  "link_dynamic_lib",
+  "create_ghc_package",
+  "gather_dep_info",
+  "get_pkg_id",
+)
+load(":set.bzl",
+  "set",
+)
+load(":providers.bzl",
+  "HaskellBuildInfo",
+  "HaskellBinaryInfo",
+  "HaskellLibraryInfo",
+)
+load(":ghci-repl.bzl",
+  _build_haskell_repl = "build_haskell_repl",
+)
+
+def haskell_binary_impl(ctx):
+  c = compile_haskell_bin(ctx)
+
+  binary = link_haskell_bin(ctx, c.object_dyn_files)
+  dep_info = gather_dep_info(ctx)
+
+  solibs = set.union(
+    set.from_list(dep_info.external_libraries.values()),
+    dep_info.dynamic_libraries,
+  )
+
+  build_info = dep_info # HaskellBuildInfo
+  bin_info = HaskellBinaryInfo(
+    source_files = c.source_files,
+    modules = c.modules,
+    binary = binary,
+  )
+  target_files = depset([binary])
+
+  _build_haskell_repl(
+    ctx,
+    build_info=build_info,
+    target_files=target_files,
+    bin_info=bin_info,
+  )
+
+  return [
+    build_info,
+    bin_info,
+    DefaultInfo(
+      executable = binary,
+      files = target_files,
+      runfiles = ctx.runfiles(
+        files = set.to_list(solibs),
+        collect_data = True,
+      ),
+    ),
+  ]
+
+def haskell_library_impl(ctx):
+
+  c = compile_haskell_lib(ctx)
+
+  static_library = link_static_lib(ctx, c.object_files)
+  dynamic_library = link_dynamic_lib(ctx, c.object_dyn_files)
+
+  dep_info = gather_dep_info(ctx)
+
+  exposed_modules = set.empty()
+  other_modules = set.from_list(ctx.attr.hidden_modules)
+
+  for module in set.to_list(c.modules):
+    if not set.is_member(other_modules, module):
+      set.mutable_insert(exposed_modules, module)
+
+  conf_file, cache_file = create_ghc_package(
+    ctx,
+    c.interfaces_dir,
+    static_library,
+    dynamic_library,
+    exposed_modules,
+    other_modules,
+  )
+
+  build_info = HaskellBuildInfo(
+    package_names = set.insert(dep_info.package_names, get_pkg_id(ctx)),
+    package_confs = set.insert(dep_info.package_confs, conf_file),
+    package_caches = set.insert(dep_info.package_caches, cache_file),
+    # NOTE We have to use lists for static libraries because the order is
+    # important for linker. Linker searches for unresolved symbols to the
+    # left, i.e. you first feed a library which has unresolved symbols and
+    # then you feed the library which resolves the symbols.
+    static_libraries = [static_library] + dep_info.static_libraries,
+    dynamic_libraries = set.insert(dep_info.dynamic_libraries, dynamic_library),
+    interface_files = set.union(dep_info.interface_files, set.from_list(c.interface_files)),
+    prebuilt_dependencies = dep_info.prebuilt_dependencies,
+    external_libraries = dep_info.external_libraries,
+  )
+  lib_info = HaskellLibraryInfo(
+    package_name = get_pkg_id(ctx),
+    import_dirs = c.import_dirs,
+    exposed_modules = exposed_modules,
+    other_modules = other_modules,
+    haddock_args = c.haddock_args,
+    source_files = c.source_files,
+  )
+  target_files = depset([conf_file, cache_file])
+
+  if hasattr(ctx, "outputs"):
+    _build_haskell_repl(
+      ctx,
+      build_info=build_info,
+      target_files=target_files,
+      lib_info=lib_info,
+    )
+
+  default_info = None
+
+  if hasattr(ctx, "runfiles"):
+    default_info = DefaultInfo(
+      files = target_files,
+      runfiles = ctx.runfiles(collect_data = True),
+    )
+  else:
+    default_info = DefaultInfo(
+      files = target_files,
+    )
+
+  return [
+    build_info,
+    lib_info,
+    default_info,
+  ]
+
+haskell_common_attrs = {
+  "src_strip_prefix": attr.string(
+    doc = "Directory in which module hierarchy starts.",
+  ),
+  "srcs": attr.label_list(
+    allow_files = FileType([".hs", ".hsc", ".lhs", ".hs-boot", ".lhs-boot", ".h"]),
+    doc = "Haskell source files.",
+  ),
+  "deps": attr.label_list(
+    doc = "List of other Haskell libraries to be linked to this target.",
+  ),
+  "data": attr.label_list(
+    doc = "See [Bazel documentation](https://docs.bazel.build/versions/master/be/common-definitions.html#common.data).",
+    allow_files = True,
+    cfg = "data",
+  ),
+  "compiler_flags": attr.string_list(
+    doc = "Flags to pass to Haskell compiler.",
+  ),
+  "prebuilt_dependencies": attr.string_list(
+    doc = "Non-Bazel supplied Cabal dependencies.",
+  ),
+  "repl_interpreted": attr.bool(
+    default=True,
+    doc = """
+Whether source files should be interpreted rather than compiled. This allows
+for e.g. reloading of sources on editing, but in this case we don't handle
+boot files and hsc processing.
+
+For `haskell_binary` targets, `repl_interpreted` must be set to `True` for
+REPL to work.
+"""),
+  "repl_ghci_args": attr.string_list(
+    doc = "Arbitrary extra arguments to pass to GHCi.",
+  ),
+  # XXX Consider making this private. Blocked on
+  # https://github.com/bazelbuild/bazel/issues/4366.
+  "version": attr.string(
+    default = "1.0.0",
+    doc = "Library/binary version. Internal - do not use."
+  ),
+  "_ghc_defs_cleanup": attr.label(
+    allow_single_file = True,
+    default = Label("@io_tweag_rules_haskell//haskell:ghc-defs-cleanup.sh"),
+  ),
+  "_ghci_script": attr.label(
+    allow_single_file = True,
+    default = Label("@io_tweag_rules_haskell//haskell:ghci-script"),
+  ),
+  "_ghci_repl_wrapper": attr.label(
+    allow_single_file = True,
+    default = Label("@io_tweag_rules_haskell//haskell:ghci-repl-wrapper.sh"),
+  ),
+}

--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -4,6 +4,7 @@ load(":providers.bzl",
   "HaskellBuildInfo",
   "HaskellLibraryInfo",
   "HaskellBinaryInfo",
+  "HaskellProtobufInfo",
   "CcSkylarkApiProviderHacked",
 )
 
@@ -20,15 +21,17 @@ load(":actions.bzl",
 
 load(":set.bzl", "set")
 load("@bazel_skylib//:lib.bzl", "paths")
-
-load(":path_utils.bzl",
-     "import_hierarchy_root",
-)
-load(":ghci-repl.bzl",
-  _build_haskell_repl = "build_haskell_repl",
+load(":haskell-impl.bzl",
+  _haskell_binary_impl = "haskell_binary_impl",
+  _haskell_library_impl = "haskell_library_impl",
+  _haskell_common_attrs = "haskell_common_attrs",
 )
 
 # For re-exports:
+load(":protobuf.bzl",
+  _haskell_proto_library = "haskell_proto_library",
+  _haskell_proto_toolchain = "haskell_proto_toolchain",
+)
 load(":haddock.bzl",
   _haskell_doc = "haskell_doc",
 )
@@ -46,100 +49,6 @@ load(":cc.bzl",
   _haskell_cc_import = "haskell_cc_import",
   _cc_haskell_import = "cc_haskell_import",
 )
-
-_haskell_common_attrs = {
-  "src_strip_prefix": attr.string(
-    doc = "Directory in which module hierarchy starts.",
-  ),
-  "srcs": attr.label_list(
-    allow_files = FileType([".hs", ".hsc", ".lhs", ".hs-boot", ".lhs-boot", ".h"]),
-    doc = "Haskell source files.",
-  ),
-  "deps": attr.label_list(
-    doc = "List of other Haskell libraries to be linked to this target.",
-  ),
-  "data": attr.label_list(
-    doc = "See [Bazel documentation](https://docs.bazel.build/versions/master/be/common-definitions.html#common.data).",
-    allow_files = True,
-    cfg = "data",
-  ),
-  "compiler_flags": attr.string_list(
-    doc = "Flags to pass to Haskell compiler.",
-  ),
-  "prebuilt_dependencies": attr.string_list(
-    doc = "Non-Bazel supplied Cabal dependencies.",
-  ),
-  "repl_interpreted": attr.bool(
-    default=True,
-    doc = """
-Whether source files should be interpreted rather than compiled. This allows
-for e.g. reloading of sources on editing, but in this case we don't handle
-boot files and hsc processing.
-
-For `haskell_binary` targets, `repl_interpreted` must be set to `True` for
-REPL to work.
-"""),
-  "repl_ghci_args": attr.string_list(
-    doc = "Arbitrary extra arguments to pass to GHCi.",
-  ),
-  # XXX Consider making this private. Blocked on
-  # https://github.com/bazelbuild/bazel/issues/4366.
-  "version": attr.string(
-    default = "1.0.0",
-    doc = "Library/binary version. Internal - do not use."
-  ),
-  "_ghc_defs_cleanup": attr.label(
-    allow_single_file = True,
-    default = Label("@io_tweag_rules_haskell//haskell:ghc-defs-cleanup.sh"),
-  ),
-  "_ghci_script": attr.label(
-    allow_single_file = True,
-    default = Label("@io_tweag_rules_haskell//haskell:ghci-script"),
-  ),
-  "_ghci_repl_wrapper": attr.label(
-    allow_single_file = True,
-    default = Label("@io_tweag_rules_haskell//haskell:ghci-repl-wrapper.sh"),
-  ),
-}
-
-def _haskell_binary_impl(ctx):
-  c = compile_haskell_bin(ctx)
-
-  binary = link_haskell_bin(ctx, c.object_dyn_files)
-  dep_info = gather_dep_info(ctx)
-
-  solibs = set.union(
-    set.from_list(dep_info.external_libraries.values()),
-    dep_info.dynamic_libraries,
-  )
-
-  build_info = dep_info # HaskellBuildInfo
-  bin_info = HaskellBinaryInfo(
-    source_files = c.source_files,
-    modules = c.modules,
-    binary = binary,
-  )
-  target_files = depset([binary])
-
-  _build_haskell_repl(
-    ctx,
-    build_info=build_info,
-    target_files=target_files,
-    bin_info=bin_info,
-  )
-
-  return [
-    build_info,
-    bin_info,
-    DefaultInfo(
-      executable = binary,
-      files = target_files,
-      runfiles = ctx.runfiles(
-        files = set.to_list(solibs),
-        collect_data = True,
-      ),
-    ),
-  ]
 
 def _mk_binary_rule(**kwargs):
   """Generate a rule that compiles a binary.
@@ -219,70 +128,6 @@ $ bazel-bin/.../hello-bin-repl  # run the script
 ```
 """
 
-def _haskell_library_impl(ctx):
-  c = compile_haskell_lib(ctx)
-
-  static_library = link_static_lib(ctx, c.object_files)
-  dynamic_library = link_dynamic_lib(ctx, c.object_dyn_files)
-
-  dep_info = gather_dep_info(ctx)
-
-  exposed_modules = set.empty()
-  other_modules = set.from_list(ctx.attr.hidden_modules)
-
-  for module in set.to_list(c.modules):
-    if not set.is_member(other_modules, module):
-      set.mutable_insert(exposed_modules, module)
-
-  conf_file, cache_file = create_ghc_package(
-    ctx,
-    c.interfaces_dir,
-    static_library,
-    dynamic_library,
-    exposed_modules,
-    other_modules,
-  )
-
-  build_info = HaskellBuildInfo(
-    package_names = set.insert(dep_info.package_names, get_pkg_id(ctx)),
-    package_confs = set.insert(dep_info.package_confs, conf_file),
-    package_caches = set.insert(dep_info.package_caches, cache_file),
-    # NOTE We have to use lists for static libraries because the order is
-    # important for linker. Linker searches for unresolved symbols to the
-    # left, i.e. you first feed a library which has unresolved symbols and
-    # then you feed the library which resolves the symbols.
-    static_libraries = [static_library] + dep_info.static_libraries,
-    dynamic_libraries = set.insert(dep_info.dynamic_libraries, dynamic_library),
-    interface_files = set.union(dep_info.interface_files, set.from_list(c.interface_files)),
-    prebuilt_dependencies = dep_info.prebuilt_dependencies,
-    external_libraries = dep_info.external_libraries,
-  )
-  lib_info = HaskellLibraryInfo(
-    package_name = get_pkg_id(ctx),
-    import_dirs = c.import_dirs,
-    exposed_modules = exposed_modules,
-    other_modules = other_modules,
-    haddock_args = c.haddock_args,
-    source_files = c.source_files,
-  )
-  target_files = depset([conf_file, cache_file])
-
-  _build_haskell_repl(
-    ctx,
-    build_info=build_info,
-    target_files=target_files,
-    lib_info=lib_info,
-  )
-
-  return [
-    build_info,
-    lib_info,
-    DefaultInfo(
-      files = target_files,
-      runfiles = ctx.runfiles(collect_data = True),
-    ),
-  ]
-
 haskell_library = rule(
   _haskell_library_impl,
   attrs = dict(
@@ -333,6 +178,10 @@ haskell_lint = _haskell_lint
 haskell_doctest  = _haskell_doctest
 
 haskell_toolchain = _haskell_toolchain
+
+haskell_proto_library = _haskell_proto_library
+
+haskell_proto_toolchain = _haskell_proto_toolchain
 
 ghc_bindist = _ghc_bindist
 

--- a/haskell/protobuf.bzl
+++ b/haskell/protobuf.bzl
@@ -1,0 +1,337 @@
+"""Support for protocol buffers"""
+
+load(":providers.bzl",
+  "HaskellBuildInfo",
+  "HaskellLibraryInfo",
+  "HaskellProtobufInfo",
+)
+load("@bazel_skylib//:lib.bzl", "dicts", "paths")
+load(":tools.bzl", "protobuf_tools")
+load(":path_utils.bzl", "target_unique_name")
+load(":haskell-impl.bzl",
+  _haskell_library_impl = "haskell_library_impl",
+  _haskell_common_attrs = "haskell_common_attrs",
+)
+
+def _capitalize_first_letter(c):
+  """Capitalize the first letter of the input. Unlike the built-in
+  `capitalize()` method, doesn't lower-case the other characters. This helps
+  mimic the behavior of `proto-lens-protoc`, which turns `Foo/Bar/BAZ.proto`
+  into `Foo/Bar/BAZ.hs` (rather than `Foo/Bar/Baz.hs`).
+
+  Args:
+    c: A non-empty string word.
+
+  Returns:
+    The input with the first letter upper-cased.
+  """
+  return c[0].capitalize() + c[1:]
+
+def _camel_case(comp):
+  """Camel-case the input string, preserving any existing capital letters.
+  """
+  # Split on both "-" and "_", matching the behavior of proto-lens-protoc.
+  return "".join([_capitalize_first_letter(c2)
+                  for c1 in comp.split("_") for c2 in c1.split("-")])
+
+def _proto_lens_output_file(path):
+  """The output file from `proto-lens-protoc` when run on the given `path`.
+  """
+
+  path = path[:-len(".proto")]
+  result = "/".join([_camel_case(p) for p in path.split("/")]) + ".hs"
+
+  return "Proto/" + result
+
+def _haskell_proto_aspect_impl(target, ctx):
+
+  args = ctx.actions.args()
+
+  src_prefix = paths.join(
+    ctx.label.workspace_root,
+    ctx.label.package,
+  )
+
+  args.add(["--plugin=protoc-gen-haskell=" +
+            protobuf_tools(ctx).plugin.path,
+  ])
+
+  hs_files = []
+  inputs = []
+
+  args.add(["-I{0}={1}".format(s.short_path, s.path)
+            for s in target.proto.transitive_sources])
+
+  inputs.extend(target.proto.transitive_sources.to_list())
+
+  for src in target.proto.direct_sources:
+
+    inputs.append(src)
+
+    # As with the native rules, require the .proto file to be in the same
+    # Bazel package as the proto_library rule. This allows us to put the
+    # output .hs file next to the input .proto file. Unfortunately Skylark
+    # doesn't let us check the package of the file directly, so instead we
+    # just look at its short_path and rely on the proto_library rule itself
+    # to check for consistency. We use the file's short_path rather than its
+    # dirname/basename in case it's in a subdirectory; for example, if the
+    # proto_library rule is in "foo/BUILD" but the .proto file is
+    # "foo/bar/baz.proto".
+
+    if not src.short_path.startswith(src_prefix):
+      fail("Mismatch between rule context " + str(ctx.label.package)
+           + " and source file " + src.short_path)
+    if src.basename[-6:] != ".proto":
+      fail("bad extension for proto file " + src)
+
+    relative_path = src.short_path
+
+    args.add([relative_path])
+
+    hs_files.append(ctx.actions.declare_file(
+      _proto_lens_output_file(relative_path),
+    ))
+
+  args.add([
+    "--haskell_out=no-reexports:" + paths.join(
+      hs_files[0].root.path,
+      src_prefix,
+    ),
+  ])
+
+  ctx.actions.run(
+    inputs = depset([
+      protobuf_tools(ctx).protoc,
+      protobuf_tools(ctx).plugin,
+    ] + inputs),
+    outputs = hs_files,
+    executable = protobuf_tools(ctx).protoc,
+    arguments = [args],
+  )
+
+  patched_attrs = {
+    "compiler_flags": [],
+    "src_strip_prefix": "",
+    "repl_interpreted": True,
+    "repl_ghci_args": [],
+    "version": "1.0.0",
+    "_ghc_defs_cleanup": ctx.attr._ghc_defs_cleanup,
+    "_ghci_script": ctx.attr._ghci_script,
+    "_ghci_repl_wrapper": ctx.attr._ghci_repl_wrapper,
+    "hidden_modules": [],
+    "name": "proto-autogen-" + ctx.rule.attr.name,
+    "srcs": hs_files,
+    "deps": ctx.rule.attr.deps +
+      ctx.toolchains["@io_tweag_rules_haskell//protobuf:toolchain"].deps,
+    "prebuilt_dependencies": ctx.toolchains["@io_tweag_rules_haskell//protobuf:toolchain"].prebuilt_deps,
+    }
+
+  patched_ctx = struct(
+    label = ctx.label,
+    attr = struct(**patched_attrs),
+    actions = ctx.actions,
+    var = ctx.var,
+    bin_dir = ctx.bin_dir,
+    genfiles_dir = ctx.genfiles_dir,
+    toolchains = ctx.toolchains,
+    file = ctx.file,
+    files = struct(
+      srcs = hs_files,
+    ),
+  )
+
+  [build_info, library_info, default_info] = _haskell_library_impl(patched_ctx)
+
+  return [
+    build_info, # HaskellBuildInfo
+    library_info, # HaskellLibraryInfo
+    # We can't return DefaultInfo here because target already provides that.
+    HaskellProtobufInfo(files=default_info.files),
+  ]
+
+_haskell_proto_aspect = aspect(
+  _haskell_proto_aspect_impl,
+  attrs = {
+    "_ghc_defs_cleanup": attr.label(
+      allow_single_file = True,
+      default = Label("@io_tweag_rules_haskell//haskell:ghc-defs-cleanup.sh"),
+    ),
+    "_ghci_script": attr.label(
+      allow_single_file = True,
+      default = Label("@io_tweag_rules_haskell//haskell:ghci-script"),
+    ),
+    "_ghci_repl_wrapper": attr.label(
+      allow_single_file = True,
+      default = Label("@io_tweag_rules_haskell//haskell:ghci-repl-wrapper.sh"),
+    ),
+  },
+  attr_aspects = ['deps'],
+  toolchains = [
+    "@io_tweag_rules_haskell//haskell:toolchain",
+    "@io_tweag_rules_haskell//protobuf:toolchain",
+  ],
+)
+
+def _haskell_proto_library_impl(ctx):
+
+  dep = ctx.attr.deps[0] # FIXME
+  return [
+    dep[HaskellBuildInfo],
+    dep[HaskellLibraryInfo],
+    DefaultInfo(files=dep[HaskellProtobufInfo].files)
+  ]
+
+haskell_proto_library = rule(
+  _haskell_proto_library_impl,
+  attrs = {
+    "deps": attr.label_list(
+      mandatory = True,
+      allow_files = False,
+      aspects = [_haskell_proto_aspect],
+      doc = "List of `proto_library` targets to use for generation.",
+    )
+  },
+  toolchains = [
+    "@io_tweag_rules_haskell//haskell:toolchain",
+    "@io_tweag_rules_haskell//protobuf:toolchain",
+  ]
+)
+"""Generate Haskell library allowing to use protobuf definitions with help
+of [`proto-lens`](https://github.com/google/proto-lens#readme).
+
+Example:
+  ```bzl
+  proto_library(
+    name = "foo_proto",
+    srcs = ["foo.proto"],
+  )
+
+  haskell_proto_library(
+    name = "foo_haskell_proto",
+    deps = [":foo_proto"],
+  )
+  ```
+
+`haskell_proto_library` targets require `haskell_proto_toolchain` to be
+registered.
+"""
+
+def _protobuf_toolchain_impl(ctx):
+  return [
+    platform_common.ToolchainInfo(
+      name = ctx.label.name,
+      tools = struct(
+        protoc = ctx.executable.protoc,
+        plugin = ctx.executable.plugin,
+      ),
+      deps = ctx.attr.deps,
+      prebuilt_deps = ctx.attr.prebuilt_deps,
+    )
+  ]
+
+_protobuf_toolchain = rule(
+  _protobuf_toolchain_impl,
+  attrs = {
+    "protoc": attr.label(
+      executable = True,
+      cfg = "host",
+      allow_single_file = True,
+      mandatory = True,
+      doc = "protoc compiler",
+    ),
+    "plugin": attr.label(
+      executable = True,
+      cfg = "host",
+      allow_single_file = True,
+      mandatory = True,
+      doc = "proto-lens-protoc plugin for protoc",
+    ),
+    "deps": attr.label_list(
+      doc = "List of other Haskell libraries to be linked to protobuf libraries.",
+    ),
+    "prebuilt_deps": attr.string_list(
+      doc = "Non-Bazel supplied Cabal dependencies for protobuf libraries.",
+    ),
+  },
+)
+
+def haskell_proto_toolchain(
+    name,
+    plugin,
+    deps=[],
+    prebuilt_deps=[],
+    protoc=Label("@com_google_protobuf//:protoc"),
+    **kwargs):
+  """Declare a Haskell protobuf toolchain.
+
+  You need at least one of these declared somewhere in your `BUILD` files
+  for the `haskell_proto_library` rules to work. Once declared, you then
+  need to *register* the toolchain using `register_toolchain` in your
+  `WORKSPACE` file (see example below).
+
+  Example:
+
+    In a `BUILD` file:
+
+    ```bzl
+    haskell_proto_toolchain(
+      name = "protobuf-toolchain",
+      protoc = "@com_google_protobuf//:protoc",
+      plugin = "@protoc_gen_haskell//:bin/proto-lens-protoc",
+      prebuilt_deps = [
+        "base",
+        "bytestring",
+        "containers",
+        "data-default-class",
+        "lens-family",
+        "lens-labels",
+        "proto-lens",
+        "text",
+      ],
+    )
+    ```
+
+    The `prebuilt_deps` and `deps` arguments allow to specify Haskell
+    libraries to use to compile the auto-generated source files.
+
+    In `WORKSPACE` you could have something like this:
+
+    ```bzl
+    http_archive(
+      name = "com_google_protobuf",
+      sha256 = "cef7f1b5a7c5fba672bec2a319246e8feba471f04dcebfe362d55930ee7c1c30",
+      strip_prefix = "protobuf-3.5.0",
+      urls = ["https://github.com/google/protobuf/archive/v3.5.0.zip"],
+    )
+
+    nixpkgs_package(
+      name = "protoc_gen_haskell",
+      repository = "@nixpkgs",
+      attribute_path = "haskell.packages.ghc822.proto-lens-protoc
+    )
+
+    register_toolchains(
+      "//tests:ghc", # assuming you called your Haskell toolchain \"ghc\"
+      "//tests:protobuf-toolchain",
+    )
+    ```
+  """
+  impl_name = name + "-impl"
+  _protobuf_toolchain(
+    name = impl_name,
+    plugin = plugin,
+    deps = deps,
+    prebuilt_deps = prebuilt_deps,
+    protoc = protoc,
+    visibility = ["//visibility:public"],
+    **kwargs
+  )
+
+  native.toolchain(
+    name = name,
+    toolchain_type = "@io_tweag_rules_haskell//protobuf:toolchain",
+    toolchain = ":" + impl_name,
+    exec_compatible_with = [
+      "@bazel_tools//platforms:x86_64",
+    ],
+  )

--- a/haskell/providers.bzl
+++ b/haskell/providers.bzl
@@ -49,6 +49,13 @@ HaskellLintInfo = provider(
   }
 )
 
+HaskellProtobufInfo = provider(
+  doc = "Provider that wraps providers of auto-generated Haskell libraries",
+  fields = {
+    "files": "files",
+  }
+)
+
 # XXX this provider shouldn't be necessary. But since Skylark rules
 # can neither return CcSkylarkApiProvider nor properly test for its
 # existence in a dependency, we're forced to introduce this hack for

--- a/haskell/toolchain.bzl
+++ b/haskell/toolchain.bzl
@@ -3,7 +3,6 @@
 load("@bazel_skylib//:lib.bzl",
      "paths",
 )
-
 load(":set.bzl",
      "set",
 )
@@ -61,7 +60,6 @@ def _haskell_toolchain_impl(ctx):
   inputs = []
   inputs.extend(ctx.files.tools)
   inputs.extend(ctx.files._crosstool)
-
 
   targets_r = {}
   targets_r.update({
@@ -211,6 +209,9 @@ def haskell_toolchain(
   example below).
 
   Example:
+
+    In a `BUILD` file:
+
     ```bzl
     haskell_toolchain(
         name = "ghc",

--- a/haskell/tools.bzl
+++ b/haskell/tools.bzl
@@ -60,3 +60,18 @@ def so_extension(ctx):
     string of extension.
   """
   return "dylib" if is_darwin(ctx) else "so"
+
+def protobuf_tools(ctx):
+  """Similarly to `tools`, return a structure containing all protobuf-related
+  tools such as `protoc` or `protoc_gen_haskell`.
+
+  Requires `@io_tweag_rules_haskell//protobuf:toolchain` toolchain to be
+  registered.
+
+  Args:
+    ctx: Rule context.
+
+  Returns:
+    struct with Files inside.
+  """
+  return ctx.toolchains["@io_tweag_rules_haskell//protobuf:toolchain"].tools

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -3,17 +3,34 @@ package(default_testonly = 1)
 load("@io_tweag_rules_haskell//haskell:haskell.bzl",
   "haskell_binary",
   "haskell_library",
+  "haskell_toolchain",
+  "haskell_proto_toolchain",
 )
 
 load("@bazel_tools//tools/build_rules:test_rules.bzl", "rule_test")
-
-load("//haskell:haskell.bzl", "haskell_toolchain")
 
 haskell_toolchain(
   name = "ghc",
   version = "8.2.2",
   tools = "@ghc//:bin",
   doctest = "@doctest//:bin",
+)
+
+haskell_proto_toolchain(
+  name = "protobuf-toolchain",
+  protoc = "@com_google_protobuf//:protoc",
+  plugin = "@protoc_gen_haskell//:bin/proto-lens-protoc",
+  prebuilt_deps = [
+    "base",
+    "bytestring",
+    "containers",
+    "data-default-class",
+    "lens-family",
+    "lens-labels",
+    "proto-lens",
+    "text",
+  ],
+  testonly = 0,
 )
 
 rule_test(
@@ -130,6 +147,16 @@ rule_test(
     "lint-log-bin-1.0.0",
   ],
   rule = "//tests/haskell_lint:lint-bin",
+  size = "small",
+)
+
+rule_test(
+  name = "test-haskell_proto_library",
+  generates = [
+    "testsZShaskellZUprotoZUlibraryZShs-lib-1.0.0/package.cache",
+    "testsZShaskellZUprotoZUlibraryZShs-lib-1.0.0/testsZShaskellZUprotoZUlibraryZShs-lib-1.0.0.conf"
+  ],
+  rule = "//tests/haskell_proto_library:hs-lib",
   size = "small",
 )
 

--- a/tests/ghc.nix
+++ b/tests/ghc.nix
@@ -1,0 +1,20 @@
+{ pkgs ? import <nixpkgs> {} }:
+
+with pkgs;
+
+let haskellPackages = pkgs.haskell.packages.ghc822.override {
+      overrides = with pkgs.haskell.lib; self: super: rec {
+        lens-labels = super.lens-labels_0_2_0_0;
+        proto-lens = super.proto-lens_0_3_0_0;
+      };
+    };
+
+in haskellPackages.ghcWithPackages (p: with p; [
+  bytestring
+  containers
+  data-default-class
+  lens-family
+  lens-labels
+  proto-lens
+  text
+  ])

--- a/tests/haskell_proto_library/BUILD
+++ b/tests/haskell_proto_library/BUILD
@@ -1,0 +1,44 @@
+package(default_testonly = 1)
+
+load("@io_tweag_rules_haskell//haskell:haskell.bzl",
+     "haskell_library",
+     "haskell_proto_library",
+)
+
+proto_library(
+  name = "zip_code_proto",
+  srcs = ["zip_code.proto"],
+)
+
+proto_library(
+  name = "address_proto",
+  srcs = ["address.proto"],
+  deps = [":zip_code_proto"],
+)
+
+proto_library(
+  name = "person_proto",
+  srcs = ["person.proto"],
+  deps = [":address_proto"],
+)
+
+haskell_proto_library(
+  name = "address_haskell_proto",
+  deps = [":address_proto"],
+)
+
+haskell_proto_library(
+  name = "person_haskell_proto",
+  deps = [":person_proto"],
+)
+
+haskell_library(
+  name = "hs-lib",
+  srcs = ["Bar.hs"],
+  deps = [
+    ":address_haskell_proto",
+    ":person_haskell_proto",
+  ],
+  prebuilt_dependencies = ["base"],
+  visibility = ["//visibility:public"],
+)

--- a/tests/haskell_proto_library/Bar.hs
+++ b/tests/haskell_proto_library/Bar.hs
@@ -1,0 +1,6 @@
+module Bar (bar) where
+
+import Proto.Tests.HaskellProtoLibrary.Person
+
+bar :: Int
+bar = 5

--- a/tests/haskell_proto_library/address.proto
+++ b/tests/haskell_proto_library/address.proto
@@ -1,0 +1,11 @@
+syntax = "proto3";
+
+package demo; // Required to generate valid code.
+
+// Always import protos with a full path relative to the WORKSPACE file.
+import "tests/haskell_proto_library/zip_code.proto";
+
+message Address {
+  string city = 1;
+  ZipCode zip_code = 2;
+}

--- a/tests/haskell_proto_library/person.proto
+++ b/tests/haskell_proto_library/person.proto
@@ -1,0 +1,13 @@
+syntax = "proto3";
+
+package demo; // Required to generate valid code.
+
+// Always import protos with a full path relative to the WORKSPACE file.
+import "tests/haskell_proto_library/address.proto";
+
+message Person {
+  string name = 1;
+  int32 id = 2;
+  string email = 3;
+  Address address = 4;
+}

--- a/tests/haskell_proto_library/zip_code.proto
+++ b/tests/haskell_proto_library/zip_code.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+
+package demo; // Required to generate valid code.
+
+message ZipCode {
+  string code = 1;
+}

--- a/tests/protoc_gen_haskell.nix
+++ b/tests/protoc_gen_haskell.nix
@@ -1,0 +1,12 @@
+{ pkgs ? import <nixpkgs> {} }:
+
+with pkgs;
+
+let haskellPackages = pkgs.haskell.packages.ghc822.override {
+      overrides = with pkgs.haskell.lib; self: super: rec {
+        lens-labels = super.lens-labels_0_2_0_0;
+        proto-lens = super.proto-lens_0_3_0_0;
+      };
+    };
+
+in haskellPackages.proto-lens-protoc


### PR DESCRIPTION
This PR adds support for [protocol buffers](https://blog.bazel.build/2017/02/27/protocol-buffers.html) using [`proto-lens`](https://hackage.haskell.org/package/proto-lens).