### PR TITLE
Create a nix FHS environment

### DIFF
--- a/fhs.nix
+++ b/fhs.nix
@@ -1,0 +1,19 @@
+/*
+
+This FHS env allows bazel to run on nixos:
+
+$ nix-shell ./fhs.nix
+
+then, `bazel build //something` will work without any other configuration.
+
+NOTE: for an unknown (yet) reason, part of bazel cache is invalidated if the nix-shell is re-run.
+
+*/
+
+{ pkgs ? import <nixpkgs> {} }:
+
+(pkgs.buildFHSUserEnv {
+  name = "rules-haskell-env";
+  targetPkgs = pkgs: (with pkgs;
+    [ bazel nix binutils go which python27]);
+}).env


### PR DESCRIPTION
Bazel supposes a lot of hardcoded binaries, such as /usr/bin/{ar,cc,c++},
... which are not available in NixOS.

Nix provided bazel is already hacked to hardcode some of these paths, but
not all of them, such as /usr/bin/ar

This FHS environment contains all the needed binaries at the "usual"
location supposed by bazel.