### PR TITLE
Introduce pkg_id struct

### DIFF
--- a/haskell/private/actions/link.bzl
+++ b/haskell/private/actions/link.bzl
@@ -1,7 +1,7 @@
 """Actions for linking object code produced by compilation"""
 
-load(":private/actions/package.bzl", "get_library_name")
 load(":private/mode.bzl", "add_mode_options")
+load(":private/pkg_id.bzl", "pkg_id")
 load(":private/set.bzl", "set")
 load(":private/tools.bzl", "so_extension")
 load(":private/utils.bzl", "get_lib_name")
@@ -221,13 +221,13 @@ def _infer_rpaths(target, solibs):
 
   return r
 
-def link_library_static(hs, dep_info, object_files, pkg_id):
+def link_library_static(hs, dep_info, object_files, my_pkg_id):
   """Link a static library for the package using given object files.
 
   Returns:
     File: Produced static library.
   """
-  library_name = get_library_name(pkg_id)
+  library_name = "HS" + pkg_id.to_string(my_pkg_id)
   static_library = hs.actions.declare_file("lib{0}.a".format(library_name))
 
   args = hs.actions.args()
@@ -243,7 +243,7 @@ def link_library_static(hs, dep_info, object_files, pkg_id):
   )
   return static_library
 
-def link_library_dynamic(hs, dep_info, object_files, pkg_id):
+def link_library_dynamic(hs, dep_info, object_files, my_pkg_id):
   """Link a dynamic library for the package using given object files.
 
   Returns:
@@ -252,7 +252,7 @@ def link_library_dynamic(hs, dep_info, object_files, pkg_id):
 
   dynamic_library = hs.actions.declare_file(
     "lib{0}-ghc{1}.{2}".format(
-      get_library_name(pkg_id),
+      "HS" + pkg_id.to_string(my_pkg_id),
       hs.toolchain.version,
       so_extension(hs),
     )

--- a/haskell/private/actions/package.bzl
+++ b/haskell/private/actions/package.bzl
@@ -1,71 +1,11 @@
 """Action for creating packages and registering them with ghc-pkg"""
 
 load(":private/path_utils.bzl", "target_unique_name")
+load(":private/pkg_id.bzl", "pkg_id")
 load(":private/set.bzl", "set")
 load("@bazel_skylib//:lib.bzl", "paths")
 
-def _zencode(s):
-  """Zero-escape a given string.
-
-  Args:
-    s: inputs string.
-
-  Returns:
-    string: zero-escaped string.
-  """
-  return s.replace("Z", "ZZ").replace("_", "ZU").replace("/", "ZS")
-
-def get_pkg_name(hs):
-  """Get package name.
-
-  The name is not required to be unique/injective; however it must be a valid
-  GHC package name (i.e., no underscores).  This encoding does not aim to
-  change as little as possible since it is used for display and also for the
-  "PackageImports" extension.
-
-  Args:
-    hs: Haskell context.
-
-  Returns:
-    string: GHC package name to use.
-  """
-  return hs.name.replace("_", "-")
-
-def get_pkg_id(ctx):
-  """Get package identifier of the form `name-version`.
-
-  The identifier is required to be unique for each Haskell rule.
-  It includes the Bazel package and the name of the this component.
-  We can't use just the latter because then two components with
-  the same names in different packages would clash.
-
-  Args:
-    ctx: Rule context
-
-  Returns:
-    string: GHC package ID to use.
-  """
-  return "{0}-{1}".format(
-    _zencode(paths.join(
-        ctx.label.workspace_root,
-        ctx.label.package,
-        ctx.attr.name)),
-    ctx.attr.version)
-
-def get_library_name(pkg_id):
-  """Get core library name for this package. This is "HS" followed by package ID.
-
-  See https://ghc.haskell.org/trac/ghc/ticket/9625 .
-
-  Args:
-    pkg_id: Package ID string.
-
-  Returns:
-    string: Library name suitable for GHC package entry.
-  """
-  return "HS{0}".format(pkg_id)
-
-def package(hs, dep_info, interfaces_dir, static_library, dynamic_library, exposed_modules, other_modules, pkg_id, version, pkg_deps):
+def package(hs, dep_info, interfaces_dir, static_library, dynamic_library, exposed_modules, other_modules, my_pkg_id, pkg_deps):
   """Create GHC package using ghc-pkg.
 
   Args:
