### PR TITLE
Forward flags to hsc2hs

### DIFF
--- a/haskell/private/actions/compile.bzl
+++ b/haskell/private/actions/compile.bzl
@@ -139,8 +139,8 @@ def _compilation_defaults(hs, cc, java, dep_info, srcs, import_dir_map, extra_sr
 
     # Forward all "-D" and "-optP-D" flags to hsc2hs
     hsc_flags = []
-    hsc_flags += ["--cflag=" + x for x in compiler_flags if x.startswith('-D')]
-    hsc_flags += ["--cflag=" + x[len("-optP"):] for x in compiler_flags if x.startswith('-optP-D')]
+    hsc_flags += ["--cflag=" + x for x in compiler_flags if x.startswith("-D")]
+    hsc_flags += ["--cflag=" + x[len("-optP"):] for x in compiler_flags if x.startswith("-optP-D")]
 
     # Add import hierarchy root.
     # Note that this is not perfect, since GHC requires hs-boot files

--- a/haskell/private/actions/compile.bzl
+++ b/haskell/private/actions/compile.bzl
@@ -137,8 +137,10 @@ def _compilation_defaults(hs, cc, java, dep_info, srcs, import_dir_map, extra_sr
     boot_files = []
     source_files = set.empty()
 
-    # Forward all "-D" flags to hsc2hs
-    hsc_flags = ["--cflag=" + x for x in compiler_flags if x.startswith('-D')]
+    # Forward all "-D" and "-optP-D" flags to hsc2hs
+    hsc_flags = []
+    hsc_flags += ["--cflag=" + x for x in compiler_flags if x.startswith('-D')]
+    hsc_flags += ["--cflag=" + x[len("-optP"):] for x in compiler_flags if x.startswith('-optP-D')]
 
     # Add import hierarchy root.
     # Note that this is not perfect, since GHC requires hs-boot files

--- a/tests/hsc/BUILD
+++ b/tests/hsc/BUILD
@@ -14,7 +14,7 @@ haskell_library(
         "Flags.hsc",
         "Foo.hsc",
     ],
-    compiler_flags = ["-DTHIS_IS_TRUE"],
+    compiler_flags = ["-DTHIS_IS_TRUE", "-optP-DTHIS_TOO_IS_TRUE" ],
     deps = ["@hackage//:base"],
 )
 

--- a/tests/hsc/BUILD
+++ b/tests/hsc/BUILD
@@ -11,8 +11,10 @@ haskell_library(
     srcs = [
         "Bar.hsc",
         "Bar/Baz.hsc",
+        "Flags.hsc",
         "Foo.hsc",
     ],
+    compiler_flags = ["-DTHIS_IS_TRUE"],
     deps = ["@hackage//:base"],
 )
 

--- a/tests/hsc/Flags.hsc
+++ b/tests/hsc/Flags.hsc
@@ -1,0 +1,6 @@
+module Flags (hscFlags) where
+
+#ifdef THIS_IS_TRUE
+hscFlags :: String
+hscFlags = "hscFlags"
+#endif

--- a/tests/hsc/Flags.hsc
+++ b/tests/hsc/Flags.hsc
@@ -1,6 +1,8 @@
 module Flags (hscFlags) where
 
 #ifdef THIS_IS_TRUE
+#ifdef THIS_TOO_IS_TRUE
 hscFlags :: String
 hscFlags = "hscFlags"
+#endif
 #endif

--- a/tests/hsc/Main.hs
+++ b/tests/hsc/Main.hs
@@ -4,6 +4,7 @@ import BinHsc ()
 import Foo (hscFiredFoo)
 import Bar (hscFiredBar)
 import Bar.Baz (hscFiredBaz)
+import Flags (hscFlags)
 
 main :: IO ()
-main = putStrLn (hscFiredFoo ++ hscFiredBar ++ hscFiredBaz)
+main = putStrLn (hscFiredFoo ++ hscFiredBar ++ hscFiredBaz ++ hscFlags)


### PR DESCRIPTION
`-D` flags were not forwarded to `hsc2hs`, which meant that `#ifdef ...` could not be used in `.hsc` files (they'd be stripped away during the `.hs` generation).