### PR TITLE
Limit the parallelism inside nix

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -7,9 +7,9 @@ haskell_repositories()
 
 http_archive(
     name = "io_tweag_rules_nixpkgs",
-    sha256 = "e08bfff0e3413cae8549df72e3fce36f7b0e2369e864dfe41d3307ef100500f8",
-    strip_prefix = "rules_nixpkgs-0.4.1",
-    urls = ["https://github.com/tweag/rules_nixpkgs/archive/v0.4.1.tar.gz"],
+    # sha256 = "e08bfff0e3413cae8549df72e3fce36f7b0e2369e864dfe41d3307ef100500f8",
+    strip_prefix = "rules_nixpkgs-c8f6bf0272708c0b84a436a4744181cb032b1dc3",
+    urls = ["https://github.com/tweag/rules_nixpkgs/archive/c8f6bf0272708c0b84a436a4744181cb032b1dc3.tar.gz"],
 )
 
 load(
@@ -118,6 +118,7 @@ haskell_nixpkgs_packageset(
     base_attribute_path = "haskellPackages",
     nix_file = "//tests:ghc.nix",
     repositories = {"nixpkgs": "@nixpkgs"},
+    nix_build_extra_args = ["-j", "1"],
 )
 
 load("@hackage-packages//:packages.bzl", "import_packages")


### PR DESCRIPTION
Tell `nix-build` to only build one derivation at a time since `bazel` already does the required parallelism work.

Depends on tweag/rules_nixpkgs#51