@@ -77,24 +17,24 @@ def package(hs, dep_info, interfaces_dir, static_library, dynamic_library, expos
   Returns:
     (File, File): GHC package conf file, GHC package cache file
   """
-  pkg_db_dir = hs.actions.declare_directory(pkg_id)
-  conf_file = hs.actions.declare_file(paths.join(pkg_db_dir.basename, "{0}.conf".format(pkg_id)))
+  pkg_db_dir = hs.actions.declare_directory(pkg_id.to_string(my_pkg_id))
+  conf_file = hs.actions.declare_file(paths.join(pkg_db_dir.basename, "{0}.conf".format(pkg_id.to_string(my_pkg_id))))
   cache_file = hs.actions.declare_file("package.cache", sibling=conf_file)
 
   # Create a file from which ghc-pkg will create the actual package from.
   registration_file = hs.actions.declare_file(target_unique_name(hs, "registration-file"))
   registration_file_entries = {
-    "name": get_pkg_name(hs),
-    "version": version,
-    "id": pkg_id,
-    "key": pkg_id,
+    "name": my_pkg_id.name,
+    "version": my_pkg_id.version,
+    "id": pkg_id.to_string(my_pkg_id),
+    "key": pkg_id.to_string(my_pkg_id),
     "exposed": "True",
     "exposed-modules": " ".join(set.to_list(exposed_modules)),
     "hidden-modules": " ".join(set.to_list(other_modules)),
     "import-dirs": paths.join("${pkgroot}", interfaces_dir.basename),
     "library-dirs": "${pkgroot}",
     "dynamic-library-dirs": "${pkgroot}",
-    "hs-libraries": get_library_name(pkg_id),
+    "hs-libraries": "HS" + pkg_id.to_string(my_pkg_id),
     "depends":
       ", ".join([d.package_id for d in pkg_deps]),
   }

--- a/haskell/private/pkg_id.bzl
+++ b/haskell/private/pkg_id.bzl
@@ -1,0 +1,50 @@
+"""Package identifiers"""
+
+load("@bazel_skylib//:lib.bzl", "paths")
+
+def _zencode(s):
+  """Z-escape special characters to make a valid GHC package identifier.
+
+  Args:
+    s: string
+  """
+  return s.replace("Z", "ZZ").replace("_", "ZU").replace("/", "ZS")
+
+def _to_string(my_pkg_id):
+  """Get package identifier of the form `name-version`.
+
+  The identifier is required to be unique for each Haskell rule.
+  It includes the Bazel package and the name of the this component.
+  We can't use just the latter because then two components with
+  the same names in different packages would clash.
+  """
+  return "{0}-{1}".format(
+    _zencode(paths.join(
+      my_pkg_id.label.workspace_root,
+      my_pkg_id.label.package,
+      my_pkg_id.name)),
+    my_pkg_id.version)
+
+def _new(label, version):
+  """Create a new package identifier.
+
+  Package identifiers should be globally unique. This is why we use
+  a label to identify them.
+
+  Args:
+    label: The label of the rule declaring the package.
+
+  Returns:
+    string: GHC package ID to use.
+
+  """
+  return struct(
+    label = label,
+    name = label.name.replace("_", "-"),
+    version = version,
+  )
+
+pkg_id = struct(
+  new = _new,
+  to_string = _to_string,
+)

--- a/tests/package-name/Main.hs
+++ b/tests/package-name/Main.hs
@@ -28,6 +28,6 @@ main :: IO ()
 main = do
     check foo 42
     check VERSION_lib_a_Z "1.2.3.4"
-    check libPackageKey "testsZSpackage-nameZSlib-aZUZZ-1.2.3.4"
+    check libPackageKey "testsZSpackage-nameZSlib-a-ZZ-1.2.3.4"
     check versionHighEnoughTest True
     check versionTooLowTest True


### PR DESCRIPTION
In the case of libraries, we unfortunately can't use just the label
for everything. We need a version component, otherwise `ghc-pkg`
complains. We used to have an unholy mishmash of stuffs: package
names, package id's and versions, all disconnected from each other.
Now we package everything into a single struct that we pass along as
an argument.

I inlined `get_library_name` because there's no good place to put that
function, and it's a trivially small one anyways.