### PR TITLE
Nix: set explicit tarball checksum

### DIFF
--- a/nixpkgs.nix
+++ b/nixpkgs.nix
@@ -1,2 +1,5 @@
 # Keep this value in sync with `WORKSPACE`
-import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/9a787af6bc75a19ac9f02077ade58ddc248e674a.tar.gz")
+import (fetchTarball {
+   url = "https://github.com/NixOS/nixpkgs/archive/9a787af6bc75a19ac9f02077ade58ddc248e674a.tar.gz";
+   sha256 = "17kp82r4dzcgsmjfzspkjhm8avny542lq6qcgqr9dkwbv1x1vyk0";
+})


### PR DESCRIPTION
As per the manual about the `fetchTarball` function:

> The fetched tarball is cached for a certain amount of time (1 hour by default) in ~/.cache/nix/tarballs/. You can change the cache timeout either on the command line with --option tarball-ttl number of seconds or in the Nix configuration file with this option: tarball-ttl number of seconds to cache.

Hence:

- Without `sha256`, each hour, we have to redownload the tarball.
- With `sha256`, it will be downloaded only once and cached in `/nix/store`

Then, this fix:

- Ensures more reproducibility (if by any chance github starts to generate broken archives)
- Avoid being annoyed by a long fetch in the middle of a working session, especially when the internet connection is not good ;)