### PR TITLE
Pass compiler_flags at link time.

### DIFF
--- a/haskell/private/actions/link.bzl
+++ b/haskell/private/actions/link.bzl
@@ -115,6 +115,7 @@ def link_binary(hs, dep_info, compiler_flags, object_files):
 
   args = hs.actions.args()
   add_mode_options(hs, args)
+  args.add(hs.toolchain.compiler_flags)
   args.add(compiler_flags)
 
   if hs.toolchain.is_darwin:

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -20,6 +20,10 @@ haskell_toolchain(
   # proto_library rules (from com_google_protobuf) can't themselves
   # be testonly.
   testonly = 0,
+  compiler_flags = [
+      "-XStandaloneDeriving", # Flag used at compile time
+      "-threaded",            # Flag used at link time
+  ],
 )
 
 haskell_doctest_toolchain(

--- a/tests/binary-with-compiler-flags/BUILD
+++ b/tests/binary-with-compiler-flags/BUILD
@@ -1,0 +1,15 @@
+package(default_testonly = 1)
+
+load("@io_tweag_rules_haskell//haskell:haskell.bzl",
+  "haskell_test",
+)
+
+haskell_test(
+    name = "binary-with-compiler-flags",
+    srcs = ["Main.hs"],
+    main_file = "Main.hs",
+    prebuilt_dependencies = ["base"],
+    # A flag that requires -threaded, which we should get from the toolchain's
+    # compiler_flags:
+    compiler_flags = ["-with-rtsopts=-qg"],
+)

--- a/tests/binary-with-compiler-flags/Main.hs
+++ b/tests/binary-with-compiler-flags/Main.hs
@@ -1,0 +1,8 @@
+-- Expects to pull -XStandaloneDeriving from the default compiler flags.
+module Main (main) where
+
+data Foo = Foo
+deriving instance Show Foo
+
+main :: IO ()
+main = print Foo


### PR DESCRIPTION
Some GHC flags, like `-threaded`, are only used at link time
and ignored during compile time.  Since those are separate steps
in our rules, we need to pass them both times.

Also add a test that both compile-time and link-time flags
are used correctly.