### PR TITLE
Fix haddock generation for proto libs

### DIFF
--- a/haskell/haddock.bzl
+++ b/haskell/haddock.bzl
@@ -40,7 +40,7 @@ def _haskell_doc_aspect_impl(target, ctx):
   args.add([
     "-D", haddock_file.path,
     "--package-name={0}".format(package_id),
-    "--package-version={0}".format(ctx.rule.attr.version),
+    "--package-version={0}".format(target[HaskellLibraryInfo].version),
     "-o", html_dir,
     "--html", "--hoogle",
     "--title={0}".format(package_id),
@@ -58,8 +58,6 @@ def _haskell_doc_aspect_impl(target, ctx):
   for pid in transitive_haddocks:
     args.add("--read-interface=../{0},{1}".format(
       pid, transitive_haddocks[pid].path))
-
-  input_sources = [ f for t in ctx.rule.attr.srcs for f in t.files.to_list() ]
 
   prebuilt_deps = ctx.actions.args()
   for dep in set.to_list(target[HaskellBuildInfo].prebuilt_dependencies):

--- a/haskell/private/haskell_impl.bzl
+++ b/haskell/private/haskell_impl.bzl
@@ -152,6 +152,7 @@ def haskell_library_impl(ctx):
   )
   lib_info = HaskellLibraryInfo(
     package_id = pkg_id.to_string(my_pkg_id),
+    version = ctx.attr.version,
     import_dirs = c.import_dirs,
     exposed_modules = exposed_modules,
     other_modules = other_modules,

--- a/haskell/private/providers.bzl
+++ b/haskell/private/providers.bzl
@@ -37,6 +37,7 @@ HaskellLibraryInfo = provider(
   doc = "Library-specific information.",
   fields = {
     "package_id": "Package id, usually of the form name-version.",
+    "version": "Package version.",
     "import_dirs": "Import hierarchy roots.",
     "exposed_modules": "Set of exposed module names.",
     "other_modules": "Set of non-public module names.",

--- a/tests/haskell_proto_library/BUILD
+++ b/tests/haskell_proto_library/BUILD
@@ -3,6 +3,7 @@ package(default_testonly = 1)
 load("@io_tweag_rules_haskell//haskell:haskell.bzl",
      "haskell_library",
      "haskell_proto_library",
+     "haskell_doc",
 )
 
 proto_library(
@@ -44,4 +45,9 @@ haskell_library(
   ],
   prebuilt_dependencies = ["base"],
   visibility = ["//visibility:public"],
+)
+
+haskell_doc(
+  name = "docs",
+  deps = [":hs-lib"],
 )


### PR DESCRIPTION
Without this change, if we use `haskell_doc` on a `haskell_proto_library` target, or a target that depends on a `haskell_proto_library` target transitively, we get an error. This PR solves that and allows to generate docs for protobuf-produced libraries too.