### PR TITLE
Ignore missing .haddock files when generating documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.7] - ???
+
+* Don’t crash on inputs missing `.haddock` interface files. See
+  [#362](https://github.com/tweag/rules_haskell/pull/362)
+
 ## [0.6] - 2018-07-21
 
 ### Added

--- a/tests/ghc.nix
+++ b/tests/ghc.nix
@@ -2,7 +2,15 @@
 
 with pkgs;
 
-haskell.packages.ghc822.ghcWithPackages (p: with p; [
+let haskellPackages = pkgs.haskell.packages.ghc822.override {
+      overrides = with pkgs.haskell.lib; self: super: rec {
+        libc = import ./haddock/libC.nix self pkgs;
+      };
+    };
+
+in haskellPackages.ghcWithPackages (p: with p; [
+
+  # haskell_proto_library inputs
   bytestring
   containers
   data-default-class
@@ -10,4 +18,8 @@ haskell.packages.ghc822.ghcWithPackages (p: with p; [
   lens-labels
   proto-lens
   text
-  ])
+
+  # test inputs
+  libc
+
+])

--- a/tests/haddock/BUILD
+++ b/tests/haddock/BUILD
@@ -40,7 +40,6 @@ haskell_library(
 haskell_import(
     name = "haddock-lib-c",
     package = "libc",
-    visibility = ["//visibility:public"],
 )
 
 haskell_library(

--- a/tests/haddock/BUILD
+++ b/tests/haddock/BUILD
@@ -5,6 +5,7 @@ package(
 
 load(
     "@io_tweag_rules_haskell//haskell:haskell.bzl",
+    "haskell_import",
     "haskell_cc_import",
     "haskell_doc",
     "haskell_library",
@@ -36,11 +37,18 @@ haskell_library(
     ],
 )
 
+haskell_import(
+    name = "haddock-lib-c",
+    package = "libc",
+    visibility = ["//visibility:public"],
+)
+
 haskell_library(
     name = "haddock-lib-b",
     srcs = ["LibB.hs"],
     deps = [
         ":haddock-lib-a",
+        ":haddock-lib-c",
         ":zlib",
         "//tests:base",
     ],

--- a/tests/haddock/LibB.hs
+++ b/tests/haddock/LibB.hs
@@ -3,7 +3,12 @@ module LibB where
 
 import LibA.A (a)
 import LibA (f)
+import LibC (mytype, LibCType)
 
 -- | Doc for 'x' using 'f' and 'a' and 'Int'.
 x :: Int
 x = const f a
+
+-- | This uses a type from an undocumented package
+y :: LibCType
+y = mytype

--- a/tests/haddock/libC.nix
+++ b/tests/haddock/libC.nix
@@ -1,0 +1,42 @@
+self: pkgs:
+let
+  # pkgs = import ../../nixpkgs.nix {};
+
+  libC = pkgs.writeText "LibC.hs" ''
+    {-# language NoImplicitPrelude #-}
+    module LibC where
+
+    data LibCType = LibCType
+
+    -- | myfunction
+    mytype :: LibCType
+    mytype = LibCType
+  '';
+
+  cabal = pkgs.writeText "libc.cabal" ''
+    name: libc
+    version: 0.1.0.0
+    build-type: simple
+    cabal-version: >=1.10
+
+    library
+      default-language: Haskell2010
+      exposed-modules: LibC
+   '';
+
+   src = pkgs.runCommand "libc-src" {} ''
+     mkdir $out
+     cp ${libC} $out/LibC.hs
+     cp ${cabal} $out/libc.cabal
+   '';
+
+in
+  pkgs.haskell.lib.dontHaddock
+    (self.callPackage
+      ({ mkDerivation }: mkDerivation {
+        pname = "libc";
+        version = "0.1.0.0";
+        src = src;
+        license = pkgs.lib.licenses.mit;
+        isExecutable = false;
+      }) {})

--- a/tests/haddock/libC.nix
+++ b/tests/haddock/libC.nix
@@ -1,3 +1,4 @@
+# A trivial `haskellPackages` library that has haddock generation disabled
 self: pkgs:
 let
   # pkgs = import ../../nixpkgs.nix {};
@@ -31,7 +32,11 @@ let
    '';
 
 in
+  # This call means the `.haddock` file is not generated,
+  # even though the ghc package still references the location
+  # where it would ordinarily be.
   pkgs.haskell.lib.dontHaddock
+
     (self.callPackage
       ({ mkDerivation }: mkDerivation {
         pname = "libc";


### PR DESCRIPTION
Fixes #335.

For now only a test reproducing the issue:

```
$ bazel test //tests/haddock
INFO: Analysed target //tests/haddock:haddock (0 packages loaded).
INFO: Found 1 target and 0 test targets...
ERROR: /home/philip/code/bazel/rules_haskell/tests/haddock/BUILD:46:1: HaskellHaddock //tests/haddock:haddock-lib-b failed (Exit 1)
haddock: internal error: /nix/store/9ab4cswajxzxgy8s6khkr99sdp96xm9k-libc-0.1.0.0/share/doc/x86_64-linux-ghc-8.2.2/libc-0.1.0.0/html/libc.haddock: openBinaryFile: does not exist (No such file or directory)
Target //tests/haddock:haddock failed to build
```