### PR TITLE
Set CURRENT_PACKAGE_KEY for every haskell_library rule.

### DIFF
--- a/haskell/actions.bzl
+++ b/haskell/actions.bzl
@@ -511,7 +511,9 @@ def compile_haskell_lib(ctx):
   # creating `Name`s for to put them in Haddock interface files which then
   # results in Haddock not being able to find names for linking in
   # environment after reading its interface file later.
-  unit_id_args = ["-this-unit-id", get_pkg_id(ctx)]
+  pkg_id = get_pkg_id(ctx)
+  unit_id_args = ["-this-unit-id", pkg_id,
+                  "-optP-DCURRENT_PACKAGE_KEY=\"{}\"".format(pkg_id)]
 
   c.args.add(unit_id_args)
   c.haddock_args.add(unit_id_args, before_each="--optghc")

--- a/tests/package-name/Lib.hs
+++ b/tests/package-name/Lib.hs
@@ -1,4 +1,8 @@
-module Lib (foo) where
+{-# LANGUAGE CPP #-}
+module Lib (foo, libPackageKey) where
 
 foo :: Integer
 foo = 42
+
+libPackageKey :: String
+libPackageKey = CURRENT_PACKAGE_KEY

--- a/tests/package-name/Main.hs
+++ b/tests/package-name/Main.hs
@@ -5,7 +5,7 @@ module Main (main) where
 import Control.Monad (when)
 
 -- Test the PackageImports extension.
-import "lib-a-Z" Lib (foo)
+import "lib-a-Z" Lib
 
 -- Test macros that GHC creates automatically based on the package version.
 versionHighEnoughTest, versionTooLowTest :: Bool
@@ -28,5 +28,6 @@ main :: IO ()
 main = do
     check foo 42
     check VERSION_lib_a_Z "1.2.3.4"
+    check libPackageKey "testsZSpackage-nameZSlib-aZUZZ-1.2.3.4"
     check versionHighEnoughTest True
     check versionTooLowTest True


### PR DESCRIPTION
It's needed by several Cabal packages; for example `lens`:
https://github.com/ekmett/lens/blob/1aa37c4/src/Control/Lens/Internal/TH.hs#L102

If you don't set it, `lens` defaults to logic like:
```
lensPackageKey          = "lens-" ++ showVersion version
```
But that doesn't work as of #222 which makes the package key more complicated.

For example the `fuzzyset` package breaks with Hazel:
```
bazel-out/k8-fastbuild/bin/external/haskell_fuzzyset/gen-srcs-fuzzyset/Data/FuzzySet/Lens.hs:17:1: error:
    * Failed to load interface for `Control.Lens.Type'
      no unit id matching `lens-4.15.4' was found
      (This unit ID looks like the source package ID;
       the real unit ID is `externalZShaskellZUlensZSlens-4.15.4')
    * In the type signature:
        _useLevenshtein :: lens-4.15.4:Control.Lens.Type.Lens' FuzzySet Bool
   |
17 | makeLensesFor
   | ^^^^^^^^^^^^^...

```

Given that `rules_haskell` has the logic that creates the id string, I think
it makes sense for it to set this parameter itself (rather than manually-written
rules, or macros that use it like Hazel/cabal2bazel).