### PR TITLE
An option to list packages ignored by `haskell_doc`

### DIFF
--- a/haskell/haddock.bzl
+++ b/haskell/haddock.bzl
@@ -55,9 +55,12 @@ def _haskell_doc_aspect_impl(target, ctx):
     args.add("--read-interface=../{0},{1}".format(
       pid, transitive_haddocks[pid].path))
 
+  hs = haskell_context(ctx, ctx.rule.attr)
+
   prebuilt_deps = ctx.actions.args()
   for dep in set.to_list(target[HaskellBuildInfo].prebuilt_dependencies):
-    prebuilt_deps.add(dep)
+    if dep not in hs.toolchain.haddock_ignore_prebuilts:
+        prebuilt_deps.add(dep)
   prebuilt_deps.use_param_file(param_file_arg = "%s", use_always = True)
 
   ctx.actions.run(

--- a/haskell/toolchain.bzl
+++ b/haskell/toolchain.bzl
@@ -231,6 +231,8 @@ def _haskell_toolchain_impl(ctx):
       compiler_flags = ctx.attr.compiler_flags,
       locale = ctx.attr.locale,
       locale_archive = locale_archive,
+      # XXX: bazel have no builtin set, so we use a dict here for later O(1) query of `haddock_ignore_prebuilts`
+      haddock_ignore_prebuilts = {i:None for i in ctx.attr.haddock_ignore_prebuilts},
       mode = ctx.var["COMPILATION_MODE"],
       actions = struct(
         compile_binary = compile_binary,
@@ -287,7 +289,11 @@ _haskell_toolchain = rule(
       doc = """
 Label pointing to the locale archive file to use. Mostly useful on NixOS.
 """,
-    )
+    ),
+    "haddock_ignore_prebuilts": attr.string_list(
+      doc = "A list of prebuilt dependencies ignored by haddock. Use it when theses dependencies does not have an haddock documentation.",
+      default = [],
+    ),
   }
 )
 

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -29,6 +29,7 @@ haskell_toolchain(
     "@bazel_tools//src/conditions:darwin": None,
     "//conditions:default": "@glib_locales//:locale-archive",
   }),
+  haddock_ignore_prebuilts = ["mtl"],
 )
 
 haskell_doctest_toolchain(

--- a/tests/ghc.nix
+++ b/tests/ghc.nix
@@ -17,4 +17,7 @@ in haskellPackages.ghcWithPackages (p: with p; [
   lens-labels
   proto-lens
   text
+
+  # mtl is imported without documentation for testing purpose (see //tests/haddock:doc_broken_deps)
+  (haskell.lib.dontCheck (haskell.lib.dontHaddock mtl))
   ])

--- a/tests/haddock/BUILD
+++ b/tests/haddock/BUILD
@@ -44,3 +44,16 @@ haskell_doc(
   deps = [":haddock-lib-b"],
   index_transitive_deps = True,
 )
+
+# the package `mtl` have no documentation (see `ghc.nix`)
+# but the following `haskell_doc` call must not fail
+haskell_library(
+  name = "lib_with_a_dep_without_haddock",
+  srcs = ["Deep.hsc"],
+  prebuilt_dependencies = ["base", "mtl"],
+)
+
+haskell_doc(
+  name = "doc_broken_deps",
+  deps = [":lib_with_a_dep_without_haddock"]
+)


### PR DESCRIPTION
Fix #335 by providing `haddock_ignore_prebuilts` attribute to `haskell_toolchain`.