### PR TITLE
Work around macOS linker limits.

### DIFF
--- a/haskell/private/actions/compile.bzl
+++ b/haskell/private/actions/compile.bzl
@@ -199,6 +199,12 @@ def _compilation_defaults(hs, cc, java, dep_info, srcs, cpp_defines, compiler_fl
 
   add_mode_options(hs, args)
 
+  # Work around macOS linker limits.  This fix has landed in GHC HEAD, but is
+  # not yet in a release; plus, we still want to support older versions of
+  # GHC.  For details, see: https://phabricator.haskell.org/D4714
+  if hs.toolchain.is_darwin:
+    args.add(["-optl-Wl,-dead_strip_dylibs"])
+
   # Add import hierarchy root.
   # Note that this is not perfect, since GHC requires hs-boot files
   # to be in the same directory as the corresponding .hs file.  Thus

--- a/haskell/private/actions/link.bzl
+++ b/haskell/private/actions/link.bzl
@@ -266,6 +266,12 @@ def link_library_dynamic(hs, dep_info, object_files, my_pkg_id):
 
   args.add(["-shared", "-dynamic"])
 
+  # Work around macOS linker limits.  This fix has landed in GHC HEAD, but is
+  # not yet in a release; plus, we still want to support older versions of
+  # GHC.  For details, see: https://phabricator.haskell.org/D4714
+  if hs.toolchain.is_darwin:
+    args.add(["-optl-Wl,-dead_strip_dylibs"])
+
   for package in set.to_list(dep_info.package_ids):
     args.add(["-package-id", package])
   for package in set.to_list(dep_info.prebuilt_dependencies):


### PR DESCRIPTION
Previously, the build would fail on macOS if there were too many
transitive Haskell dependencies.  We encountered that situation
in our repo this week:
```
ghc: panic! (the 'impossible' happened)
  (GHC version 8.2.2 for x86_64-apple-darwin):
    Loading temp shared object failed: dlopen(/var/folders/ql/cdls48955v94j_wr38p7kq300000gp/T/ghc39877_0/libghc_16.dylib, 5): no suitable image found.  Did find:
    /var/folders/ql/cdls48955v94j_wr38p7kq300000gp/T/ghc39877_0/libghc_16.dylib: malformed mach-o: load commands size (37032) > 32768
```
This is a known issue that several other builds systems have worked around
(e.g.: Cabal, Stack, Nix).

Luckily, a new fix *just* (two days ago!) landed in GHC HEAD, and is easy to
replicate in `rules_haskell`.  For details, see:
https://phabricator.haskell.org/D4714

I had to add it in a couple places; I saw a bit of other redundant code, but let me know if it makes sense to move this into an existing utility function.