### PR TITLE
Make REPLs not to depend on their targets

### DIFF
--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -68,17 +68,6 @@ _haskell_common_attrs = {
     "prebuilt_dependencies": attr.string_list(
         doc = "Non-Bazel supplied Cabal dependencies.",
     ),
-    "repl_interpreted": attr.bool(
-        default = True,
-        doc = """
-Whether source files should be interpreted rather than compiled. This allows
-for e.g. reloading of sources on editing, but in this case we don't handle
-boot files and hsc processing.
-
-For `haskell_binary` targets, `repl_interpreted` must be set to `True` for
-REPL to work.
-""",
-    ),
     "repl_ghci_args": attr.string_list(
         doc = "Arbitrary extra arguments to pass to GHCi. This extends `compiler_flags` and `repl_ghci_args` from the toolchain",
     ),

--- a/haskell/private/haskell_impl.bzl
+++ b/haskell/private/haskell_impl.bzl
@@ -127,9 +127,7 @@ def haskell_binary_impl(ctx):
         compiler_flags = ctx.attr.compiler_flags,
         repl_ghci_args = ctx.attr.repl_ghci_args,
         output = ctx.outputs.repl,
-        interpreted = ctx.attr.repl_interpreted,
         build_info = build_info,
-        target_files = target_files,
         bin_info = bin_info,
     )
 
@@ -294,9 +292,7 @@ def haskell_library_impl(ctx):
             repl_ghci_args = ctx.attr.repl_ghci_args,
             compiler_flags = ctx.attr.compiler_flags,
             output = ctx.outputs.repl,
-            interpreted = ctx.attr.repl_interpreted,
             build_info = build_info,
-            target_files = target_files,
             lib_info = lib_info,
         )
 


### PR DESCRIPTION
Close #289.

There seems to be no way to tell GHCi "keep going and load as many modules as possible even if some fail", but now we can load REPL with *some* modules in it, and the rest can be done from the running REPL. As good as you can get, apparently, stack works the same way.

----

Also remove the `repl_interpreted` attribute which was an attribute I introduced on my own and which I'm sure none is using. Further, the bug that we're trying to fix is unavoidable when `repl_interpreted = False`, hence it makes sense to always assume it to be `True` satisfying the expectations that users have for Haskell REPLs (as established by other tooling such as Cabal and Stack).
