### PR TITLE
Hide external dependencies from ghci

### DIFF
--- a/haskell/toolchain.bzl
+++ b/haskell/toolchain.bzl
@@ -401,12 +401,13 @@ def haskell_toolchain(
       ```
     """
     impl_name = name + "-impl"
+    corrected_ghci_args = repl_ghci_args + ["-no-user-package-db"]
     _haskell_toolchain(
         name = impl_name,
         version = version,
         tools = tools,
         compiler_flags = compiler_flags,
-        repl_ghci_args = repl_ghci_args,
+        repl_ghci_args = corrected_ghci_args,
         haddock_flags = haddock_flags,
         visibility = ["//visibility:public"],
         is_darwin = select({


### PR DESCRIPTION
Per https://github.com/tweag/rules_haskell/issues/470, ghci is currently not correctly isolated from external depedencies. This aims to resolve that, through ghci flags used on its initialization.