### PR TITLE
Make an env variable test in the REPL more portable.

### DIFF
--- a/haskell/private/ghci_repl_wrapper.sh
+++ b/haskell/private/ghci_repl_wrapper.sh
@@ -3,7 +3,7 @@
 # Usage: ghci_repl_wrapper.sh <ARGS>
 
 # this variable is set by `bazel run`
-if ! test -v BUILD_WORKSPACE_DIRECTORY
+if [ "$BUILD_WORKSPACE_DIRECTORY" = "" ]
 then
     cat <<EOF
 It looks like you are trying to invoke the REPL incorrectly.


### PR DESCRIPTION
Previously it used `test -v` which is only available on bash 4.2
or newer.  (In particular, that version isn't available on MacOS
Sierra.)

The difference between `test -v VAR` and `"$VAR" = ""` is negligible
in this case.  If the `VAR` is the empty string, the former will accept it
and the latter will reject it.  But since `BUILD_WORKSPACE_DIRECTORY`
is an absolute path, that won't cause a problem in practice.