### PR TITLE
Add ability to specify hidden haddock modules

### DIFF
--- a/haskell/haddock.bzl
+++ b/haskell/haddock.bzl
@@ -87,7 +87,7 @@ def _haskell_doc_aspect_impl(target, ctx):
       ),
       sibling=haddock_interface
     )
-    for f in input_sources
+    for f in input_sources if f not in ctx.rule.files.hidden_haddock_modules
   ]
 
   self_outputs = [

--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -188,7 +188,12 @@ haskell_library = rule(
     _haskell_common_attrs,
     hidden_modules = attr.string_list(
       doc = "Modules that should be unavailable for import by dependencies."
-    )),
+    ),
+    hidden_haddock_modules = attr.label_list(
+      allow_files = FileType([".hs", ".hsc", ".lhs", ".hs-boot", ".lhs-boot"]),
+      doc = "List of source files that have hiding haddock option declaration inside.",
+    ),
+  ),
   outputs = {
     "repl": "%{name}-repl",
   },

--- a/tests/haddock/BUILD
+++ b/tests/haddock/BUILD
@@ -27,7 +27,8 @@ haskell_library(
 
 haskell_library(
   name = "haddock-lib-b",
-  srcs = ["LibB.hs"],
+  srcs = ["LibB.hs", "LibBHidden.hs"],
+  hidden_haddock_modules = ["LibBHidden.hs"],
   deps = [":haddock-lib-a", ":zlib"],
   prebuilt_dependencies = ["base"],
 )

--- a/tests/haddock/LibBHidden.hs
+++ b/tests/haddock/LibBHidden.hs
@@ -1,0 +1,10 @@
+{-# OPTIONS_HADDOCK hide #-}
+
+-- | Here is a hidden module.
+
+module LibBHidden where
+
+-- | Something.
+
+hidden_thing :: Int
+hidden_thing = 107


### PR DESCRIPTION
Let's not rush with this and wait what @judah says. One problem is that we still need to detect hidden modules in Hazel automatically or otherwise we'll have to write rules manually for packages with hidden haddock modules.