### PR TITLE
HaskellBuildInfo: revert external_libraries to a set

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -117,8 +117,11 @@ haskell_nixpkgs_packageset(
     name = "hackage-packages",
     base_attribute_path = "haskellPackages",
     nix_file = "//tests:ghc.nix",
+    nixopts = [
+        "-j",
+        "1",
+    ],
     repositories = {"nixpkgs": "@nixpkgs"},
-    nixopts = ["-j", "1"],
 )
 
 load("@hackage-packages//:packages.bzl", "import_packages")

--- a/haskell/haddock.bzl
+++ b/haskell/haddock.bzl
@@ -94,7 +94,7 @@ def _haskell_doc_aspect_impl(target, ctx):
             set.to_depset(target[HaskellBuildInfo].package_caches),
             set.to_depset(target[HaskellBuildInfo].interface_dirs),
             set.to_depset(target[HaskellBuildInfo].dynamic_libraries),
-            depset(target[HaskellBuildInfo].external_libraries.values()),
+            depset([e.mangled_lib for e in set.to_list(target[HaskellBuildInfo].external_libraries)]),
             depset(transitive_haddocks.values()),
             depset(transitive_html.values()),
             # Need to give source files this way because the source_files field of

--- a/haskell/import.bzl
+++ b/haskell/import.bzl
@@ -74,7 +74,7 @@ def _haskell_import_impl(ctx):
         dynamic_libraries = set.empty(),
         interface_dirs = set.empty(),
         prebuilt_dependencies = set.empty(),
-        external_libraries = {},
+        external_libraries = set.empty(),
         direct_prebuilt_deps = set.empty(),
     )
     html_files = list(ctx.attr.haddock_html.files)

--- a/haskell/lint.bzl
+++ b/haskell/lint.bzl
@@ -79,7 +79,7 @@ def _haskell_lint_aspect_impl(target, ctx):
             set.to_depset(build_info.package_caches),
             set.to_depset(build_info.interface_dirs),
             set.to_depset(build_info.dynamic_libraries),
-            depset(build_info.external_libraries.values()),
+            depset([e.mangled_lib for e in set.to_list(build_info.external_libraries)]),
             depset([
                 hs.tools.ghc,
                 hs.tools.cat,

--- a/haskell/private/actions/compile.bzl
+++ b/haskell/private/actions/compile.bzl
@@ -10,7 +10,7 @@ load(
 load(
     ":private/path_utils.bzl",
     "declare_compiled",
-    "get_external_libs_path",
+    "make_external_libs_path",
     "target_unique_name",
 )
 load(":private/pkg_id.bzl", "pkg_id")
@@ -248,7 +248,7 @@ def _compilation_defaults(hs, cc, java, dep_info, srcs, import_dir_map, extra_sr
             depset(dep_info.static_libraries),
             depset(dep_info.static_libraries_prof),
             set.to_depset(dep_info.dynamic_libraries),
-            depset(dep_info.external_libraries.values()),
+            depset([e.mangled_lib for e in set.to_list(dep_info.external_libraries)]),
             java.inputs,
             depset([hs.tools.cc]),
             locale_archive_depset,
@@ -263,7 +263,7 @@ def _compilation_defaults(hs, cc, java, dep_info, srcs, import_dir_map, extra_sr
         import_dirs = import_dirs,
         env = dicts.add(
             {
-                "LD_LIBRARY_PATH": get_external_libs_path(set.from_list(dep_info.external_libraries.values())),
+                "LD_LIBRARY_PATH": make_external_libs_path(dep_info.external_libraries),
             },
             java.env,
             hs.env,

--- a/haskell/private/actions/link.bzl
+++ b/haskell/private/actions/link.bzl
@@ -20,7 +20,7 @@ def _backup_path(target):
 
     return "/".join([".."] * n)
 
-def _fix_linker_paths(hs, inp, out, external_libraries):
+def _fix_darwin_linker_paths(hs, inp, out, external_libraries):
     """Postprocess a macOS binary to make shared library references relative.
 
     On macOS, in order to simulate the linker "rpath" behavior and make the
@@ -106,7 +106,7 @@ def link_binary(
         compile_output = executable
     else:
         compile_output = hs.actions.declare_file(hs.name + ".temp")
-        _fix_linker_paths(
+        _fix_darwin_linker_paths(
             hs,
             compile_output,
             executable,
@@ -363,7 +363,7 @@ def link_library_dynamic(hs, cc, dep_info, extra_srcs, objects_dir, my_pkg_id):
 
     if hs.toolchain.is_darwin:
         dynamic_library_tmp = hs.actions.declare_file(dynamic_library.basename + ".temp")
-        _fix_linker_paths(
+        _fix_darwin_linker_paths(
             hs,
             dynamic_library_tmp,
             dynamic_library,

--- a/haskell/private/haskell_impl.bzl
+++ b/haskell/private/haskell_impl.bzl
@@ -27,6 +27,7 @@ load(
 )
 load(":private/pkg_id.bzl", "pkg_id")
 load(":private/set.bzl", "set")
+load(":private/providers.bzl", "external_libraries_get_mangled")
 
 def _prepare_srcs(srcs):
     srcs_files = []
@@ -126,7 +127,7 @@ use the 'haskell_import' rule instead.
     )
 
     solibs = set.union(
-        set.from_list(dep_info.external_libraries.values()),
+        set.map(dep_info.external_libraries, external_libraries_get_mangled),
         dep_info.dynamic_libraries,
     )
 

--- a/haskell/private/providers.bzl
+++ b/haskell/private/providers.bzl
@@ -27,10 +27,17 @@ HaskellBuildInfo = provider(
         "dynamic_libraries": "Set of dynamic libraries.",
         "interface_dirs": "Set of interface dirs belonging to the packages.",
         "prebuilt_dependencies": "Transitive collection of names of wired-in Haskell dependencies.",
-        "external_libraries": "Set of dynamic shared libraries needed for linking.",
+        "external_libraries": "Set of dynamic shared libraries needed for linking. " +
+                              "Each entry is a struct(lib, mangled_lib) " +
+                              "because the Darwin linker needs the original library path, " +
+                              "while the Linux linker needs the mangled path.",
         "direct_prebuilt_deps": "Set of direct prebuilt dependencies.",
     },
 )
+
+def external_libraries_get_mangled(ext_lib):
+    """Just a dumb helper because skylark doesn’t do lambdas."""
+    return ext_lib.mangled_lib
 
 HaskellLibraryInfo = provider(
     doc = "Library-specific information.",


### PR DESCRIPTION
In commit 4b5117d1b64aa87476bedb02df078cc20b316d70 external_libraries
was turned to a dict and all list uses correctly converted by using
.values(). It was done in order to support MacOS and the keys were
used in exactly one place. However, it was found out that this wasn’t
working with transitive libraries, so the one use of the keys was
removed again in commit 182df778143d47dbd2dc77a08fb40074fc4e80b5, yet
external_libraries was not converted back to a set. In the following
commits many new usages of external_commits did not take into account
that it is a dict, some treating it as a list, some as a set.

Fixes https://github.com/tweag/rules_haskell/issues/428