### PR TITLE
Custom flags settings for haddock process

### DIFF
--- a/haskell/haddock.bzl
+++ b/haskell/haddock.bzl
@@ -59,6 +59,8 @@ def _haskell_doc_aspect_impl(target, ctx):
         "--hyperlinked-source",
     ])
 
+    args.add(hs.toolchain.haddock_flags)
+
     transitive_haddocks = {}
     transitive_html = {}
 

--- a/haskell/toolchain.bzl
+++ b/haskell/toolchain.bzl
@@ -272,6 +272,7 @@ def _haskell_toolchain_impl(ctx):
             extra_binaries = extra_binaries_files,
             compiler_flags = ctx.attr.compiler_flags,
             repl_ghci_args = ctx.attr.repl_ghci_args,
+            haddock_flags = ctx.attr.haddock_flags,
             locale = ctx.attr.locale,
             locale_archive = locale_archive,
             mode = ctx.var["COMPILATION_MODE"],
@@ -313,6 +314,9 @@ _haskell_toolchain = rule(
         "repl_ghci_args": attr.string_list(
             doc = "A collection of flags that will be passed to GHCI on repl invocation. It extends the `compiler_flags` collection. Flags set here have precedance over `compiler_flags`.",
         ),
+        "haddock_flags": attr.string_list(
+            doc = "A collection of flags that will be passed to haddock.",
+        ),
         "c2hs": attr.label(
             doc = "c2hs executable",
             allow_single_file = True,
@@ -352,6 +356,7 @@ def haskell_toolchain(
         tools,
         compiler_flags = [],
         repl_ghci_args = [],
+        haddock_flags = [],
         **kwargs):
     """Declare a compiler toolchain.
 
@@ -402,6 +407,7 @@ def haskell_toolchain(
         tools = tools,
         compiler_flags = compiler_flags,
         repl_ghci_args = repl_ghci_args,
+        haddock_flags = haddock_flags,
         visibility = ["//visibility:public"],
         is_darwin = select({
             "@bazel_tools//src/conditions:darwin": True,

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -31,6 +31,7 @@ haskell_toolchain(
         "-DTESTS_TOOLCHAIN_COMPILER_FLAGS",
         "-XNoOverloadedStrings",  # this is the default, so it does not harm other tests
     ],
+    haddock_flags = ["-U"],
     locale_archive = select({
         # For some reason glibcLocales is not available on Darwin.
         "@bazel_tools//src/conditions:darwin": None,


### PR DESCRIPTION
Closes #425.

This just add an `haddock_flags` attribute to `haskell_toolchain`. This flag will be passed to the haddock process.

# Design discussion

This design do not allow:

- per package flags. This can be achieved by adding a `haddock_flags` attribute to `haskell_library` / `haskell_binary`.
- different `haskell_doc` rule with different flags.

The original design was to pu the `haddock_flags` attribute to `haskell_doc` instead of `haskell_toolchain`. However it is more complicated to implement due to the lack of attribute passing between `haskell_doc` rule and the used aspect (see #425 for details). It is possible (I have a POC) to refactor `haskell_doc` and aspect such that the aspect only gather the meta data of the documentation and let `haskell_doc` do the build phase, but it is a more complex refactoring, so I won't push it except if there is a request for it.