### PR TITLE
Add missing args to the `haskell_lint` rule

### DIFF
--- a/tests/library-with-sysincludes/BUILD
+++ b/tests/library-with-sysincludes/BUILD
@@ -2,6 +2,7 @@ load(
     "@io_tweag_rules_haskell//haskell:haskell.bzl",
     "haskell_cc_import",
     "haskell_library",
+    "haskell_lint",
 )
 
 package(default_testonly = 1)
@@ -79,4 +80,10 @@ haskell_library(
         "@hackage//:base",
         "@hackage//:template-haskell",
     ],
+)
+
+# Regression test for #390
+haskell_lint(
+    name = "lint",
+    deps = ["//tests/textual-hdrs"],
 )

--- a/tests/textual-hdrs/BUILD
+++ b/tests/textual-hdrs/BUILD
@@ -1,6 +1,7 @@
 load(
     "@io_tweag_rules_haskell//haskell:haskell.bzl",
     "haskell_binary",
+    "haskell_lint",
 )
 
 package(default_testonly = 1)
@@ -14,4 +15,10 @@ haskell_binary(
     compiler_flags = ["-Itests/textual-hdrs/include"],
     visibility = ["//visibility:public"],
     deps = ["@hackage//:base"],
+)
+
+# Regression test for #390
+haskell_lint(
+    name = "lint",
+    deps = ["//tests/textual-hdrs"],
 )


### PR DESCRIPTION
Fix #390 