### PR TITLE
WIP: CPP macro conflict

### DIFF
--- a/tests/cpp_macro_conflict/BS.hs
+++ b/tests/cpp_macro_conflict/BS.hs
@@ -1,0 +1,1 @@
+module BS where

--- a/tests/cpp_macro_conflict/BUILD
+++ b/tests/cpp_macro_conflict/BUILD
@@ -1,0 +1,23 @@
+package(default_testonly = 1)
+
+load(
+    "@io_tweag_rules_haskell//haskell:haskell.bzl",
+    "haskell_library",
+    "haskell_binary",
+)
+
+# empty library with package name "bytestring"
+haskell_library(
+  name = "bytestring",
+  srcs = ["BS.hs"],
+  deps = ["//tests:base"],
+)
+
+# This depends on two packages "bytestring"
+# There should be no CPP macro conflict
+haskell_binary(
+  name = "macro_conflict",
+  srcs = ["Main.hs"],
+  deps = ["//tests:base", "//tests:bytestring", ":bytestring"],
+  compiler_flags = ["-XCPP", "-Werror"],
+)

--- a/tests/cpp_macro_conflict/Main.hs
+++ b/tests/cpp_macro_conflict/Main.hs
@@ -1,0 +1,4 @@
+import qualified Data.ByteString
+import BS
+
+main = putStrLn "hello"


### PR DESCRIPTION
This PR adds an unit test to reproduce a conflit in CPP macro which arise when:

- `LANGUAGE CPP` is enable in a module
- This module depends on two haskell packages with the same name. The package name is based on the bazel rule name, so `//tests/cpp_macro_conflict:bytestring` and `//tests:bytestring` have the same name `bytestring`.

See the associated unit test for details.