### PR TITLE
Fix MacOS dynamic linking issue

### DIFF
--- a/haskell/private/actions/link.bzl
+++ b/haskell/private/actions/link.bzl
@@ -43,7 +43,10 @@ def _fix_linker_paths(hs, inp, out, external_libraries):
             [
                 "cp {} {}".format(inp.path, out.path),
                 "chmod +w {}".format(out.path),
-                "/usr/bin/install_name_tool -id @rpath/{} {}".format(out.basename, out.path),
+                "/usr/bin/install_name_tool -id @rpath/{} {}".format(
+                    out.basename,
+                    out.path,
+                ),
             ] +
             [
                 "/usr/bin/install_name_tool -change {} {} {}".format(
@@ -180,6 +183,7 @@ def link_binary(
         # should do always when using a toolchain from Nixpkgs.
         # TODO remove this gross hack.
         args.add("-liconv")
+
     for rpath in set.to_list(_infer_rpaths(hs, executable, solibs)):
         args.add(["-optl-Wl,-rpath," + rpath])
 
@@ -241,9 +245,9 @@ def _infer_rpaths(hs, target, solibs):
     r = set.empty()
 
     if hs.toolchain.is_darwin:
-      origin = "@loader_path/"
+        origin = "@loader_path/"
     else:
-      origin = "$ORIGIN/"
+        origin = "$ORIGIN/"
 
     for solib in set.to_list(solibs):
         rpath = paths.normalize(
@@ -374,6 +378,7 @@ def link_library_dynamic(hs, cc, dep_info, extra_srcs, objects_dir, my_pkg_id):
         args.add(["-optl-Wl,-headerpad_max_install_names"])
     else:
         dynamic_library_tmp = dynamic_library
+
     for rpath in set.to_list(_infer_rpaths(hs, dynamic_library, solibs)):
         args.add(["-optl-Wl,-rpath," + rpath])
 

--- a/haskell/private/actions/link.bzl
+++ b/haskell/private/actions/link.bzl
@@ -43,12 +43,20 @@ def _fix_linker_paths(hs, inp, out, external_libraries):
             [
                 "cp {} {}".format(inp.path, out.path),
                 "chmod +w {}".format(out.path),
+                # Patch the "install name" or "library identifaction name".
+                # The "install name" informs targets that link against `out`
+                # where `out` can be found during runtime. Here we update this
+                # "install name" to the new filename of the fixed binary.
+                # Refer to the Oracle blog post linked above for details.
                 "/usr/bin/install_name_tool -id @rpath/{} {}".format(
                     out.basename,
                     out.path,
                 ),
             ] +
             [
+                # Make rpaths for external library dependencies relative to the
+                # binary's installation path, rather than the working directory
+                # at execution time.
                 "/usr/bin/install_name_tool -change {} {} {}".format(
                     f.path,
                     paths.join("@loader_path", _backup_path(out), f.path),

--- a/haskell/private/actions/link.bzl
+++ b/haskell/private/actions/link.bzl
@@ -192,7 +192,7 @@ def link_binary(
         # TODO remove this gross hack.
         args.add("-liconv")
 
-    for rpath in set.to_list(_infer_rpaths(hs, executable, solibs)):
+    for rpath in set.to_list(_infer_rpaths(hs.toolchain.is_darwin, executable, solibs)):
         args.add(["-optl-Wl,-rpath," + rpath])
 
     objects_dir_manifest = _create_objects_dir_manifest(
@@ -238,12 +238,12 @@ def _add_external_libraries(args, libs):
                 "-L{0}".format(paths.dirname(lib.path)),
             ])
 
-def _infer_rpaths(hs, target, solibs):
+def _infer_rpaths(is_darwin, target, solibs):
     """Return set of RPATH values to be added to target so it can find all
     solibs.
 
     Args:
-      hs: Haskell context.
+      is_darwin: Whether we're compiling on and for Darwin.
       target: File, executable or library we're linking.
       solibs: A set of Files, shared objects that the target needs.
 
@@ -252,7 +252,7 @@ def _infer_rpaths(hs, target, solibs):
     """
     r = set.empty()
 
-    if hs.toolchain.is_darwin:
+    if is_darwin:
         origin = "@loader_path/"
     else:
         origin = "$ORIGIN/"
@@ -387,7 +387,7 @@ def link_library_dynamic(hs, cc, dep_info, extra_srcs, objects_dir, my_pkg_id):
     else:
         dynamic_library_tmp = dynamic_library
 
-    for rpath in set.to_list(_infer_rpaths(hs, dynamic_library, solibs)):
+    for rpath in set.to_list(_infer_rpaths(hs.toolchain.is_darwin, dynamic_library, solibs)):
         args.add(["-optl-Wl,-rpath," + rpath])
 
     args.add(["-o", dynamic_library_tmp.path])

--- a/haskell/private/actions/link.bzl
+++ b/haskell/private/actions/link.bzl
@@ -19,7 +19,7 @@ def _backup_path(target):
 
     return "/".join([".."] * n)
 
-def _fix_linker_paths(hs, inp, out, external_libraries):
+def _fix_darwin_linker_paths(hs, inp, out, external_libraries):
     """Postprocess a macOS binary to make shared library references relative.
 
     On macOS, in order to simulate the linker "rpath" behavior and make the
@@ -116,7 +116,7 @@ def link_binary(
         compile_output = executable
     else:
         compile_output = hs.actions.declare_file(hs.name + ".temp")
-        _fix_linker_paths(
+        _fix_darwin_linker_paths(
             hs,
             compile_output,
             executable,
@@ -377,7 +377,7 @@ def link_library_dynamic(hs, cc, dep_info, extra_srcs, objects_dir, my_pkg_id):
 
     if hs.toolchain.is_darwin:
         dynamic_library_tmp = hs.actions.declare_file(dynamic_library.basename + ".temp")
-        _fix_linker_paths(
+        _fix_darwin_linker_paths(
             hs,
             dynamic_library_tmp,
             dynamic_library,

--- a/haskell/private/actions/link.bzl
+++ b/haskell/private/actions/link.bzl
@@ -43,6 +43,7 @@ def _fix_linker_paths(hs, inp, out, external_libraries):
             [
                 "cp {} {}".format(inp.path, out.path),
                 "chmod +w {}".format(out.path),
+                "/usr/bin/install_name_tool -id @rpath/{} {}".format(out.basename, out.path),
             ] +
             [
                 "/usr/bin/install_name_tool -change {} {} {}".format(

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -327,6 +327,24 @@ rule_test(
 )
 
 genrule(
+    name = "run-bin-with-lib-dynamic",
+    outs = ["dyn-dummy"],
+    cmd = """sh -c '
+    set -e
+    $(location //tests/binary-with-lib-dynamic:binary-with-lib-dynamic)
+    touch $(location dyn-dummy)
+'""",
+    tools = ["//tests/binary-with-lib-dynamic"],
+)
+
+rule_test(
+    name = "test-run-bin-with-lib-dynamic",
+    size = "small",
+    generates = ["dyn-dummy"],
+    rule = "//tests:run-bin-with-lib-dynamic",
+)
+
+genrule(
     name = "run-bin-with-c-lib",
     outs = ["c-dummy"],
     cmd = """sh -c '

--- a/tests/binary-with-lib-dynamic/BUILD
+++ b/tests/binary-with-lib-dynamic/BUILD
@@ -1,0 +1,25 @@
+load(
+    "@io_tweag_rules_haskell//haskell:haskell.bzl",
+    "haskell_binary",
+    "haskell_library",
+)
+
+package(default_testonly = 1)
+
+haskell_library(
+    name = "lib",
+    srcs = glob(["src/*.hs"]),
+    src_strip_prefix = "src",
+    linkstatic = False,
+)
+
+haskell_binary(
+    name = "binary-with-lib-dynamic",
+    srcs = ["Main.hs"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":lib",
+        "@hackage//:base",
+    ],
+    linkstatic = False,
+)

--- a/tests/binary-with-lib-dynamic/Main.hs
+++ b/tests/binary-with-lib-dynamic/Main.hs
@@ -1,0 +1,5 @@
+module Main where
+
+import Lib (value)
+
+main = print value

--- a/tests/binary-with-lib-dynamic/src/Lib.hs
+++ b/tests/binary-with-lib-dynamic/src/Lib.hs
@@ -1,0 +1,5 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
+module Lib (value) where
+
+value = 42


### PR DESCRIPTION
- Fixes the dylib install name on MacOS. Previously, it included the `.temp` postfix, now it doesn't.
- Fixes the rpath on MacOS. Previously, it was relative to the execution directory. Now it is prefixed with `@loader_path` (analogous to `$ORIGIN` on Linux)
- Adds a regression test for #521.

Closes #521 