### PR TITLE
Fix c2hs_library in external repositories.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -162,6 +162,12 @@ maven_jar(
   artifact = "org.apache.spark:spark-core_2.10:1.6.0",
 )
 
+# c2hs rule in its own repository
+local_repository(
+    name = "c2hs_repo",
+    path = "tests/c2hs/repo",
+)
+
 # For Skydoc
 
 http_archive(

--- a/haskell/c2hs.bzl
+++ b/haskell/c2hs.bzl
@@ -58,6 +58,7 @@ def _c2hs_library_impl(ctx):
 
     idir = paths.join(
         hs.bin_dir.path,
+        hs.label.workspace_root,
         hs.label.package,
         chs_dir_raw,
     )

--- a/tests/c2hs/BUILD
+++ b/tests/c2hs/BUILD
@@ -12,6 +12,7 @@ haskell_cc_import(
     hdrs = ["@zlib.dev//:include"],
     shared_library = "@zlib//:lib",
     strip_include_prefix = "/external/zlib.dev/include",
+    visibility = ["@c2hs_repo//:__pkg__"],
 )
 
 c2hs_library(
@@ -31,6 +32,7 @@ haskell_library(
     srcs = [
         ":bar",
         ":foo",
+        "@c2hs_repo//:baz",
     ],
     deps = ["//tests:base"],
 )

--- a/tests/c2hs/repo/BUILD
+++ b/tests/c2hs/repo/BUILD
@@ -1,0 +1,14 @@
+package(default_testonly = 1)
+
+load("@io_tweag_rules_haskell//haskell:c2hs.bzl", "c2hs_library")
+load(
+    "@io_tweag_rules_haskell//haskell:haskell.bzl",
+    "haskell_cc_import",
+)
+
+c2hs_library(
+    name = "baz",
+    srcs = ["Baz.chs"],
+    deps = ["@io_tweag_rules_haskell//tests/c2hs:zlib"],
+    visibility = ["//visibility:public"],
+)

--- a/tests/c2hs/repo/Baz.chs
+++ b/tests/c2hs/repo/Baz.chs
@@ -1,0 +1,6 @@
+module Baz (baz) where
+
+#include <zlib.h>
+
+baz :: Int
+baz = {# sizeof gz_header_s #}

--- a/tests/c2hs/repo/WORKSPACE
+++ b/tests/c2hs/repo/WORKSPACE
@@ -1,0 +1,1 @@
+workspace(name = "c2hs_repo")


### PR DESCRIPTION
Previously the rule didn't work when `workspace_root` was nontrivial.