### PR TITLE
Implement extra_binaries in haskell_toolchain.

### DIFF
--- a/haskell/private/actions/compile.bzl
+++ b/haskell/private/actions/compile.bzl
@@ -41,9 +41,11 @@ def _make_ghc_defs_dump(hs, cpp_defines):
   hs.actions.run(
     inputs = [dummy_src],
     outputs = [ghc_defs_dump_raw],
+    tools = hs.extra_binaries,
     mnemonic = "HaskellCppDefines",
     executable = hs.tools.ghc,
     arguments = [args],
+    env = hs.env,
   )
 
   hs.actions.run_shell(
@@ -355,6 +357,7 @@ def _compilation_defaults(hs, cc, java, dep_info, srcs, extra_srcs, cpp_defines,
       "LD_LIBRARY_PATH": get_external_libs_path(set.from_list(dep_info.external_libraries.values())),
       },
       java.env,
+      hs.env,
     ),
   )
 
@@ -374,6 +377,7 @@ def compile_binary(hs, cc, java, dep_info, srcs, extra_srcs, cpp_defines, compil
   hs.actions.run(
     inputs = c.inputs,
     outputs = c.outputs,
+    tools = hs.extra_binaries,
     mnemonic = "HaskellBuildBinary",
     progress_message = "HaskellBuildBinary {}".format(hs.label),
     env = c.env,
@@ -418,6 +422,7 @@ def compile_library(hs, cc, java, dep_info, srcs, extra_srcs, cpp_defines, compi
 
   hs.actions.run(
     inputs = c.inputs,
+    tools = hs.extra_binaries,
     outputs = c.outputs,
     mnemonic = "HaskellBuildLibrary",
     progress_message = "HaskellBuildLibrary {}".format(hs.label),

--- a/haskell/private/actions/compile.bzl
+++ b/haskell/private/actions/compile.bzl
@@ -39,9 +39,8 @@ def _make_ghc_defs_dump(hs, cpp_defines):
   ])
 
   hs.actions.run(
-    inputs = [dummy_src],
+    inputs = [dummy_src] + hs.extra_binaries,
     outputs = [ghc_defs_dump_raw],
-    tools = hs.extra_binaries,
     mnemonic = "HaskellCppDefines",
     executable = hs.tools.ghc,
     arguments = [args],
@@ -375,9 +374,8 @@ def compile_binary(hs, cc, java, dep_info, srcs, extra_srcs, cpp_defines, compil
   c.args.add(["-main-is", main_function])
 
   hs.actions.run(
-    inputs = c.inputs,
+    inputs = c.inputs + hs.extra_binaries,
     outputs = c.outputs,
-    tools = hs.extra_binaries,
     mnemonic = "HaskellBuildBinary",
     progress_message = "HaskellBuildBinary {}".format(hs.label),
     env = c.env,
@@ -421,8 +419,7 @@ def compile_library(hs, cc, java, dep_info, srcs, extra_srcs, cpp_defines, compi
   c.haddock_args.add(unit_id_args, before_each="--optghc")
 
   hs.actions.run(
-    inputs = c.inputs,
-    tools = hs.extra_binaries,
+    inputs = c.inputs + hs.extra_binaries,
     outputs = c.outputs,
     mnemonic = "HaskellBuildLibrary",
     progress_message = "HaskellBuildLibrary {}".format(hs.label),

--- a/haskell/private/context.bzl
+++ b/haskell/private/context.bzl
@@ -27,6 +27,7 @@ def haskell_context(ctx, attr=None):
     toolchain = toolchain,
     tools = toolchain.tools,
     tools_runfiles = toolchain.tools_runfiles,
+    extra_binaries = toolchain.extra_binaries,
     src_root = src_root,
     env = env,
     mode = ctx.var["COMPILATION_MODE"],

--- a/haskell/toolchain.bzl
+++ b/haskell/toolchain.bzl
@@ -111,11 +111,10 @@ def _haskell_toolchain_impl(ctx):
     inputs.append(ctx.file.c2hs)
 
   extra_binaries_names = set.empty()
-  for binaries in ctx.attr.extra_binaries:
-    for binary in binaries.files:
-      targets_r[binary.basename] = binary.path
-      inputs.append(binary)
-      set.mutable_insert(extra_binaries_names, binary.basename)
+  for binary in ctx.files.extra_binaries:
+    targets_r[binary.basename] = binary.path
+    inputs.append(binary)
+    set.mutable_insert(extra_binaries_names, binary.basename)
 
   extra_binaries_files = []
   for target in targets_r:


### PR DESCRIPTION
Now we can make javac visible to ghc to build packages which use inline-java.

Closes #282.