### PR TITLE
Enable protos from external repositories.

### DIFF
--- a/tests/BUILD
+++ b/tests/BUILD
@@ -14,6 +14,7 @@ haskell_toolchain(
   version = "8.2.2",
   tools = "@ghc//:bin",
   doctest = "@doctest//:bin",
+  testonly = 0,
 )
 
 haskell_proto_toolchain(

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -14,6 +14,10 @@ haskell_toolchain(
   version = "8.2.2",
   tools = "@ghc//:bin",
   doctest = "@doctest//:bin",
+  # This toolchain is morally testonly.  However, that would break
+  # our tests of haskell_library_rules: aspects of non-testonly
+  # proto_library rules (from com_google_protobuf) can't themselves
+  # be testonly.
   testonly = 0,
 )
 

--- a/tests/haskell_proto_library/BUILD
+++ b/tests/haskell_proto_library/BUILD
@@ -19,7 +19,10 @@ proto_library(
 proto_library(
   name = "person_proto",
   srcs = ["person.proto"],
-  deps = [":address_proto"],
+  deps = [
+      ":address_proto",
+      "@com_google_protobuf//:timestamp_proto",
+  ],
 )
 
 haskell_proto_library(

--- a/tests/haskell_proto_library/person.proto
+++ b/tests/haskell_proto_library/person.proto
@@ -5,9 +5,12 @@ package demo; // Required to generate valid code.
 // Always import protos with a full path relative to the WORKSPACE file.
 import "tests/haskell_proto_library/address.proto";
 
+import "google/protobuf/timestamp.proto";
+
 message Person {
   string name = 1;
   int32 id = 2;
   string email = 3;
   Address address = 4;
+  google.protobuf.Timestamp timestamp = 5;
 }


### PR DESCRIPTION
The `short_path` for an external file contains `..` which messes
up the logic around prefixes and also isn't permitted by `protoc`.
Instead, compute it manually from `path`.  Logic emulated from
rules_go:
https://github.com/bazelbuild/rules_go/blob/67f44035d84a352cffb9465159e199066ecb814c/proto/compiler.bzl#L72

This change required marking the test `haskell_toolchain` as `testonly=0`.
The test that I added works on `@com_google_protobuf//:timestamp_proto`, a
`proto_library` which is not testonly; it looks like the aspect that's
generated also can't be testonly.  If this is an issue we can create a new
local repo for the test; I just wasn't sure it was worth the effort.