### PR TITLE
Add mnemonics to most actions

### DIFF
--- a/haskell/cc.bzl
+++ b/haskell/cc.bzl
@@ -182,6 +182,7 @@ def _cc_haskell_import(ctx):
     ctx.actions.run(
       inputs = [bin],
       outputs = [dyn_lib],
+      mnemonic = "Symlink",
       executable = tools(ctx).ln,
       arguments = ["-s", relative_bin, dyn_lib.path],
     )

--- a/haskell/haddock.bzl
+++ b/haskell/haddock.bzl
@@ -85,8 +85,9 @@ def _haskell_doc_aspect_impl(target, ctx):
         tools(ctx).haddock,
       ]),
     ]),
-    outputs = [html_dir, haddock_file],
-    progress_message = "Haddock {0}".format(ctx.rule.attr.name),
+    outputs = [haddock_file, html_dir],
+    mnemonic = "HaskellHaddock",
+    progress_message = "HaskellHaddock {}".format(ctx.label),
     executable = ctx.file._haddock_wrapper,
     arguments = [
       prebuilt_deps,
@@ -210,10 +211,10 @@ def _haskell_doc_rule_impl(ctx):
   static_haddock_outputs = [
     ctx.actions.declare_file(paths.join(doc_root_raw, f))
     for f in [
+      "index.html",
       "doc-index.html",
       "haddock-util.js",
       "hslogo-16.png",
-      "index.html",
       "minus.gif",
       "ocean.css",
       "plus.gif",
@@ -228,7 +229,7 @@ def _haskell_doc_rule_impl(ctx):
       depset(haddock_dict.values()),
     ]),
     outputs = static_haddock_outputs,
-    progress_message = "Creating unified Haddock index {0}".format(ctx.attr.name),
+    mnemonic = "HaskellHaddockIndex",
     executable = tools(ctx).haddock,
     arguments = [args],
   )

--- a/haskell/lint.bzl
+++ b/haskell/lint.bzl
@@ -96,7 +96,8 @@ def _haskell_lint_aspect_impl(target, ctx):
       ]),
     ]),
     outputs = [lint_log],
-    progress_message = "Linting {0}".format(ctx.rule.attr.name),
+    mnemonic = "HaskellLint",
+    progress_message = "HaskellLint {}".format(ctx.label),
     command = """
     ghc "$@" > {output} 2>&1 || rc=$? && cat {output} && exit $rc
     """.format(
@@ -197,7 +198,8 @@ def _haskell_doctest_aspect_impl(target, ctx):
       ]),
     ]),
     outputs = [lint_log],
-    progress_message = "Doctesting {0}".format(ctx.rule.attr.name),
+    mnemonic = "HaskellDoctest",
+    progress_message = "HaskellDoctest {}".format(ctx.label),
     command = """
     doctest "$@" > {output} 2>&1 || rc=$? && cat {output} && exit $rc
     """.format(output = lint_log.path),

--- a/haskell/private/actions/compile.bzl
+++ b/haskell/private/actions/compile.bzl
@@ -41,6 +41,7 @@ def _make_ghc_defs_dump(hs, cpp_defines):
   hs.actions.run(
     inputs = [dummy_src],
     outputs = [ghc_defs_dump_raw],
+    mnemonic = "HaskellCppDefines",
     executable = hs.tools.ghc,
     arguments = [args],
   )
@@ -95,7 +96,7 @@ def _process_hsc_file(hs, cc, ghc_defs_dump, hsc_file):
       depset([hsc_file, ghc_defs_dump])
     ]),
     outputs = [hs_out, hsc_output_dir],
-    progress_message = "hsc2hs {0}".format(hsc_file.basename),
+    mnemonic = "HaskellHsc2hs",
     executable = hs.tools.hsc2hs,
     arguments = [args],
     env = hs.env,
@@ -301,7 +302,8 @@ def compile_binary(hs, cc, java, dep_info, srcs, cpp_defines, compiler_flags, ma
   hs.actions.run(
     inputs = c.inputs,
     outputs = c.outputs,
-    progress_message = "Building {0}".format(hs.name),
+    mnemonic = "HaskellBuildBinary",
+    progress_message = "HaskellBuildBinary {}".format(hs.label),
     env = c.env,
     executable = hs.tools.ghc,
     arguments = [c.args]
@@ -345,7 +347,8 @@ def compile_library(hs, cc, java, dep_info, srcs, cpp_defines, compiler_flags, m
   hs.actions.run(
     inputs = c.inputs,
     outputs = c.outputs,
-    progress_message = "Compiling {0}".format(hs.name),
+    mnemonic = "HaskellBuildLibrary",
+    progress_message = "HaskellBuildLibrary {}".format(hs.label),
     env = c.env,
     executable = hs.tools.ghc,
     arguments = [c.args],

--- a/haskell/private/actions/link.bzl
+++ b/haskell/private/actions/link.bzl
@@ -46,6 +46,7 @@ module BazelDummy () where
   hs.actions.run(
     inputs = [dummy_input],
     outputs = [dummy_object],
+    mnemonic = "HaskellDummyObjectGhc",
     executable = hs.tools.ghc,
     arguments = ["-c", dummy_input.path],
   )
@@ -56,6 +57,7 @@ module BazelDummy () where
   hs.actions.run(
     inputs = [dummy_object] + hs.tools_runfiles.ar,
     outputs = [dummy_static_lib],
+    mnemonic = "HaskellDummyObjectAr",
     executable = hs.tools.ar,
     arguments = [ar_args]
   )
@@ -80,8 +82,8 @@ def _fix_linker_paths(hs, inp, out, external_libraries):
   hs.actions.run_shell(
       inputs=[inp],
       outputs=[out],
-      progress_message =
-          "Fixing install paths for {0}".format(out.basename),
+      mnemonic = "HaskellFixupLoaderPath",
+      progress_message = "Fixing install paths for {0}".format(out.basename),
       command = " &&\n    ".join(
           ["cp {} {}".format(inp.path, out.path),
            "chmod +w {}".format(out.path)]
@@ -173,7 +175,7 @@ def link_binary(hs, dep_info, compiler_flags, object_files):
       depset(dep_info.external_libraries.values()),
     ]),
     outputs = [compile_output],
-    progress_message = "Linking {0}".format(hs.name),
+    mnemonic = "HaskellLinkBinary",
     executable = hs.tools.ghc,
     arguments = [args],
   )
@@ -237,7 +239,7 @@ def link_library_static(hs, dep_info, object_files, my_pkg_id):
   hs.actions.run(
     inputs = object_files + hs.tools_runfiles.ar,
     outputs = [static_library],
-    progress_message = "Linking static library {0}".format(static_library.basename),
+    mnemonic = "HaskellLinkStaticLibrary",
     executable = hs.tools.ar,
     arguments = [args],
   )
@@ -305,7 +307,7 @@ def link_library_dynamic(hs, dep_info, object_files, my_pkg_id):
       depset(dep_info.external_libraries.values()),
     ]),
     outputs = [dynamic_library_tmp],
-    progress_message = "Linking dynamic library {0}".format(dynamic_library.basename),
+    mnemonic = "HaskellLinkDynamicLibrary",
     executable = hs.tools.ghc,
     arguments = [args]
   )

