### PR TITLE
Extra source files

### DIFF
--- a/haskell/haddock.bzl
+++ b/haskell/haddock.bzl
@@ -78,6 +78,7 @@ def _haskell_doc_aspect_impl(target, ctx):
       set.to_depset(target[HaskellLibraryInfo].header_files),
       set.to_depset(target[HaskellLibraryInfo].boot_files),
       set.to_depset(target[HaskellLibraryInfo].source_files),
+      target[HaskellLibraryInfo].extra_source_files,
       depset([
         tools(ctx).bash,
         tools(ctx).ghc_pkg,

--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -48,7 +48,7 @@ _haskell_common_attrs = {
   ),
   "extra_srcs": attr.label_list(
     allow_files = True,
-    doc = "Extra (non-Haskell) source files that will be needed at compile time (e.g. by TH).",
+    doc = "Extra (non-Haskell) source files that will be needed at compile time (e.g. by Template Haskell).",
   ),
   "deps": attr.label_list(
     doc = "List of other Haskell libraries to be linked to this target.",

--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -46,6 +46,10 @@ _haskell_common_attrs = {
     allow_files = FileType([".hs", ".hsc", ".chs", ".lhs", ".hs-boot", ".lhs-boot", ".h"]),
     doc = "Haskell source files.",
   ),
+  "extra_srcs": attr.label_list(
+    allow_files = True,
+    doc = "Extra (non-Haskell) source files that will be needed at compile time (e.g. by TH).",
+  ),
   "deps": attr.label_list(
     doc = "List of other Haskell libraries to be linked to this target.",
   ),

--- a/haskell/private/actions/compile.bzl
+++ b/haskell/private/actions/compile.bzl
@@ -156,7 +156,7 @@ def _process_chs_file(hs, cc, ghc_defs_dump, chs_file, chi_files=[]):
 
   return hs_out, chi_out
 
-def _compilation_defaults(hs, cc, java, dep_info, srcs, cpp_defines, compiler_flags, main_file = None, my_pkg_id = None):
+def _compilation_defaults(hs, cc, java, dep_info, srcs, extra_srcs, cpp_defines, compiler_flags, main_file = None, my_pkg_id = None):
   """Declare default compilation targets and create default compiler arguments.
 
   Returns:
@@ -328,6 +328,7 @@ def _compilation_defaults(hs, cc, java, dep_info, srcs, cpp_defines, compiler_fl
       depset(header_files),
       depset(boot_files),
       set.to_depset(source_files),
+      extra_srcs,
       depset(cc.hdrs),
       set.to_depset(dep_info.package_confs),
       set.to_depset(dep_info.package_caches),
@@ -347,6 +348,7 @@ def _compilation_defaults(hs, cc, java, dep_info, srcs, cpp_defines, compiler_fl
     header_files = set.from_list(cc.hdrs + header_files),
     boot_files = set.from_list(boot_files),
     source_files = source_files,
+    extra_source_files = extra_srcs,
     import_dirs = import_dirs,
     env = dicts.add({
       "LD_LIBRARY_PATH": get_external_libs_path(set.from_list(dep_info.external_libraries.values())),
@@ -355,7 +357,7 @@ def _compilation_defaults(hs, cc, java, dep_info, srcs, cpp_defines, compiler_fl
     ),
   )
 
-def compile_binary(hs, cc, java, dep_info, srcs, cpp_defines, compiler_flags, main_file, main_function):
+def compile_binary(hs, cc, java, dep_info, srcs, extra_srcs, cpp_defines, compiler_flags, main_file, main_function):
   """Compile a Haskell target into object files suitable for linking.
 
   Returns:
@@ -365,7 +367,7 @@ def compile_binary(hs, cc, java, dep_info, srcs, cpp_defines, compiler_flags, ma
       modules: set of module names
       source_files: set of Haskell source files
   """
-  c = _compilation_defaults(hs, cc, java, dep_info, srcs, cpp_defines, compiler_flags, main_file = main_file)
+  c = _compilation_defaults(hs, cc, java, dep_info, srcs, extra_srcs, cpp_defines, compiler_flags, main_file = main_file)
   c.args.add(["-main-is", main_function])
 
   hs.actions.run(
@@ -385,7 +387,7 @@ def compile_binary(hs, cc, java, dep_info, srcs, cpp_defines, compiler_flags, ma
     source_files = c.source_files,
   )
 
-def compile_library(hs, cc, java, dep_info, srcs, cpp_defines, compiler_flags, my_pkg_id):
+def compile_library(hs, cc, java, dep_info, srcs, extra_srcs, cpp_defines, compiler_flags, my_pkg_id):
   """Build arguments for Haskell package build.
 
   Returns:
@@ -399,7 +401,7 @@ def compile_library(hs, cc, java, dep_info, srcs, cpp_defines, compiler_flags, m
       source_files: set of Haskell module files
       import_dirs: import directories that should make all modules visible (for GHCi)
   """
-  c = _compilation_defaults(hs, cc, java, dep_info, srcs, cpp_defines, compiler_flags, my_pkg_id)
+  c = _compilation_defaults(hs, cc, java, dep_info, srcs, extra_srcs, cpp_defines, compiler_flags, my_pkg_id)
 
   # This is absolutely required otherwise GHC doesn't know what package it's
   # creating `Name`s for to put them in Haddock interface files which then
@@ -433,5 +435,6 @@ def compile_library(hs, cc, java, dep_info, srcs, cpp_defines, compiler_flags, m
     header_files = c.header_files,
     boot_files = c.boot_files,
     source_files = c.source_files,
+    extra_source_files = c.extra_source_files,
     import_dirs = c.import_dirs,
   )

--- a/haskell/private/haskell_impl.bzl
+++ b/haskell/private/haskell_impl.bzl
@@ -36,6 +36,7 @@ def haskell_binary_impl(ctx):
     cpp_defines = ctx.file._cpp_defines,
     compiler_flags = ctx.attr.compiler_flags,
     srcs = ctx.files.srcs,
+    extra_srcs = depset(ctx.files.extra_srcs),
     main_file = ctx.file.main_file,
     main_function = ctx.attr.main_function,
   )
@@ -97,6 +98,7 @@ def haskell_library_impl(ctx):
     cpp_defines = ctx.file._cpp_defines,
     compiler_flags = ctx.attr.compiler_flags,
     srcs = ctx.files.srcs,
+    extra_srcs = depset(ctx.files.extra_srcs),
     my_pkg_id = my_pkg_id,
   )
 
@@ -160,6 +162,7 @@ def haskell_library_impl(ctx):
     header_files = c.header_files,
     boot_files = c.boot_files,
     source_files = c.source_files,
+    extra_source_files = c.extra_source_files,
   )
   target_files = depset([conf_file, cache_file])
 

--- a/haskell/private/providers.bzl
+++ b/haskell/private/providers.bzl
@@ -14,6 +14,7 @@ DefaultCompileInfo = provider(
     "header_files": "Set of header files.",
     "boot_files": "Set of boot files.",
     "source_files": "Set of files that contain Haskell modules.",
+    "extra_source_files": "A depset of non-Haskell source files.",
     "import_dirs": "Import hierarchy roots.",
     "env": "Default env vars."
   },
@@ -45,6 +46,7 @@ HaskellLibraryInfo = provider(
     "header_files": "Set of header files.",
     "boot_files": "Set of boot files.",
     "source_files": "Set of files that contain Haskell modules.",
+    "extra_source_files": "A depset of non-Haskell source files.",
   },
 )
 

--- a/haskell/protobuf.bzl
+++ b/haskell/protobuf.bzl
@@ -139,6 +139,7 @@ def _haskell_proto_aspect_impl(target, ctx):
     file = ctx.file,
     files = struct(
       srcs = hs_files,
+      extra_srcs = depset(),
     ),
   )
 

--- a/tests/extra-source-files/BUILD
+++ b/tests/extra-source-files/BUILD
@@ -1,0 +1,21 @@
+package(default_testonly = 1)
+
+load(
+  "@io_tweag_rules_haskell//haskell:haskell.bzl",
+  "haskell_library",
+)
+
+haskell_library(
+  name = "extra-source-files",
+  srcs = [
+    "FooTH.hs",
+    "Foo.hs",
+  ],
+  extra_srcs = [
+    "file.txt",
+  ],
+  prebuilt_dependencies = [
+    "base",
+    "template-haskell",
+  ],
+)

--- a/tests/extra-source-files/Foo.hs
+++ b/tests/extra-source-files/Foo.hs
@@ -1,0 +1,8 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+module Foo (foo) where
+
+import FooTH (embedFile)
+
+foo :: String
+foo = $(embedFile "tests/extra-source-files/file.txt") ++ "!"

--- a/tests/extra-source-files/FooTH.hs
+++ b/tests/extra-source-files/FooTH.hs
@@ -1,0 +1,12 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+module FooTH (embedFile) where
+
+import Language.Haskell.TH
+import Language.Haskell.TH.Syntax
+
+embedFile :: FilePath -> Q Exp
+embedFile path = do
+  str <- runIO (readFile path)
+  addDependentFile path
+  [| str |]

--- a/tests/extra-source-files/file.txt
+++ b/tests/extra-source-files/file.txt
@@ -1,0 +1,1 @@
+And here we go


### PR DESCRIPTION
Close #291.

This makes it possible to compile TH code that references external files with arbitrary extensions, see the test. Unfortunately this still doesn't work out-of-the-box with Hackage packages because the path to files should include package names. Not a problem for new code though.