### PR TITLE
_cc_haskell_import: remove dead code

### DIFF
--- a/haskell/cc.bzl
+++ b/haskell/cc.bzl
@@ -230,28 +230,6 @@ def _cc_haskell_import(ctx):
         ),
     ]
 
-    if HaskellBinaryInfo in ctx.attr.dep:
-        dbin = ctx.attr.dep[HaskellBinaryInfo].dynamic_bin
-        if dbin != None:
-            set.mutable_insert(dyn_libs, dbin)
-
-    return [
-        DefaultInfo(
-            files = set.to_depset(dyn_libs),
-        ),
-    ]
-
-    if HaskellBinaryInfo in ctx.attr.dep:
-        dbin = ctx.attr.dep[HaskellBinaryInfo].dynamic_bin
-        if dbin != None:
-            set.mutable_insert(dyn_libs, dbin)
-
-    return [
-        DefaultInfo(
-            files = set.to_depset(dyn_libs),
-        ),
-    ]
-
 cc_haskell_import = rule(
     _cc_haskell_import,
     attrs = {


### PR DESCRIPTION
Anything after the first return can’t be reached, and the code doesn’t seem to
export anything not already exported by the first return.