### PR TITLE
REPL targets no longer depend on their binary/library targets

### DIFF
--- a/haskell/assets/ghci_script
+++ b/haskell/assets/ghci_script
@@ -1,1 +1,35 @@
 :add {ADD_SOURCES}
+:module + System.IO GHC.IO.Handle Control.Exception System.Directory
+rules_haskell_stdout_dupe <- hDuplicate stdout
+:{
+(rules_haskell_stdout_copy_file, rules_haskell_stdout_copy_h) <- do
+  tmpDir <- getTemporaryDirectory >>= canonicalizePath
+  (fn, h) <- openTempFile tmpDir "rules-haskell-ghci-repl"
+  hDuplicateTo h stdout
+  return (fn, h)
+:}
+:show modules
+:{
+rules_haskell_loaded_modules <- do
+  hClose rules_haskell_stdout_copy_h
+  -- I had to do it like this because flushing and then searching in the
+  -- stream at offset 0 did not work (no data is there, although the
+  -- corresponding file certainly contained it after flushing). Couldn't
+  -- figure this one out, so we first close the file and then read from it.
+  h <- openFile rules_haskell_stdout_copy_file ReadMode
+  xs <- hGetContents h
+  removeFile rules_haskell_stdout_copy_file
+  return $ takeWhile (/= ' ') <$> lines xs
+:}
+hDuplicateTo rules_haskell_stdout_dupe stdout
+:{
+let rules_haskell_add_loaded_modules _ =
+      return $ ":module + " ++
+        Data.List.intercalate " " (("*" ++) <$> rules_haskell_loaded_modules)
+:}
+:module - System.IO GHC.IO.Handle Control.Exception System.Directory
+:def rules_haskell_add_loaded_modules rules_haskell_add_loaded_modules
+:rules_haskell_add_loaded_modules
+:undef rules_haskell_add_loaded_modules
+-- reload modules to drop the rules_haskell* definitions
+:reload

--- a/haskell/private/ghci_repl_wrapper.sh
+++ b/haskell/private/ghci_repl_wrapper.sh
@@ -32,11 +32,11 @@ fi
 # location of exec root reliably and then prefix locations of various
 # components, such as shared libraries with that exec root.
 
-
 RULES_HASKELL_EXEC_ROOT=$(dirname $(readlink ${BUILD_WORKSPACE_DIRECTORY}/bazel-out))
 GHCI_LOCATION="$RULES_HASKELL_EXEC_ROOT/{GHCi}"
 SCRIPT_LOCATION="$RULES_HASKELL_EXEC_ROOT/{SCRIPT_LOCATION}"
 
-
 export LD_LIBRARY_PATH={LDLIBPATH}
-"$GHCI_LOCATION" {ARGS} "$@"
+# The base and directory packages are necessary for the GHCi script we use
+# (loads source files and brings in scope the corresponding modules).
+"$GHCI_LOCATION" -package base -package directory {ARGS} "$@"

--- a/haskell/private/haskell_impl.bzl
+++ b/haskell/private/haskell_impl.bzl
@@ -133,10 +133,10 @@ use the 'haskell_import' rule instead.
         hs,
         ghci_script = ctx.file._ghci_script,
         ghci_repl_wrapper = ctx.file._ghci_repl_wrapper,
-        exposed_modules_file = c.exposed_modules_file,
         compiler_flags = ctx.attr.compiler_flags,
         repl_ghci_args = ctx.attr.repl_ghci_args,
         output = ctx.outputs.repl,
+        package_caches = dep_info.package_caches,
         build_info = build_info,
         bin_info = bin_info,
     )
@@ -304,10 +304,10 @@ use the 'haskell_import' rule instead.
             hs,
             ghci_script = ctx.file._ghci_script,
             ghci_repl_wrapper = ctx.file._ghci_repl_wrapper,
-            exposed_modules_file = c.exposed_modules_file,
             repl_ghci_args = ctx.attr.repl_ghci_args,
             compiler_flags = ctx.attr.compiler_flags,
             output = ctx.outputs.repl,
+            package_caches = dep_info.package_caches,
             build_info = build_info,
             lib_info = lib_info,
         )

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -79,6 +79,7 @@ test_repl_libraries() {
     # itself:
     bazel clean
     bazel run --config=ci //tests/repl-targets:hs-lib-repl -- -e "show (foo 10) ++ bar ++ baz ++ gen"
+    bazel run --config=ci //tests/repl-targets:hs-lib-bad-repl -- -e "1 + 2"
 }
 
 # Test REPL for binaries

--- a/tests/repl-targets/BUILD
+++ b/tests/repl-targets/BUILD
@@ -55,6 +55,21 @@ haskell_library(
 )
 
 haskell_library(
+    name = "hs-lib-bad",
+    srcs = [
+        "Bad.hs",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":cbits",
+        ":zlib",
+        "//tests:array",
+        "//tests:base",
+    ],
+    tags = ["manual"],
+)
+
+haskell_library(
     name = "QuuxLib",
     srcs = ["QuuxLib.hs"],
     deps = ["//tests:base"],

--- a/tests/repl-targets/Bad.hs
+++ b/tests/repl-targets/Bad.hs
@@ -1,0 +1,6 @@
+module Bad
+  ( bad )
+where
+
+bad :: Into
+bad = "foo"


### PR DESCRIPTION
Close #280.

Fixes the regression and adds a test to prevent similar regressions in the future.