### PR TITLE
Configure CC toolchain using nixpkgs_cc_configure()

### DIFF
--- a/.netlify/build.sh
+++ b/.netlify/build.sh
@@ -4,6 +4,21 @@ set -eux
 
 export PATH=$HOME/bin:$PATH
 
+# XXX We don't want to be using the Nixpkgs CC toolchain, because
+# Nixpkgs is not available. But currently we can only override the
+# autoconfigured CC toolchain, not have several (which we would then
+# select via --extra_toolchains). So here's a gross hack that simply
+# patches out the nixpkgs_cc_configure() line.
+#
+# See https://github.com/bazelbuild/bazel/issues/6696.
+awk '
+  BEGIN {del=0}
+  /^nixpkgs_cc_configure\(/ {del=1}
+  del==0 {print}
+  /\)/ {del=0}' WORKSPACE > WORKSPACE.tmp
+  # Note: awk -i inplace not available
+mv WORKSPACE.tmp WORKSPACE
+
 bazel build //docs:api_html
 unzip -d public bazel-bin/docs/api_html-skydoc.zip
 cp start public

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -5,13 +5,14 @@ haskell_repositories()
 
 http_archive(
     name = "io_tweag_rules_nixpkgs",
-    strip_prefix = "rules_nixpkgs-0.3.1",
-    urls = ["https://github.com/tweag/rules_nixpkgs/archive/v0.3.1.tar.gz"],
-    sha256 = "1dc7ad9d4e0e7e690962317fa70bf5ab3bac5b4944e4f40eff3c2d6f5255eb20",
+    strip_prefix = "rules_nixpkgs-0.4.0",
+    urls = ["https://github.com/tweag/rules_nixpkgs/archive/v0.4.0.tar.gz"],
+    sha256 = "a4aefad582fcc22301b8696df7d6f55ac3183593f7efa693583f3a5d79a0aa58",
 )
 
 load("@io_tweag_rules_nixpkgs//nixpkgs:nixpkgs.bzl",
     "nixpkgs_git_repository",
+    "nixpkgs_local_repository",
     "nixpkgs_package",
 )
 load("@io_tweag_rules_haskell//haskell:nix.bzl",
@@ -37,6 +38,11 @@ http_archive(
     urls = ["https://github.com/google/protobuf/archive/v3.5.0.zip"],
 )
 
+nixpkgs_local_repository(
+    name = "nixpkgs",
+    nix_file = "//nixpkgs:default.nix",
+)
+
 register_toolchains(
     "//tests:ghc",
     "//tests:doctest-toolchain",
@@ -45,7 +51,7 @@ register_toolchains(
 
 nixpkgs_package(
     name = "zlib",
-    repositories = { "nixpkgs": "//nixpkgs:default.nix" },
+    repository = "@nixpkgs",
     build_file_content = """
 package(default_visibility = ["//visibility:public"])
 
@@ -63,7 +69,7 @@ filegroup (
 
 nixpkgs_package(
     name = "zlib.dev",
-    repositories = { "nixpkgs": "//nixpkgs:default.nix" },
+    repository = "@nixpkgs",
     build_file_content = """
 load("@io_tweag_rules_haskell//haskell:haskell.bzl", "haskell_cc_import")
 package(default_visibility = ["//visibility:public"])
@@ -86,7 +92,7 @@ haskell_cc_import(
 
 nixpkgs_package(
     name = "glib_locales",
-    repositories = { "nixpkgs": "//nixpkgs:default.nix" },
+    repository = "@nixpkgs",
     attribute_path = "glibcLocales",
     build_file_content = """
 package(default_visibility = ["//visibility:public"])
@@ -100,7 +106,7 @@ filegroup(
 
 haskell_nixpkgs_packageset(
     name = "hackage-packages",
-    repositories = { "nixpkgs": "//nixpkgs:default.nix" },
+    repositories = { "nixpkgs": "@nixpkgs" },
     nix_file = "//tests:ghc.nix",
     base_attribute_path = "haskellPackages",
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -5,12 +5,13 @@ haskell_repositories()
 
 http_archive(
     name = "io_tweag_rules_nixpkgs",
-    strip_prefix = "rules_nixpkgs-0.4.0",
-    urls = ["https://github.com/tweag/rules_nixpkgs/archive/v0.4.0.tar.gz"],
-    sha256 = "a4aefad582fcc22301b8696df7d6f55ac3183593f7efa693583f3a5d79a0aa58",
+    strip_prefix = "rules_nixpkgs-0.4.1",
+    urls = ["https://github.com/tweag/rules_nixpkgs/archive/v0.4.1.tar.gz"],
+    sha256 = "e08bfff0e3413cae8549df72e3fce36f7b0e2369e864dfe41d3307ef100500f8",
 )
 
 load("@io_tweag_rules_nixpkgs//nixpkgs:nixpkgs.bzl",
+    "nixpkgs_cc_configure",
     "nixpkgs_git_repository",
     "nixpkgs_local_repository",
     "nixpkgs_package",
@@ -47,6 +48,11 @@ register_toolchains(
     "//tests:ghc",
     "//tests:doctest-toolchain",
     "//tests:protobuf-toolchain",
+)
+
+nixpkgs_cc_configure(
+    repository = "@nixpkgs",
+    nix_file = "//nixpkgs:cc-toolchain.nix",
 )
 
 nixpkgs_package(

--- a/nixpkgs/cc-toolchain.nix
+++ b/nixpkgs/cc-toolchain.nix
@@ -1,0 +1,36 @@
+with import <nixpkgs> {};
+with darwin.apple_sdk.frameworks;
+
+# XXX On Darwin, workaround
+# https://github.com/NixOS/nixpkgs/issues/42059. See also
+# https://github.com/NixOS/nixpkgs/pull/41589.
+let cc = runCommand "cc-wrapper-bazel" {
+    buildInputs = [ pkgs.stdenv.cc makeWrapper ];
+  }
+  ''
+    mkdir -p $out/bin
+
+    # Copy the content of pkgs.stdenv.cc
+    for i in ${pkgs.stdenv.cc}/bin/*
+    do
+      ln -sf $i $out/bin
+    done
+
+    # Override clang
+    rm $out/bin/clang
+
+    makeWrapper ${pkgs.stdenv.cc}/bin/clang $out/bin/clang \
+      --add-flags "-isystem ${llvmPackages.libcxx}/include/c++/v1 \
+                   -F${CoreFoundation}/Library/Frameworks \
+                   -F${CoreServices}/Library/Frameworks \
+                   -F${Security}/Library/Frameworks \
+                   -F${Foundation}/Library/Frameworks \
+                   -L${libcxx}/lib \
+                   -L${darwin.libobjc}/lib"
+  '';
+  stdenv = if pkgs.stdenv.isDarwin then overrideCC pkgs.stdenv cc else pkgs.stdenv;
+in
+buildEnv {
+  name = "bazel-cc-toolchain";
+  paths = [ stdenv.cc ] ++ (if stdenv.isDarwin then [ ] else [ binutils ]);
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,40 +1,7 @@
 { pkgs ? import ./nixpkgs {} }:
 
 with pkgs;
-with darwin.apple_sdk.frameworks;
 
-# XXX On Darwin, workaround
-# https://github.com/NixOS/nixpkgs/issues/42059. See also
-# https://github.com/NixOS/nixpkgs/pull/41589.
-let cc = runCommand "cc-wrapper-bazel" {
-    buildInputs = [ stdenv.cc makeWrapper ];
-  }
-  ''
-    mkdir -p $out/bin
-
-    # Copy the content of stdenv.cc
-    for i in ${stdenv.cc}/bin/*
-    do
-      ln -sf $i $out/bin
-    done
-
-    # Override clang
-    rm $out/bin/clang
-
-    makeWrapper ${stdenv.cc}/bin/clang $out/bin/clang \
-      --add-flags "-isystem ${llvmPackages.libcxx}/include/c++/v1 \
-                   -F${CoreFoundation}/Library/Frameworks \
-                   -F${CoreServices}/Library/Frameworks \
-                   -F${Security}/Library/Frameworks \
-                   -F${Foundation}/Library/Frameworks \
-                   -L${libcxx}/lib \
-                   -L${darwin.libobjc}/lib"
- '';
-
-  mkShell = pkgs.mkShell.override {
-    stdenv = if stdenv.isDarwin then overrideCC stdenv cc else stdenv;
-  };
-in
 mkShell {
   # XXX: hack for macosX, this flags disable bazel usage of xcode
   # Note: this is set even for linux so any regression introduced by this flag
@@ -43,7 +10,6 @@ mkShell {
   BAZEL_USE_CPP_ONLY_TOOLCHAIN=1;
 
   buildInputs = [
-    binutils
     go
     graphviz
     nix

--- a/start
+++ b/start
@@ -42,17 +42,31 @@ haskell_repositories()
 
 http_archive(
   name = "io_tweag_rules_nixpkgs",
-  strip_prefix = "rules_nixpkgs-0.2.3",
-  urls = ["https://github.com/tweag/rules_nixpkgs/archive/v0.2.3.tar.gz"],
+  strip_prefix = "rules_nixpkgs-0.4.0",
+  urls = ["https://github.com/tweag/rules_nixpkgs/archive/v0.4.0.tar.gz"],
 )
 
-load("@io_tweag_rules_nixpkgs//nixpkgs:nixpkgs.bzl", "nixpkgs_package")
+load(
+    "@io_tweag_rules_nixpkgs//nixpkgs:nixpkgs.bzl",
+    "nixpkgs_package",
+    "nixpkgs_git_repository",
+    "nixpkgs_cc_configure",
+)
+
+nixpkgs_git_repository(
+    name = "nixpkgs",
+    remote = "https://github.com/NixOS/nixpkgs",
+    revision = "18.09",
+    sha256 = "6451af4083485e13daa427f745cbf859bc23cb8b70454c017887c006a13bd65e",
+)
 
 nixpkgs_package(
   name = "ghc",
-  attribute_path = "haskell.compiler.ghc844",
+  attribute_path = "haskell.compiler.ghc843",
+  repository = "@nixpkgs",
 )
 
+nixpkgs_cc_configure(repository = "@nixpkgs")
 register_toolchains("//:ghc")
 EOF
 
@@ -67,7 +81,7 @@ load(
 
 haskell_toolchain(
   name = "ghc",
-  version = "8.4.4",
+  version = "8.4.3",
   tools = "@ghc//:bin",
 )
 


### PR DESCRIPTION
This obviates the need to provision compiler tools in the Nix shell.
In fact with this change, most targets build even outside the Nix
shell.

Close #407.