### PR TITLE
Use the local checkout in start script testing

### DIFF
--- a/tests/RunTests.hs
+++ b/tests/RunTests.hs
@@ -59,7 +59,11 @@ main = hspec $ do
 
       -- Set Nixpkgs in environment variable to avoid hardcoding it in
       -- start script itself
-      , "NIX_PATH=nixpkgs=$pwd/nixpkgs/default.nix bazel fetch //... --config=ci"
+      , "NIX_PATH=nixpkgs=$pwd/nixpkgs/default.nix \
+        \bazel fetch \
+        \--config=ci \
+        \--override_repository=io_tweag_rules_haskell=$pwd \
+        \//..."
       ])
 
   describe "failures" $ do


### PR DESCRIPTION
Previously, the `start` script was always using the latest
rules_haskell release. As it should. But when we're testing it on
a feature branch, the latest rules_haskell version doesn't always
work. If on the branch we update Bazel to a version with breaking
changes, then we need to adapt to those changes in the branch. Which
in turn means the start script should pull in those changes too.