### PR TITLE
Make REPL outputs force their dependencies

### DIFF
--- a/haskell/private/actions/repl.bzl
+++ b/haskell/private/actions/repl.bzl
@@ -103,6 +103,8 @@ def build_haskell_repl(
         },
     )
 
+    source_files = lib_info.source_files if lib_info != None else bin_info.source_files
+
     args += ["-ghci-script", ghci_repl_script.path]
 
     # Extra arguments.
@@ -140,5 +142,14 @@ def build_haskell_repl(
     # hs.tools.ghci and ghci_script and the best way to do that is
     # to use hs.actions.run. That action, it turn must produce
     # a result, so using ln seems to be the only sane choice.
-    extra_inputs = depset([hs.tools.ghci, ghci_repl_script, repl_file])
+    extra_inputs = depset(transitive = [
+        depset([
+            hs.tools.ghci,
+            ghci_repl_script,
+            repl_file,
+        ]),
+        set.to_depset(build_info.package_caches),
+        depset(build_info.external_libraries.values()),
+        set.to_depset(source_files),
+    ])
     ln(hs, repl_file, output, extra_inputs)

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -75,14 +75,18 @@ test_failures() {
 
 # Test REPL for libraries
 test_repl_libraries() {
-    bazel build --config=ci //tests/repl-targets:hs-lib-repl
-    bazel-bin/tests/repl-targets/hs-lib-repl -e "show (foo 10) ++ bar ++ baz ++ gen"
+    # Test whether building of repl forces all runtime dependencies by
+    # itself:
+    bazel clean
+    bazel run --config=ci //tests/repl-targets:hs-lib-repl -- -e "show (foo 10) ++ bar ++ baz ++ gen"
 }
 
 # Test REPL for binaries
 test_repl_binaries() {
-    bazel build --config=ci //tests/repl-targets:hs-bin-repl
-    bazel-bin/tests/repl-targets/hs-bin-repl -e ":main"
+    # Test whether building of repl forces all runtime dependencies by
+    # itself:
+    bazel clean
+    bazel run --config=ci //tests/repl-targets:hs-bin-repl -- -e ":main"
 }
 
 # Test `compiler_flags` from toolchain and rule for REPL


### PR DESCRIPTION
This fixes the regression introduced by #352: we have removed the dependency on compiled “parent” target, but this also removed dependency on other things that are necessary to run a REPL, such as:

* Haskell library dependencies
* pre-processed source files (hsc and chs)
* external shared libraries

And so they won't be built if a REPL is built.

This commit restores the dependencies allowing to run REPL without having to build its “parent” target before that (still this does not cancel the intended effects of #352).