### PR TITLE
Move API docs out of the //haskell package

### DIFF
--- a/.netlify/build.sh
+++ b/.netlify/build.sh
@@ -4,6 +4,6 @@ set -eux
 
 export PATH=$HOME/bin:$PATH
 
-bazel build //haskell:doc_html
-unzip -d public bazel-bin/haskell/doc_html-skydoc.zip
+bazel build //docs:api_html
+unzip -d public bazel-bin/docs/api_html-skydoc.zip
 cp start public

--- a/docs/BUILD
+++ b/docs/BUILD
@@ -1,9 +1,10 @@
+load("@io_bazel_skydoc//skylark:skylark.bzl", "skylark_doc")
 load("//skylark:lint.bzl", "skylark_lint")
 
 genrule(
-    name = "docs",
+    name = "guide_html",
     srcs = ["conf.py"] + glob(["*.rst"]),
-    outs = ["docs.zip"],
+    outs = ["guide_html.zip"],
     cmd = """
     set -euo pipefail
     sourcedir=$$(dirname $(location conf.py))
@@ -12,6 +13,24 @@ genrule(
     (CWD=`pwd` && cd $$builddir/html && zip -q -r $$CWD/$@ .)
     rm -rf $$builddir
     """,
+)
+
+skylark_doc(
+    name = "api_html",
+    srcs = [
+
+        # The order of these files defines the order in which the corresponding
+        # sections are presented in the docs.
+        "//haskell:haskell.bzl",
+        "//haskell:haddock.bzl",
+        "//haskell:lint.bzl",
+        "//haskell:toolchain.bzl",
+        "//haskell:protobuf.bzl",
+        "//haskell:cc.bzl",
+        "//haskell:repositories.bzl",
+        "//haskell:ghc_bindist.bzl",
+    ],
+    format = "html",
 )
 
 skylark_lint()

--- a/haskell/BUILD
+++ b/haskell/BUILD
@@ -1,6 +1,5 @@
 load("//skylark:lint.bzl", "skylark_lint")
 load(":private/dummy_linker_archive.bzl", "dummy_linker_archive")
-load("@io_bazel_skydoc//skylark:skylark.bzl", "skylark_doc")
 
 dummy_linker_archive(
     name = "dummy_static_lib",
@@ -20,24 +19,6 @@ py_binary(
     name = "ls_modules",
     srcs = ["private/ls_modules.py"],
     visibility = ["//visibility:public"],
-)
-
-skylark_doc(
-    name = "doc_html",
-    srcs = [
-
-        # The order of these files defines the order in which the corresponding
-        # sections are presented in the docs.
-        "//haskell:haskell.bzl",
-        "//haskell:haddock.bzl",
-        "//haskell:lint.bzl",
-        "//haskell:toolchain.bzl",
-        "//haskell:protobuf.bzl",
-        "//haskell:cc.bzl",
-        "//haskell:repositories.bzl",
-        "//haskell:ghc_bindist.bzl",
-    ],
-    format = "html",
 )
 
 skylark_lint()

--- a/serve-docs.sh
+++ b/serve-docs.sh
@@ -16,13 +16,13 @@ function finish {
 
 trap finish EXIT
 
-bazel build //haskell:doc_html
+bazel build //docs:api_html
 mkdir $SCRATCH/api
-unzip -d $SCRATCH/api bazel-bin/haskell/doc_html-skydoc.zip
+unzip -d $SCRATCH/api bazel-bin/docs/api_html-skydoc.zip
 
-bazel build //docs
-mkdir $SCRATCH/docs
-unzip -d $SCRATCH/docs bazel-genfiles/docs/docs.zip
+bazel build //docs:guide_html
+mkdir $SCRATCH/guide
+unzip -d $SCRATCH/guide bazel-genfiles/docs/guide_html.zip
 
 cd $SCRATCH
 python -m SimpleHTTPServer $PORT


### PR DESCRIPTION
Having them in the //haskell package had the side effect that all
users needed to have skydoc defined in their workspace. That is not
desirable, since it's an extra (unnecessary) dependency.

cc @philderbeast

Fixes #416 