### PR TITLE
Fix doctesting of targets with transitive non-haskell deps

### DIFF
--- a/haskell/lint.bzl
+++ b/haskell/lint.bzl
@@ -78,10 +78,6 @@ def _haskell_lint_aspect_impl(target, ctx):
     target_unique_name(hs, "lint-log")
   )
 
-  lint_logs = _collect_lint_logs(
-    ctx.rule.attr.deps
-  )
-
   ctx.actions.run_shell(
     inputs = depset(transitive = [
       depset(sources),
@@ -109,7 +105,7 @@ def _haskell_lint_aspect_impl(target, ctx):
   )
 
   return [HaskellLintInfo(
-    outputs = set.mutable_insert(lint_logs, lint_log)
+    outputs = set.singleton(lint_log)
   )]
 
 haskell_lint_aspect = aspect(
@@ -181,10 +177,6 @@ def _haskell_doctest_aspect_impl(target, ctx):
     target_unique_name(hs, "doctest-log")
   )
 
-  lint_logs = _collect_lint_logs(
-    ctx.rule.attr.deps
-  )
-
   ctx.actions.run_shell(
     inputs = depset(transitive = [
       depset(sources),
@@ -209,7 +201,7 @@ def _haskell_doctest_aspect_impl(target, ctx):
   )
 
   return [HaskellLintInfo(
-    outputs = set.mutable_insert(lint_logs, lint_log)
+    outputs = set.singleton(lint_log)
   )]
 
 haskell_doctest_aspect = aspect(

--- a/haskell/lint.bzl
+++ b/haskell/lint.bzl
@@ -142,10 +142,11 @@ The following flags will be used:
 """
 
 def _haskell_doctest_aspect_impl(target, ctx):
-  hs = haskell_context(ctx, ctx.rule.attr)
 
   if HaskellBuildInfo not in target:
     return []
+
+  hs = haskell_context(ctx, ctx.rule.attr)
 
   build_info = target[HaskellBuildInfo]
   lib_info = target[HaskellLibraryInfo] if HaskellLibraryInfo in target else None

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -138,7 +138,6 @@ rule_test(
 rule_test(
   name = "test-haskell_lint-library",
   generates = [
-    "lint-log-lib-a",
     "lint-log-lib-b",
   ],
   rule = "//tests/haskell_lint:lint-lib-b",
@@ -148,7 +147,6 @@ rule_test(
 rule_test(
   name = "test-haskell_lint-binary",
   generates = [
-    "lint-log-lib-a",
     "lint-log-bin",
   ],
   rule = "//tests/haskell_lint:lint-bin",
@@ -168,7 +166,6 @@ rule_test(
 rule_test(
   name = "test-haskell_doctest",
   generates = [
-    "doctest-log-lib-a",
     "doctest-log-lib-b",
   ],
   rule = "//tests/haskell_doctest:haskell_doctest",

--- a/tests/haskell_doctest/BUILD
+++ b/tests/haskell_doctest/BUILD
@@ -8,6 +8,7 @@ load("@io_tweag_rules_haskell//haskell:haskell.bzl",
 haskell_library(
   name = "lib-a",
   srcs = ["Foo.hs"],
+  deps = ["@zlib.dev//:zlib"],
   prebuilt_dependencies = ["base"],
   visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
We need to place the check earlier because if we try get the context on non-haskell transitive deps, they are going to miss some import attributes.