### PR TITLE
Allow directly using the haddock aspect

### DIFF
--- a/haskell/haddock.bzl
+++ b/haskell/haddock.bzl
@@ -122,11 +122,14 @@ def _haskell_doc_aspect_impl(target, ctx):
     transitive_html.update({package_id: html_dir})
     transitive_haddocks.update({package_id: haddock_file})
 
-    return [HaddockInfo(
+    haddockInfo = HaddockInfo(
         package_id = package_id,
         transitive_html = transitive_html,
         transitive_haddocks = transitive_haddocks,
-    )]
+    )
+    outputFiles = OutputGroupInfo(default = transitive_html.values())
+
+    return [haddockInfo, outputFiles]
 
 haskell_doc_aspect = aspect(
     _haskell_doc_aspect_impl,

--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -23,6 +23,7 @@ load(
 load(
     ":haddock.bzl",
     _haskell_doc = "haskell_doc",
+    _haskell_doc_aspect = "haskell_doc_aspect",
 )
 load(
     ":lint.bzl",
@@ -262,6 +263,8 @@ haskell_import = rule(
 )
 
 haskell_doc = _haskell_doc
+
+haskell_doc_aspect = _haskell_doc_aspect
 
 haskell_lint = _haskell_lint
 


### PR DESCRIPTION
Similar in spirit to #423, allows building the haddock for any
`haskell_library` or `haskell_binary` rule with

```console
$ bazel build //my/haskell:target --aspects @io_tweag_rules_haskell//haskell:haskell.bzl%haskell_haddock_aspect
```