### PR TITLE
Drop setting a bogus version number when none needed

### DIFF
--- a/haskell/haddock.bzl
+++ b/haskell/haddock.bzl
@@ -33,12 +33,19 @@ def _haskell_doc_aspect_impl(target, ctx):
     html_dir = ctx.actions.declare_directory(html_dir_raw)
     haddock_file = ctx.actions.declare_file(_get_haddock_path(package_id))
 
+    # XXX Haddock really wants a version number, so invent one from
+    # thin air. See https://github.com/haskell/haddock/issues/898.
+    if target[HaskellLibraryInfo].version:
+        version = target[HaskellLibraryInfo].version
+    else:
+        version = "0"
+
     args = ctx.actions.args()
+    args.add("--package-name={0}".format(package_id))
+    args.add("--package-version={0}".format(version))
     args.add([
         "-D",
         haddock_file.path,
-        "--package-name={0}".format(package_id),
-        "--package-version={0}".format(target[HaskellLibraryInfo].version),
         "-o",
         html_dir,
         "--html",

--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -75,12 +75,6 @@ _haskell_common_attrs = {
     "repl_ghci_args": attr.string_list(
         doc = "Arbitrary extra arguments to pass to GHCi. This extends `compiler_flags` and `repl_ghci_args` from the toolchain",
     ),
-    # XXX Consider making this private. Blocked on
-    # https://github.com/bazelbuild/bazel/issues/4366.
-    "version": attr.string(
-        default = "1.0.0",
-        doc = "Library/binary version. Internal - do not use.",
-    ),
     "_ghci_script": attr.label(
         allow_single_file = True,
         default = Label("@io_tweag_rules_haskell//haskell:assets/ghci_script"),
@@ -189,6 +183,10 @@ haskell_library = rule(
         _haskell_common_attrs,
         hidden_modules = attr.string_list(
             doc = "Modules that should be unavailable for import by dependencies.",
+        ),
+        version = attr.string(
+            doc = """Library version. Not normally necessary unless to build a library
+            originally defined as a Cabal package.""",
         ),
     ),
     outputs = {

--- a/haskell/private/actions/package.bzl
+++ b/haskell/private/actions/package.bzl
@@ -66,6 +66,7 @@ def package(hs, dep_info, interfaces_dir, interfaces_dir_prof, static_library, d
         content = "\n".join([
             "{0}: {1}".format(k, v)
             for k, v in metadata_entries.items()
+            if v
         ]) + "\n",
     )
 

--- a/haskell/private/haskell_impl.bzl
+++ b/haskell/private/haskell_impl.bzl
@@ -161,7 +161,8 @@ use the 'haskell_import' rule instead.
 
     hs = haskell_context(ctx)
     dep_info = gather_dep_info(ctx)
-    my_pkg_id = pkg_id.new(ctx.label, ctx.attr.version)
+    version = ctx.attr.version if ctx.attr.version else None
+    my_pkg_id = pkg_id.new(ctx.label, version)
     with_profiling = is_profiling_enabled(hs)
 
     # Add any interop info for other languages.
@@ -284,7 +285,7 @@ use the 'haskell_import' rule instead.
     )
     lib_info = HaskellLibraryInfo(
         package_id = pkg_id.to_string(my_pkg_id),
-        version = ctx.attr.version,
+        version = version,
         import_dirs = c.import_dirs,
         ghc_args = c.ghc_args,
         header_files = c.header_files,

--- a/haskell/private/pkg_id.bzl
+++ b/haskell/private/pkg_id.bzl
@@ -12,23 +12,22 @@ def _zencode(s):
     return s.replace("Z", "ZZ").replace("_", "ZU").replace("/", "ZS")
 
 def _to_string(my_pkg_id):
-    """Get package identifier of the form `name-version`.
+    """Get a globally unique package identifier.
 
     The identifier is required to be unique for each Haskell rule.
-    It includes the Bazel package and the name of the this component.
+    It includes the Bazel package and the name of this component.
     We can't use just the latter because then two components with
     the same names in different packages would clash.
     """
-    return "{0}-{1}".format(
-        _zencode(paths.join(
+    return _zencode(
+        paths.join(
             my_pkg_id.label.workspace_root,
             my_pkg_id.label.package,
             my_pkg_id.name,
-        )),
-        my_pkg_id.version,
+        ),
     )
 
-def _new(label, version):
+def _new(label, version = None):
     """Create a new package identifier.
 
     Package identifiers should be globally unique. This is why we use
@@ -36,6 +35,7 @@ def _new(label, version):
 
     Args:
       label: The label of the rule declaring the package.
+      version: an optional version annotation.
 
     Returns:
       string: GHC package ID to use.

--- a/haskell/private/providers.bzl
+++ b/haskell/private/providers.bzl
@@ -35,7 +35,7 @@ HaskellBuildInfo = provider(
 HaskellLibraryInfo = provider(
     doc = "Library-specific information.",
     fields = {
-        "package_id": "Package id, usually of the form name-version.",
+        "package_id": "Workspace unique package identifier.",
         "version": "Package version.",
         "import_dirs": "Import hierarchy roots.",
         "header_files": "Set of header files.",

--- a/haskell/protobuf.bzl
+++ b/haskell/protobuf.bzl
@@ -136,7 +136,7 @@ def _haskell_proto_aspect_impl(target, ctx):
         "src_strip_prefix": "",
         "repl_interpreted": True,
         "repl_ghci_args": [],
-        "version": "1.0.0",
+        "version": "",
         "_ghci_script": ctx.attr._ghci_script,
         "_ghci_repl_wrapper": ctx.attr._ghci_repl_wrapper,
         "hidden_modules": [],

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -217,8 +217,8 @@ rule_test(
     size = "small",
     generates =
         [
-            "testsZSlibrary-depsZSlibrary-deps-1.0.0/testsZSlibrary-depsZSlibrary-deps-1.0.0.conf",
-            "testsZSlibrary-depsZSlibrary-deps-1.0.0/package.cache",
+            "testsZSlibrary-depsZSlibrary-deps/testsZSlibrary-depsZSlibrary-deps.conf",
+            "testsZSlibrary-depsZSlibrary-deps/package.cache",
         ],
     rule = "//tests/library-deps",
 )
@@ -228,8 +228,8 @@ rule_test(
     size = "small",
     generates =
         [
-            "testsZSlibrary-with-sysdepsZSlibrary-with-sysdeps-1.0.0/testsZSlibrary-with-sysdepsZSlibrary-with-sysdeps-1.0.0.conf",
-            "testsZSlibrary-with-sysdepsZSlibrary-with-sysdeps-1.0.0/package.cache",
+            "testsZSlibrary-with-sysdepsZSlibrary-with-sysdeps/testsZSlibrary-with-sysdepsZSlibrary-with-sysdeps.conf",
+            "testsZSlibrary-with-sysdepsZSlibrary-with-sysdeps/package.cache",
         ],
     rule = "//tests/library-with-sysdeps",
 )
@@ -246,9 +246,9 @@ rule_test(
     size = "small",
     generates = [
         "haddock/index",
-        "haddock/testsZShaddockZShaddock-lib-a-1.0.0",
-        "haddock/testsZShaddockZShaddock-lib-b-1.0.0",
-        "haddock/testsZShaddockZShaddock-lib-deep-1.0.0",
+        "haddock/testsZShaddockZShaddock-lib-a",
+        "haddock/testsZShaddockZShaddock-lib-b",
+        "haddock/testsZShaddockZShaddock-lib-deep",
     ],
     rule = "//tests/haddock",
 )
@@ -275,8 +275,8 @@ rule_test(
     name = "test-haskell_proto_library",
     size = "small",
     generates = [
-        "testsZShaskellZUprotoZUlibraryZShs-lib-1.0.0/package.cache",
-        "testsZShaskellZUprotoZUlibraryZShs-lib-1.0.0/testsZShaskellZUprotoZUlibraryZShs-lib-1.0.0.conf",
+        "testsZShaskellZUprotoZUlibraryZShs-lib/package.cache",
+        "testsZShaskellZUprotoZUlibraryZShs-lib/testsZShaskellZUprotoZUlibraryZShs-lib.conf",
     ],
     rule = "//tests/haskell_proto_library:hs-lib",
 )
@@ -285,7 +285,7 @@ rule_test(
     name = "test-haskell_doctest",
     size = "small",
     generates = [
-        "doctest-log-doctest-lib-testsZShaskellZUdoctestZSlib-b-1.0.0",
+        "doctest-log-doctest-lib-testsZShaskellZUdoctestZSlib-b",
     ],
     rule = "//tests/haskell_doctest:doctest-lib",
 )
@@ -301,8 +301,8 @@ rule_test(
     name = "test-hidden-modules",
     size = "small",
     generates = [
-        "testsZShidden-modulesZSlib-c-1.0.0/testsZShidden-modulesZSlib-c-1.0.0.conf",
-        "testsZShidden-modulesZSlib-c-1.0.0/package.cache",
+        "testsZShidden-modulesZSlib-c/testsZShidden-modulesZSlib-c.conf",
+        "testsZShidden-modulesZSlib-c/package.cache",
     ],
     rule = "//tests/hidden-modules:lib-c",
 )
@@ -312,8 +312,8 @@ rule_test(
     size = "small",
     generates =
         [
-            "testsZSlibrary-with-sysincludesZSlibrary-with-sysincludes-1.0.0/testsZSlibrary-with-sysincludesZSlibrary-with-sysincludes-1.0.0.conf",
-            "testsZSlibrary-with-sysincludesZSlibrary-with-sysincludes-1.0.0/package.cache",
+            "testsZSlibrary-with-sysincludesZSlibrary-with-sysincludes/testsZSlibrary-with-sysincludesZSlibrary-with-sysincludes.conf",
+            "testsZSlibrary-with-sysincludesZSlibrary-with-sysincludes/package.cache",
         ],
     rule = "//tests/library-with-sysincludes",
 )
@@ -323,8 +323,8 @@ rule_test(
     size = "small",
     generates =
         [
-            "testsZSpackage-id-clashZSlib-1.0.0/testsZSpackage-id-clashZSlib-1.0.0.conf",
-            "testsZSpackage-id-clashZSlib-1.0.0/package.cache",
+            "testsZSpackage-id-clashZSlib/testsZSpackage-id-clashZSlib.conf",
+            "testsZSpackage-id-clashZSlib/package.cache",
         ],
     rule = "//tests/package-id-clash:lib",
 )
@@ -341,12 +341,12 @@ rule_test(
     size = "small",
     generates = select({
         "@bazel_tools//src/conditions:darwin": [
-            "libHStestsZSccZUhaskellZUimportZShs-lib-a-1.0.0-ghc8.2.2.dylib",
-            "libHStestsZSccZUhaskellZUimportZShs-lib-b-1.0.0-ghc8.2.2.dylib",
+            "libHStestsZSccZUhaskellZUimportZShs-lib-a-ghc8.2.2.dylib",
+            "libHStestsZSccZUhaskellZUimportZShs-lib-b-ghc8.2.2.dylib",
         ],
         "//conditions:default": [
-            "libHStestsZSccZUhaskellZUimportZShs-lib-a-1.0.0-ghc8.2.2.so",
-            "libHStestsZSccZUhaskellZUimportZShs-lib-b-1.0.0-ghc8.2.2.so",
+            "libHStestsZSccZUhaskellZUimportZShs-lib-a-ghc8.2.2.so",
+            "libHStestsZSccZUhaskellZUimportZShs-lib-b-ghc8.2.2.so",
         ],
     }),
     rule = "//tests/cc_haskell_import:hs-lib-b-so",

--- a/tests/package-name/Main.hs
+++ b/tests/package-name/Main.hs
@@ -28,6 +28,6 @@ main :: IO ()
 main = do
     check foo 42
     check VERSION_lib_a_Z "1.2.3.4"
-    check libPackageKey "testsZSpackage-nameZSlib-a-ZZ-1.2.3.4"
+    check libPackageKey "testsZSpackage-nameZSlib-a-ZZ"
     check versionHighEnoughTest True
     check versionTooLowTest True


### PR DESCRIPTION
In a monorepo use case, version numbers are not useful. All code
always builds against the "latest" version of every component in any
particular snapshot of the monorepo. In fact I'd be up for dropping
the `version` field entirely, if it were not for supporting Bazelified
Cabal packages via Hazel (these need version numbers to correctly
evaluate CPP macros).

Even if version numbers were usually not set, internally we always
used one. But it turns out that GHC is quite happy to handle
versionless packages, so there is no need to set a bogus "1.0.0"
default version number like we did. With this PR, we drop this default
and allow package id's with no version. We don't use version numbers
in package keys. Version numbers only appear in one place: in the
`version` field of a package configuration.

Dropping versions everywhere else is safe to do because all our
packages are already uniquely named across the workspace even without
version numbers.

Breaking change: the `version` field is now only supported for `haskell_library`, not `haskell_binary`.