### PR TITLE
Override TMPDIR in haddock_wrapper.sh

### DIFF
--- a/haskell/haddock.bzl
+++ b/haskell/haddock.bzl
@@ -95,6 +95,8 @@ def _haskell_doc_aspect_impl(target, ctx):
                 hs.tools.bash,
                 hs.tools.ghc_pkg,
                 hs.tools.haddock,
+                hs.tools.mkdir,
+                hs.tools.rmdir,
             ]),
             locale_archive_depset,
         ]),

--- a/haskell/haddock.bzl
+++ b/haskell/haddock.bzl
@@ -95,7 +95,7 @@ def _haskell_doc_aspect_impl(target, ctx):
                 hs.tools.bash,
                 hs.tools.ghc_pkg,
                 hs.tools.haddock,
-                hs.tools.mkdir,
+                hs.tools.mktemp,
                 hs.tools.rmdir,
             ]),
             locale_archive_depset,

--- a/haskell/private/haddock_wrapper.sh
+++ b/haskell/private/haddock_wrapper.sh
@@ -36,4 +36,8 @@ do
     fi
 done
 
+# Override TMPDIR to prevent race conditions on certain platforms.
+mkdir haddock-tmp
+TMPDIR=haddock-tmp
 haddock "${extra_args[@]}" "$@"
+rmdir haddock-tmp

--- a/haskell/private/haddock_wrapper.sh
+++ b/haskell/private/haddock_wrapper.sh
@@ -37,7 +37,9 @@ do
 done
 
 # Override TMPDIR to prevent race conditions on certain platforms.
-mkdir haddock-tmp
-TMPDIR=haddock-tmp
-haddock "${extra_args[@]}" "$@"
-rmdir haddock-tmp
+# BSD and GNU mktemp are very different; attempt GNU first
+TEMP=$(mktemp -d 2>/dev/null || mktemp -d -t 'haddock_wrapper')
+trap cleanup 1 2 3 6
+cleanup() { rmdir "$TEMP"; }
+TMPDIR=$TEMP haddock "${extra_args[@]}" "$@"
+rmdir "$TEMP"

--- a/haskell/private/haddock_wrapper.sh
+++ b/haskell/private/haddock_wrapper.sh
@@ -42,4 +42,4 @@ TEMP=$(mktemp -d 2>/dev/null || mktemp -d -t 'haddock_wrapper')
 trap cleanup 1 2 3 6
 cleanup() { rmdir "$TEMP"; }
 TMPDIR=$TEMP haddock "${extra_args[@]}" "$@"
-rmdir "$TEMP"
+cleanup

--- a/haskell/toolchain.bzl
+++ b/haskell/toolchain.bzl
@@ -197,6 +197,7 @@ def _haskell_toolchain_impl(ctx):
         "grep",
         "ln",
         "mkdir",
+        "rmdir",
     ]
 
     for target in targets_w:

--- a/haskell/toolchain.bzl
+++ b/haskell/toolchain.bzl
@@ -197,6 +197,7 @@ def _haskell_toolchain_impl(ctx):
         "grep",
         "ln",
         "mkdir",
+        "mktemp",
         "rmdir",
     ]
 


### PR DESCRIPTION
This fixes #229 by overriding `TMPDIR` on each Haddock execution.