### PR TITLE
Generate uniq haskell packages name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [0.7] - ???
 
+* Package name change. See
+  [#396](https://github.com/tweag/rules_haskell/pull/396)
+
 * Don’t crash on inputs missing `.haddock` interface files. See
   [#362](https://github.com/tweag/rules_haskell/pull/362)
 

--- a/haskell/private/actions/compile.bzl
+++ b/haskell/private/actions/compile.bzl
@@ -100,7 +100,7 @@ def _compilation_defaults(hs, cc, java, dep_info, srcs, import_dir_map, extra_sr
         # package directory.
         interfaces_dir = hs.actions.declare_directory(
             paths.join(
-                pkg_id.to_string(my_pkg_id),
+                my_pkg_id.name,
                 interface_dir_raw,
             ),
         )
@@ -184,8 +184,8 @@ def _compilation_defaults(hs, cc, java, dep_info, srcs, import_dir_map, extra_sr
     if my_pkg_id != None:
         unit_id_args = [
             "-this-unit-id",
-            pkg_id.to_string(my_pkg_id),
-            "-optP-DCURRENT_PACKAGE_KEY=\"{}\"".format(pkg_id.to_string(my_pkg_id)),
+            my_pkg_id.name,
+            "-optP-DCURRENT_PACKAGE_KEY=\"{}\"".format(my_pkg_id.name),
         ]
         ghc_args += unit_id_args
 

--- a/haskell/private/actions/package.bzl
+++ b/haskell/private/actions/package.bzl
@@ -18,7 +18,7 @@ def package(hs, dep_info, interfaces_dir, interfaces_dir_prof, static_library, d
     Returns:
       (File, File): GHC package conf file, GHC package cache file
     """
-    pkg_db_dir = pkg_id.to_string(my_pkg_id)
+    pkg_db_dir = my_pkg_id.name
     conf_file = hs.actions.declare_file(
         paths.join(pkg_db_dir, "{0}.conf".format(pkg_db_dir)),
     )
@@ -42,8 +42,8 @@ def package(hs, dep_info, interfaces_dir, interfaces_dir_prof, static_library, d
     metadata_entries = {
         "name": my_pkg_id.name,
         "version": my_pkg_id.version,
-        "id": pkg_id.to_string(my_pkg_id),
-        "key": pkg_id.to_string(my_pkg_id),
+        "id": my_pkg_id.name,
+        "key": my_pkg_id.name,
         "exposed": "True",
         "hidden-modules": " ".join(other_modules),
         "import-dirs": " ".join([import_dir, import_dir_prof]),

--- a/haskell/private/haskell_impl.bzl
+++ b/haskell/private/haskell_impl.bzl
@@ -273,7 +273,7 @@ use the 'haskell_import' rule instead.
         )
 
     build_info = HaskellBuildInfo(
-        package_ids = set.insert(dep_info.package_ids, pkg_id.to_string(my_pkg_id)),
+        package_ids = set.insert(dep_info.package_ids, my_pkg_id.name),
         package_confs = set.insert(dep_info.package_confs, conf_file),
         package_caches = set.insert(dep_info.package_caches, cache_file),
         # NOTE We have to use lists for static libraries because the order is
@@ -288,7 +288,7 @@ use the 'haskell_import' rule instead.
         external_libraries = dep_info.external_libraries,
     )
     lib_info = HaskellLibraryInfo(
-        package_id = pkg_id.to_string(my_pkg_id),
+        package_id = my_pkg_id.name,
         version = version,
         import_dirs = c.import_dirs,
         ghc_args = c.ghc_args,

--- a/haskell/private/pkg_id.bzl
+++ b/haskell/private/pkg_id.bzl
@@ -11,7 +11,7 @@ def _zencode(s):
     """
     return s.replace("Z", "ZZ").replace("_", "ZU").replace("/", "ZS")
 
-def _to_string(my_pkg_id):
+def _to_string(label):
     """Get a globally unique package identifier.
 
     The identifier is required to be unique for each Haskell rule.
@@ -21,9 +21,9 @@ def _to_string(my_pkg_id):
     """
     return _zencode(
         paths.join(
-            my_pkg_id.label.workspace_root,
-            my_pkg_id.label.package,
-            my_pkg_id.name,
+            label.workspace_root,
+            label.package,
+            label.name,
         ),
     )
 
@@ -43,7 +43,7 @@ def _new(label, version = None):
     """
     return struct(
         label = label,
-        name = label.name.replace("_", "-"),
+        name = _to_string(label),
         version = version,
     )
 
@@ -55,13 +55,12 @@ def _library_name(hs, my_pkg_id, prof_suffix = False):
       my_pkg_id: pkg_id struct.
       prof_suffix: whether to automatically add profiling suffix.
     """
-    library_name = "HS" + _to_string(my_pkg_id)
+    library_name = "HS" + my_pkg_id.name
     if is_profiling_enabled(hs) and prof_suffix:
         library_name += "_p"
     return library_name
 
 pkg_id = struct(
     new = _new,
-    to_string = _to_string,
     library_name = _library_name,
 )

--- a/tests/package-name/BUILD
+++ b/tests/package-name/BUILD
@@ -8,8 +8,6 @@ load(
 )
 
 haskell_library(
-    # The character "Z" should be untouched in the GHC package name.
-    # However, underscores (which are not legal) should be turned into dashes.
     name = "lib-a_Z",
     srcs = ["Lib.hs"],
     version = "1.2.3.4",

--- a/tests/package-name/Main.hs
+++ b/tests/package-name/Main.hs
@@ -5,17 +5,17 @@ module Main (main) where
 import Control.Monad (when)
 
 -- Test the PackageImports extension.
-import "lib-a-Z" Lib
+import "testsZSpackage-nameZSlib-aZUZZ" Lib
 
 -- Test macros that GHC creates automatically based on the package version.
 versionHighEnoughTest, versionTooLowTest :: Bool
-#if MIN_VERSION_lib_a_Z(1,2,3)
+#if MIN_VERSION_testsZSpackage_nameZSlib_aZUZZ(1,2,3)
 versionHighEnoughTest = True
 #else
 versionHighEnoughTest = False
 #endif
 
-#if MIN_VERSION_lib_a_Z(1,2,4)
+#if MIN_VERSION_testsZSpackage_nameZSlib_aZUZZ(1,2,4)
 versionTooLowTest = False
 #else
 versionTooLowTest = True
@@ -27,7 +27,7 @@ check x y = when (x /= y) $ error $ "Failed check: " ++ show (x, y)
 main :: IO ()
 main = do
     check foo 42
-    check VERSION_lib_a_Z "1.2.3.4"
-    check libPackageKey "testsZSpackage-nameZSlib-a-ZZ"
+    check VERSION_testsZSpackage_nameZSlib_aZUZZ "1.2.3.4"
+    check libPackageKey "testsZSpackage-nameZSlib-aZUZZ"
     check versionHighEnoughTest True
     check versionTooLowTest True

--- a/tests/same_name/a/A/Type.hs
+++ b/tests/same_name/a/A/Type.hs
@@ -1,0 +1,3 @@
+module A.Type where
+
+foo = "A"

--- a/tests/same_name/a/BUILD
+++ b/tests/same_name/a/BUILD
@@ -1,0 +1,10 @@
+load("@io_tweag_rules_haskell//haskell:haskell.bzl", "haskell_library", "haskell_import")
+
+haskell_import(name = "base")
+
+haskell_library(
+    name = "type",
+    srcs = ["A/Type.hs"],
+    deps = [":base"],
+    visibility = ["//visibility:public"],
+)

--- a/tests/same_name/b/B/Type.hs
+++ b/tests/same_name/b/B/Type.hs
@@ -1,0 +1,3 @@
+module B.Type where
+
+foo = "B"

--- a/tests/same_name/b/BUILD
+++ b/tests/same_name/b/BUILD
@@ -1,0 +1,10 @@
+load("@io_tweag_rules_haskell//haskell:haskell.bzl", "haskell_library", "haskell_import")
+
+haskell_import(name = "base")
+
+haskell_library(
+    name = "type",
+    srcs = ["B/Type.hs"],
+    deps = [":base"],
+    visibility = ["//visibility:public"],
+)

--- a/tests/same_name/bin/BUILD
+++ b/tests/same_name/bin/BUILD
@@ -1,0 +1,16 @@
+load("@io_tweag_rules_haskell//haskell:haskell.bzl", "haskell_binary", "haskell_import")
+
+haskell_import(name = "base")
+
+haskell_binary(
+    name = "foo",
+    srcs = ["Foo.hs"],
+    deps = [
+
+    # this test ensure that these two deps, with the same rule name
+    # are correctly linked as two different packages
+    "//tests/same_name/a:type",
+    "//tests/same_name/b:type",
+    ":base",
+    ],
+)

--- a/tests/same_name/bin/Foo.hs
+++ b/tests/same_name/bin/Foo.hs
@@ -1,0 +1,6 @@
+import A.Type as A
+import B.Type as B
+
+main = do
+  print A.foo
+  print B.foo

--- a/tests/same_name2/bin/BUILD
+++ b/tests/same_name2/bin/BUILD
@@ -1,0 +1,16 @@
+load("@io_tweag_rules_haskell//haskell:haskell.bzl", "haskell_binary", "haskell_import")
+
+haskell_import(name = "base")
+
+haskell_binary(
+    name = "foo",
+    srcs = ["Foo.hs"],
+    deps = [
+
+    # this test ensure that these two deps, with similar package:name label
+    # are correctly linked as two different packages
+    "//tests/same_name2/foo/b:type",
+    "//tests/same_name2/foo:b-type",
+    ":base",
+    ],
+)

--- a/tests/same_name2/bin/Foo.hs
+++ b/tests/same_name2/bin/Foo.hs
@@ -1,0 +1,7 @@
+import A.Type as A
+import B.Type as B
+
+main = do
+  print A.foo
+
+  print B.foo

--- a/tests/same_name2/foo/A/Type.hs
+++ b/tests/same_name2/foo/A/Type.hs
@@ -1,0 +1,3 @@
+module A.Type where
+
+foo = "A"

--- a/tests/same_name2/foo/BUILD
+++ b/tests/same_name2/foo/BUILD
@@ -1,0 +1,10 @@
+load("@io_tweag_rules_haskell//haskell:haskell.bzl", "haskell_library", "haskell_import")
+
+haskell_import(name = "base")
+
+haskell_library(
+    name = "b-type",
+    srcs = ["A/Type.hs"],
+    deps = [":base"],
+    visibility = ["//visibility:public"],
+)

--- a/tests/same_name2/foo/b/B/Type.hs
+++ b/tests/same_name2/foo/b/B/Type.hs
@@ -1,0 +1,3 @@
+module B.Type where
+
+foo = "B"

--- a/tests/same_name2/foo/b/BUILD
+++ b/tests/same_name2/foo/b/BUILD
@@ -1,0 +1,10 @@
+load("@io_tweag_rules_haskell//haskell:haskell.bzl", "haskell_library", "haskell_import")
+
+haskell_import(name = "base")
+
+haskell_library(
+    name = "type",
+    srcs = ["B/Type.hs"],
+    deps = [":base"],
+    visibility = ["//visibility:public"],
+)


### PR DESCRIPTION
Closes #395 

Haskell package name was setup with `bazel_rule.name`, which is not unique, for example `//a:foo` and `//b:foo` have the same rule `name` but different rule `package`.

We add the package name (here `a` and `b`) to the haskell package name to avoid package name conflicts.