### PR TITLE
Tether haskell toolchain and CC toolchain

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,11 +67,11 @@ jobs:
           shell: /bin/bash -eilo pipefail
           command: |
             nix-build ./tests/protoc_gen_haskell.nix | cachix push tweag
-            nix-shell --run 'bazel build --jobs=2 //...'
+            nix-shell --run 'CC=$(which clang) bazel build --jobs=2 //...'
       - run:
           name: Run tests
           shell: /bin/bash -eilo pipefail
-          command: nix-shell --run ./run_tests.sh
+          command: nix-shell --run 'CC=$(which clang) ./run_tests.sh'
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,17 +62,16 @@ jobs:
           command: |
             brew update
             brew install bazel
-            brew install go
       - run:
           name: Build
           shell: /bin/bash -eilo pipefail
           command: |
             nix-build ./tests/protoc_gen_haskell.nix | cachix push tweag
-            bazel build --jobs=2 //...
+            nix-shell --run 'bazel build --jobs=2 //...'
       - run:
           name: Run tests
           shell: /bin/bash -eilo pipefail
-          command: ./run_tests.sh
+          command: nix-shell --run ./run_tests.sh
 
 workflows:
   version: 2

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -5,8 +5,8 @@ haskell_repositories()
 
 http_archive(
   name = "io_tweag_rules_nixpkgs",
-  strip_prefix = "rules_nixpkgs-0.2.2",
-  urls = ["https://github.com/tweag/rules_nixpkgs/archive/v0.2.2.tar.gz"],
+  strip_prefix = "rules_nixpkgs-0.2.3",
+  urls = ["https://github.com/tweag/rules_nixpkgs/archive/v0.2.3.tar.gz"],
 )
 
 load("@io_tweag_rules_nixpkgs//nixpkgs:nixpkgs.bzl",
@@ -21,7 +21,10 @@ nixpkgs_git_repository(
   # use a version of nixpkgs that is newer than 18.03.
 
   # Keep this value in sync with `nixpkgs.nix`
-  revision = "7c3dc2f53fc837be79426f11c9133f73d15a05c4",
+  revision = "8d5f06cbeedcfb4a88c111754baf2d7e315e74de",
+  # TODO Using a fork with Bazel v0.15. Switch to mainline once
+  # https://github.com/NixOS/nixpkgs/pull/42735 merged.
+  remote = "https://github.com/mboes/nixpkgs",
 )
 
 nixpkgs_package(

--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -131,7 +131,10 @@ def _mk_binary_rule(**kwargs):
     outputs = {
       "repl": "%{name}-repl",
     },
-    toolchains = ["@io_tweag_rules_haskell//haskell:toolchain"],
+    toolchains = [
+      "@io_tweag_rules_haskell//haskell:toolchain",
+      "@bazel_tools//tools/cpp:toolchain_type",
+    ],
     **kwargs
   )
 
@@ -186,7 +189,10 @@ haskell_library = rule(
   outputs = {
     "repl": "%{name}-repl",
   },
-  toolchains = ["@io_tweag_rules_haskell//haskell:toolchain"],
+  toolchains = [
+    "@io_tweag_rules_haskell//haskell:toolchain",
+    "@bazel_tools//tools/cpp:toolchain_type",
+  ],
 )
 """Build a library from Haskell source.
 

--- a/haskell/lint.bzl
+++ b/haskell/lint.bzl
@@ -1,6 +1,5 @@
 """Linting"""
 
-load(":cc.bzl", "cc_headers")
 load(":private/context.bzl", "haskell_context")
 load(":private/set.bzl", "set")
 load(":private/path_utils.bzl",

--- a/haskell/private/actions/compile.bzl
+++ b/haskell/private/actions/compile.bzl
@@ -84,6 +84,7 @@ def _process_hsc_file(hs, cc, ghc_defs_dump, hsc_file):
   hs_out = declare_compiled(hs, hsc_file, ".hs", directory=hsc_dir_raw)
   args.add([hsc_file.path, "-o", hs_out.path])
 
+  args.add(["-c", hs.tools.cc])
   args.add(["--cflag=" + f for f in cc.cpp_flags])
   args.add(["--cflag=" + f for f in cc.include_args])
   args.add("-I{0}".format(ghc_defs_dump.dirname))
@@ -92,7 +93,7 @@ def _process_hsc_file(hs, cc, ghc_defs_dump, hsc_file):
   hs.actions.run(
     inputs = depset(transitive = [
       depset(cc.hdrs),
-      depset([hs.tools.gcc]),
+      depset([hs.tools.cc]),
       depset([hsc_file, ghc_defs_dump]),
     ]),
     outputs = [hs_out],
@@ -127,7 +128,7 @@ def _process_chs_file(hs, cc, ghc_defs_dump, chs_file, chi_files=[]):
   args.add([chs_file.path, "-o", hs_out.path])
 
   args.add(["-C-E"])
-  args.add(["--cpp", hs.tools.gcc.path])
+  args.add(["--cpp", hs.tools.cc.path])
   args.add(["-C-I{0}".format(ghc_defs_dump.dirname)])
   args.add(["-C-include{0}".format(ghc_defs_dump.basename)])
   args.add(["-C" + x for x in cc.cpp_flags])
@@ -144,7 +145,7 @@ def _process_chs_file(hs, cc, ghc_defs_dump, chs_file, chi_files=[]):
   hs.actions.run(
     inputs = depset(transitive = [
       depset(cc.hdrs),
-      depset([hs.tools.gcc]),
+      depset([hs.tools.cc]),
       depset([chs_file, ghc_defs_dump]),
       depset(chi_files),
     ]),
@@ -342,7 +343,7 @@ def _compilation_defaults(hs, cc, java, dep_info, srcs, extra_srcs, cpp_defines,
       set.to_depset(dep_info.dynamic_libraries),
       depset(dep_info.external_libraries.values()),
       java.inputs,
-      depset([hs.tools.gcc]),
+      depset([hs.tools.cc]),
     ]),
     outputs = [objects_dir, interfaces_dir] + object_files + object_dyn_files + interface_files,
     objects_dir = objects_dir,

--- a/haskell/private/actions/compile.bzl
+++ b/haskell/private/actions/compile.bzl
@@ -87,7 +87,9 @@ def _process_hsc_file(hs, cc, ghc_defs_dump, hsc_file):
   args.add(["-c", hs.tools.cc])
   args.add(["-l", hs.tools.cc])
   args.add(["--cflag=" + f for f in cc.cpp_flags])
+  args.add(["--cflag=" + f for f in cc.compiler_flags])
   args.add(["--cflag=" + f for f in cc.include_args])
+  args.add(["--lflag=" + f for f in cc.linker_flags])
   args.add("-I{0}".format(ghc_defs_dump.dirname))
   args.add("-i{0}".format(ghc_defs_dump.basename))
 
@@ -167,6 +169,17 @@ def _compilation_defaults(hs, cc, java, dep_info, srcs, extra_srcs, cpp_defines,
   """
   args = hs.actions.args()
   haddock_args = hs.actions.args()
+
+  # GHC expects the CC compiler as the assembler, but segregates the
+  # set of flags to pass to it when used as an assembler. So we have
+  # to set both -optc and -opta.
+  cc_args = [
+    "-optc" + f for f in cc.compiler_flags
+  ] + [
+    "-opta" + f for f in cc.compiler_flags
+  ]
+  args.add(cc_args)
+  haddock_args.add(cc_args, before_each="--optghc")
 
   # Declare file directories
   objects_dir_raw = target_unique_name(hs, "objects")

--- a/haskell/private/actions/compile.bzl
+++ b/haskell/private/actions/compile.bzl
@@ -38,11 +38,11 @@ def _make_ghc_defs_dump(hs, cpp_defines):
     dummy_src.path,
   ])
 
