### PR TITLE
Don't use version field to uniquify target names.

### DIFF
--- a/haskell/lint.bzl
+++ b/haskell/lint.bzl
@@ -75,7 +75,7 @@ def _haskell_lint_aspect_impl(target, ctx):
   args.add(sources)
 
   lint_log = ctx.actions.declare_file(
-    target_unique_name(hs, "lint-log", ctx.rule.attr.version)
+    target_unique_name(hs, "lint-log")
   )
 
   lint_logs = _collect_lint_logs(
@@ -172,7 +172,7 @@ def _haskell_doctest_aspect_impl(target, ctx):
   args.add(sources)
 
   lint_log = ctx.actions.declare_file(
-    target_unique_name(hs, "doctest-log", ctx.rule.attr.version)
+    target_unique_name(hs, "doctest-log")
   )
 
   lint_logs = _collect_lint_logs(

--- a/haskell/private/actions/package.bzl
+++ b/haskell/private/actions/package.bzl
@@ -82,7 +82,7 @@ def package(hs, dep_info, interfaces_dir, static_library, dynamic_library, expos
   cache_file = hs.actions.declare_file("package.cache", sibling=conf_file)
 
   # Create a file from which ghc-pkg will create the actual package from.
-  registration_file = hs.actions.declare_file(target_unique_name(hs, "registration-file", version))
+  registration_file = hs.actions.declare_file(target_unique_name(hs, "registration-file"))
   registration_file_entries = {
     "name": get_pkg_name(hs),
     "version": version,

--- a/haskell/private/actions/repl.bzl
+++ b/haskell/private/actions/repl.bzl
@@ -35,7 +35,6 @@ def build_haskell_repl(
     ghci_repl_wrapper,
     repl_ghci_args,
     build_info,
-    version,
     target_files,
     interpreted,
     output,
@@ -86,8 +85,8 @@ def build_haskell_repl(
         "-L{0}".format(paths.dirname(lib.path)),
       ]
 
-  ghci_repl_script = hs.actions.declare_file(target_unique_name(hs, "ghci-repl-script", version))
-  repl_file = hs.actions.declare_file(target_unique_name(hs, "repl", version))
+  ghci_repl_script = hs.actions.declare_file(target_unique_name(hs, "ghci-repl-script"))
+  repl_file = hs.actions.declare_file(target_unique_name(hs, "repl"))
 
   add_modules = []
   if lib_info != None:

--- a/haskell/private/haskell_impl.bzl
+++ b/haskell/private/haskell_impl.bzl
@@ -38,7 +38,6 @@ def haskell_binary_impl(ctx):
     prebuilt_dependencies = ctx.attr.prebuilt_dependencies,
     cpp_defines = ctx.file._cpp_defines,
     compiler_flags = ctx.attr.compiler_flags,
-    version = ctx.attr.version,
     srcs = ctx.files.srcs,
     main_file = ctx.file.main_file,
     main_function = ctx.attr.main_function,
@@ -67,7 +66,6 @@ def haskell_binary_impl(ctx):
     output = ctx.outputs.repl,
     interpreted = ctx.attr.repl_interpreted,
     build_info = build_info,
-    version = ctx.attr.version,
     target_files = target_files,
     bin_info = bin_info,
   )
@@ -99,12 +97,11 @@ def haskell_library_impl(ctx):
     cc,
     java,
     dep_info,
+    pkg_id = pkg_id,
     prebuilt_dependencies = ctx.attr.prebuilt_dependencies,
     cpp_defines = ctx.file._cpp_defines,
     compiler_flags = ctx.attr.compiler_flags,
-    version = ctx.attr.version,
     srcs = ctx.files.srcs,
-    pkg_id = pkg_id,
   )
 
   static_library = link_library_static(
@@ -178,7 +175,6 @@ def haskell_library_impl(ctx):
       output = ctx.outputs.repl,
       interpreted = ctx.attr.repl_interpreted,
       build_info = build_info,
-      version = ctx.attr.version,
       target_files = target_files,
       lib_info = lib_info,
     )

--- a/haskell/private/path_utils.bzl
+++ b/haskell/private/path_utils.bzl
@@ -1,7 +1,7 @@
 """Utilities for module and path manipulations."""
 
 load(":private/set.bzl", "set")
-load("@bazel_skylib//:lib.bzl", "paths", "shell")
+load("@bazel_skylib//:lib.bzl", "paths")
 
 def module_name(hs, f):
   """Given Haskell source file path, turn it into a dot-separated module name.
@@ -23,16 +23,16 @@ def module_name(hs, f):
   )
   return hsmod
 
-def target_unique_name(hs, name_prefix, version):
+def target_unique_name(hs, name_prefix):
   """Make a target-unique name.
 
-  `name_prefix` is made target-unique by adding rule name and target version
+  `name_prefix` is made target-unique by adding a rule name
   suffix to it. This means that given two different rules, the same
   `name_prefix` is distinct. Note that this is does not disambiguate two
-  names within the same rule. Given a haskell_library with name foo and
-  version 0.1.0, you could expect:
+  names within the same rule. Given a haskell_library with name foo
+  you could expect:
 
-  target_unique_name(hs, "libdir") => "libdir-foo-0.1.0"
+  target_unique_name(hs, "libdir") => "libdir-foo"
 
   This allows two rules using same name_prefix being built in same
   environment to avoid name clashes of their output files and directories.
@@ -44,16 +44,16 @@ def target_unique_name(hs, name_prefix, version):
   Returns:
     string: Target-unique name_prefix.
   """
-  return "{0}-{1}-{2}".format(name_prefix, hs.name, version)
+  return "{0}-{1}".format(name_prefix, hs.name)
 
-def module_unique_name(hs, source_file, name_prefix, version):
+def module_unique_name(hs, source_file, name_prefix):
   """Make a target- and module- unique name.
 
   module_unique_name(
     hs,
     "some-workspace/some-package/src/Foo/Bar/Baz.hs",
     "libdir"
-  ) => "libdir-foo-0.1.0-Foo.Bar.Baz"
+  ) => "libdir-foo-Foo.Bar.Baz"
 
   This is quite similar to `target_unique_name` but also uses a path built
   from `source_file` to prevent clashes with other names produced using the
@@ -68,7 +68,7 @@ def module_unique_name(hs, source_file, name_prefix, version):
     string: Target- and source-unique name.
   """
   return "{0}-{1}".format(
-    target_unique_name(hs, name_prefix, version),
+    target_unique_name(hs, name_prefix),
     module_name(hs, source_file)
   )
 

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -137,8 +137,8 @@ rule_test(
 rule_test(
   name = "test-haskell_lint-library",
   generates = [
-    "lint-log-lib-a-1.0.0",
-    "lint-log-lib-b-1.0.0",
+    "lint-log-lib-a",
+    "lint-log-lib-b",
   ],
   rule = "//tests/haskell_lint:lint-lib-b",
   size = "small",
@@ -147,8 +147,8 @@ rule_test(
 rule_test(
   name = "test-haskell_lint-binary",
   generates = [
-    "lint-log-lib-a-1.0.0",
-    "lint-log-bin-1.0.0",
+    "lint-log-lib-a",
+    "lint-log-bin",
   ],
   rule = "//tests/haskell_lint:lint-bin",
   size = "small",
@@ -167,8 +167,8 @@ rule_test(
 rule_test(
   name = "test-haskell_doctest",
   generates = [
-    "doctest-log-lib-a-1.0.0",
-    "doctest-log-lib-b-1.0.0",
+    "doctest-log-lib-a",
+    "doctest-log-lib-b",
   ],
   rule = "//tests/haskell_doctest:haskell_doctest",
   size = "small",


### PR DESCRIPTION
A rule name is already unique within a package. So we don't need
versions to add extra uniqueness. Dropping versions means we don't
need to thread them across a compilation and linking, when in the end
only packaging cares about versions.