### PR TITLE
Introduce c2hs_library

### DIFF
--- a/haskell/c2hs.bzl
+++ b/haskell/c2hs.bzl
@@ -1,0 +1,87 @@
+"""Support for c2hs"""
+
+load(":cc.bzl", "cc_interop_info")
+load(":private/context.bzl", "haskell_context")
+load(":private/path_utils.bzl",
+  "declare_compiled",
+  "target_unique_name",
+)
+load(":private/providers.bzl",
+     "C2hsLibraryInfo",
+)
+load("@bazel_skylib//:lib.bzl", "paths")
+
+def _c2hs_library_impl(ctx):
+  hs = haskell_context(ctx)
+  cc = cc_interop_info(ctx)
+  args = hs.actions.args()
+
+  if len(ctx.files.srcs) != 1:
+    fail("srcs field should contain exactly one file.")
+  chs_file = ctx.files.srcs[0]
+
+  # Output a Haskell source file.
+  chs_dir_raw = target_unique_name(hs, "chs")
+  hs_file = declare_compiled(hs, chs_file, ".hs", directory=chs_dir_raw)
+  chi_file = declare_compiled(hs, chs_file, ".chi", directory=chs_dir_raw)
+  args.add([chs_file.path, "-o", hs_file.path])
+
+  args.add(["-C-E"])
+  args.add(["--cpp", hs.tools.cc.path])
+  args.add("-C-includeghcplatform.h")
+  args.add("-C-includeghcversion.h")
+  args.add(["-C" + x for x in cc.cpp_flags])
+  args.add(["-C" + x for x in cc.include_args])
+
+  dep_chi_files = [
+    dep[C2hsLibraryInfo].chi_file
+    for dep in ctx.attr.deps if C2hsLibraryInfo in dep
+  ]
+  chi_includes = ["-i" + chi.dirname for chi in dep_chi_files]
+  args.add(chi_includes)
+
+  hs.actions.run(
+    inputs = depset(transitive = [
+      depset(cc.hdrs),
+      depset([hs.tools.cc, hs.tools.ghc, hs.tools.c2hs, chs_file]),
+      depset(dep_chi_files),
+    ]),
+    outputs = [hs_file, chi_file],
+    executable = ctx.file._chs_wrapper,
+    mnemonic = "HaskellC2Hs",
+    arguments = [args],
+    env = hs.env,
+  )
+
+  idir = paths.join(
+    hs.bin_dir.path,
+    hs.label.package,
+    chs_dir_raw,
+  )
+
+  return [
+    DefaultInfo(files = depset([hs_file])),
+    C2hsLibraryInfo(
+      chi_file = chi_file,
+      import_dir = idir,
+    ),
+  ]
+
+c2hs_library = rule(
+  _c2hs_library_impl,
+  attrs = {
+    "deps": attr.label_list(),
+    "srcs": attr.label_list(allow_files = [".chs"]),
+    "src_strip_prefix": attr.string(
+      doc = "Directory in which module hierarchy starts.",
+    ),
+    "_chs_wrapper": attr.label(
+      allow_single_file = True,
+      default = Label("@io_tweag_rules_haskell//haskell:private/c2hs_wrapper.sh"),
+    ),
+  },
+  toolchains = [
+    "@io_tweag_rules_haskell//haskell:toolchain",
+    "@bazel_tools//tools/cpp:toolchain_type",
+  ],
+)

--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -79,10 +79,6 @@ REPL to work.
     default = "1.0.0",
     doc = "Library/binary version. Internal - do not use."
   ),
