### PR TITLE
Document using Nix to expose prebuilt Cabal packages

### DIFF
--- a/docs/haskell-use-cases.rst
+++ b/docs/haskell-use-cases.rst
@@ -150,13 +150,17 @@ construct a compiler with all the packages you depend on in scope::
     text
   ])
 
+Each package mentioned in ``ghc.nix`` can then be imported using
+`haskell_import`_ in ``BUILD`` files.
+
+.. _haskell_import: http://api.haskell.build/haskell/haskell.html#haskell_import
+
 Building code with Hackage dependencies (using Hazel)
 -----------------------------------------------------
 
 .. todo
 
    Explain how to use Hazel instead of Nix
-
 
 Generating API documentation
 ----------------------------


### PR DESCRIPTION
This includes the following two new sections:

- Picking a compiler
- Building code with Hackage dependencies (using Nix)