### PR TITLE
CPP macro are only generated when 'version' attribute is specified.

### DIFF
--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -119,6 +119,9 @@ def _mk_binary_rule(**kwargs):
                 allow_single_file = FileType([".hs", ".hsc", ".lhs"]),
                 doc = "File containing `Main` module (deprecated).",
             ),
+            version = attr.string(
+                doc = "Executable version. If this is specified, CPP version macros will be generated for this build.",
+            ),
             _dummy_static_lib = attr.label(
                 default = Label("@io_tweag_rules_haskell//haskell:dummy_static_lib"),
                 allow_single_file = True,
@@ -189,7 +192,7 @@ haskell_library = rule(
         ),
         version = attr.string(
             doc = """Library version. Not normally necessary unless to build a library
-            originally defined as a Cabal package.""",
+            originally defined as a Cabal package. If this is specified, CPP version macro will be generated.""",
         ),
     ),
     outputs = {

--- a/haskell/lint.bzl
+++ b/haskell/lint.bzl
@@ -59,6 +59,7 @@ def _haskell_lint_aspect_impl(target, ctx):
         use_direct = False,
         use_my_pkg_id = None,
         custom_package_caches = None,
+        version = ctx.rule.attr.version,
     ))
 
     sources = set.to_list(

--- a/haskell/private/actions/compile.bzl
+++ b/haskell/private/actions/compile.bzl
@@ -65,7 +65,7 @@ def _process_hsc_file(hs, cc, hsc_file):
 
     return hs_out, idir
 
-def _compilation_defaults(hs, cc, java, dep_info, srcs, import_dir_map, extra_srcs, compiler_flags, with_profiling, my_pkg_id = None):
+def _compilation_defaults(hs, cc, java, dep_info, srcs, import_dir_map, extra_srcs, compiler_flags, with_profiling, my_pkg_id, version):
     """Declare default compilation targets and create default compiler arguments.
 
     Returns:
@@ -129,6 +129,7 @@ def _compilation_defaults(hs, cc, java, dep_info, srcs, import_dir_map, extra_sr
         use_direct = True,
         use_my_pkg_id = my_pkg_id,
         custom_package_caches = None,
+        version = version,
     ))
 
     header_files = []
@@ -269,7 +270,7 @@ def _compilation_defaults(hs, cc, java, dep_info, srcs, import_dir_map, extra_sr
         ),
     )
 
-def compile_binary(hs, cc, java, dep_info, srcs, ls_modules, import_dir_map, extra_srcs, compiler_flags, with_profiling, main_function):
+def compile_binary(hs, cc, java, dep_info, srcs, ls_modules, import_dir_map, extra_srcs, compiler_flags, with_profiling, main_function, version):
     """Compile a Haskell target into object files suitable for linking.
 
     Returns:
@@ -279,7 +280,7 @@ def compile_binary(hs, cc, java, dep_info, srcs, ls_modules, import_dir_map, ext
         modules: set of module names
         source_files: set of Haskell source files
     """
-    c = _compilation_defaults(hs, cc, java, dep_info, srcs, import_dir_map, extra_srcs, compiler_flags, with_profiling)
+    c = _compilation_defaults(hs, cc, java, dep_info, srcs, import_dir_map, extra_srcs, compiler_flags, with_profiling, my_pkg_id = None, version = version)
     c.args.add(["-main-is", main_function])
 
     hs.toolchain.actions.run_ghc(
@@ -335,7 +336,7 @@ def compile_library(hs, cc, java, dep_info, srcs, ls_modules, other_modules, exp
         source_files: set of Haskell module files
         import_dirs: import directories that should make all modules visible (for GHCi)
     """
-    c = _compilation_defaults(hs, cc, java, dep_info, srcs, import_dir_map, extra_srcs, compiler_flags, with_profiling, my_pkg_id = my_pkg_id)
+    c = _compilation_defaults(hs, cc, java, dep_info, srcs, import_dir_map, extra_srcs, compiler_flags, with_profiling, my_pkg_id = my_pkg_id, version = my_pkg_id.version)
 
     hs.toolchain.actions.run_ghc(
         hs,

--- a/haskell/private/actions/link.bzl
+++ b/haskell/private/actions/link.bzl
@@ -84,7 +84,8 @@ def link_binary(
         compiler_flags,
         objects_dir,
         with_profiling,
-        dummy_static_lib):
+        dummy_static_lib,
+        version):
     """Link Haskell binary from static object files.
 
     Returns:
@@ -138,6 +139,7 @@ def link_binary(
         use_direct = False,
         use_my_pkg_id = None,
         custom_package_caches = None,
+        version = version,
     ))
 
     _add_external_libraries(args, dep_info.external_libraries.values())
@@ -314,6 +316,7 @@ def link_library_dynamic(hs, cc, dep_info, extra_srcs, objects_dir, my_pkg_id):
         use_direct = False,
         use_my_pkg_id = None,
         custom_package_caches = None,
+        version = my_pkg_id.version if my_pkg_id else None,
     ))
 
     _add_external_libraries(args, dep_info.external_libraries.values())

