### PR TITLE
Calling Haskell/FFI from Python, with linker fixes

### DIFF
--- a/haskell/BUILD
+++ b/haskell/BUILD
@@ -7,6 +7,12 @@ exports_files(
     ],
 )
 
+# to make functions visible to unit tests
+exports_files(
+    ["private/actions/link.bzl"],
+    visibility = ["//tests/unit-tests:__pkg__"],
+)
+
 py_binary(
     name = "ls_modules",
     srcs = ["private/ls_modules.py"],

--- a/haskell/ghc.BUILD
+++ b/haskell/ghc.BUILD
@@ -12,7 +12,11 @@ cc_library(
     srcs = glob(["lib/ghc-*/rts/libHSrts_thr-ghc*." + ext for ext in [
         "so",
         "dylib",
-    ]]),
+    ]]
+      # dependency of `libHSrts_thr_ghc*`
+      # globbing on the `so` version to stay working when they update
+    + ["lib/ghc-*/rts/libffi.so.*"],
+    ),
     hdrs = glob(["lib/ghc-*/include/**/*.h"]),
     strip_include_prefix = glob(
         ["lib/ghc-*/include"],

--- a/haskell/private/actions/link.bzl
+++ b/haskell/private/actions/link.bzl
@@ -22,6 +22,7 @@ def backup_path(target):
       A path of the form "../../.."
     """
     short_path_dir = paths.normalize(paths.dirname(target.short_path))
+
     # dirname returns "" if there is no parent directory
     # and normalize returns "." for "". In that case we
     # return the identity path, which is ".".

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -256,7 +256,7 @@ rule_test(
             "libHStestsZSccZUhaskellZUimportZShs-lib-b-ghc{version}.so".format(version = ghc_version),
         ],
     }),
-    rule = "//tests/cc_haskell_import:hs-lib-b-so",
+    rule = "//tests/cc_haskell_import:hs-lib-b.so",
 )
 
 rule_test(

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -266,6 +266,19 @@ rule_test(
     rule = "//tests/cc_haskell_import:cc-bin",
 )
 
+# TODO(Profpatsch) blocked on https://github.com/bazelbuild/bazel/issues/6093
+# (among possibly others ..)
+# sh_test(
+#     name = "test-cc_haskell_import_python",
+#     size = "small",
+#     srcs = ["scripts/exec.sh"],
+#     args = ["tests/cc_haskell_import/python_add_one"],
+#     data = [
+#         "//tests/cc_haskell_import:python_add_one",
+#         "@bazel_tools//tools/bash/runfiles",
+#     ],
+# )
+
 sh_inline_test(
     name = "test-haskell_binary-with-link-flags",
     size = "small",

--- a/tests/cc_haskell_import/BUILD
+++ b/tests/cc_haskell_import/BUILD
@@ -25,7 +25,7 @@ haskell_library(
 )
 
 cc_haskell_import(
-    name = "hs-lib-b-so",
+    name = "hs-lib-b.so",
     dep = ":hs-lib-b",
     visibility = ["//tests:__subpackages__"],
 )
@@ -34,17 +34,22 @@ cc_binary(
     name = "cc-bin",
     srcs = [
         "main.c",
-        ":hs-lib-b-so",
+        ":hs-lib-b.so",
     ],
     visibility = ["//tests:__subpackages__"],
     deps = ["@ghc//:threaded-rts"],
 )
 
+
+# We go one step further and use the Haskell library from above
+# to build a static .so which is then loaded with a Python script
+# and calls the Haskell function constructed from GHC C FFI.
+
 # shared library which python will dlopen
 cc_binary(
     name = "libadd_one.so",
     srcs = [
-        ":hs-lib-b-so",
+        ":hs-lib-b.so",
     ],
     visibility = ["//tests:__subpackages__"],
     deps = ["@ghc//:threaded-rts"],
@@ -57,8 +62,10 @@ py_binary(
     name = "python_add_one",
     srcs = ["python_add_one.py"],
     data = [
-        "libadd_one.so",
+        ":libadd_one.so",
     ],
+    visibility = ["//tests:__subpackages__"],
+    deps = ["@bazel_tools//tools/python/runfiles"],
     srcs_version = "PY3ONLY",
     default_python_version = "PY3"
 )

--- a/tests/cc_haskell_import/BUILD
+++ b/tests/cc_haskell_import/BUILD
@@ -39,3 +39,26 @@ cc_binary(
     visibility = ["//tests:__subpackages__"],
     deps = ["@ghc//:threaded-rts"],
 )
+
+# shared library which python will dlopen
+cc_binary(
+    name = "libadd_one.so",
+    srcs = [
+        ":hs-lib-b-so",
+    ],
+    visibility = ["//tests:__subpackages__"],
+    deps = ["@ghc//:threaded-rts"],
+    linkstatic = 1,
+    linkshared = 1,
+)
+
+# just dlopens libadd_one.so and prints it
+py_binary(
+    name = "python_add_one",
+    srcs = ["python_add_one.py"],
+    data = [
+        "libadd_one.so",
+    ],
+    srcs_version = "PY3ONLY",
+    default_python_version = "PY3"
+)

--- a/tests/cc_haskell_import/BUILD
+++ b/tests/cc_haskell_import/BUILD
@@ -40,32 +40,31 @@ cc_binary(
     deps = ["@ghc//:threaded-rts"],
 )
 
-
 # We go one step further and use the Haskell library from above
 # to build a static .so which is then loaded with a Python script
 # and calls the Haskell function constructed from GHC C FFI.
 
 # shared library which python will dlopen
 cc_binary(
-    name = "libadd_one.so",
+    name = "hs-lib-b-wrapped.so",
     srcs = [
         ":hs-lib-b.so",
     ],
+    linkshared = 1,
+    linkstatic = 1,
     visibility = ["//tests:__subpackages__"],
     deps = ["@ghc//:threaded-rts"],
-    linkstatic = 1,
-    linkshared = 1,
 )
 
-# just dlopens libadd_one.so and prints it
+# just dlopens hb-lib-b-wrapped.so and prints it
 py_binary(
     name = "python_add_one",
     srcs = ["python_add_one.py"],
     data = [
-        ":libadd_one.so",
+        ":hs-lib-b-wrapped.so",
     ],
+    default_python_version = "PY3",
+    srcs_version = "PY3ONLY",
     visibility = ["//tests:__subpackages__"],
     deps = ["@bazel_tools//tools/python/runfiles"],
-    srcs_version = "PY3ONLY",
-    default_python_version = "PY3"
 )

--- a/tests/cc_haskell_import/LibA.hs
+++ b/tests/cc_haskell_import/LibA.hs
@@ -2,5 +2,7 @@ module LibA (add_one) where
 
 import Data.Int (Int32)
 
+foreign import ccall "c_add_one" c_add_one' :: Int32 -> Int32
+
 add_one :: Int32 -> Int32
-add_one x = x + 1
+add_one x = c_add_one' x

--- a/tests/cc_haskell_import/cbits.c
+++ b/tests/cc_haskell_import/cbits.c
@@ -1,0 +1,5 @@
+#include <stdint.h>
+
+int32_t c_add_one(int32_t x) {
+  return 1 + x;
+}

--- a/tests/cc_haskell_import/python_add_one.py
+++ b/tests/cc_haskell_import/python_add_one.py
@@ -1,0 +1,7 @@
+import ctypes
+
+foreignlib = ctypes.cdll.LoadLibrary('tests/cc_haskell_import/libadd_one.so')
+print(foreignlib)
+foreignlib.hs_init()
+print('one plus one equals: ' + str(foreignlib.add_one_hs(1)))
+print('success!')

--- a/tests/cc_haskell_import/python_add_one.py
+++ b/tests/cc_haskell_import/python_add_one.py
@@ -1,7 +1,29 @@
+import os
 import ctypes
+from bazel_tools.tools.python.runfiles import runfiles
+import subprocess
 
-foreignlib = ctypes.cdll.LoadLibrary('tests/cc_haskell_import/libadd_one.so')
+r = runfiles.Create()
+
+# print("runfiles manifest: {}".format(r._strategy._path))
+# for k, f in r._strategy._runfiles.iteritems():
+#     # print("{}    -> {}".format(k, f))
+#     print(f)
+
+path = r.Rlocation('io_tweag_rules_haskell/tests/cc_haskell_import/libadd_one.so')
+
+subprocess.call("find $RUNFILES_DIR", shell=True)
+
+# subprocess.call(["ldd", path])
+# subprocess.call("objdump -x {} | grep -i runpath".format(path), shell=True)
+# print("path: {}".format(path))
+
+foreignlib = ctypes.cdll.LoadLibrary(path)
+
+# ATTN: If you remove this print(), hs_init will segfault!
+# TODO: why?
 print(foreignlib)
+
 foreignlib.hs_init()
 print('one plus one equals: ' + str(foreignlib.add_one_hs(1)))
 print('success!')

--- a/tests/cc_haskell_import/python_add_one.py
+++ b/tests/cc_haskell_import/python_add_one.py
@@ -5,25 +5,14 @@ import subprocess
 
 r = runfiles.Create()
 
-# print("runfiles manifest: {}".format(r._strategy._path))
-# for k, f in r._strategy._runfiles.iteritems():
-#     # print("{}    -> {}".format(k, f))
-#     print(f)
-
-path = r.Rlocation('io_tweag_rules_haskell/tests/cc_haskell_import/libadd_one.so')
-
-subprocess.call("find $RUNFILES_DIR", shell=True)
-
-# subprocess.call(["ldd", path])
-# subprocess.call("objdump -x {} | grep -i runpath".format(path), shell=True)
-# print("path: {}".format(path))
+path = r.Rlocation('io_tweag_rules_haskell/tests/cc_haskell_import/hs-lib-b-wrapped.so')
 
 foreignlib = ctypes.cdll.LoadLibrary(path)
 
-# ATTN: If you remove this print(), hs_init will segfault!
-# TODO: why?
-print(foreignlib)
+# ATTN: If you remove this print *statement* hs_init will segfault!
+# If you use the python3 print *function*, it will segfault as well!
+# TODO: wtf?
+print foreignlib
 
 foreignlib.hs_init()
-print('one plus one equals: ' + str(foreignlib.add_one_hs(1)))
-print('success!')
+assert(str(foreignlib.add_one_hs(1)) == "2")

--- a/tests/scripts/exec.sh
+++ b/tests/scripts/exec.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -e
+
+exec "$1"

--- a/tests/unit-tests/BUILD
+++ b/tests/unit-tests/BUILD
@@ -1,0 +1,19 @@
+load(":tests.bzl", "link_backup_path_test")
+
+link_backup_path_test(
+    name = "backup_path_file",
+    filename = "foo",
+    output = ".",
+)
+
+link_backup_path_test(
+    name = "backup_path_dir_file",
+    filename = "foo/bar",
+    output = "..",
+)
+
+link_backup_path_test(
+    name = "backup_path_dir_dir_file",
+    filename = "foo/bar/baz",
+    output = "../..",
+)

--- a/tests/unit-tests/tests.bzl
+++ b/tests/unit-tests/tests.bzl
@@ -1,0 +1,24 @@
+load(
+    "@bazel_skylib//:lib.bzl",
+    unit = "unittest",
+    "asserts",
+)
+load("//haskell:private/actions/link.bzl", "backup_path")
+
+def link_backup_path_test_impl(ctx):
+    env = unit.begin(ctx)
+    file_stub = struct(short_path=ctx.attr.filename)
+    asserts.equals(
+        env,
+        expected = ctx.attr.output,
+        actual = backup_path(file_stub),
+    )
+    unit.end(env)
+
+link_backup_path_test = unit.make(
+    link_backup_path_test_impl,
+    attrs = {
+        "filename": attr.string(),
+        "output": attr.string(),
+    }
+)

--- a/tests/unit-tests/tests.bzl
+++ b/tests/unit-tests/tests.bzl
@@ -1,13 +1,13 @@
 load(
     "@bazel_skylib//:lib.bzl",
-    unit = "unittest",
     "asserts",
+    unit = "unittest",
 )
 load("//haskell:private/actions/link.bzl", "backup_path")
 
 def link_backup_path_test_impl(ctx):
     env = unit.begin(ctx)
-    file_stub = struct(short_path=ctx.attr.filename)
+    file_stub = struct(short_path = ctx.attr.filename)
     asserts.equals(
         env,
         expected = ctx.attr.output,
@@ -20,5 +20,5 @@ link_backup_path_test = unit.make(
     attrs = {
         "filename": attr.string(),
         "output": attr.string(),
-    }
+    },
 )


### PR DESCRIPTION
Fixes #370 

Building on Greg’s original issue, I learned a crapton about `LD_RUNPATH`, `$ORIGIN`, linking, bazel runfiles (and their manifold corner cases), and finally got the original issue running.

This changes the way `LD_RUNPATH` is constructed, basing it on going upwards to the (closer) runfiles directory instead of root of the bazel cache, only runfiles are available in a sandbox. I’m still not 100% certain this can be made correct at all, based on the current state of the runfiles implementation.

@judah I don’t know how this will interact with MacOS, apart from CircleCI I have no way to test.

Based on the changes to `LD_RUNPATH` I found that finding `libffi.so` in the GHC toolchain was found only as a side-effect of the value of `$ORIGIN`, so we need to add it explicitely to the toolchain. Then it is added to the runfiles as well.

The last commits adds a test that should be working in theory, but a bug in bazel prevents it from doing so.

The commits are best reviewed one at a time.