### PR TITLE
Move to Bazel v0.20

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,14 +40,15 @@ jobs:
           name: Build
           shell: /bin/bash -eilo pipefail
           command: |
-            nix-shell --run 'CC=$(which clang) bazel build --jobs=2 //...'
+            # Disable docs on macOS because deps not cached in Hydra.
+            nix-shell --arg docTools false --pure --run 'bazel build --jobs=2 //...'
       - run:
           name: Run tests
           shell: /bin/bash -eilo pipefail
           # bazel does not support recursive bazel call, so we
           # cannot use bazel run here because the test runner uses
           # bazel
-          command: nix-shell --run 'CC=$(which clang) bazel build //tests:run-tests && ./bazel-bin/tests/run-tests'
+          command: nix-shell --arg docTools false --pure --run 'bazel build //tests:run-tests && ./bazel-bin/tests/run-tests'
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,12 +37,6 @@ jobs:
           command: |
             curl https://nixos.org/nix/install | sh
       - run:
-          name: Build
-          shell: /bin/bash -eilo pipefail
-          command: |
-            # Disable docs on macOS because deps not cached in Hydra.
-            nix-shell --arg docTools false --pure --run 'bazel build --jobs=2 //...'
-      - run:
           name: Run tests
           shell: /bin/bash -eilo pipefail
           # bazel does not support recursive bazel call, so we

--- a/.netlify/build.sh
+++ b/.netlify/build.sh
@@ -19,6 +19,10 @@ awk '
   # Note: awk -i inplace not available
 mv WORKSPACE.tmp WORKSPACE
 
+# We don't want to be depending on Nixpkgs for documentation
+# generation either.
+sed -i 's/vendored_node = "@nixpkgs_nodejs"/vendored_node = None/' WORKSPACE
+
 bazel build //docs:api_html
 unzip -d public bazel-bin/docs/api_html-skydoc.zip
 cp start public

--- a/.netlify/install.sh
+++ b/.netlify/install.sh
@@ -2,7 +2,7 @@
 
 set -eux
 
-V=0.16.0
+V=0.20.0
 
 curl -LO https://github.com/bazelbuild/bazel/releases/download/$V/bazel-$V-installer-linux-x86_64.sh
 chmod +x bazel-$V-installer-linux-x86_64.sh

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The full reference documentation for rules is at https://haskell.build.
 
 ## Setup
 