--- a/haskell/private/actions/repl.bzl
+++ b/haskell/private/actions/repl.bzl
@@ -33,6 +33,7 @@ def build_haskell_repl(
         build_info,
         output,
         package_caches,
+        version,
         lib_info = None,
         bin_info = None):
     """Build REPL script.
@@ -58,6 +59,7 @@ def build_haskell_repl(
         use_direct = False,
         use_my_pkg_id = None,
         custom_package_caches = package_caches,
+        version = version,
     )
 
     if lib_info != None:

--- a/haskell/private/haskell_impl.bzl
+++ b/haskell/private/haskell_impl.bzl
@@ -77,6 +77,7 @@ use the 'haskell_import' rule instead.
         compiler_flags = ctx.attr.compiler_flags,
         with_profiling = False,
         main_function = ctx.attr.main_function,
+        version = ctx.attr.version,
     )
 
     c_p = None
@@ -100,6 +101,7 @@ use the 'haskell_import' rule instead.
             compiler_flags = ctx.attr.compiler_flags,
             with_profiling = True,
             main_function = ctx.attr.main_function,
+            version = ctx.attr.version,
         )
 
     binary = link_binary(
@@ -111,6 +113,7 @@ use the 'haskell_import' rule instead.
         c_p.objects_dir if with_profiling else c.objects_dir,
         with_profiling,
         ctx.file._dummy_static_lib,
+        version = ctx.attr.version,
     )
 
     solibs = set.union(
@@ -137,6 +140,7 @@ use the 'haskell_import' rule instead.
         repl_ghci_args = ctx.attr.repl_ghci_args,
         output = ctx.outputs.repl,
         package_caches = dep_info.package_caches,
+        version = ctx.attr.version,
         build_info = build_info,
         bin_info = bin_info,
     )
@@ -308,6 +312,7 @@ use the 'haskell_import' rule instead.
             compiler_flags = ctx.attr.compiler_flags,
             output = ctx.outputs.repl,
             package_caches = dep_info.package_caches,
+            version = ctx.attr.version,
             build_info = build_info,
             lib_info = lib_info,
         )

--- a/tests/cpp_macro_conflict/BS.hs
+++ b/tests/cpp_macro_conflict/BS.hs
@@ -1,0 +1,1 @@
+module BS where

--- a/tests/cpp_macro_conflict/BUILD
+++ b/tests/cpp_macro_conflict/BUILD
@@ -1,0 +1,29 @@
+package(default_testonly = 1)
+
+load(
+    "@io_tweag_rules_haskell//haskell:haskell.bzl",
+    "haskell_library",
+    "haskell_binary",
+)
+
+# empty library with package name "bytestring"
+haskell_library(
+  name = "bytestring",
+  srcs = ["BS.hs"],
+  deps = ["//tests:base"],
+)
+
+# This depends on two packages "bytestring"
+# There should be no CPP macro conflict
+haskell_binary(
+  name = "macro_conflict",
+  srcs = ["Main.hs"],
+  deps = ["//tests:base", "//tests:bytestring", ":bytestring"],
+  compiler_flags = ["-XCPP", "-Werror"] + select({
+      # clang on darwin fails because of unused command line argument, it fails because of -Werror
+      "@bazel_tools//src/conditions:darwin": [
+          "-optP-Wno-unused-command-line-argument",
+      ],
+      "//conditions:default": [],
+  }),
+)

--- a/tests/cpp_macro_conflict/Main.hs
+++ b/tests/cpp_macro_conflict/Main.hs
@@ -1,0 +1,4 @@
+import qualified Data.ByteString
+import BS
+
+main = putStrLn "hello"

--- a/tests/package-name/BUILD
+++ b/tests/package-name/BUILD
@@ -20,6 +20,7 @@ haskell_test(
     name = "bin",
     size = "small",
     srcs = ["Main.hs"],
+    version = "0.0.0", # This flags triggers the `MIN_VERSION` macro generation
     deps = [
         ":lib-a_Z",
         "//tests:base",


### PR DESCRIPTION
This fix #414.

In #414, we observed that CPP version macro generated by GHC can leads to conflict if two bazel targets have the same name, hence the same GHC package name. For example `//foo:bar` and `//frob:bar` will have package name `bar` and will generated `VERSION_bar` macros.

This PR deactivate macro generation if rule does not have a `version` attribute. see #414 for discussion.