### PR TITLE
Refactor duplicated code to expose packages

### DIFF
--- a/haskell/lint.bzl
+++ b/haskell/lint.bzl
@@ -13,6 +13,7 @@ load(
     "HaskellLibraryInfo",
     "HaskellLintInfo",
 )
+load(":private/packages.bzl", "expose_packages")
 
 def _collect_lint_logs(deps):
     lint_logs = set.empty()
@@ -50,20 +51,15 @@ def _haskell_lint_aspect_impl(target, ctx):
         "-Wredundant-constraints",
         "-Wnoncanonical-monad-instances",
         "--make",
-        "-hide-all-packages",
     ])
 
-    # Expose all prebuilt dependencies
-    for prebuilt_dep in set.to_list(build_info.prebuilt_dependencies):
-        args.add(["-package", prebuilt_dep])
-
-    # Expose all bazel dependencies
-    for package in set.to_list(build_info.package_ids):
-        if lib_info == None or package != lib_info.package_id:
-            args.add(["-package-id", package])
-
-    for cache in set.to_list(build_info.package_caches):
-        args.add(["-package-db", cache.dirname])
+    args.add(expose_packages(
+        build_info,
+        lib_info,
+        use_direct = False,
+        use_my_pkg_id = None,
+        custom_package_caches = None,
+    ))
 
     sources = set.to_list(
         lib_info.source_files if lib_info != None else bin_info.source_files,

--- a/haskell/private/actions/repl.bzl
+++ b/haskell/private/actions/repl.bzl
@@ -22,6 +22,7 @@ load(
     ":private/set.bzl",
     "set",
 )
+load(":private/packages.bzl", "expose_packages")
 
 def build_haskell_repl(
         hs,
@@ -51,15 +52,13 @@ def build_haskell_repl(
       None.
     """
 
-    # Bring packages in scope.
-    args = ["-hide-all-packages"]
-    for dep in set.to_list(build_info.prebuilt_dependencies):
-        args += ["-package ", dep]
-    for package in set.to_list(build_info.package_ids):
-        if not (lib_info != None and package == lib_info.package_id):
-            args += ["-package-id", package]
-    for cache in set.to_list(package_caches):
-        args += ["-package-db", cache.dirname]
+    args = expose_packages(
+        build_info,
+        lib_info,
+        use_direct = False,
+        use_my_pkg_id = None,
+        custom_package_caches = package_caches,
+    )
 
     if lib_info != None:
         for idir in set.to_list(lib_info.import_dirs):

--- a/haskell/private/packages.bzl
+++ b/haskell/private/packages.bzl
@@ -1,0 +1,56 @@
+"""Package list handling"""
+
+load(":private/set.bzl", "set")
+
+def expose_packages(build_info, lib_info, use_direct, use_my_pkg_id, custom_package_caches):
+    """
+    Returns the list of command line argument which should be passed
+    to GHC in order to enable haskell packages.
+
+    build_info: is common to all builds
+
+    All the other arguments are not understood well:
+
+    lib_info: only used for repl and linter
+    use_direct: only used for one specific task in compile.bzl
+    use_my_pkg_id: only used for one specific task in compile.bzl
+    custom_package_caches: override the package_caches of build_info, used only by the repl
+    """
+
+    args = [
+        # In compile.bzl, we pass this just before all -package-id
+        # arguments. Not doing so leads to bizarre compile-time failures.
+        # It turns out that equally, not doing so leads to bizarre
+        # link-time failures. See
+        # https://github.com/tweag/rules_haskell/issues/395.
+        "-hide-all-packages",
+    ]
+
+    # Expose all prebuilt dependencies
+
+    # We have to remember to specify all (transitive) wired-in
+    # dependencies or we can't find objects for linking
+
+    # XXX: This should be really dep_info.direct_prebuilt_deps, but since we
+    # cannot add prebuilt_dependencies to the "depends" field on package
+    # registration (see a comment there), we have to pass all transitive
+    # prebuilt_dependencies on linking like this
+    for prebuilt_dep in set.to_list(build_info.direct_prebuilt_deps if use_direct else build_info.prebuilt_dependencies):
+        args.extend(["-package", prebuilt_dep])
+
+    # Expose all bazel dependencies
+    for package in set.to_list(build_info.package_ids):
+        # XXX: repl and lint uses this lib_info flags
+        # It is set to None in all other usage of this function
+        # TODO: find the meaning of this flag
+        if lib_info == None or package != lib_info.package_id:
+            # XXX: use_my_pkg_id is not None only in compile.bzl
+            if (use_my_pkg_id == None) or package != use_my_pkg_id:
+                args.extend(["-package-id", package])
+
+    # Only include package DBs for deps, prebuilt deps should be found
+    # auto-magically by GHC
+    for cache in set.to_list(build_info.package_caches if not custom_package_caches else custom_package_caches):
+        args.extend(["-package-db", cache.dirname])
+
+    return args


### PR DESCRIPTION
This is a blind refactor, it mostly moves every `-package` duplicated code in the `expose_packages` functions.

There is a special case for `lib_info` which is sometimes `None`, sometimes has a value. I wonder if the two cases where it is fixed to `None` are not "copy/paste" errors and if they should be fixed.

It closes #406 