### PR TITLE
Make external libraries available to Haddock

### DIFF
--- a/haskell/haddock.bzl
+++ b/haskell/haddock.bzl
@@ -70,6 +70,7 @@ def _haskell_doc_aspect_impl(target, ctx):
       set.to_depset(target[HaskellBuildInfo].package_caches),
       set.to_depset(target[HaskellBuildInfo].interface_files),
       set.to_depset(target[HaskellBuildInfo].dynamic_libraries),
+      depset(target[HaskellBuildInfo].external_libraries.values()),
       depset(transitive_haddocks.values()),
       depset(transitive_html.values()),
       # Need to give source files this way because the source_files field of


### PR DESCRIPTION
This fixes a bug I've discovered with the `log-domain` package which complained about unavailable c bits of `primitive`. My understanding is that the bug is triggered when we try to run haddock on a package that uses TH from another package (or the same package) that uses functions from c bits. That's the idea, but I could not reproduce it in a simple enough example to add to the test suite, for some reason I'm running into a GHC panic:

```
INFO: Analysed target //tests/haddock:haddock-lib-a (0 packages loaded).
INFO: Found 1 target...
ERROR: /home/mark/projects/tweag/rules_haskell/tests/haddock/BUILD:28:1: Compiling haddock-lib-a failed (Exit 1)
ghc: panic! (the 'impossible' happened)
  (GHC version 8.2.2 for x86_64-unknown-linux):
        Loading temp shared object failed: /tmp/ghc17443_0/libghc_6.so: undefined symbol: add_five

Please report this as a GHC bug:  http://www.haskell.org/ghc/reportabug

Target //tests/haddock:haddock-lib-a failed to build
Use --verbose_failures to see the command lines of failed build steps.
INFO: Elapsed time: 0.447s, Critical Path: 0.34s
FAILED: Build did NOT complete successfully
```

So `add_five` is a function from C bits, but it should be available since I provide `cc_library` as a  dependency of `haddock-lib-a`.

Anyway I think the change is obvious enough (even though reproducing the issue may be not?) so we can merge as is and unblock further work on `platform-core`.