### PR TITLE
Support building mostly-static binaries

### DIFF
--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -107,6 +107,10 @@ def _mk_binary_rule(**kwargs):
         executable = True,
         attrs = dict(
             _haskell_common_attrs,
+            linkstatic = attr.bool(
+                default = False,
+                doc = "If enabled, this option tells GHC to link statically whenever possible. While this captures all Haskell code built, some system libraries may still be linked dynamically, as are libraries for which there is no static library. So the resulting executable will still be dynamically linked, hence only mostly static.",
+            ),
             generate_so = attr.bool(
                 default = False,
                 doc = "Whether to generate also a .so version of executable.",

--- a/haskell/private/actions/link.bzl
+++ b/haskell/private/actions/link.bzl
@@ -122,14 +122,6 @@ def link_binary(
     if not linkstatic:
         if hs.toolchain.is_darwin:
             args.add(["-optl-Wl,-headerpad_max_install_names"])
-
-            # Nixpkgs commit 3513034208a introduces -liconv in NIX_LDFLAGS on
-            # Darwin. We don't currently handle NIX_LDFLAGS in any special
-            # way, so a hack is to simply do what NIX_LDFLAGS is telling us we
-            # should do always when using a toolchain from Nixpkgs.
-            # TODO remove this gross hack.
-            # TODO: enable dynamic linking of Haskell dependencies for macOS.
-            args.add("-liconv")
         elif not with_profiling:
             args.add(["-pie", "-dynamic"])
 
@@ -168,6 +160,14 @@ def link_binary(
             "-optc-Wno-unused-command-line-argument",
             "-optl-Wno-unused-command-line-argument",
         ])
+
+        # Nixpkgs commit 3513034208a introduces -liconv in NIX_LDFLAGS on
+        # Darwin. We don't currently handle NIX_LDFLAGS in any special
+        # way, so a hack is to simply do what NIX_LDFLAGS is telling us we
+        # should do always when using a toolchain from Nixpkgs.
+        # TODO remove this gross hack.
+        # TODO: enable dynamic linking of Haskell dependencies for macOS.
+        args.add("-liconv")
     else:
         for rpath in set.to_list(_infer_rpaths(executable, solibs)):
             args.add(["-optl-Wl,-rpath," + rpath])

--- a/haskell/private/actions/link.bzl
+++ b/haskell/private/actions/link.bzl
@@ -83,6 +83,7 @@ def link_binary(
         extra_srcs,
         compiler_flags,
         objects_dir,
+        linkstatic,
         with_profiling,
         dummy_static_lib,
         version):
@@ -111,18 +112,26 @@ def link_binary(
     args.add(hs.toolchain.compiler_flags)
     args.add(compiler_flags)
 
-    if hs.toolchain.is_darwin:
-        args.add(["-optl-Wl,-headerpad_max_install_names"])
+    # By default, GHC will produce mostly-static binaries, i.e. in which all
+    # Haskell code is statically linked and foreign libraries and system
+    # dependencies are dynamically linked. If linkstatic is false, i.e. the user
+    # has requested fully dynamic linking, we must therefore add flags to make
+    # sure that GHC dynamically links Haskell code too. The one exception to
+    # this is when we are compiling for profiling, which currently does not play
+    # nicely with dynamic linking.
+    if not linkstatic:
+        if hs.toolchain.is_darwin:
+            args.add(["-optl-Wl,-headerpad_max_install_names"])
 
-        # Nixpkgs commit 3513034208a introduces -liconv in NIX_LDFLAGS on
-        # Darwin. We don't currently handle NIX_LDFLAGS in any special
-        # way, so a hack is to simply do what NIX_LDFLAGS is telling us we
-        # should do always when using a toolchain from Nixpkgs.
-        # TODO remove this gross hack.
-        # TODO: enable dynamic linking of Haskell dependencies for macOS.
-        args.add("-liconv")
-    elif not with_profiling:
-        args.add(["-pie", "-dynamic"])
+            # Nixpkgs commit 3513034208a introduces -liconv in NIX_LDFLAGS on
+            # Darwin. We don't currently handle NIX_LDFLAGS in any special
+            # way, so a hack is to simply do what NIX_LDFLAGS is telling us we
+            # should do always when using a toolchain from Nixpkgs.
+            # TODO remove this gross hack.
+            # TODO: enable dynamic linking of Haskell dependencies for macOS.
+            args.add("-liconv")
+        elif not with_profiling:
+            args.add(["-pie", "-dynamic"])
 
     args.add(["-o", compile_output.path, dummy_static_lib.path])
 

--- a/haskell/private/haskell_impl.bzl
+++ b/haskell/private/haskell_impl.bzl
@@ -111,6 +111,7 @@ use the 'haskell_import' rule instead.
         ctx.files.extra_srcs,
         ctx.attr.compiler_flags,
         c_p.objects_dir if with_profiling else c.objects_dir,
+        ctx.attr.linkstatic,
         with_profiling,
         ctx.file._dummy_static_lib,
         version = ctx.attr.version,

--- a/tests/binary-mostly-static/BUILD
+++ b/tests/binary-mostly-static/BUILD
@@ -1,0 +1,14 @@
+package(default_testonly = 1)
+
+load(
+    "@io_tweag_rules_haskell//haskell:haskell.bzl",
+    "haskell_binary",
+)
+
+haskell_binary(
+    name = "binary-mostly-static",
+    srcs = ["Main.hs"],
+    visibility = ["//visibility:public"],
+    deps = ["//tests:base"],
+    linkstatic = True,
+)

--- a/tests/binary-mostly-static/Main.hs
+++ b/tests/binary-mostly-static/Main.hs
@@ -1,0 +1,3 @@
+module Main where
+
+main = putStrLn "hello world"


### PR DESCRIPTION
Closes #378.

* Adds a `linkstatic` attribute to the `haskell_binary` rule (and `haskell_test` through use of `_mk_binary_rule` -- but I think this is OK?).
* `linkstatic` defaults to `False`, which produces the behaviour shown currently, in which all code is dynamically linked (unless profiling is enabled).
* When `linkstatic` is set to `True`, GHC will produce _mostly-static_ binaries (in which all Haskell code is statically linked where possible but system and foreign libraries are still dynamically linked).
* While not matching other attributes in `snake_case`, `linkstatic` is the attribute used in e.g. the C/C++ rules shipped with Bazel (and also corresponds to _mostly-static_ linking in those cases), so it was chosen here for consistency.