### PR TITLE
Change REPL convention and add documentation about REPL's in guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [0.7] - ???
 
+### Changed
+
+* REPL targets have changed name. If you have a library target `foo`,
+  then the corresponding REPL target is now called `foo@repl`. It was
+  previously called `foo-repl`. The old name is still supported but is
+  deprecated.
+
+### Fixed
+
 * Don’t crash on inputs missing `.haddock` interface files. See
   [#362](https://github.com/tweag/rules_haskell/pull/362)
 

--- a/docs/haskell-use-cases.rst
+++ b/docs/haskell-use-cases.rst
@@ -3,6 +3,40 @@
 Common Haskell Build Use Cases
 ==============================
 
-.. todo::
+Loading targets in a REPL
+-------------------------
 
-   Write up build use cases
+Rebuilds are currently not incremental *within* a binary or library
+target (rebuilds are incremental across targets of course). Any change
+in any source file will trigger a rebuild of all source files listed
+in a target. In Bazel, it is conventional to decompose libraries into
+small units. In this way, libraries require less work to rebuild.
+Still, for interactive development full incrementality and fast
+recompilation times are crucial for a good developer experience. We
+recommend making all development REPL-driven for fast feedback when
+source files change.
+
+Every `haskell_binary`_ and every `haskell_library`_ target has an
+optional executable output that can be run to drop you into an
+interactive session. If the target's name is ``foo``, then the REPL
+output is called ``foo@repl``.
+
+Consider the following binary target::
+
+  haskell_binary(
+      name = "hello",
+      srcs = ["Main.hs", "Other.hs"],
+      deps = ["//lib:some_lib"],
+  )
+
+The target above also implicitly defines ``hello@repl``. You can call
+the REPL like this (requires Bazel 0.15 or later)::
+
+  $ bazel run //:hello@repl
+
+This works for any ``haskell_binary`` or ``haskell_library`` target.
+Modules of all libraries will be loaded in interpreted mode and can be
+reloaded using the ``:r`` GHCi command when source files change.
+
+.. _haskell_binary: http://api.haskell.build/haskell/haskell.html#haskell_binary
+.. _haskell_library: http://api.haskell.build/haskell/haskell.html#haskell_library

--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -135,7 +135,8 @@ A dummy library needed for the GHC linking process.
             ),
         ),
         outputs = {
-            "repl": "%{name}-repl",
+            "repl": "%{name}@repl",
+            "repl_deprecated": "%{name}-repl",
         },
         toolchains = [
             "@io_tweag_rules_haskell//haskell:toolchain",
@@ -160,7 +161,7 @@ haskell_binary = _mk_binary_rule()
 Example:
   ```bzl
   haskell_binary(
-      name = "main",
+      name = "hello",
       srcs = ["Main.hs", "Other.hs"],
       deps = ["//lib:some_lib"]
   )
@@ -168,20 +169,15 @@ Example:
 
 Every `haskell_binary` target also defines an optional REPL target that is
 not built by default, but can be built on request. The name of the REPL
-target is the same as the name of binary with `"-repl"` added at the end.
-For example, the target above also defines `main-repl`.
+target is the same as the name of binary with `"@repl"` added at the end.
+For example, the target above also defines `main@repl`.
 
 You can call the REPL like this (requires Bazel 0.15 or later):
 
 ```
-$ bazel run //:hello-bin-repl
+$ bazel run //:hello@repl
 ```
 
-With Bazel > 0.12:
-
-```
-$ bazel run --direct_run //:hello-bin-repl
-```
 """
 
 haskell_library = rule(
@@ -200,7 +196,8 @@ haskell_library = rule(
         ),
     ),
     outputs = {
-        "repl": "%{name}-repl",
+        "repl": "%{name}@repl",
+        "repl_deprecated": "%{name}-repl",
     },
     toolchains = [
         "@io_tweag_rules_haskell//haskell:toolchain",

--- a/haskell/private/haskell_impl.bzl
+++ b/haskell/private/haskell_impl.bzl
@@ -17,6 +17,10 @@ load(":private/java.bzl", "java_interop_info")
 load(":private/set.bzl", "set")
 load(":private/mode.bzl", "is_profiling_enabled")
 load(
+    ":private/path_utils.bzl",
+    "ln",
+)
+load(
     ":private/providers.bzl",
     "C2hsLibraryInfo",
     "HaskellBinaryInfo",
@@ -145,6 +149,10 @@ use the 'haskell_import' rule instead.
         build_info = build_info,
         bin_info = bin_info,
     )
+
+    # XXX Temporary backwards compatibility hack. Remove eventually.
+    # See https://github.com/tweag/rules_haskell/pull/460.
+    ln(hs, ctx.outputs.repl, ctx.outputs.repl_deprecated)
 
     return [
         build_info,
@@ -317,6 +325,10 @@ use the 'haskell_import' rule instead.
             build_info = build_info,
             lib_info = lib_info,
         )
+
+        # XXX Temporary backwards compatibility hack. Remove eventually.
+        # See https://github.com/tweag/rules_haskell/pull/460.
+        ln(hs, ctx.outputs.repl, ctx.outputs.repl_deprecated)
 
     default_info = None
 

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -78,8 +78,8 @@ test_repl_libraries() {
     # Test whether building of repl forces all runtime dependencies by
     # itself:
     bazel clean
-    bazel run --config=ci //tests/repl-targets:hs-lib-repl -- -e "show (foo 10) ++ bar ++ baz ++ gen"
-    bazel run --config=ci //tests/repl-targets:hs-lib-bad-repl -- -e "1 + 2"
+    bazel run --config=ci //tests/repl-targets:hs-lib@repl -- -e "show (foo 10) ++ bar ++ baz ++ gen"
+    bazel run --config=ci //tests/repl-targets:hs-lib-bad@repl -- -e "1 + 2"
 }
 
 # Test REPL for binaries
@@ -87,19 +87,19 @@ test_repl_binaries() {
     # Test whether building of repl forces all runtime dependencies by
     # itself:
     bazel clean
-    bazel run --config=ci //tests/repl-targets:hs-bin-repl -- -e ":main"
+    bazel run --config=ci //tests/repl-targets:hs-bin@repl -- -e ":main"
 }
 
 # Test `compiler_flags` from toolchain and rule for REPL
 test_repl_compiler_flags() {
     # `compiler_flags` from toolchain are correctly used
-    bazel run --config=ci //tests/repl-flags:compiler_flags-repl -- -e ":main"
+    bazel run --config=ci //tests/repl-flags:compiler_flags@repl -- -e ":main"
 }
 
 # Test `repl_ghci_args` from toolchain and rule for REPL
 test_repl_flags() {
     # `compiler_flags` from toolchain are correctly used
-    bazel run --config=ci //tests/repl-flags:repl_flags-repl -- -e "foo"
+    bazel run --config=ci //tests/repl-flags:repl_flags@repl -- -e "foo"
 }
 
 # Test start script

--- a/tests/repl-flags/BUILD
+++ b/tests/repl-flags/BUILD
@@ -8,7 +8,7 @@ load("@io_tweag_rules_haskell//haskell:haskell.bzl", "haskell_binary", "haskell_
 # - toolchain and rule `compiler_flags` are additive, else one of the previous test will fail
 # - the ordering is as such as rule flags are more important that toolchain flags
 
-# This rule must build correctly (using `bazel build`), but also as a repl (using `bazel run //tests/repl-flags:compiler_flags-repl`)
+# This rule must build correctly (using `bazel build`), but also as a repl (using `bazel run //tests/repl-flags:compiler_flags@repl`)
 haskell_binary(
     name = "compiler_flags",
     srcs = ["CompilerFlags.hs"],
@@ -30,7 +30,7 @@ haskell_binary(
 #    toolchain flags and that repl flags are more important that
 #    copmiler flags
 
-# This rule must build correctly (using `bazel build`), but also as a repl (using `bazel run //tests/repl-flags:compiler_flags-repl`). The final result between the repl and the binary must be different
+# This rule must build correctly (using `bazel build`), but also as a repl (using `bazel run //tests/repl-flags:compiler_flags@repl`). The final result between the repl and the binary must be different
 haskell_binary(
     name = "repl_flags",
     srcs = ["ReplFlags.hs"],


### PR DESCRIPTION
These two changes should technically be two separate PR's, but the
first one is small (and the second depends on it) so I couldn't be
bothered.

The main change here is a new section to the user guide. While writing
up the documentation, I realized I was unhappy with the existing
convention for naming REPL targets, so I propose a change. I've
retained BC by still supporting the old naming (but it's now
undocumented).