### PR TITLE
Misc fixes for the ‘c2hs_library’ rule

### DIFF
--- a/haskell/c2hs.bzl
+++ b/haskell/c2hs.bzl
@@ -40,7 +40,12 @@ def _c2hs_library_impl(ctx):
         for dep in ctx.attr.deps
         if C2hsLibraryInfo in dep
     ]
-    chi_includes = ["-i" + chi.dirname for chi in dep_chi_files]
+
+    chi_includes = [
+        "-i" + dep[C2hsLibraryInfo].import_dir
+        for dep in ctx.attr.deps
+        if C2hsLibraryInfo in dep
+    ]
     args.add(chi_includes)
 
     hs.actions.run(

--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -41,13 +41,17 @@ load(
     _cc_haskell_import = "cc_haskell_import",
     _haskell_cc_import = "haskell_cc_import",
 )
+load(
+    ":c2hs.bzl",
+    _c2hs_library = "c2hs_library",
+)
 
 _haskell_common_attrs = {
     "src_strip_prefix": attr.string(
         doc = "Directory in which module hierarchy starts.",
     ),
     "srcs": attr.label_list(
-        allow_files = FileType([".hs", ".hsc", ".chs", ".lhs", ".hs-boot", ".lhs-boot", ".h"]),
+        allow_files = FileType([".hs", ".hsc", ".lhs", ".hs-boot", ".lhs-boot", ".h"]),
         doc = "Haskell source files.",
     ),
     "extra_srcs": attr.label_list(
@@ -266,3 +270,5 @@ ghc_bindist = _ghc_bindist
 haskell_cc_import = _haskell_cc_import
 
 cc_haskell_import = _cc_haskell_import
+
+c2hs_library = _c2hs_library

--- a/tests/c2hs/BUILD
+++ b/tests/c2hs/BUILD
@@ -17,7 +17,8 @@ haskell_cc_import(
 
 c2hs_library(
     name = "foo",
-    srcs = ["Foo.chs"],
+    srcs = ["src/Foo/Foo.chs"],
+    src_strip_prefix = "src",
     deps = [":zlib"],
 )
 

--- a/tests/c2hs/Bar.chs
+++ b/tests/c2hs/Bar.chs
@@ -1,6 +1,6 @@
 module Bar (bar) where
 
-{#import Foo#}
+{#import Foo.Foo#}
 
 bar :: Int
 bar = 6

--- a/tests/c2hs/src/Foo/Foo.chs
+++ b/tests/c2hs/src/Foo/Foo.chs
@@ -1,4 +1,4 @@
-module Foo (foo) where
+module Foo.Foo (foo) where
 
 #include <zlib.h>
 


### PR DESCRIPTION
Previously detection of import directories was incorrect: taking just dirname of every produced `.chi` does not work when we have module names containing several “segments”.

Other changes:

* we're providing all rules from `haskell.bzl`, so let's re-export `c2hs_library` from there for consistency too.
* `srcs` of `haskell_binary` and `haskell_library` should not accept `.chs` files because they do not know what do to with them.