### PR TITLE
Specify Nix docker image tag.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   build-linux:
     docker:
-      - image: nixos/nix
+      - image: nixos/nix:1.11.14
     working_directory: ~/rules_haskell
     steps:
       - checkout


### PR DESCRIPTION
Previously, CI used `nixos/nix` without a tag.  7 hours ago, a `2.0` release
was pushed to Docker Hub:

https://hub.docker.com/r/nixos/nix/tags/

Unfortunately, that seems to trigger a bug when copying the "ghc" package; see
discussion in #239.

Resolved for now by fixing the Linux build to a specific docker tag.
Not sure about the corresponding macOS failures. (Unlike that PR, this one seemed to build fine on darwin.)

We should separately investigate the issues with nix-2; they may be related
to:
https://github.com/NixOS/nix/issues/1988