### PR TITLE
Make the repl actually load the target's srcs.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,12 +24,12 @@ jobs:
           name: Test REPL for libraries
           command: |
             bazel build //tests/repl-targets:hs-lib-repl
-            bazel-bin/tests/repl-targets/hs-lib-repl -e ":quit"
+            bazel-bin/tests/repl-targets/hs-lib-repl -e "foo 10"
       - run:
           name: Test REPL for binaries
           command: |
             bazel build //tests/repl-targets:hs-bin-repl
-            bazel-bin/tests/repl-targets/hs-bin-repl -e ":quit"
+            bazel-bin/tests/repl-targets/hs-bin-repl -e ":main"
       - run:
           name: Test start script
           command: |

--- a/haskell/private/actions/repl.bzl
+++ b/haskell/private/actions/repl.bzl
@@ -119,7 +119,7 @@ def build_haskell_repl(
     },
   )
 
-  args += ["-ghci-script", ghci_script.path]
+  args += ["-ghci-script", ghci_repl_script.path]
 
   # Extra arguments.
   args += repl_ghci_args
@@ -152,7 +152,7 @@ def build_haskell_repl(
       # hs.tools.ghci and ghci_script and the best way to do that is
       # to use hs.actions.run. That action, it turn must produce
       # a result, so using ln seems to be the only sane choice.
-      depset([hs.tools.ghci, ghci_script, repl_file]),
+      depset([hs.tools.ghci, ghci_repl_script, repl_file]),
       target_files,
     ]),
     outputs = [output],


### PR DESCRIPTION
Previously, running the repl for a target would load
its dependencies but not its own source files:
```
$ bazel-bin/tests/repl-targets/hs-lib-repl
GHCi, version 8.2.2: http://www.haskell.org/ghc/  :? for help
Prelude>
```

After this change:
```
$ bazel-bin/tests/repl-targets/hs-lib-repl
GHCi, version 8.2.2: http://www.haskell.org/ghc/  :? for help
[1 of 1] Compiling Foo              ( tests/repl-targets/Foo.hs, interpreted )
Ok, one module loaded.
Loaded GHCi configuration from
bazel-out/darwin-fastbuild/bin/tests/repl-targets/ghci-repl-script-hs-lib
*Foo Foo>
```

I'm not sure why the module "Foo" looks like it gets loaded twice, but
that's probably a separate issue and seems harmless for now.