### PR TITLE
Add perl to nix-shell

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -14,6 +14,7 @@ mkShell {
     graphviz
     nix
     which
+    perl
     python
     python36Packages.sphinx
     zip


### PR DESCRIPTION
This PR fixes a mostly innocuous error when running tests regarding missing Perl:

```
[nix-shell:~/code/rules_haskell]$ bazel test tests/haskell_test/...
INFO: Analysed 2 targets (0 packages loaded).
INFO: Found 1 target and 1 test target...
haskell_test fired
external/bazel_tools/tools/test/test-setup.sh: line 160: perl: command not found
INFO: Elapsed time: 0.247s, Critical Path: 0.11s
INFO: 1 process: 1 processwrapper-sandbox.
INFO: Build completed successfully, 2 total actions
//tests/haskell_test:haskell_test                                        PASSED in 0.0s

INFO: Build completed successfully, 2 total actions
```

It seems Bazel expects Perl to be in PATH for minor things, such as regexp-based editing.

@Profpatsch mentioned that we could instead file a patch upstream to remove the dependencies. We could have that discussion here.