### PR TITLE
Create only one dummy archive for ghc linking

### DIFF
--- a/haskell/BUILD
+++ b/haskell/BUILD
@@ -1,7 +1,7 @@
 load("//skylark:lint.bzl", "skylark_lint")
-load(":private/create_dummy_archive.bzl", "create_dummy_archive")
+load(":private/dummy_linker_archive.bzl", "dummy_linker_archive")
 
-create_dummy_archive(
+dummy_linker_archive(
   name = "dummy_static_lib",
   visibility = ["//visibility:public"]
 )

--- a/haskell/BUILD
+++ b/haskell/BUILD
@@ -1,4 +1,10 @@
 load("//skylark:lint.bzl", "skylark_lint")
+load(":private/create_dummy_archive.bzl", "create_dummy_archive")
+
+create_dummy_archive(
+  name = "dummy_static_lib",
+  visibility = ["//visibility:public"]
+)
 
 exports_files(
   glob(["*.bzl"]) + [

--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -117,7 +117,14 @@ def _mk_binary_rule(**kwargs):
       main_file = attr.label(
         allow_single_file = FileType([".hs", ".hsc", ".lhs"]),
         doc = "File containing `Main` module.",
-      )
+      ),
+      _dummy_static_lib = attr.label(
+        default = Label("@io_tweag_rules_haskell//haskell:dummy_static_lib"),
+        allow_single_file = True,
+        doc = """
+A dummy library needed for the GHC linking process.
+""",
+      ),
     ),
     outputs = {
       "repl": "%{name}-repl",

--- a/haskell/private/actions/link.bzl
+++ b/haskell/private/actions/link.bzl
@@ -18,52 +18,6 @@ def _backup_path(target):
 
   return "/".join([".."] * n)
 
-def _create_dummy_archive(hs, cc):
-  """Create empty archive so that GHC has some input files to work on during
-  linking.
-
-  See: https://github.com/facebook/buck/blob/126d576d5c07ce382e447533b57794ae1a358cc2/src/com/facebook/buck/haskell/HaskellDescriptionUtils.java#L295
-
-  Args:
-    hs: Haskell context.
-
-  Returns:
-    File, the created dummy archive.
-  """
-
-  dummy_raw = "BazelDummy.hs"
-  dummy_input = hs.actions.declare_file(dummy_raw)
-  dummy_object = hs.actions.declare_file(paths.replace_extension(dummy_raw, ".o"))
-
-  hs.actions.write(output=dummy_input, content="""
-{-# LANGUAGE NoImplicitPrelude #-}
-module BazelDummy () where
-""")
-
-  dummy_static_lib = hs.actions.declare_file("libempty.a")
-  hs.toolchain.actions.run_ghc(
-    hs,
-    inputs = [dummy_input],
-    outputs = [dummy_object],
-    mnemonic = "HaskellDummyObjectGhc",
-    arguments = [
-      "-optc" + f for f in cc.compiler_flags
-    ] + ["-c", dummy_input.path],
-  )
-
-  ar_args = hs.actions.args()
-  ar_args.add(["qc", dummy_static_lib, dummy_object])
-
-  hs.actions.run(
-    inputs = [dummy_object] + hs.tools_runfiles.ar,
-    outputs = [dummy_static_lib],
-    mnemonic = "HaskellDummyObjectAr",
-    executable = hs.tools.ar,
-    arguments = [ar_args]
-  )
-
-  return dummy_static_lib
-
 def _fix_linker_paths(hs, inp, out, external_libraries):
   """Postprocess a macOS binary to make shared library references relative.
 
@@ -93,14 +47,13 @@ def _fix_linker_paths(hs, inp, out, external_libraries):
                      out.path)
                      for f in external_libraries]))
 
-def link_binary(hs, cc, dep_info, extra_srcs, compiler_flags, object_files, with_profiling):
+def link_binary(hs, cc, dep_info, extra_srcs, compiler_flags,
+                object_files, with_profiling, dummy_static_lib):
   """Link Haskell binary from static object files.
 
   Returns:
     File: produced executable
   """
-
-  dummy_static_lib = _create_dummy_archive(hs, cc)
 
   executable = hs.actions.declare_file(hs.name)
   if not hs.toolchain.is_darwin:

--- a/haskell/private/create_dummy_archive.bzl
+++ b/haskell/private/create_dummy_archive.bzl
@@ -1,0 +1,58 @@
+load("@bazel_skylib//:lib.bzl", "paths")
+load(":private/context.bzl", "haskell_context")
+
+def _impl(ctx):
+  """Create empty archive so that GHC has some input files to work on during
+  linking.
+
+  See: https://github.com/facebook/buck/blob/126d576d5c07ce382e447533b57794ae1a358cc2/src/com/facebook/buck/haskell/HaskellDescriptionUtils.java#L295
+
+  Returns:
+    File, the created dummy archive.
+  """
+
+  # TODO: this is a duplication from ./haskell_impl.bzl
+  hs = haskell_context(ctx)
+  cc_toolchain = ctx.toolchains["@bazel_tools//tools/cpp:toolchain_type"]
+
+  dummy_raw = "BazelDummy.hs"
+  dummy_input = hs.actions.declare_file(dummy_raw)
+  dummy_object = hs.actions.declare_file(paths.replace_extension(dummy_raw, ".o"))
+
+  hs.actions.write(output=dummy_input, content="""
+{-# LANGUAGE NoImplicitPrelude #-}
+module BazelDummy () where
+""")
+
+  hs.toolchain.actions.run_ghc(
+    hs,
+    inputs = [dummy_input],
+    outputs = [dummy_object],
+    mnemonic = "HaskellDummyObjectGhc",
+    arguments = [
+      "-optc" + f for f in cc_toolchain.compiler_options()
+    ] + ["-c", dummy_input.path],
+  )
+
+  ar_args = hs.actions.args()
+  ar_args.add(["qc", ctx.outputs.archive, dummy_object])
+
+  hs.actions.run(
+    inputs = [dummy_object] + hs.tools_runfiles.ar,
+    outputs = [ctx.outputs.archive],
+    mnemonic = "HaskellDummyObjectAr",
+    executable = hs.tools.ar,
+    arguments = [ar_args]
+  )
+
+
+create_dummy_archive = rule(
+  implementation = _impl,
+  toolchains = [
+    "@io_tweag_rules_haskell//haskell:toolchain",
+    "@bazel_tools//tools/cpp:toolchain_type",
+  ],
+  outputs = {
+    "archive": "libempty.a"
+  }
+)

--- a/haskell/private/dummy_linker_archive.bzl
+++ b/haskell/private/dummy_linker_archive.bzl
@@ -46,7 +46,7 @@ module BazelDummy () where
   )
 
 
-create_dummy_archive = rule(
+dummy_linker_archive = rule(
   implementation = _impl,
   toolchains = [
     "@io_tweag_rules_haskell//haskell:toolchain",

--- a/haskell/private/haskell_impl.bzl
+++ b/haskell/private/haskell_impl.bzl
@@ -98,6 +98,7 @@ def haskell_binary_impl(ctx):
     ctx.attr.compiler_flags,
     c_p.object_files if with_profiling else c.object_dyn_files,
     with_profiling,
+    ctx.file._dummy_static_lib,
   )
 
   solibs = set.union(


### PR DESCRIPTION
Before, each run of the Haskell rule would create a static dummy library, which
the ghc linker needs. Factor out into a default target.

Have only tested the analyze phase locally, the build [fails with some strange nix-based error](https://github.com/tweag/rules_haskell/issues/340).

Fixes #278