### PR TITLE
Make non-haskell sources available to Haddock

### DIFF
--- a/haskell/private/actions/compile.bzl
+++ b/haskell/private/actions/compile.bzl
@@ -199,6 +199,7 @@ def _compilation_defaults(ctx, dep_info):
   # modules cross-package.
   interface_files = []
   other_sources = []
+  header_files = []
   modules = set.empty()
   source_files = set.empty()
   import_dirs = set.singleton(import_root)
@@ -212,7 +213,9 @@ def _compilation_defaults(ctx, dep_info):
 
   for s in ctx.files.srcs:
 
-    if s.extension in ["h", "hs-boot", "lhs-boot"]:
+    if s.extension == "h":
+      header_files.append(s)
+    if s.extension in ["hs-boot", "lhs-boot"]:
       other_sources.append(s)
     elif s.extension in ["hs", "lhs", "hsc"]:
       if not hasattr(ctx.file, "main_file") or (s != ctx.file.main_file):
@@ -273,6 +276,8 @@ def _compilation_defaults(ctx, dep_info):
     haddock_args = haddock_args,
     inputs = depset(transitive = [
       set.to_depset(source_files),
+      depset(header_files),
+      depset(other_sources),
       depset(cc.hdrs),
       set.to_depset(dep_info.package_confs),
       set.to_depset(dep_info.package_caches),
@@ -280,7 +285,6 @@ def _compilation_defaults(ctx, dep_info):
       set.to_depset(dep_info.dynamic_libraries),
       depset(dep_info.external_libraries.values()),
       java.inputs,
-      depset(other_sources),
       depset([tools(ctx).gcc]),
     ]),
     outputs = [objects_dir, interfaces_dir] + object_files + object_dyn_files + interface_files,
@@ -291,7 +295,7 @@ def _compilation_defaults(ctx, dep_info):
     interface_files = interface_files,
     modules = modules,
     source_files = source_files,
-    header_files = set.from_list(cc.hdrs),
+    header_files = set.from_list(cc.hdrs + header_files),
     import_dirs = import_dirs,
     env = dicts.add({
       "LD_LIBRARY_PATH": get_external_libs_path(set.from_list(dep_info.external_libraries.values())),

--- a/tests/haddock/BUILD
+++ b/tests/haddock/BUILD
@@ -20,8 +20,9 @@ haskell_library(
 
 haskell_library(
   name = "haddock-lib-a",
-  srcs = ["LibA.hs", "LibA/A.hs"],
+  srcs = ["LibA.hs", "LibA/A.hs", "header.h"],
   deps = [":haddock-lib-deep"],
+  compiler_flags = ["-I."],
   prebuilt_dependencies = ["base", "template-haskell"],
 )
 

--- a/tests/haddock/LibA.hs
+++ b/tests/haddock/LibA.hs
@@ -1,5 +1,8 @@
 -- | "Lib" header
+{-# LANGUAGE CPP             #-}
 {-# LANGUAGE TemplateHaskell #-}
+
+#include "header.h"
 
 module LibA where
 
@@ -13,4 +16,4 @@ data A =
 
 -- | Doc for 'f' using 'a' and 'deep_lib'.
 f :: Int
-f = const $a deep_lib
+f = const $a deep_lib + MAGIC_NUMBER

--- a/tests/haddock/header.h
+++ b/tests/haddock/header.h
@@ -1,0 +1,1 @@
+#define MAGIC_NUMBER 100


### PR DESCRIPTION
Without this building of Haddocks for files including headers (as with recent `vault` example) fails.