### PR TITLE
Fix doctest invocation without a `module` argument

### DIFF
--- a/haskell/doctest.bzl
+++ b/haskell/doctest.bzl
@@ -132,14 +132,12 @@ def _haskell_doctest_single(target, ctx):
     )
 
     if not ctx.attr.modules:
-      exposed_modules_file = lib_info.exposed_modules_file if lib_info != None \
-            else bin_info.exposed_modules_file
+        exposed_modules_file = lib_info.exposed_modules_file if lib_info != None else bin_info.exposed_modules_file
     else:
-      exposed_modules_file = ctx.actions.declare_file("doctest_modules")
-      exposed_args = ctx.actions.args()
-      exposed_args.add(ctx.attr.modules)
-      ctx.actions.write(exposed_modules_file, exposed_args)
-
+        exposed_modules_file = ctx.actions.declare_file("doctest_modules")
+        exposed_args = ctx.actions.args()
+        exposed_args.add(ctx.attr.modules)
+        ctx.actions.write(exposed_modules_file, exposed_args)
 
     ctx.actions.run_shell(
         inputs = depset(transitive = [

--- a/haskell/doctest.bzl
+++ b/haskell/doctest.bzl
@@ -131,7 +131,15 @@ def _haskell_doctest_single(target, ctx):
         lib_info.source_files if lib_info != None else bin_info.source_files,
     )
 
-    args.add(ctx.attr.modules)
+    if not ctx.attr.modules:
+      exposed_modules_file = lib_info.exposed_modules_file if lib_info != None \
+            else bin_info.exposed_modules_file
+    else:
+      exposed_modules_file = ctx.actions.declare_file("doctest_modules")
+      exposed_args = ctx.actions.args()
+      exposed_args.add(ctx.attr.modules)
+      ctx.actions.write(exposed_modules_file, exposed_args)
+
 
     ctx.actions.run_shell(
         inputs = depset(transitive = [
@@ -142,6 +150,7 @@ def _haskell_doctest_single(target, ctx):
             set.to_depset(build_info.dynamic_libraries),
             set.to_depset(header_files),
             set.to_depset(external_libs),
+            depset([exposed_modules_file]),
             depset(
                 toolchain.doctest +
                 [hs.tools.cat, hs.tools.ghc],
@@ -151,8 +160,8 @@ def _haskell_doctest_single(target, ctx):
         mnemonic = "HaskellDoctest",
         progress_message = "HaskellDoctest {}".format(ctx.label),
         command = """
-    {doctest} "$@" > {output} 2>&1 || rc=$? && cat {output} && exit $rc
-    """.format(doctest = toolchain.doctest[0].path, output = doctest_log.path),
+    {doctest} "$@" $(cat {module_list} | tr , ' ') > {output} 2>&1 || rc=$? && cat {output} && exit $rc
+    """.format(doctest = toolchain.doctest[0].path, output = doctest_log.path, module_list = exposed_modules_file.path),
         arguments = [args],
         # NOTE It looks like we must specify the paths here as well as via -L
         # flags because there are at least two different "consumers" of the info

--- a/haskell/private/haskell_impl.bzl
+++ b/haskell/private/haskell_impl.bzl
@@ -295,6 +295,7 @@ use the 'haskell_import' rule instead.
         header_files = c.header_files,
         boot_files = c.boot_files,
         source_files = c.source_files,
+        exposed_modules_file = c.exposed_modules_file,
         extra_source_files = c.extra_source_files,
     )
     target_files = depset([conf_file, cache_file])


### PR DESCRIPTION
Probably due to #383, calling `haskell_doctest` without a `module`
argument resulted in doctest being run on no module at all instead of
all the modules.

This PR fixes it.