### PR TITLE
Make package names more similar to the rule name.

### DIFF
--- a/haskell/actions.bzl
+++ b/haskell/actions.bzl
@@ -875,7 +875,7 @@ def get_pkg_name(ctx):
   Returns:
     string: GHC package name to use.
   """
-  return ctx.attr.name.replace("_", "ZU")
+  return ctx.attr.name.replace("_", "-")
 
 def get_pkg_id(ctx):
   """Get package identifier of the form `name-version`.

--- a/haskell/cc.bzl
+++ b/haskell/cc.bzl
@@ -187,6 +187,7 @@ def _cc_haskell_import(ctx):
     if dbin != None:
       set.mutable_insert(dyn_libs, dbin)
 
+  print(dyn_libs)
   return [
     DefaultInfo(
       files = set.to_depset(dyn_libs)

--- a/haskell/ghci-repl.bzl
+++ b/haskell/ghci-repl.bzl
@@ -60,9 +60,9 @@ def build_haskell_repl(
   args = ["-hide-all-packages"]
   for dep in set.to_list(build_info.prebuilt_dependencies):
     args += ["-package ", dep]
-  for package in set.to_list(build_info.package_names):
-    if not (interpreted and lib_info != None and package == lib_info.package_name):
-      args += ["-package", package]
+  for package in set.to_list(build_info.package_ids):
+    if not (interpreted and lib_info != None and package == lib_info.package_id):
+      args += ["-package-id", package]
   for cache in set.to_list(build_info.package_caches):
     args += ["-package-db", cache.dirname]
 

--- a/haskell/haddock.bzl
+++ b/haskell/haddock.bzl
@@ -49,7 +49,7 @@ def _haskell_doc_aspect_impl(target, ctx):
   if HaskellBuildInfo not in target or HaskellLibraryInfo not in target:
     return []
 
-  pkg_id = target[HaskellLibraryInfo].package_name
+  pkg_id = target[HaskellLibraryInfo].package_id
 
   doc_dir_raw = "doc-{0}".format(pkg_id)
 

--- a/haskell/haskell-impl.bzl
+++ b/haskell/haskell-impl.bzl
@@ -87,7 +87,7 @@ def haskell_library_impl(ctx):
   )
 
   build_info = HaskellBuildInfo(
-    package_names = set.insert(dep_info.package_names, get_pkg_id(ctx)),
+    package_ids = set.insert(dep_info.package_ids, get_pkg_id(ctx)),
     package_confs = set.insert(dep_info.package_confs, conf_file),
     package_caches = set.insert(dep_info.package_caches, cache_file),
     # NOTE We have to use lists for static libraries because the order is
@@ -101,7 +101,7 @@ def haskell_library_impl(ctx):
     external_libraries = dep_info.external_libraries,
   )
   lib_info = HaskellLibraryInfo(
-    package_name = get_pkg_id(ctx),
+    package_id = get_pkg_id(ctx),
     import_dirs = c.import_dirs,
     exposed_modules = exposed_modules,
     other_modules = other_modules,

--- a/haskell/lint.bzl
+++ b/haskell/lint.bzl
@@ -66,9 +66,9 @@ def _haskell_lint_aspect_impl(target, ctx):
     args.add(["-package", prebuilt_dep])
 
   # Expose all bazel dependencies
-  for package in set.to_list(build_info.package_names):
-    if lib_info == None or package != lib_info.package_name:
-      args.add(["-package", package])
+  for package in set.to_list(build_info.package_ids):
+    if lib_info == None or package != lib_info.package_id:
+      args.add(["-package-id", package])
 
   for cache in set.to_list(build_info.package_caches):
     args.add(["-package-db", cache.dirname])
@@ -171,9 +171,9 @@ def _haskell_doctest_aspect_impl(target, ctx):
     args.add(["-package", prebuilt_dep])
 
   # Expose all bazel dependencies
-  for package in set.to_list(build_info.package_names):
-    if lib_info != None or package != lib_info.package_name:
-      args.add(["-package", package])
+  for package in set.to_list(build_info.package_ids):
+    if lib_info != None or package != lib_info.package_id:
+      args.add(["-package-id", package])
 
   for cache in set.to_list(build_info.package_caches):
     args.add(["-package-db", cache.dirname])

--- a/haskell/providers.bzl
+++ b/haskell/providers.bzl
@@ -1,7 +1,7 @@
 HaskellBuildInfo = provider(
   doc = "Common information about build process: dependencies, etc.",
   fields = {
-    "package_names": "Set of all package names of transitive dependencies.",
+    "package_ids": "Set of all package ids of transitive dependencies.",
     "package_confs": "Set of package .conf files.",
     "package_caches": "Set of package cache files.",
     "static_libraries": "Ordered collection of compiled library archives.",
@@ -15,7 +15,7 @@ HaskellBuildInfo = provider(
 HaskellLibraryInfo = provider(
   doc = "Library-specific information.",
   fields = {
-    "package_name": "Package name, usually of the form name-version.",
+    "package_id": "Package name, usually of the form name-version.",
     "import_dirs": "Import hierarchy roots.",
     "exposed_modules": "Set of exposed module names.",
     "other_modules": "Set of non-public module names.",

--- a/tests/package-name/BUILD
+++ b/tests/package-name/BUILD
@@ -1,0 +1,24 @@
+# Tests around our use of package names.
+package(default_testonly = 1)
+
+load(
+  "@io_tweag_rules_haskell//haskell:haskell.bzl",
+  "haskell_library",
+  "haskell_test",
+)
+
+haskell_library(
+    # A package with the character "Z" in it shouldn't change its name
+    name = "lib-aZ",
+    srcs = ["Lib.hs"],
+    prebuilt_dependencies = ["base"],
+    version = "1.2.3.4",
+)
+
+haskell_test(
+    name = "bin",
+    srcs = ["Main.hs"],
+    main_file = "Main.hs",
+    prebuilt_dependencies = ["base"],
+    deps = [":lib-aZ"],
+)

--- a/tests/package-name/BUILD
+++ b/tests/package-name/BUILD
@@ -8,8 +8,9 @@ load(
 )
 
 haskell_library(
-    # A package with the character "Z" in it shouldn't change its name
-    name = "lib-aZ",
+    # The character "Z" should be untouched in the GHC package name.
+    # However, underscores (which are not legal) should be turned into dashes.
+    name = "lib-a_Z",
     srcs = ["Lib.hs"],
     prebuilt_dependencies = ["base"],
     version = "1.2.3.4",
@@ -20,5 +21,5 @@ haskell_test(
     srcs = ["Main.hs"],
     main_file = "Main.hs",
     prebuilt_dependencies = ["base"],
-    deps = [":lib-aZ"],
+    deps = [":lib-a_Z"],
 )

--- a/tests/package-name/Lib.hs
+++ b/tests/package-name/Lib.hs
@@ -1,0 +1,4 @@
+module Lib (foo) where
+
+foo :: Integer
+foo = 42

--- a/tests/package-name/Main.hs
+++ b/tests/package-name/Main.hs
@@ -5,17 +5,17 @@ module Main (main) where
 import Control.Monad (when)
 
 -- Test the PackageImports extension.
-import "lib-aZ" Lib (foo)
+import "lib-a-Z" Lib (foo)
 
 -- Test macros that GHC creates automatically based on the package version.
 versionHighEnoughTest, versionTooLowTest :: Bool
-#if MIN_VERSION_lib_aZ(1,2,3)
+#if MIN_VERSION_lib_a_Z(1,2,3)
 versionHighEnoughTest = True
 #else
 versionHighEnoughTest = False
 #endif
 
-#if MIN_VERSION_lib_aZ(1,2,4)
+#if MIN_VERSION_lib_a_Z(1,2,4)
 versionTooLowTest = False
 #else
 versionTooLowTest = True
@@ -27,6 +27,6 @@ check x y = when (x /= y) $ error $ "Failed check: " ++ show (x, y)
 main :: IO ()
 main = do
     check foo 42
-    check VERSION_lib_aZ "1.2.3.4"
+    check VERSION_lib_a_Z "1.2.3.4"
     check versionHighEnoughTest True
     check versionTooLowTest True

--- a/tests/package-name/Main.hs
+++ b/tests/package-name/Main.hs
@@ -1,0 +1,32 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE PackageImports #-}
+module Main (main) where
+
+import Control.Monad (when)
+
+-- Test the PackageImports extension.
+import "lib-aZ" Lib (foo)
+
+-- Test macros that GHC creates automatically based on the package version.
+versionHighEnoughTest, versionTooLowTest :: Bool
+#if MIN_VERSION_lib_aZ(1,2,3)
+versionHighEnoughTest = True
+#else
+versionHighEnoughTest = False
+#endif
+
+#if MIN_VERSION_lib_aZ(1,2,4)
+versionTooLowTest = False
+#else
+versionTooLowTest = True
+#endif
+
+check :: (Show a, Eq a) => a -> a -> IO ()
+check x y = when (x /= y) $ error $ "Failed check: " ++ show (x, y)
+
+main :: IO ()
+main = do
+    check foo 42
+    check VERSION_lib_aZ "1.2.3.4"
+    check versionHighEnoughTest True
+    check versionTooLowTest True

--- a/tests/repl-targets/BUILD
+++ b/tests/repl-targets/BUILD
@@ -18,10 +18,17 @@ haskell_library(
   visibility = ["//visibility:public"],
 )
 
+haskell_library(
+    name = "QuuxLib",
+    srcs = ["QuuxLib.hs"],
+    prebuilt_dependencies = ["base"],
+)
+
 haskell_binary(
   name = "hs-bin",
   srcs = ["Quux.hs"],
   main_file = "Quux.hs",
+  deps = [":QuuxLib"],
   prebuilt_dependencies = ["base"],
   visibility = ["//visibility:public"],
 )

--- a/tests/repl-targets/Quux.hs
+++ b/tests/repl-targets/Quux.hs
@@ -1,4 +1,6 @@
 module Main (main) where
 
+import QuuxLib (message)
+
 main :: IO ()
-main = putStrLn "Hello GHCi!"
+main = putStrLn message

--- a/tests/repl-targets/QuuxLib.hs
+++ b/tests/repl-targets/QuuxLib.hs
@@ -1,0 +1,4 @@
+module QuuxLib (message) where
+
+message :: String
+message = "Hello GHCi!"


### PR DESCRIPTION
As of #222, both the package name and ID are z-encoded.  However,
GHC only needs the package *ID* to be unique, as long as you
call `-package-id` instead of `-package`.  As a result we can
simplify how package-names are encoded: we can keep them the same
as the rule name, other than fixing underscores.

In addition to (I think) making error messages nicer, this paves the way for
some improvements in Hazel (or similar tools), now that the rule and package
names can be identical:
- It helps support the PackageImports extension.
- GHC >= 8.0 generates the Cabal macros (e.g., `MIN_VERSION_*`) automatically.

Prebuilt dependencies are still passed with `-package` since their IDs are internal details of GHC.