### PR TITLE
Allow directly using the lint aspect

### DIFF
--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -27,6 +27,7 @@ load(
 load(
     ":lint.bzl",
     _haskell_lint = "haskell_lint",
+    _haskell_lint_aspect = "haskell_lint_aspect",
 )
 load(
     ":toolchain.bzl",
@@ -264,6 +265,8 @@ haskell_import = rule(
 haskell_doc = _haskell_doc
 
 haskell_lint = _haskell_lint
+
+haskell_lint_aspect = _haskell_lint_aspect
 
 haskell_doctest = _haskell_doctest
 

--- a/haskell/lint.bzl
+++ b/haskell/lint.bzl
@@ -101,9 +101,10 @@ def _haskell_lint_aspect_impl(target, ctx):
         env = hs.env,
     )
 
-    return [HaskellLintInfo(
-        outputs = set.singleton(lint_log),
-    )]
+    lintInfo = HaskellLintInfo(outputs = set.singleton(lint_log))
+    outputFiles = OutputGroupInfo(default = [lint_log])
+
+    return [lintInfo, outputFiles]
 
 haskell_lint_aspect = aspect(
     _haskell_lint_aspect_impl,


### PR DESCRIPTION
Expose the `haskell_lint_aspect` in `haskell.bzl` and adds the (dummy)
generated file to it so that we can directly use it from the
command-line without having to write a `haskell_lint` target, with

```console
$ bazel build //my/haskell:target --aspects @io_tweag_rules_haskell//haskell:haskell.bzl%haskell_lint_aspect
```

Fixes #384 