-  hs.actions.run(
+  hs.toolchain.actions.run_ghc(
+    hs,
     inputs = [dummy_src] + hs.extra_binaries,
     outputs = [ghc_defs_dump_raw],
     mnemonic = "HaskellCppDefines",
-    executable = hs.tools.ghc,
     arguments = [args],
     env = hs.env,
   )
@@ -85,6 +85,7 @@ def _process_hsc_file(hs, cc, ghc_defs_dump, hsc_file):
   args.add([hsc_file.path, "-o", hs_out.path])
 
   args.add(["-c", hs.tools.cc])
+  args.add(["-l", hs.tools.cc])
   args.add(["--cflag=" + f for f in cc.cpp_flags])
   args.add(["--cflag=" + f for f in cc.include_args])
   args.add("-I{0}".format(ghc_defs_dump.dirname))
@@ -378,13 +379,13 @@ def compile_binary(hs, cc, java, dep_info, srcs, extra_srcs, cpp_defines, compil
   c = _compilation_defaults(hs, cc, java, dep_info, srcs, extra_srcs, cpp_defines, compiler_flags, main_file = main_file)
   c.args.add(["-main-is", main_function])
 
-  hs.actions.run(
+  hs.toolchain.actions.run_ghc(
+    hs,
     inputs = c.inputs + hs.extra_binaries,
     outputs = c.outputs,
     mnemonic = "HaskellBuildBinary",
     progress_message = "HaskellBuildBinary {}".format(hs.label),
     env = c.env,
-    executable = hs.tools.ghc,
     arguments = [c.args]
   )
 
@@ -423,13 +424,13 @@ def compile_library(hs, cc, java, dep_info, srcs, extra_srcs, cpp_defines, compi
   c.args.add(unit_id_args)
   c.haddock_args.add(unit_id_args, before_each="--optghc")
 
-  hs.actions.run(
+  hs.toolchain.actions.run_ghc(
+    hs,
     inputs = c.inputs + hs.extra_binaries,
     outputs = c.outputs,
     mnemonic = "HaskellBuildLibrary",
     progress_message = "HaskellBuildLibrary {}".format(hs.label),
     env = c.env,
-    executable = hs.tools.ghc,
     arguments = [c.args],
   )
 

--- a/haskell/private/actions/link.bzl
+++ b/haskell/private/actions/link.bzl
@@ -42,11 +42,11 @@ module BazelDummy () where
 """)
 
   dummy_static_lib = hs.actions.declare_file("libempty.a")
-  hs.actions.run(
+  hs.toolchain.actions.run_ghc(
+    hs,
     inputs = [dummy_input],
     outputs = [dummy_object],
     mnemonic = "HaskellDummyObjectGhc",
-    executable = hs.tools.ghc,
     arguments = ["-c", dummy_input.path],
   )
 
@@ -165,7 +165,8 @@ def link_binary(hs, dep_info, compiler_flags, object_files):
     for rpath in set.to_list(_infer_rpaths(executable, solibs)):
       args.add(["-optl-Wl,-rpath," + rpath])
 
-  hs.actions.run(
+  hs.toolchain.actions.run_ghc(
+    hs,
     inputs = depset(transitive = [
       set.to_depset(dep_info.package_caches),
       set.to_depset(dep_info.dynamic_libraries),
@@ -176,7 +177,6 @@ def link_binary(hs, dep_info, compiler_flags, object_files):
     ]),
     outputs = [compile_output],
     mnemonic = "HaskellLinkBinary",
-    executable = hs.tools.ghc,
     arguments = [args],
   )
 
@@ -321,7 +321,8 @@ def link_library_dynamic(hs, dep_info, object_files, my_pkg_id):
 
   args.add(["-o", dynamic_library_tmp.path])
 
-  hs.actions.run(
+  hs.toolchain.actions.run_ghc(
+    hs,
     inputs = depset(transitive = [
       depset(object_files),
       set.to_depset(dep_info.package_caches),
@@ -330,8 +331,7 @@ def link_library_dynamic(hs, dep_info, object_files, my_pkg_id):
     ]),
     outputs = [dynamic_library_tmp],
     mnemonic = "HaskellLinkDynamicLibrary",
-    executable = hs.tools.ghc,
-    arguments = [args]
+    arguments = [args],
   )
 
   return dynamic_library

--- a/haskell/private/actions/link.bzl
+++ b/haskell/private/actions/link.bzl
@@ -120,6 +120,12 @@ def link_binary(hs, dep_info, compiler_flags, object_files):
 
   if hs.toolchain.is_darwin:
     args.add(["-optl-Wl,-headerpad_max_install_names"])
+    # Nixpkgs commit 3513034208a introduces -liconv in NIX_LDFLAGS on
+    # Darwin. We don't currently handle NIX_LDFLAGS in any special
+    # way, so a hack is to simply do what NIX_LDFLAGS is telling us we
+    # should do always when using a toolchain from Nixpkgs.
+    # TODO remove this gross hack.
+    args.add("-liconv")
   else:
     # TODO: enable dynamic linking of Haskell dependencies for macOS.
     args.add(["-dynamic", "-pie"])

--- a/haskell/private/haskell_impl.bzl
+++ b/haskell/private/haskell_impl.bzl
@@ -1,6 +1,6 @@
 """Implementation of core Haskell rules"""
 
-load(":cc.bzl", "cc_headers")
+load(":cc.bzl", "cc_interop_info")
 load(":private/context.bzl", "haskell_context")
 load(":private/actions/compile.bzl", "compile_library")
 load(":private/actions/link.bzl",
@@ -25,7 +25,7 @@ def haskell_binary_impl(ctx):
   dep_info = gather_dep_info(ctx)
 
   # Add any interop info for other languages.
-  cc = cc_headers(ctx)
+  cc = cc_interop_info(ctx)
   java = java_interop_info(ctx)
 
   c = hs.toolchain.actions.compile_binary(
@@ -41,7 +41,7 @@ def haskell_binary_impl(ctx):
     main_function = ctx.attr.main_function,
   )
 
-  binary = link_binary(hs, dep_info, ctx.attr.compiler_flags, c.object_dyn_files)
+  binary = link_binary(hs, cc, dep_info, ctx.attr.compiler_flags, c.object_dyn_files)
 
   solibs = set.union(
     set.from_list(dep_info.external_libraries.values()),
@@ -87,7 +87,7 @@ def haskell_library_impl(ctx):
   my_pkg_id = pkg_id.new(ctx.label, ctx.attr.version)
 
   # Add any interop info for other languages.
-  cc = cc_headers(ctx)
+  cc = cc_interop_info(ctx)
   java = java_interop_info(ctx)
 
   c = hs.toolchain.actions.compile_library(
@@ -104,12 +104,14 @@ def haskell_library_impl(ctx):
 
   static_library = link_library_static(
     hs,
+    cc,
     dep_info,
     c.object_files,
     my_pkg_id,
   )
   dynamic_library = link_library_dynamic(
     hs,
+    cc,
     dep_info,
     c.object_dyn_files,
     my_pkg_id,

--- a/haskell/protobuf.bzl
+++ b/haskell/protobuf.bzl
@@ -177,6 +177,7 @@ _haskell_proto_aspect = aspect(
   },
   attr_aspects = ['deps'],
   toolchains = [
+    "@bazel_tools//tools/cpp:toolchain_type",
     "@io_tweag_rules_haskell//haskell:toolchain",
     "@io_tweag_rules_haskell//protobuf:toolchain",
   ],

--- a/haskell/toolchain.bzl
+++ b/haskell/toolchain.bzl
@@ -77,7 +77,7 @@ def _haskell_toolchain_impl(ctx):
   targets_r = {}
   targets_r.update({
       "ar": ctx.host_fragments.cpp.ar_executable,
-      "gcc": ctx.host_fragments.cpp.compiler_executable,
+      "cc": ctx.host_fragments.cpp.compiler_executable,
       "ld": ctx.host_fragments.cpp.ld_executable,
       "nm": ctx.host_fragments.cpp.nm_executable,
       "cpp": ctx.host_fragments.cpp.preprocessor_executable,

--- a/nixpkgs.nix
+++ b/nixpkgs.nix
@@ -1,2 +1,2 @@
 # Keep this value in sync with `WORKSPACE`
-import (fetchTarball "https://github.com/nixos/nixpkgs/archive/7c3dc2f53fc837be79426f11c9133f73d15a05c4.tar.gz")
+import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/8d5f06cbeedcfb4a88c111754baf2d7e315e74de.tar.gz")

--- a/shell.nix
+++ b/shell.nix
@@ -1,7 +1,31 @@
 { pkgs ? import ./nixpkgs.nix {} }:
 
 with pkgs;
+with darwin.apple_sdk.frameworks;
 
+# XXX On Darwin, workaround
+# https://github.com/NixOS/nixpkgs/issues/42059. See also
+# https://github.com/NixOS/nixpkgs/pull/41589.
+let cc = stdenv.mkDerivation {
+  name = "cc-wrapper-bazel";
+  buildInputs = [ stdenv.cc makeWrapper ];
+  phases = [ "fixupPhase" ];
+  postFixup = ''
+    mkdir -p $out/bin
+    makeWrapper ${stdenv.cc}/bin/clang $out/bin/clang \
+      --add-flags "-isystem ${llvmPackages.libcxx}/include \
+                   -F${CoreFoundation}/Library/Frameworks \
+                   -F${CoreServices}/Library/Frameworks \
+                   -F${Security}/Library/Frameworks \
+                   -F${Foundation}/Library/Frameworks \
+                   -L${libcxx}/lib \
+                   -L${darwin.libobjc}/lib"
+ '';
+  };
+  mkShell = pkgs.mkShell.override {
+    stdenv = if stdenv.isDarwin then overrideCC stdenv cc else stdenv;
+  };
+in
 mkShell {
   buildInputs = [
     binutils
@@ -10,6 +34,8 @@ mkShell {
     which
     python
     nix
-    bazel
-  ];
+  ]
+  # TODO use Bazel from Nixpkgs even on Darwin. Blocked by
+  # https://github.com/NixOS/nixpkgs/issues/30590.
+  ++ lib.optional stdenv.isLinux bazel;
 }

--- a/shell.nix
+++ b/shell.nix
@@ -33,7 +33,6 @@ mkShell {
     nix
     which
     python
-    nix
   ]
   # TODO use Bazel from Nixpkgs even on Darwin. Blocked by
   # https://github.com/NixOS/nixpkgs/issues/30590.

--- a/start
+++ b/start
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 MIN_BAZEL_MAJOR=0
-MIN_BAZEL_MINOR=8
+MIN_BAZEL_MINOR=14
 
 set -e
 

--- a/tests/ghc.nix
+++ b/tests/ghc.nix
@@ -4,8 +4,8 @@ with pkgs;
 
 let haskellPackages = pkgs.haskell.packages.ghc822.override {
       overrides = with pkgs.haskell.lib; self: super: rec {
-        lens-labels = super.lens-labels_0_2_0_0;
-        proto-lens = super.proto-lens_0_3_0_0;
+        lens-labels = super.lens-labels_0_2_0_1;
+        proto-lens = super.proto-lens_0_3_1_0;
       };
     };
 

--- a/tests/protoc_gen_haskell.nix
+++ b/tests/protoc_gen_haskell.nix
@@ -4,8 +4,8 @@ with pkgs;
 
 let haskellPackages = pkgs.haskell.packages.ghc822.override {
       overrides = with pkgs.haskell.lib; self: super: rec {
-        lens-labels = super.lens-labels_0_2_0_0;
-        proto-lens = super.proto-lens_0_3_0_0;
+        lens-labels = super.lens-labels_0_2_0_1;
+        proto-lens = super.proto-lens_0_3_1_0;
       };
     };
 


### PR DESCRIPTION
GHC calls GCC itself when it wants to do some linking, assembly, or
preprocessing. The problem is, GHC might not be calling the same GCC we
expect. While we expect the GCC autodected for the Bazel CC toolchain, GHC
uses whatever GCC is found in a `settings` file that it ships with.

The key is to override the defaults by passing `-pgm*` flags to GHC. In
this way, GHC uses the same GCC as the rest of the Bazel rules, hence
avoiding any potential linker issues.

Fixes #250.