### PR TITLE
Allow rules to override -O2 with their own compiler_flags.

### DIFF
--- a/haskell/private/actions/compile.bzl
+++ b/haskell/private/actions/compile.bzl
@@ -133,6 +133,11 @@ def _compilation_defaults(hs, cc, java, dep_info, srcs, import_dir_map, extra_sr
     )
 
     # Default compiler flags.
+
+    # Compilation mode.  Allow rule-supplied compiler flags to override it.
+    if hs.mode == "opt":
+      ghc_args += ["-O2"]
+
     ghc_args += hs.toolchain.compiler_flags
     ghc_args += compiler_flags
     ghc_args.append("-hide-all-packages")
@@ -276,10 +281,6 @@ def _compilation_defaults(hs, cc, java, dep_info, srcs, import_dir_map, extra_sr
 
     args = hs.actions.args()
     args.add(ghc_args)
-
-    # Compilation mode and explicit user flags
-    if hs.mode == "opt":
-        args.add("-O2")
 
     args.add(["-static"])
 

--- a/haskell/private/actions/compile.bzl
+++ b/haskell/private/actions/compile.bzl
@@ -133,11 +133,6 @@ def _compilation_defaults(hs, cc, java, dep_info, srcs, import_dir_map, extra_sr
     )
 
     # Default compiler flags.
-
-    # Compilation mode.  Allow rule-supplied compiler flags to override it.
-    if hs.mode == "opt":
-      ghc_args += ["-O2"]
-
     ghc_args += hs.toolchain.compiler_flags
     ghc_args += compiler_flags
     ghc_args.append("-hide-all-packages")
@@ -280,6 +275,11 @@ def _compilation_defaults(hs, cc, java, dep_info, srcs, import_dir_map, extra_sr
         ghc_args += unit_id_args
 
     args = hs.actions.args()
+
+    # Compilation mode.  Allow rule-supplied compiler flags to override it.
+    if hs.mode == "opt":
+        args.add("-O2")
+
     args.add(ghc_args)
 
     args.add(["-static"])


### PR DESCRIPTION
Currently, `-c opt` will turn on optimization for all Haskell
rules with no way to disable it.  Previously, it was possible
to do so with `compiler_flags = ["-O0"]`, but that behavior was
changed in #342:
https://github.com/tweag/rules_haskell/pull/342/files#diff-33a8c46955e2a9917090b5258346aee2L247

Some Haskell packages take a *lot* of memory and a lot longer to compile with
optimizations.  So it's useful for us to be able to control this tradeoff.