--- a/haskell/private/actions/package.bzl
+++ b/haskell/private/actions/package.bzl
@@ -52,10 +52,11 @@ def package(hs, dep_info, interfaces_dir, static_library, dynamic_library, expos
       set.to_depset(dep_info.package_caches),
       depset([static_library, interfaces_dir, registration_file, dynamic_library]),
     ]),
-    outputs = [pkg_db_dir, conf_file, cache_file],
+    outputs = [conf_file, pkg_db_dir, cache_file],
     env = {
       "GHC_PACKAGE_PATH": package_path,
     },
+    mnemonic = "HaskellRegisterPackage",
     executable = hs.tools.ghc_pkg,
     arguments = [
       "register", "--package-db={0}".format(pkg_db_dir.path),

--- a/haskell/private/actions/repl.bzl
+++ b/haskell/private/actions/repl.bzl
@@ -156,6 +156,7 @@ def build_haskell_repl(
       target_files,
     ]),
     outputs = [output],
+    mnemonic = "Symlink",
     executable = hs.tools.ln,
     arguments = ["-s", relative_target, output.path],
   )

--- a/haskell/private/context.bzl
+++ b/haskell/private/context.bzl
@@ -23,6 +23,7 @@ def haskell_context(ctx, attr=None):
   return HaskellContext(
     # Fields
     name = attr.name,
+    label = ctx.label,
     toolchain = toolchain,
     tools = toolchain.tools,
     tools_runfiles = toolchain.tools_runfiles,

--- a/haskell/private/dependencies.bzl
+++ b/haskell/private/dependencies.bzl
@@ -56,6 +56,7 @@ def _mangle_solib(ctx, label, solib, preserve_name):
   ctx.actions.run(
     inputs = [solib],
     outputs = [qualsolib],
+    mnemonic = "Symlink",
     executable = tools(ctx).ln,
     arguments = ["-s", relative_solib, qualsolib.path],
   )

--- a/haskell/protobuf.bzl
+++ b/haskell/protobuf.bzl
@@ -106,6 +106,7 @@ def _haskell_proto_aspect_impl(target, ctx):
       protobuf_tools(ctx).plugin,
     ] + inputs),
     outputs = hs_files,
+    mnemonic = "HaskellProtoc",
     executable = protobuf_tools(ctx).protoc,
     arguments = [args],
   )

--- a/haskell/toolchain.bzl
+++ b/haskell/toolchain.bzl
@@ -35,6 +35,7 @@ def _haskell_toolchain_impl(ctx):
   ctx.actions.run_shell(
     inputs = [compiler],
     outputs = [version_file],
+    mnemonic = "HaskellVersionCheck",
     command = """
     {compiler} --numeric-version > {version_file}
     if [[ {expected_version} != $(< {version_file}) ]]
@@ -116,6 +117,7 @@ def _haskell_toolchain_impl(ctx):
     ctx.actions.run(
       inputs = inputs,
       outputs = [symlink],
+      mnemonic = "Symlink",
       executable = "ln",
       # FIXME Currently this part of the process is not hermetic. This
       # should be adjusted when
@@ -151,6 +153,7 @@ def _haskell_toolchain_impl(ctx):
     ctx.actions.run_shell(
       inputs = ctx.files.tools,
       outputs = [symlink],
+      mnemonic = "Symlink",
       command = """
       mkdir -p $(dirname "{symlink}")
       ln -s $(which "{target}") "{symlink}"


### PR DESCRIPTION
The mnemonics follow these principles:

* they all use `Haskell*` as a prefix, to easily distinguish them from
  actions for other rule sets in the real-time status section at the
  bottom of the screen during a build. `rules_go` also follows this
  convention.
* Some outputs had to be reordered because in build logs, Bazel only
  prints the *first* output name together with the mnemonic.
* We prefer mnemonics where they are sufficient. Where there is no
  good output name to print alongside it, we use a `progress_message`
  instead but still define a matching mnemonic.