### PR TITLE
Link indirect static dependencies

### DIFF
--- a/tests/indirect-link/BUILD.bazel
+++ b/tests/indirect-link/BUILD.bazel
@@ -1,0 +1,29 @@
+load("@io_tweag_rules_haskell//haskell:haskell.bzl", "haskell_binary", "haskell_library", "haskell_import")
+
+haskell_import(name = "base")
+
+cc_library(
+    name = "cbits-indirect",
+    srcs = ["cbits/impl.c"],
+)
+
+cc_library(
+    name = "cbits",
+    srcs = ["cbits/intf.c"],
+    deps = ["cbits-indirect"],
+)
+
+
+haskell_library(
+    name = "mypkg",
+    srcs = ["src/MyModule.hs"],
+    src_strip_prefix = "src",
+    deps = [":cbits", ":base"],
+)
+
+haskell_binary(
+    name = "mytest",
+    srcs = ["test/Main.hs"],
+    src_strip_prefix = "test",
+    deps = [":mypkg", ":base"],
+)

--- a/tests/indirect-link/cbits/impl.c
+++ b/tests/indirect-link/cbits/impl.c
@@ -1,0 +1,9 @@
+static int thing;
+
+int real_get_thing(void) {
+  return thing;
+}
+
+void real_set_thing(int value) {
+  thing = value;
+}

--- a/tests/indirect-link/cbits/intf.c
+++ b/tests/indirect-link/cbits/intf.c
@@ -1,0 +1,10 @@
+extern int real_get_thing(void);
+extern void real_set_thing(int value);
+
+int get_thing(void) {
+  return real_get_thing();
+}
+
+void set_thing(int value) {
+  real_set_thing(value);
+}

--- a/tests/indirect-link/src/MyModule.hs
+++ b/tests/indirect-link/src/MyModule.hs
@@ -1,0 +1,11 @@
+module MyModule where
+
+foreign import ccall get_thing :: IO Int
+
+getThing :: IO Int
+getThing = get_thing
+
+foreign import ccall set_thing :: Int -> IO ()
+
+setThing :: Int -> IO ()
+setThing = set_thing

--- a/tests/indirect-link/test/Main.hs
+++ b/tests/indirect-link/test/Main.hs
@@ -1,0 +1,9 @@
+module Main (main) where
+
+import qualified MyModule
+
+main :: IO ()
+main = do
+  print =<< MyModule.getThing
+  MyModule.setThing 123
+  print =<< MyModule.getThing


### PR DESCRIPTION
Fix #170.

A static archive only contains code which generate the archive, but not the code of direct or indirect dependencies.

For example, suppose we have `libA` which contains function `a` and `libB` contains function `b` which uses `a`. An executable who want to use `b` must link to `libB`. If `libB` is linked as a dynamic library, it is self contained: all symbols are contained OR available in another dynamic library, hence we only need to link to `libB`. However, if `libB` is linked as a static library, it only contains the symbols created by `libB`, no the symbols from any other dependencies (such as `libA`). In that case, we need to link to the static `libA` and `libB`.

The current version of `rules_haskell` was only linking with direct cxx dependencies, hence a few missing symbol during link.

This PR:

- Introduce a test with indirect dependencies
- Pick the list of indirect dependencies from the `CC` provider `cc.libs` and inject it to the list of dependencies used for the link.