### PR TITLE
Add a `haskell_criterion` rule

### DIFF
--- a/docs/haskell-use-cases.rst
+++ b/docs/haskell-use-cases.rst
@@ -76,3 +76,36 @@ Alternatively, you can directly check a target using
       --aspects @io_tweag_rules_haskell//haskell:haskell.bzl%haskell_lint_aspect
 
 .. _haskell_lint: http://api.haskell.build/haskell/lint.html#haskell_lint
+
+Benchmarking your code with Criterion
+-------------------------------------
+
+`Criterion`_ is the reference testing framework for haskell and is
+integated into ruless_haskell thanks to the `haskell_criterion`_ rule.
+This rule is similar to the `haskell_test`_ one.
+You can then run it with
+
+.. code-block:: console
+
+  $ bazel test //my/library:benchmark
+
+Since the benchmark targets are internally defined as test targets (because
+bazel has no builtin notion of "benchmark"), your benchmarks will be included
+in wildcards such as ``bazel test //...``.
+
+Fortunately, bazel provides some ways to filter them out easily:
+
+- You can tag them as ``manual`` (by passing ``tags = ["manual"]`` to the
+  target definition). That way bazel will know that they should be excluded
+  from wildcards.
+- Alternatively, you can use the fact that they are implicitely tagged as
+  ``benchmark``. This means that you can filter them out by using the
+  ``--test_tag_filters=-benchmark`` argument.
+  You can also make this the default by adding ``test
+  --test_tag_filters=-benchmark`` to your ``bazelrc``.
+  If you do so, you need to pass ``--test_tag_filters=benchmark`` to re-include
+  them.
+
+.. _criterion: http://www.serpentine.com/criterion/
+.. _haskell_criterion: http://api.haskell.build/haskell/haskell.html#haskell_criterion
+.. _haskell_test: http://api.haskell.build/haskell/haskell.html#haskell_test

--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -150,6 +150,39 @@ timeout and resource allocation for the test.
 [bazel-test-attrs]: https://docs.bazel.build/versions/master/be/common-definitions.html#common-attributes-tests
 """
 
+def haskell_criterion(
+    tags = [],
+    args = [],
+    size = "enormous",
+    **kwargs
+  ):
+  """Build a benchmark suite using [criterion][criterion].
+
+This rule accepts the same arguments as [haskell_test][haskell_test_rule]
+The resulting benchmark is internally considered as a test because bazel has
+no primitive notion of benchmark.
+
+[criterion]: http://www.serpentine.com/criterion/
+[haskell_test_rule]: /haskell/haskell.html#haskell_test
+  """
+  default_criterion_args = \
+    [
+     "--csv=result.csv",
+     "--json=result.json",
+     "--output=result.html",
+     "--junit=result.xml",
+     # Needed because the tests don't run with an utf8-aware locale, and this
+     # causes a crash in criterion because of of
+     # https://github.com/bos/criterion/issues/205
+     "--verbosity=0",
+     ]
+  return haskell_test(
+    tags = tags + ["benchmark", "exclusive"],
+    args = default_criterion_args + args,
+    size = size,
+    **kwargs
+  )
+
 haskell_binary = _mk_binary_rule()
 """Build an executable from Haskell source.
 

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -164,6 +164,13 @@ haskell_import(
     visibility = ["//visibility:public"],
 )
 
+haskell_import(
+    name = "criterion",
+    testonly = 0,
+    package = "criterion",
+    visibility = ["//visibility:public"],
+)
+
 rule_test(
     name = "test-binary-simple",
     size = "small",

--- a/tests/criterion/BUILD
+++ b/tests/criterion/BUILD
@@ -1,0 +1,23 @@
+package(default_testonly = 1)
+
+load(
+    "@io_tweag_rules_haskell//haskell:haskell.bzl",
+    "haskell_library",
+    "haskell_criterion",
+)
+
+haskell_library(
+    name = "mylib",
+    srcs = ["Lib.hs"],
+    deps = ["//tests:base"],
+)
+
+haskell_criterion(
+    name = "criterion",
+    srcs = ["Bench.hs"],
+    deps = [
+        ":mylib",
+        "//tests:base",
+        "//tests:criterion",
+    ],
+)

--- a/tests/criterion/Bench.hs
+++ b/tests/criterion/Bench.hs
@@ -1,0 +1,7 @@
+import           Criterion.Main
+import           Lib
+
+main :: IO ()
+main = defaultMain
+  [ bench "AddOne" $ whnf addOne 5
+  ]

--- a/tests/criterion/Lib.hs
+++ b/tests/criterion/Lib.hs
@@ -1,0 +1,4 @@
+module Lib where
+
+addOne :: Int -> Int
+addOne = (+ 1)

--- a/tests/ghc.nix
+++ b/tests/ghc.nix
@@ -13,6 +13,7 @@ in haskellPackages.ghcWithPackages (p: with p; [
   # haskell_proto_library inputs
   bytestring
   containers
+  criterion
   data-default-class
   lens-family
   lens-labels


### PR DESCRIPTION
Simple wrapper around `haskell_test` to run criterion benchmarks.

Also add a use-case for it.