### PR TITLE
Add link checks for Skylark code

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
             apk --no-progress update
             apk --no-progress add bash ca-certificates
             nix-channel --update
-            nix-env -iA nixpkgs.bazel nixpkgs.binutils nixpkgs.python
+            nix-env -iA nixpkgs.bazel nixpkgs.binutils nixpkgs.python nixpkgs.go
       - run:
           name: Build
           command: bazel build --jobs=2 //... @haskell_zlib//...
@@ -58,6 +58,7 @@ jobs:
           command: |
             brew update
             brew install bazel
+            brew install go
       - run:
           name: Build
           shell: /bin/bash -eilo pipefail

--- a/README.md
+++ b/README.md
@@ -138,6 +138,21 @@ installed. To build and run tests locally, execute:
 $ bazel test //...
 ```
 
+Skylark code in this project is formatted according to the output of
+[buildifier]. You can check that the formatting is correct using:
+
+```
+$ bazel test --config lint //...
+```
+
+If tests fail then run the following to fix the formatting:
+
+```
+$ bazel run --direct_run //skylark:buildifier **/*.bzl **/BUILD
+```
+
+[buildifier]: https://github.com/bazelbuild/buildtools/tree/master/buildifier
+
 ## Rules
 
 See https://haskell.build for the reference documentation on provided

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -158,3 +158,32 @@ http_archive(
 )
 load("@io_bazel_skydoc//skylark:skylark.bzl", "skydoc_repositories")
 skydoc_repositories()
+
+# For buildifier
+
+# XXX Need a patched version of rules_go to workaround warnings fixed
+# by https://github.com/NixOS/nixpkgs/pull/28029 on NixOS. Revert to
+# official release once fix hits Nixpkgs master.
+http_archive(
+  name = "io_bazel_rules_go",
+  strip_prefix = "rules_go-6a2b1f780b475a75a7baae5b441635c566f0ed8a",
+  urls = ["https://github.com/mboes/rules_go/archive/6a2b1f780b475a75a7baae5b441635c566f0ed8a.tar.gz"],
+)
+
+http_archive(
+  name = "com_github_bazelbuild_buildtools",
+  strip_prefix = "buildtools-588d90030bc8054b550967aa45a8a8d170deba0b",
+  urls = ["https://github.com/bazelbuild/buildtools/archive/588d90030bc8054b550967aa45a8a8d170deba0b.tar.gz"],
+)
+
+load(
+  "@io_bazel_rules_go//go:def.bzl",
+  "go_rules_dependencies",
+  "go_register_toolchains",
+)
+
+go_rules_dependencies()
+
+# Use host version because none of the SDK's that rules_go knows about
+# are compatible with NixOS.
+go_register_toolchains(go_version = "host")

--- a/docs/BUILD
+++ b/docs/BUILD
@@ -1,7 +1,5 @@
-load(
-    "@io_bazel_skydoc//skylark:skylark.bzl",
-    "skylark_doc",
-)
+load("@io_bazel_skydoc//skylark:skylark.bzl", "skylark_doc")
+load("//skylark:lint.bzl", "skylark_lint")
 
 skylark_doc(
   name = "docs",
@@ -22,3 +20,5 @@ skylark_doc(
   ],
   format = "html",
 )
+
+skylark_lint()

--- a/haskell/BUILD
+++ b/haskell/BUILD
@@ -1,3 +1,5 @@
+load("//skylark:lint.bzl", "skylark_lint")
+
 exports_files(
   glob(["*.bzl"]) + [
   "assets/cpp_defines",
@@ -6,3 +8,5 @@ exports_files(
   "private/ghci_repl_wrapper.sh",
   "private/haddock_wrapper.sh",
 ])
+
+skylark_lint()

--- a/skylark/BUILD
+++ b/skylark/BUILD
@@ -1,0 +1,1 @@
+exports_files(["lint.bzl"])

--- a/skylark/BUILD
+++ b/skylark/BUILD
@@ -1,1 +1,8 @@
 exports_files(["lint.bzl"])
+
+sh_binary(
+  name = "buildifier",
+  srcs = ["buildifier.sh"],
+  data = ["@com_github_bazelbuild_buildtools//buildifier"],
+  args = ["$(location @com_github_bazelbuild_buildtools//buildifier)"],
+)

--- a/skylark/buildifier.sh
+++ b/skylark/buildifier.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+buildifier=$(pwd)/$1
+shift
+
+function die() {
+  echo "$1"
+  exit 1
+}
+
+if [[ -n "$BUILD_WORKING_DIRECTORY" ]]
+then
+    die "Error: script must be called using bazel run --direct_run."
+fi
+
+cd $BUILD_WORKING_DIRECTORY
+$buildifier $@

--- a/skylark/lint.bzl
+++ b/skylark/lint.bzl
@@ -1,0 +1,57 @@
+"""Lint checks for BUILD and *.bzl files."""
+
+# sh_binary(
+#   name = "buildify",
+#   srcs = ["apply.sh"],
+#   data = ["@com_github_bazelbuild_buildtools//buildifier", ":srcs"],
+#   args = [
+#     "$(location @com_github_bazelbuild_buildtools//buildifier)",
+#     "$(locations :srcs)",
+#   ]
+# )
+
+def _buildifier_generate_impl(ctx):
+  output = ctx.actions.declare_file(ctx.attr.name)
+  ctx.actions.write(
+    output = output,
+    is_executable = True,
+    content = """
+    {buildifier} -mode=check {args}
+    """.format(
+      buildifier = ctx.file._buildifier.short_path,
+      args = " ".join([entry.path for entry in ctx.files.data])
+    )
+  )
+  return DefaultInfo(
+    files = depset([output]),
+    runfiles = ctx.runfiles(
+      files = [ctx.file._buildifier] + ctx.files.data,
+      collect_data = True),
+  )
+
+_buildifier_generate = rule(
+  _buildifier_generate_impl,
+  attrs = {
+    "data": attr.label_list(allow_files = True, cfg = "data"),
+    "_buildifier": attr.label(
+      default = "@com_github_bazelbuild_buildtools//buildifier",
+      single_file = True,
+    )
+  }
+)
+
+def skylark_lint(name = "lint", data = None):
+  """Add a lint test to check style of BUILD and *.bzl files."""
+  if not data:
+    data = native.glob(["**/*.bzl", "**/BUILD"])
+  script_name = name + "_buildifier_generate"
+  _buildifier_generate(
+    name = script_name,
+    data = data,
+  )
+  native.sh_test(
+    name = name + "_buildifier",
+    srcs = [script_name],
+    data = data,
+    tags = ["lint"],
+  )

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -6,8 +6,8 @@ load("@io_tweag_rules_haskell//haskell:haskell.bzl",
   "haskell_toolchain",
   "haskell_proto_toolchain",
 )
-
 load("@bazel_tools//tools/build_rules:test_rules.bzl", "rule_test")
+load("//skylark:lint.bzl", "skylark_lint")
 
 haskell_toolchain(
   name = "ghc",
@@ -311,3 +311,5 @@ rule_test(
   rule = "//tests:run-bin-with-c-lib",
   size = "small",
 )
+
+skylark_lint()

--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -1,5 +1,4 @@
-# This file contains options passed to Bazel when running tests on
-# continuous integration services. Run with: bazel test --config=ci
+# See https://docs.bazel.build/versions/master/user-manual.html#bazelrc.
 
 #build:ci --all_incompatible_changes
 build:ci --genrule_strategy=standalone
@@ -10,3 +9,8 @@ build:ci --jobs=0 # avoid OOM condition caused by high levels of concurrency on 
 common:ci --color=no
 test:ci --test_output=errors
 test:ci --test_strategy=standalone
+# TODO remove following line once branch passes lint.
+test:ci --test_tag_filters=-lint
+
+test:lint --build_tests_only
+test:lint --test_tag_filters=lint


### PR DESCRIPTION
We do this in the form of tests, defined using the `skylark_lint`
macro with a default name. This macro is purely for internal use on
rules_haskell code, not client code. It could be upstreamed to
bazelbuild/buildtools eventually.

The lint tests are for *checking* the formatting. Developers are
expected to use buildifier as a formatter integrated into their
editor. There are instructions in the README to call the formatter
from the command-line.