### PR TITLE
MacOSX: use the default macosx toolchain

### DIFF
--- a/haskell/private/actions/link.bzl
+++ b/haskell/private/actions/link.bzl
@@ -268,6 +268,9 @@ def link_library_static(hs, cc, dep_info, objects_dir, my_pkg_id, with_profiling
             mnemonic = "HaskellLinkStaticLibrary",
             command = "{ar} qc $1 $(< $2)".format(ar = hs.tools.ar.path),
             arguments = [args],
+
+            # Use the default macosx toolchain
+            env = {"SDKROOT": "macosx"},
         )
     else:
         args.add([

--- a/haskell/private/dummy_linker_archive.bzl
+++ b/haskell/private/dummy_linker_archive.bzl
@@ -44,6 +44,9 @@ module BazelDummy () where
         mnemonic = "HaskellDummyObjectAr",
         executable = hs.tools.ar,
         arguments = [ar_args],
+
+        # Use the default macosx toolchain if needed
+        env = {"SDKROOT": "macosx"} if hs.toolchain.is_darwin else {},
     )
 
 dummy_linker_archive = rule(


### PR DESCRIPTION
fix #450 and https://github.com/tweag/rules_haskell_examples/issues/11

This should fix the CI on darwin.

Review needed, I don't know what I'm doing.

Rational: the `ar` tool on macosx needs a `SDKROOT` environment variable set to either a full path to a sdk or a symbolic name of an sdk. `macosx` is a symbolic name which uses the default sdk for macosx.