-  "_chs_wrapper": attr.label(
-    allow_single_file = True,
-    default = Label("@io_tweag_rules_haskell//haskell:private/c2hs_wrapper.sh"),
-  ),
   "_ghci_script": attr.label(
     allow_single_file = True,
     default = Label("@io_tweag_rules_haskell//haskell:assets/ghci_script"),

--- a/haskell/private/haskell_impl.bzl
+++ b/haskell/private/haskell_impl.bzl
@@ -19,7 +19,28 @@ load(":private/providers.bzl",
   "HaskellBuildInfo",
   "HaskellBinaryInfo",
   "HaskellLibraryInfo",
+  "C2hsLibraryInfo",
 )
+
+def _prepare_srcs(srcs):
+
+  srcs_files = []
+  import_dir_map = {}
+
+  for src in srcs:
+    # If it has the "files" attribute, it must be a Target
+    if hasattr(src, "files"):
+      if C2hsLibraryInfo in src:
+        srcs_files += src.files.to_list()
+        for f in src.files:
+          import_dir_map[f] = src[C2hsLibraryInfo].import_dir
+      else:
+        srcs_files += src.files.to_list()
+    # otherwise it's just a file
+    else:
+      srcs_files.append(src)
+
+  return srcs_files, import_dir_map
 
 def haskell_binary_impl(ctx):
   hs = haskell_context(ctx)
@@ -30,14 +51,16 @@ def haskell_binary_impl(ctx):
   java = java_interop_info(ctx)
   with_profiling = is_profiling_enabled(hs)
 
+  srcs_files, import_dir_map = _prepare_srcs(ctx.attr.srcs)
+
   c = hs.toolchain.actions.compile_binary(
     hs,
     cc,
     java,
     dep_info,
-    srcs = ctx.files.srcs,
+    srcs = srcs_files,
+    import_dir_map = import_dir_map,
     extra_srcs = depset(ctx.files.extra_srcs),
-    chs_wrapper = ctx.file._chs_wrapper,
     compiler_flags = ctx.attr.compiler_flags,
     with_profiling = False,
     main_file = ctx.file.main_file,
@@ -52,7 +75,8 @@ def haskell_binary_impl(ctx):
       cc,
       java,
       dep_info,
-      srcs = ctx.files.srcs,
+      srcs = srcs_files,
+      import_dir_map = import_dir_map,
       # NOTE We must make the object files compiled without profiling
       # available to this step for TH to work, presumably because GHC is
       # linked against RTS without profiling.
@@ -60,7 +84,6 @@ def haskell_binary_impl(ctx):
         depset(ctx.files.extra_srcs),
         depset(c.object_dyn_files),
       ]),
-      chs_wrapper = ctx.file._chs_wrapper,
       compiler_flags = ctx.attr.compiler_flags,
       with_profiling = True,
       main_file = ctx.file.main_file,
@@ -128,14 +151,16 @@ def haskell_library_impl(ctx):
   cc = cc_interop_info(ctx)
   java = java_interop_info(ctx)
 
+  srcs_files, import_dir_map = _prepare_srcs(ctx.attr.srcs)
+
   c = hs.toolchain.actions.compile_library(
     hs,
     cc,
     java,
     dep_info,
-    srcs = ctx.files.srcs,
+    srcs = srcs_files,
+    import_dir_map = import_dir_map,
     extra_srcs = depset(ctx.files.extra_srcs),
-    chs_wrapper = ctx.file._chs_wrapper,
     compiler_flags = ctx.attr.compiler_flags,
     with_profiling = False,
     my_pkg_id = my_pkg_id,
@@ -149,7 +174,8 @@ def haskell_library_impl(ctx):
       cc,
       java,
       dep_info,
-      srcs = ctx.files.srcs,
+      srcs = srcs_files,
+      import_dir_map = import_dir_map,
       # NOTE We must make the object files compiled without profiling
       # available to this step for TH to work, presumably because GHC is
       # linked against RTS without profiling.
@@ -157,7 +183,6 @@ def haskell_library_impl(ctx):
         depset(ctx.files.extra_srcs),
         depset(c.object_dyn_files),
       ]),
-      chs_wrapper = ctx.file._chs_wrapper,
       compiler_flags = ctx.attr.compiler_flags,
       with_profiling = True,
       my_pkg_id = my_pkg_id,

