### PR TITLE
Add a `shell.nix` file

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,11 +15,17 @@ jobs:
             nix-channel --update
       - run:
           name: Build
-          command: nix-shell --command "bazel build --jobs=2 //... @haskell_zlib//..."
+          command: |
+            # XXX Workaround https://github.com/NixOS/nix/issues/1969.
+            nix-build nixpkgs.nix -A haskell.compiler.ghc822
+            nix-shell --command "bazel build --jobs=2 //... @haskell_zlib//..."
 
       - run:
           name: Run tests
-          command: nix-shell --command "./run_tests.sh"
+          command: |
+            # XXX Workaround https://github.com/NixOS/nix/issues/1969.
+            nix-build '<nixpkgs>' -A haskell.compiler.ghc822
+            nix-shell --command "./run_tests.sh"
 
   build-darwin:
     macos:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,7 @@ jobs:
     docker:
       - image: nixos/nix:2.0
     working_directory: ~/rules_haskell
+    resource_class: large
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,14 +13,13 @@ jobs:
             apk --no-progress update
             apk --no-progress add bash ca-certificates
             nix-channel --update
-            nix-env -iA nixpkgs.bazel nixpkgs.binutils nixpkgs.python nixpkgs.go
       - run:
           name: Build
-          command: bazel build --jobs=2 //... @haskell_zlib//...
+          command: nix-shell --command "bazel build --jobs=2 //... @haskell_zlib//..."
 
       - run:
           name: Run tests
-          command: ./run_tests.sh
+          command: nix-shell --command "./run_tests.sh"
 
   build-darwin:
     macos:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   build-linux:
     docker:
-      - image: nixos/nix:1.11.14
+      - image: nixos/nix:2.0
     working_directory: ~/rules_haskell
     steps:
       - checkout

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -19,6 +19,8 @@ nixpkgs_git_repository(
   # To make protobuf support work we need packages such as
   # lens-labels_0_2_0_0 to be available in nixpkgs. This means we need to
   # use a version of nixpkgs that is newer than 18.03.
+
+  # Keep this value in sync with `nixpkgs.nix`
   revision = "7c3dc2f53fc837be79426f11c9133f73d15a05c4",
 )
 

--- a/nixpkgs.nix
+++ b/nixpkgs.nix
@@ -1,0 +1,2 @@
+# Keep this value in sync with `WORKSPACE`
+import (fetchTarball "https://github.com/nixos/nixpkgs/archive/7c3dc2f53fc837be79426f11c9133f73d15a05c4.tar.gz")

--- a/shell.nix
+++ b/shell.nix
@@ -5,9 +5,6 @@ with pkgs;
 mkShell {
   buildInputs = [
     binutils
-    # XXX Prepopulating the shell with ghc to workaround OOM conditions
-    # caused by https://github.com/NixOS/nix/issues/1969.
-    ghc
     go
     which
     python

--- a/shell.nix
+++ b/shell.nix
@@ -5,6 +5,8 @@ with pkgs;
 mkShell {
   buildInputs = [
     binutils
+    # XXX Prepopulating the shell with ghc to workaround OOM conditions
+    # caused by https://github.com/NixOS/nix/issues/1969.
     ghc
     go
     which

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,15 @@
+{ pkgs ? import ./nixpkgs.nix {} }:
+
+with pkgs;
+
+mkShell {
+  buildInputs = [
+    binutils
+    ghc
+    go
+    which
+    python
+    nix
+    bazel
+  ];
+}


### PR DESCRIPTION
This allows the setup of the development environment using `nix-shell`.

- nixpkgs commit hash is set inside `nixpkgs.nix` and should be kept in
sync with the one used in `WORKSPACE`. This is a manual process for now,
but will later be integrated inside the `rules_nixpkgs` repository as an
argument to `nixpkgs_repository`.
- circleci script is updated to use (for linux) the nix-shell.