### PR TITLE
Add additional filegroup srcs in the GHC `new_local_repository` declaration

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ new_local_repository(
 package(default_visibility = ["//visibility:public"])
 filegroup(
     name = "bin",
-    srcs = glob(["bin/ghc*"]) + ["bin/hsc2hs", "bin/haddock"],
+    srcs = glob(["bin/*"]),
 )
 """
 )

--- a/README.md
+++ b/README.md
@@ -120,8 +120,11 @@ new_local_repository(
   path = "/usr/local", # Change path accordingly.
   build_file_content = """
 package(default_visibility = ["//visibility:public"])
-filegroup (name = "bin", srcs = glob(["bin/ghc*"]))
-  """
+filegroup(
+    name = "bin",
+    srcs = glob(["bin/ghc*"]) + ["bin/hsc2hs", "bin/haddock"],
+)
+"""
 )
 ```
 


### PR DESCRIPTION
`hsc2hs` and `haddock` are required during compilation, but they're not globbed by `ghc*`. Let's add them in manually.