--- a/haskell/private/providers.bzl
+++ b/haskell/private/providers.bzl
@@ -111,3 +111,11 @@ Returns the list of include directories used to compile this target.
 """,
   },
 )
+
+C2hsLibraryInfo = provider(
+  doc = "Information about c2hs dependencies.",
+  fields = {
+    "chi_file": "c2hs interface file",
+    "import_dir": "Import directory containing generated Haskell source file.",
+  }
+)

--- a/haskell/protobuf.bzl
+++ b/haskell/protobuf.bzl
@@ -124,7 +124,6 @@ def _haskell_proto_aspect_impl(target, ctx):
     "repl_interpreted": True,
     "repl_ghci_args": [],
     "version": "1.0.0",
-    "_chs_wrapper": ctx.attr._chs_wrapper,
     "_ghci_script": ctx.attr._ghci_script,
     "_ghci_repl_wrapper": ctx.attr._ghci_repl_wrapper,
     "hidden_modules": [],
@@ -162,10 +161,6 @@ def _haskell_proto_aspect_impl(target, ctx):
 _haskell_proto_aspect = aspect(
   _haskell_proto_aspect_impl,
   attrs = {
-    "_chs_wrapper": attr.label(
-      allow_single_file = True,
-      default = Label("@io_tweag_rules_haskell//haskell:private/c2hs_wrapper.sh"),
-    ),
     "_ghci_script": attr.label(
       allow_single_file = True,
       default = Label("@io_tweag_rules_haskell//haskell:assets/ghci_script"),

--- a/tests/c2hs/BUILD
+++ b/tests/c2hs/BUILD
@@ -1,9 +1,9 @@
 package(default_testonly = 1)
 
-load(
-  "@io_tweag_rules_haskell//haskell:haskell.bzl",
-  "haskell_library",
+load("@io_tweag_rules_haskell//haskell:c2hs.bzl", "c2hs_library")
+load("@io_tweag_rules_haskell//haskell:haskell.bzl",
   "haskell_cc_import",
+  "haskell_library",
 )
 
 haskell_cc_import(
@@ -13,16 +13,20 @@ haskell_cc_import(
   strip_include_prefix = "/external/zlib.dev/include",
 )
 
+c2hs_library(
+  name = "foo",
+  srcs = ["Foo.chs"],
+  deps = [":zlib"],
+)
+
+c2hs_library(
+  name = "bar",
+  srcs = ["Bar.chs"],
+  deps = [":foo"],
+)
+
 haskell_library(
   name = "c2hs",
-  srcs = [
-    "Foo.chs",
-    "Bar.chs",
-  ],
-  deps = [
-    ":zlib",
-  ],
-  prebuilt_dependencies = [
-    "base",
-  ],
+  srcs = [":foo", ":bar"],
+  prebuilt_dependencies = ["base"],
 )

--- a/tests/repl-targets/BUILD
+++ b/tests/repl-targets/BUILD
@@ -1,5 +1,6 @@
 package(default_testonly = 1)
 
+load("@io_tweag_rules_haskell//haskell:c2hs.bzl", "c2hs_library")
 load("@io_tweag_rules_haskell//haskell:haskell.bzl",
      "haskell_library",
      "haskell_binary",
@@ -30,12 +31,17 @@ genrule(
 """,
 )
 
+c2hs_library(
+  name = "chs",
+  srcs = ["Chs.chs"],
+)
+
 haskell_library(
   name = "hs-lib",
   srcs = [
     "Foo.hs",
     "Hsc.hsc",
-    "Chs.chs",
+    ":chs",
     ":codegen",
   ],
   prebuilt_dependencies = ["base", "array"],


### PR DESCRIPTION
As suggested in #346. A future PR will separate c2hs from the haskell toolchain and move it to a separate toolchain to avoid import loops.