### PR TITLE
Use bazel from nixpkgs instead of brew for darwin CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,11 +34,6 @@ jobs:
           command: |
             curl https://nixos.org/nix/install | sh
       - run:
-          name: System dependencies
-          command: |
-            brew update
-            brew install bazel
-      - run:
           name: Build
           shell: /bin/bash -eilo pipefail
           command: |

--- a/haskell/toolchain.bzl
+++ b/haskell/toolchain.bzl
@@ -225,6 +225,7 @@ def _haskell_toolchain_impl(ctx):
     targets_w = [
         "bash",
         "cat",
+        "tr",
         "cp",
         "grep",
         "ln",

--- a/shell.nix
+++ b/shell.nix
@@ -52,8 +52,6 @@ mkShell {
     python36Packages.sphinx
     zip
     unzip
-  ]
-  # TODO use Bazel from Nixpkgs even on Darwin. Blocked by
-  # https://github.com/NixOS/nixpkgs/issues/30590.
-  ++ lib.optional stdenv.isLinux bazel;
+    bazel
+  ];
 }

--- a/shell.nix
+++ b/shell.nix
@@ -6,11 +6,10 @@ with darwin.apple_sdk.frameworks;
 # XXX On Darwin, workaround
 # https://github.com/NixOS/nixpkgs/issues/42059. See also
 # https://github.com/NixOS/nixpkgs/pull/41589.
-let cc = stdenv.mkDerivation {
-  name = "cc-wrapper-bazel";
-  buildInputs = [ stdenv.cc makeWrapper ];
-  phases = [ "fixupPhase" ];
-  postFixup = ''
+let cc = runCommand "cc-wrapper-bazel" {
+    buildInputs = [ stdenv.cc makeWrapper ];
+  }
+  ''
     mkdir -p $out/bin
     makeWrapper ${stdenv.cc}/bin/clang $out/bin/clang \
       --add-flags "-isystem ${llvmPackages.libcxx}/include/c++/v1 \
@@ -21,7 +20,7 @@ let cc = stdenv.mkDerivation {
                    -L${libcxx}/lib \
                    -L${darwin.libobjc}/lib"
  '';
-  };
+
   mkShell = pkgs.mkShell.override {
     stdenv = if stdenv.isDarwin then overrideCC stdenv cc else stdenv;
   };

--- a/shell.nix
+++ b/shell.nix
@@ -13,7 +13,7 @@ let cc = stdenv.mkDerivation {
   postFixup = ''
     mkdir -p $out/bin
     makeWrapper ${stdenv.cc}/bin/clang $out/bin/clang \
-      --add-flags "-isystem ${llvmPackages.libcxx}/include \
+      --add-flags "-isystem ${llvmPackages.libcxx}/include/c++/v1 \
                    -F${CoreFoundation}/Library/Frameworks \
                    -F${CoreServices}/Library/Frameworks \
                    -F${Security}/Library/Frameworks \

--- a/shell.nix
+++ b/shell.nix
@@ -11,6 +11,16 @@ let cc = runCommand "cc-wrapper-bazel" {
   }
   ''
     mkdir -p $out/bin
+
+    # Copy the content of stdenv.cc
+    for i in ${stdenv.cc}/bin/*
+    do
+      ln -sf $i $out/bin
+    done
+
+    # Override clang
+    rm $out/bin/clang
+
     makeWrapper ${stdenv.cc}/bin/clang $out/bin/clang \
       --add-flags "-isystem ${llvmPackages.libcxx}/include/c++/v1 \
                    -F${CoreFoundation}/Library/Frameworks \

--- a/shell.nix
+++ b/shell.nix
@@ -26,6 +26,12 @@ let cc = runCommand "cc-wrapper-bazel" {
   };
 in
 mkShell {
+  # XXX: hack for macosX, this flags disable bazel usage of xcode
+  # Note: this is set even for linux so any regression introduced by this flag
+  # will be catched earlier
+  # See: https://github.com/bazelbuild/bazel/issues/4231
+  BAZEL_USE_CPP_ONLY_TOOLCHAIN=1;
+
   buildInputs = [
     binutils
     go


### PR DESCRIPTION
This way, bazel version is pinned and build is more reproducible. Fix #451.