### PR TITLE
Decouple actions from rule context

### DIFF
--- a/haskell/haddock.bzl
+++ b/haskell/haddock.bzl
@@ -3,10 +3,6 @@
 load (":private/path_utils.bzl", "module_name")
 load (":private/set.bzl", "set")
 
-load(":private/actions/package.bzl",
-  "get_pkg_name",
-)
-
 load(":private/tools.bzl",
   "get_build_tools_path",
   "tools",

--- a/haskell/private/context.bzl
+++ b/haskell/private/context.bzl
@@ -1,0 +1,35 @@
+"""Derived context with Haskell-specific fields and methods"""
+
+load("@bazel_skylib//:lib.bzl", "paths")
+
+HaskellContext = provider()
+
+def haskell_context(ctx, attr=None):
+  toolchain = ctx.toolchains["@io_tweag_rules_haskell//haskell:toolchain"]
+
+  if not attr:
+    attr = ctx.attr
+
+  src_root = paths.join(
+    ctx.label.workspace_root,
+    ctx.label.package,
+    attr.src_strip_prefix,
+  )
+
+  env = {
+    "PATH": toolchain.visible_bin_path
+  }
+
+  return HaskellContext(
+    # Fields
+    name = attr.name,
+    toolchain = toolchain,
+    tools = toolchain.tools,
+    tools_runfiles = toolchain.tools_runfiles,
+    src_root = src_root,
+    env = env,
+    mode = ctx.var["COMPILATION_MODE"],
+    actions = ctx.actions,
+    bin_dir = ctx.bin_dir,
+    genfiles_dir = ctx.genfiles_dir,
+  )

--- a/haskell/private/mode.bzl
+++ b/haskell/private/mode.bzl
@@ -1,37 +1,25 @@
 """Compilation modes."""
 
-def _is_mode_enabled(ctx, mode):
-  """Check whether a compilation mode is enabled.
-
-  Args:
-    ctx: Rule context.
-    mode: Mode to check.
-
-  Returns:
-    bool: True if the mode is enabled, False otherwise.
-  """
-  return ctx.var["COMPILATION_MODE"] == mode;
-
-def is_profiling_enabled(ctx):
+def is_profiling_enabled(hs):
   """Check whether profiling mode is enabled.
 
   Args:
-    ctx: Rule context.
+    hs: Haskell context.
 
   Returns:
     bool: True if the mode is enabled, False otherwise.
   """
-  return _is_mode_enabled(ctx, "dbg")
+  return hs.mode == "dbg"
 
-def add_mode_options(ctx, args):
+def add_mode_options(hs, args):
   """Add mode options to the given args object.
 
   Args:
-    ctx: Rule context.
+    hs: Haskell context.
     args: args object.
 
   Returns:
     None
   """
-  if is_profiling_enabled(ctx):
+  if is_profiling_enabled(hs):
     args.add("-prof")

--- a/haskell/private/tools.bzl
+++ b/haskell/private/tools.bzl
@@ -61,7 +61,7 @@ def is_darwin(ctx):
   """
   return ctx.toolchains["@io_tweag_rules_haskell//haskell:toolchain"].is_darwin
 
-def so_extension(ctx):
+def so_extension(hs):
   """Returns the extension for shared libraries.
 
   Args:
@@ -70,7 +70,7 @@ def so_extension(ctx):
   Returns:
     string of extension.
   """
-  return "dylib" if is_darwin(ctx) else "so"
+  return "dylib" if hs.toolchain.is_darwin else "so"
 
 def protobuf_tools(ctx):
   """Similarly to `tools`, return a structure containing all protobuf-related

--- a/haskell/toolchain.bzl
+++ b/haskell/toolchain.bzl
@@ -1,11 +1,17 @@
 """Rules for defining toolchains"""
 
-load("@bazel_skylib//:lib.bzl",
-     "paths",
+load(":private/actions/compile.bzl",
+  "compile_binary",
+  "compile_library",
 )
-load(":private/set.bzl",
-     "set",
+load(":private/actions/link.bzl",
+  "link_binary",
+  "link_library_dynamic",
+  "link_library_static",
 )
+load(":private/actions/package.bzl", "package")
+load(":private/set.bzl", "set")
+load("@bazel_skylib//:lib.bzl", "paths")
 
 _GHC_BINARIES = ["ghc", "ghc-pkg", "hsc2hs", "haddock", "ghci"]
 
@@ -166,6 +172,15 @@ def _haskell_toolchain_impl(ctx):
       name = ctx.label.name,
       tools = struct(**tools_struct_args),
       tools_runfiles = struct(**tools_runfiles_struct_args),
+      mode = ctx.var["COMPILATION_MODE"],
+      actions = struct(
+        compile_binary = compile_binary,
+        compile_library = compile_library,
+        link_binary = link_binary,
+        link_library_dynamic = link_library_dynamic,
+        link_library_static = link_library_static,
+        package = package,
+      ),
       # All symlinks are guaranteed to be in the same directory so we just
       # provide directory name of the first one (the collection cannot be
       # empty). The rest of the program may rely consider visible_bin_path


### PR DESCRIPTION
Actions all took a `ctx` argument. But there was a huge amount of
immutable state hidden in there. This had two problems:

* it means that action implementation is coupled to rule definition,
  when you'd expect actions to be defined largely independently of any
  particular rule. Actions shouldn't have direct access to rule
  attributes, because difficult to mock and test actions in isolation.
* while action implementations are "functional" in the sense of being
  referentially transparent, they implicitly depend on "everything",
  instead of just the things they need being passed as arguments. E.g.
  rule attributes that should only concern linking were passed to
  compilation and vice versa. It was like having functions of type
  `Heap -> Args -> ResultStruct`.

The conjunction of these two problems meant that it was hard to see
what abstractions we should be piecing together. Solution: create
a much smaller derived context and pass that to actions instead. The
derived context, called the "Haskell context", resolves the toolchain,
constructs a standard environment (including `PATH`) to run actions
in, and only contains a very small number of common attributes. Extra
subcontexts are derived for special purposes and passed as explicit
arguments to action functions, e.g. `dep_info`, `cc` and `java`
subcontexts during compilation. So the dependencies of each action is
now more explicit.

Note that in this PR, action functions take many more arguments, due
to being more explicit about dependencies. The arguments are also very
often similar across related functions and self-explanatory. That's
because they ought to be grouped together in structs expressing
specific abstractions. That was not done in this PR, to keep it as
small as possible. In this interim state, the documentation for the
list of arguments of many functions has been *removed*, because right
now we can't document them without a lot of redundancy. The
documentation will come back in a factored out form in the next PR in
the series.