### PR TITLE
Make a separate toolchain for `doctest`.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -81,6 +81,7 @@ nixpkgs_package(
 
 register_toolchains(
   "//tests:ghc",
+  "//tests:doctest-toolchain",
   "//tests:protobuf-toolchain",
 )
 

--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -26,6 +26,7 @@ load(":haddock.bzl",
 load(":lint.bzl",
   _haskell_lint = "haskell_lint",
   _haskell_doctest = "haskell_doctest",
+  _haskell_doctest_toolchain = "haskell_doctest_toolchain",
 )
 load(":toolchain.bzl",
   _haskell_toolchain = "haskell_toolchain",
@@ -224,6 +225,8 @@ haskell_doc = _haskell_doc
 haskell_lint = _haskell_lint
 
 haskell_doctest  = _haskell_doctest
+
+haskell_doctest_toolchain  = _haskell_doctest_toolchain
 
 haskell_toolchain = _haskell_toolchain
 

--- a/haskell/toolchain.bzl
+++ b/haskell/toolchain.bzl
@@ -102,10 +102,6 @@ def _haskell_toolchain_impl(ctx):
     ar_runfiles += [xcrun]
     targets_r["xcrunwrapper.sh"] = xcrun.path
 
-  if ctx.attr.doctest != None:
-    targets_r["doctest"] = ctx.file.doctest.path
-    inputs.append(ctx.file.doctest)
-
   if ctx.attr.c2hs != None:
     targets_r["c2hs"] = ctx.file.c2hs.path
     inputs.append(ctx.file.c2hs)
@@ -221,10 +217,6 @@ _haskell_toolchain = rule(
       doc = "GHC and executables that come with it",
       mandatory = True,
     ),
-    "doctest": attr.label(
-      doc = "Doctest executable",
-      allow_single_file = True,
-    ),
     "c2hs": attr.label(
       doc = "c2hs executable",
       allow_single_file = True,
@@ -318,4 +310,3 @@ def haskell_toolchain(
     target_compatible_with = [
       '@bazel_tools//platforms:x86_64'],
   )
-  # TODO: perhaps make a toolchain for darwin?

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -4,6 +4,7 @@ load("@io_tweag_rules_haskell//haskell:haskell.bzl",
   "haskell_binary",
   "haskell_library",
   "haskell_toolchain",
+  "haskell_doctest_toolchain",
   "haskell_proto_toolchain",
 )
 load("@bazel_tools//tools/build_rules:test_rules.bzl", "rule_test")
@@ -13,13 +14,17 @@ haskell_toolchain(
   name = "ghc",
   version = "8.2.2",
   tools = "@ghc//:bin",
-  doctest = "@doctest//:bin",
   c2hs = "@c2hs//:bin",
   # This toolchain is morally testonly.  However, that would break
   # our tests of haskell_library_rules: aspects of non-testonly
   # proto_library rules (from com_google_protobuf) can't themselves
   # be testonly.
   testonly = 0,
+)
+
+haskell_doctest_toolchain(
+  name = "doctest-toolchain",
+  doctest = "@doctest//:bin",
 )
 
 haskell_proto_toolchain(


### PR DESCRIPTION
For Hazel, we would like `haskell_doctest` to use a `doctest` binary built
by Hazel itself.  However, since `haskell_binary` depends on the
`haskell_toolchain`, which takes the binary as an attribute, doing so would
currently cause a dependency loop.  (The alternative is to pull it from
Nix, which is redundant since Hazel can already build its library
dependencies.)

Making a separate toolchain resolves the loop, and also seems fairly
reasonable since the doctest parameter was already optional in
`haskell_toolchain`.