### PR TITLE
Reexported modules, take 3

### DIFF
--- a/haskell/private/actions/compile.bzl
+++ b/haskell/private/actions/compile.bzl
@@ -305,11 +305,12 @@ def compile_binary(hs, cc, java, dep_info, srcs, ls_modules, import_dir_map, ext
             target_unique_name(hs, "exposed-modules"),
         )
         hs.actions.run(
-            inputs = [c.interfaces_dir],
+            inputs = [c.interfaces_dir, hs.toolchain.global_pkg_db],
             outputs = [exposed_modules_file],
             executable = ls_modules,
             arguments = [
                 c.interfaces_dir.path,
+                hs.toolchain.global_pkg_db.path,
                 "/dev/null",  # no hidden modules
                 "/dev/null",  # no reexported modules
                 exposed_modules_file.path,
@@ -375,6 +376,7 @@ def compile_library(hs, cc, java, dep_info, srcs, ls_modules, other_modules, exp
         hs.actions.run(
             inputs = [
                 c.interfaces_dir,
+                hs.toolchain.global_pkg_db,
                 hidden_modules_file,
                 reexported_modules_file,
             ],
@@ -382,6 +384,7 @@ def compile_library(hs, cc, java, dep_info, srcs, ls_modules, other_modules, exp
             executable = ls_modules,
             arguments = [
                 c.interfaces_dir.path,
+                hs.toolchain.global_pkg_db.path,
                 hidden_modules_file.path,
                 reexported_modules_file.path,
                 exposed_modules_file.path,

--- a/tests/library-exports/BUILD
+++ b/tests/library-exports/BUILD
@@ -9,8 +9,8 @@ load(
 haskell_library(
     name = "sublib",
     srcs = ["TestSubLib.hs"],
-    exports = {"//tests:base": "Data.List as SubLib.List"},
-    deps = ["//tests:base"],
+    exports = {"//tests:containers": "Data.Map as SubLib.Map"},
+    deps = ["//tests:base", "//tests:containers"],
 )
 
 haskell_library(
@@ -19,7 +19,7 @@ haskell_library(
     deps = ["//tests:base", ":sublib"],
     exports = {
         ":sublib": "TestSubLib",
-        "//tests:base": "Data.List as Lib.List",
+        "//tests:containers": "Data.Map as Lib.Map",
     },
 )
 

--- a/tests/library-exports/Bin.hs
+++ b/tests/library-exports/Bin.hs
@@ -1,7 +1,7 @@
 module Main (main) where
 
 import TestSubLib (messageEnd)
-import Lib.List
+import Lib.Map
 
 main :: IO ()
-main = putStrLn $ Lib.List.tail messageEnd
+main = print $ Lib.Map.singleton 1 messageEnd

--- a/tests/library-exports/TestLib.hs
+++ b/tests/library-exports/TestLib.hs
@@ -1,7 +1,7 @@
 module TestLib (testMessage) where
 
 import TestSubLib (messageEnd)
-import SubLib.List
+import SubLib.Map
 
 testMessage :: String
-testMessage = "hello " ++ SubLib.List.nub messageEnd
+testMessage = "hello " ++ messageEnd


### PR DESCRIPTION
In #385, we claimed to exploit the fact that GHC only needs package
names in reexport declarations to obviate the need for knowing the
versions (and dependency hashes) of all prebuilt packages. We provided
a test to substantiate this indeed works. But it turns that the test
was not a good test.

The test was flawed because it featured libraries reexporting `base`.
It turns out that `base` (along with `rts`) are magical in GHC.
Because they are so-called "wired-in packages", they are assumed
unique and are therefore not located using a version number. So while
the scheme in #385 worked for `base`, it didn't work in the general
case, as observed by @lunaris.

The fix consists qualifying all package reexports with full package
id's, not package names. How do we derive a package id given only
a package name? The solution is to have the toolchain generate a dump
of the global package database that ships with the compiler. This is
only needed once for the entire workspace. From this dump, we can
lookup the full package id given any particular name.

Fixes #357.