-You'll need [Bazel >= 0.14.0][bazel-getting-started] installed.
+You'll need [Bazel >= 0.20.0][bazel-getting-started] installed.
 
 ### The easy way
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -37,9 +37,9 @@ haskell_nixpkgs_package(
 
 http_archive(
     name = "com_google_protobuf",
-    sha256 = "d625beb4a43304409429a0466bb4fb44c89f7e7d90aeced972b8a61dbe92c80b",
-    strip_prefix = "protobuf-7b28271a61a3da0a37f6fda399b0c4c86464e5b3",
-    urls = ["https://github.com/google/protobuf/archive/7b28271a61a3da0a37f6fda399b0c4c86464e5b3.zip"],  # 2018-11-16
+    sha256 = "73fdad358857e120fd0fa19e071a96e15c0f23bb25f85d3f7009abfd4f264a2a",
+    strip_prefix = "protobuf-3.6.1.3",
+    urls = ["https://github.com/google/protobuf/archive/v3.6.1.3.tar.gz"],
 )
 
 nixpkgs_local_repository(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -130,9 +130,9 @@ import_packages(name = "hackage")
 
 # zlib as a Haskell library
 
-new_http_archive(
+http_archive(
     name = "haskell_zlib",
-    build_file = "tests/BUILD.zlib",
+    build_file = "//tests:BUILD.zlib",
     strip_prefix = "zlib-0.6.2",
     urls = ["https://hackage.haskell.org/package/zlib-0.6.2/zlib-0.6.2.tar.gz"],
 )
@@ -150,46 +150,77 @@ local_repository(
 
 # For Skydoc
 
-http_archive(
-    name = "io_bazel_rules_sass",
-    sha256 = "14536292b14b5d36d1d72ae68ee7384a51e304fa35a3c4e4db0f4590394f36ad",
-    strip_prefix = "rules_sass-0.0.3",
-    urls = ["https://github.com/bazelbuild/rules_sass/archive/0.0.3.tar.gz"],
+nixpkgs_package(
+    name = "nixpkgs_nodejs",
+    # XXX Indirection derivation to make all of NodeJS rooted in
+    # a single directory. We shouldn't need this, but it's
+    # a workaround for
+    # https://github.com/bazelbuild/bazel/issues/2927.
+    nix_file_content = """
+    with import <nixpkgs> {};
+    runCommand "nodejs-rules_haskell" { buildInputs = [ nodejs ]; } ''
+      mkdir -p $out/nixpkgs_nodejs
+      cd $out/nixpkgs_nodejs
+      for i in ${nodejs}/*; do ln -s $i; done
+      ''
+    """,
+    repository = "@nixpkgs",
 )
 
-load("@io_bazel_rules_sass//sass:sass.bzl", "sass_repositories")
+http_archive(
+    name = "build_bazel_rules_nodejs",
+    sha256 = "f79f605a920145216e64991d6eff4e23babc48810a9efd63a31744bb6637b01e",
+    strip_prefix = "rules_nodejs-b4dad57d2ecc63d74db1f5523593639a635e447d",
+    # Tip of https://github.com/bazelbuild/rules_nodejs/pull/471.
+    urls = ["https://github.com/mboes/rules_nodejs/archive/b4dad57d2ecc63d74db1f5523593639a635e447d.tar.gz"],
+)
+
+http_archive(
+    name = "io_bazel_rules_sass",
+    sha256 = "1e135452dc627f52eab39a50f4d5b8d13e8ed66cba2e6da56ac4cbdbd776536c",
+    strip_prefix = "rules_sass-1.15.2",
+    urls = ["https://github.com/bazelbuild/rules_sass/archive/1.15.2.tar.gz"],
+)
+
+load("@io_bazel_rules_sass//:package.bzl", "rules_sass_dependencies")
+
+rules_sass_dependencies()
+
+load("@io_bazel_rules_sass//:defs.bzl", "sass_repositories")
 
 sass_repositories()
 
-http_archive(
-    name = "io_bazel_skydoc",
-    sha256 = "12a82b494a40c4ef96230bc66aeff654420dd39a537eb3064ff18ce1838f1fb7",
-    strip_prefix = "skydoc-9bbdf62c03b5c3fed231604f78d3976f47753d79",
-    urls = ["https://github.com/mrkkrp/skydoc/archive/9bbdf62c03b5c3fed231604f78d3976f47753d79.tar.gz"],
+load("@build_bazel_rules_nodejs//:defs.bzl", "node_repositories")
+
+node_repositories(
+    vendored_node = "@nixpkgs_nodejs",
 )
 
-load("@io_bazel_skydoc//skylark:skylark.bzl", "skydoc_repositories")
+http_archive(
+    name = "io_bazel_skydoc",
+    sha256 = "19eb6c162075707df5703c274d3348127625873dbfa5ff83b1ef4b8f5dbaa449",
+    strip_prefix = "skydoc-0.2.0",
+    urls = ["https://github.com/bazelbuild/skydoc/archive/0.2.0.tar.gz"],
+)
+
+load("@io_bazel_skydoc//:setup.bzl", "skydoc_repositories")
 
 skydoc_repositories()
 
 # For buildifier
 
-# XXX Need a patched version of rules_go to workaround warnings fixed
-# by https://github.com/NixOS/nixpkgs/pull/28029 on NixOS. Revert to
-# official release once fix hits Nixpkgs master.
 http_archive(
     name = "io_bazel_rules_go",
-    strip_prefix = "rules_go-6a2b1f780b475a75a7baae5b441635c566f0ed8a",
-    urls = ["https://github.com/mboes/rules_go/archive/6a2b1f780b475a75a7baae5b441635c566f0ed8a.tar.gz"],
+    sha256 = "8be57ff66da79d9e4bd434c860dce589195b9101b2c187d144014bbca23b5166",
+    strip_prefix = "rules_go-0.16.3",
+    urls = ["https://github.com/bazelbuild/rules_go/archive/0.16.3.tar.gz"],
 )
-
-bazelbuild_buildtools_rev = "4a7914a1466ff7388c934bfcd43a3852928536f6"
 
 http_archive(
     name = "com_github_bazelbuild_buildtools",
-    sha256 = "45775c7bb7ee7656e9df4ca4278f977c8e4e260aff755734734c19321e14bc84",
-    strip_prefix = "buildtools-%s" % bazelbuild_buildtools_rev,
-    url = "https://github.com/bazelbuild/buildtools/archive/%s.zip" % bazelbuild_buildtools_rev,
+    sha256 = "d42e4c9727958bc5814d3bc44f19db5a24f419436cbba09f1e8913eb4a09da31",
+    strip_prefix = "buildtools-0.19.2.1",
+    urls = ["https://github.com/bazelbuild/buildtools/archive/0.19.2.1.tar.gz"],
 )
 
 load(

--- a/haskell/c2hs.bzl
+++ b/haskell/c2hs.bzl
@@ -88,9 +88,11 @@ c2hs_library = rule(
             allow_single_file = True,
             default = Label("@io_tweag_rules_haskell//haskell:private/c2hs_wrapper.sh"),
         ),
+        "_cc_toolchain": attr.label(
+            default = Label("@bazel_tools//tools/cpp:current_cc_toolchain"),
+        ),
     },
     toolchains = [
         "@io_tweag_rules_haskell//haskell:toolchain",
-        "@bazel_tools//tools/cpp:toolchain_type",
     ],
 )

--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -90,6 +90,9 @@ _haskell_common_attrs = {
         cfg = "host",
         default = Label("@io_tweag_rules_haskell//haskell:ls_modules"),
     ),
+    "_cc_toolchain": attr.label(
+        default = Label("@bazel_tools//tools/cpp:current_cc_toolchain"),
+    ),
 }
 
 def _mk_binary_rule(**kwargs):
@@ -135,7 +138,6 @@ def _mk_binary_rule(**kwargs):
         },
         toolchains = [
             "@io_tweag_rules_haskell//haskell:toolchain",
-            "@bazel_tools//tools/cpp:toolchain_type",
         ],
         **kwargs
     )
@@ -200,7 +202,6 @@ haskell_library = rule(
     },
     toolchains = [
         "@io_tweag_rules_haskell//haskell:toolchain",
-        "@bazel_tools//tools/cpp:toolchain_type",
     ],
 )
 """Build a library from Haskell source.

--- a/haskell/protobuf.bzl
+++ b/haskell/protobuf.bzl
@@ -146,6 +146,7 @@ def _haskell_proto_aspect_impl(target, ctx):
         "deps": ctx.rule.attr.deps +
                 ctx.toolchains["@io_tweag_rules_haskell//protobuf:toolchain"].deps,
         "prebuilt_dependencies": ctx.toolchains["@io_tweag_rules_haskell//protobuf:toolchain"].prebuilt_deps,
+        "_cc_toolchain": ctx.attr._cc_toolchain,
     }
 
     patched_ctx = struct(
@@ -164,6 +165,9 @@ def _haskell_proto_aspect_impl(target, ctx):
         executable = struct(
             _ls_modules = ctx.executable._ls_modules,
         ),
+        # Necessary for CC interop (see cc.bzl).
+        features = ctx.rule.attr.features,
+        disabled_features = ctx.rule.attr.features,
     )
 
     [build_info, library_info, default_info] = _haskell_library_impl(patched_ctx)
@@ -191,10 +195,12 @@ _haskell_proto_aspect = aspect(
             cfg = "host",
             default = Label("@io_tweag_rules_haskell//haskell:ls_modules"),
         ),
+        "_cc_toolchain": attr.label(
+            default = Label("@bazel_tools//tools/cpp:current_cc_toolchain"),
+        ),
     },
     attr_aspects = ["deps"],
     toolchains = [
-        "@bazel_tools//tools/cpp:toolchain_type",
         "@io_tweag_rules_haskell//haskell:toolchain",
         "@io_tweag_rules_haskell//protobuf:toolchain",
     ],

--- a/haskell/repositories.bzl
+++ b/haskell/repositories.bzl
@@ -8,7 +8,7 @@ def haskell_repositories():
     """
     http_archive(
         name = "bazel_skylib",
-        strip_prefix = "bazel-skylib-0.5.0",
-        urls = ["https://github.com/bazelbuild/bazel-skylib/archive/0.5.0.tar.gz"],
-        sha256 = "b5f6abe419da897b7901f90cbab08af958b97a8f3575b0d3dd062ac7ce78541f",
+        sha256 = "eb5c57e4c12e68c0c20bc774bfbc60a568e800d025557bc4ea022c6479acc867",
+        strip_prefix = "bazel-skylib-0.6.0",
+        urls = ["https://github.com/bazelbuild/bazel-skylib/archive/0.6.0.tar.gz"],
     )

--- a/nixpkgs/default.nix
+++ b/nixpkgs/default.nix
@@ -1,5 +1,5 @@
 import (fetchTarball {
    # Nixpkgs checkout from 2018-11-03.
-   url = "https://github.com/NixOS/nixpkgs/archive/ef4d78adedcfbb69392e7634bc6912c019b88bcc.tar.gz";
-   sha256 = "0xmlklvh1as83fcfmy169m62kaj9w7nfm8y1c9x3ws29cjrpypf0";
+   url = "https://github.com/NixOS/nixpkgs/archive/cb692e6f52f6d4ca619c9fbc7a80afc081a93103.tar.gz";
+   sha256 = "1aww7wjgv868asd4yl0wnzh8qa26j4wsmqn85b3s9fkqkz4p2m0f";
 })

--- a/shell.nix
+++ b/shell.nix
@@ -16,7 +16,7 @@ mkShell {
     perl
     python
     bazel
-    # needed for cloning protobuf in @com_google_protobuf
+    # Needed for @com_github_golang_protobuf, itself needed by buildifier.
     git
   ] ++ lib.optionals docTools [graphviz python36Packages.sphinx zip unzip];
 

--- a/shell.nix
+++ b/shell.nix
@@ -1,4 +1,4 @@
-{ pkgs ? import ./nixpkgs {} }:
+{ pkgs ? import ./nixpkgs {}, docTools ? true }:
 
 with pkgs;
 
@@ -11,18 +11,14 @@ mkShell {
 
   buildInputs = [
     go
-    graphviz
     nix
     which
     perl
     python
-    python36Packages.sphinx
-    zip
-    unzip
     bazel
     # needed for cloning protobuf in @com_google_protobuf
     git
-  ];
+  ] ++ lib.optionals docTools [graphviz python36Packages.sphinx zip unzip];
 
   shellHook = ''
     # source bazel bash completion

--- a/start
+++ b/start
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 MIN_BAZEL_MAJOR=0
-MIN_BAZEL_MINOR=14
+MIN_BAZEL_MINOR=20
 
 set -e
 

--- a/tests/RunTests.hs
+++ b/tests/RunTests.hs
@@ -17,10 +17,10 @@ main = hspec $ do
     assertSuccess (bazel ["run", "//:buildifier"])
 
   it "bazel test" $ do
-    assertSuccess (bazel ["test", "//..."])
+    assertSuccess (bazel ["test", "//...", "--build_tests_only"])
 
   it "bazel test prof" $ do
-    assertSuccess (bazel ["test", "-c", "dbg", "//..."])
+    assertSuccess (bazel ["test", "-c", "dbg", "//...", "--build_tests_only"])
 
   describe "repl" $ do
     it "for libraries" $ do


### PR DESCRIPTION
Fixes #492.

v0.20 has breaking changes that we can't adapt to without
simultaneously losing compatibility with earlier versions. So the
minimum requirement is now Bazel >= v0.20. This is also true of our
upstream dependencies, so we had to update them as part of this
change.

We're now using the new C++ toolchain API. This in principle should
enable us to shed long standing limitations around linking. But that
will have to be kept as future work.

DON'T MERGE YET: this PR is using a fork of Nixpkgs while Bazel
v0.20.0 gets merged upstream.