### PR TITLE
Support reexporting modules from `haskell_library`

### DIFF
--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -185,6 +185,9 @@ haskell_library = rule(
         hidden_modules = attr.string_list(
             doc = "Modules that should be unavailable for import by dependencies.",
         ),
+        exports = attr.label_keyed_string_dict(
+            doc = "A dictionary mapping dependencies to module reexports that should be available for import by dependencies.",
+        ),
     ),
     outputs = {
         "repl": "%{name}-repl",
@@ -202,8 +205,12 @@ Example:
       name = "hello-lib",
       srcs = glob(["src/**/*.hs"]),
       src_strip_prefix = "src",
-      deps = ["//hello-sublib:lib"],
-      prebuilt_dependencies = ["base", "bytestring"],
+      deps = [
+          "//hello-sublib:lib",
+      ],
+      exports = {
+          "//hello-sublib:lib": "Lib1 as HelloLib1, Lib2",
+      },
   )
   ```
 
@@ -217,7 +224,12 @@ def _haskell_import_impl(ctx):
         package = ctx.attr.package
     else:
         package = ctx.label.name
-    return [HaskellPrebuiltPackageInfo(package = package)]
+
+    if ctx.attr.version:
+        package_id = "{}-{}".format(package, ctx.attr.version)
+    else:
+        package_id = package
+    return [HaskellPrebuiltPackageInfo(package = package, package_id = package_id)]
 
 """Wrap a prebuilt dependency as a rule.
 
@@ -226,6 +238,7 @@ Example:
   haskell_import(
       name = "base_pkg",
       package = "base",
+      version = "4.9.0.0",
   )
   haskell_library(
       name = "hello-lib",
@@ -248,6 +261,7 @@ haskell_import = rule(
     _haskell_import_impl,
     attrs = dict(
         package = attr.string(doc = "A non-Bazel-supplied GHC package name.  Defaults to the name of the rule."),
+        version = attr.string(doc = "A non-Bazel-supplied GHC package version.", mandatory = True)
     ),
 )
 

--- a/haskell/private/dependencies.bzl
+++ b/haskell/private/dependencies.bzl
@@ -101,8 +101,9 @@ def gather_dep_info(ctx):
             )
         elif HaskellPrebuiltPackageInfo in dep:
             pkg = dep[HaskellPrebuiltPackageInfo].package
+            pkg_id = dep[HaskellPrebuiltPackageInfo].package_id
             acc = HaskellBuildInfo(
-                package_ids = acc.package_ids,
+                package_ids = set.mutable_insert(acc.package_ids, pkg_id),
                 package_confs = acc.package_confs,
                 package_caches = acc.package_caches,
                 static_libraries = acc.static_libraries,

--- a/haskell/private/haskell_impl.bzl
+++ b/haskell/private/haskell_impl.bzl
@@ -22,6 +22,7 @@ load(
     "HaskellBinaryInfo",
     "HaskellBuildInfo",
     "HaskellLibraryInfo",
+    "HaskellPrebuiltPackageInfo",
 )
 
 def _prepare_srcs(srcs):
@@ -230,6 +231,7 @@ use the 'haskell_import' rule instead.
         )
 
     exposed_modules = set.empty()
+    exposed_modules_reexports = _exposed_modules_reexports(ctx.attr.exports)
     other_modules = set.from_list(ctx.attr.hidden_modules)
 
     for module in set.to_list(c.modules):
@@ -243,6 +245,7 @@ use the 'haskell_import' rule instead.
         static_library,
         dynamic_library,
         exposed_modules,
+        exposed_modules_reexports,
         other_modules,
         my_pkg_id,
         static_library_prof = static_library_prof,
@@ -323,3 +326,57 @@ use the 'haskell_import' rule instead.
         lib_info,
         default_info,
     ]
+
+def _exposed_modules_reexports(exports):
+    """Creates a ghc-pkg-compatible list of reexport declarations.
+
+    A ghc-pkg registration file declares reexports as part of the
+    exposed-modules field in the following format:
+
+    exposed-modules: A, B, C from pkg-c:C, D from pkg-d:Original.D
+
+    Here, the Original.D module from pkg-d is renamed by virtue of a
+    different name being used before the "from" keyword.
+
+    This function creates a ghc-pkg-compatible list of reexport declarations
+    (as shown above) from a dictionary mapping package targets to "Cabal-style"
+    reexported-modules declarations. That is, something like:
+
+    {
+      ":pkg-c": "C",
+      ":pkg-d": "Original.D as D",
+      ":pkg-e": "E1, Original.E2 as E2",
+    }
+
+    Args:
+      exports: a dictionary mapping package targets to "Cabal-style"
+               reexported-modules declarations.
+
+    Returns:
+      a ghc-pkg-compatible list of reexport declarations.
+    """
+    exposed_reexports = []
+    for dep, cabal_decls in exports.items():
+        for cabal_decl in cabal_decls.split(","):
+          stripped_cabal_decl = cabal_decl.strip()
+          cabal_decl_parts = stripped_cabal_decl.split(" as ")
+          original = cabal_decl_parts[0]
+          if len(cabal_decl_parts) == 2:
+              reexported = cabal_decl_parts[1]
+          else:
+              reexported = cabal_decl_parts[0]
+
+          if HaskellPrebuiltPackageInfo in dep:
+              pkg = dep[HaskellPrebuiltPackageInfo].package_id
+          elif HaskellLibraryInfo in dep:
+              pkg = dep[HaskellLibraryInfo].package_id
+
+          exposed_reexport = "{reexported} from {pkg}:{original}".format(
+              reexported = reexported,
+              pkg = pkg,
+              original = original,
+          )
+
+          exposed_reexports.append(exposed_reexport)
+
+    return exposed_reexports

--- a/haskell/private/providers.bzl
+++ b/haskell/private/providers.bzl
@@ -67,7 +67,8 @@ HaskellBinaryInfo = provider(
 HaskellPrebuiltPackageInfo = provider(
     doc = "Information about a prebuilt GHC package.",
     fields = {
-        "package": "Package name",
+        "package": "Package name.",
+        "package_id": "Package id, usually of the form name-version.",
     },
 )
 

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -66,6 +66,7 @@ haskell_proto_toolchain(
 
 haskell_import(
     name = "base",
+    version = "4.10.1.0",
     testonly = 0,
     package = "base",
     visibility = ["//visibility:public"],
@@ -73,6 +74,7 @@ haskell_import(
 
 haskell_import(
     name = "bytestring",
+    version = "0.10.8.2",
     testonly = 0,
     package = "bytestring",
     visibility = ["//visibility:public"],
@@ -80,6 +82,7 @@ haskell_import(
 
 haskell_import(
     name = "containers",
+    version = "0.5.10.2",
     testonly = 0,
     package = "containers",
     visibility = ["//visibility:public"],
@@ -87,6 +90,7 @@ haskell_import(
 
 haskell_import(
     name = "directory",
+    version = "1.3.0.2",
     testonly = 0,
     package = "directory",
     visibility = ["//visibility:public"],
@@ -94,6 +98,7 @@ haskell_import(
 
 haskell_import(
     name = "data-default-class",
+    version = "0.1.2.0",
     testonly = 0,
     package = "data-default-class",
     visibility = ["//visibility:public"],
@@ -101,6 +106,7 @@ haskell_import(
 
 haskell_import(
     name = "filepath",
+    version = "1.4.1.2",
     testonly = 0,
     package = "filepath",
     visibility = ["//visibility:public"],
@@ -108,6 +114,7 @@ haskell_import(
 
 haskell_import(
     name = "ghc-prim",
+    version = "0.5.1.1",
     testonly = 0,
     package = "ghc-prim",
     visibility = ["//visibility:public"],
@@ -115,6 +122,7 @@ haskell_import(
 
 haskell_import(
     name = "process",
+    version = "1.6.1.0",
     testonly = 0,
     package = "process",
     visibility = ["//visibility:public"],
@@ -122,6 +130,7 @@ haskell_import(
 
 haskell_import(
     name = "template-haskell",
+    version = "2.12.0.0",
     testonly = 0,
     package = "template-haskell",
     visibility = ["//visibility:public"],
@@ -129,6 +138,7 @@ haskell_import(
 
 haskell_import(
     name = "lens-family",
+    version = "1.2.2",
     testonly = 0,
     package = "lens-family",
     visibility = ["//visibility:public"],
@@ -136,6 +146,7 @@ haskell_import(
 
 haskell_import(
     name = "lens-labels",
+    version = "0.2.0.1",
     testonly = 0,
     package = "lens-labels",
     visibility = ["//visibility:public"],
@@ -143,6 +154,7 @@ haskell_import(
 
 haskell_import(
     name = "array",
+    version = "0.5.2.0",
     testonly = 0,
     package = "array",
     visibility = ["//visibility:public"],
@@ -150,6 +162,7 @@ haskell_import(
 
 haskell_import(
     name = "text",
+    version = "1.2.3.0",
     testonly = 0,
     package = "text",
     visibility = ["//visibility:public"],
@@ -157,6 +170,7 @@ haskell_import(
 
 haskell_import(
     name = "proto-lens",
+    version = "0.3.1.0",
     testonly = 0,
     package = "proto-lens",
     visibility = ["//visibility:public"],

--- a/tests/haddock/BUILD
+++ b/tests/haddock/BUILD
@@ -40,6 +40,7 @@ haskell_library(
 haskell_import(
     name = "haddock-lib-c",
     package = "libc",
+    version = "0.1.0.0",
 )
 
 haskell_library(

--- a/tests/haskell_import/BUILD
+++ b/tests/haskell_import/BUILD
@@ -9,11 +9,13 @@ load(
 
 haskell_import(
     name = "bytestring",
+    version = "0.10.8.2",
 )
 
 haskell_import(
     name = "text_pkg",
     package = "text",
+    version = "1.2.3.0",
 )
 
 haskell_library(


### PR DESCRIPTION
Cabal's `reexported-modules` field allows one to reexport and optionally
rename modules from a library. This commit adds an `exports` attribute
to `haskell_library` which accomplishes the same, accepting a dictionary
mapping dependencies to strings using the same syntax. For example:

```
haskell_library(
    ...,
    exports = {
        ":dependency": "A, B as BNew",
    },
    ...
)
```

Addresses https://github.com/tweag/rules_haskell/issues/357 