### PR TITLE
Prevent duplicate installs of bazel_skylib

### DIFF
--- a/haskell/repositories.bzl
+++ b/haskell/repositories.bzl
@@ -6,9 +6,12 @@ def haskell_repositories():
     """Provide all repositories that are necessary for `rules_haskell` to
     function.
     """
-    http_archive(
-        name = "bazel_skylib",
-        sha256 = "eb5c57e4c12e68c0c20bc774bfbc60a568e800d025557bc4ea022c6479acc867",
-        strip_prefix = "bazel-skylib-0.6.0",
-        urls = ["https://github.com/bazelbuild/bazel-skylib/archive/0.6.0.tar.gz"],
-    )
+    excludes = native.existing_rules().keys()
+
+    if "bazel_skylib" not in excludes:
+        http_archive(
+            name = "bazel_skylib",
+            sha256 = "eb5c57e4c12e68c0c20bc774bfbc60a568e800d025557bc4ea022c6479acc867",
+            strip_prefix = "bazel-skylib-0.6.0",
+            urls = ["https://github.com/bazelbuild/bazel-skylib/archive/0.6.0.tar.gz"],
+        )


### PR DESCRIPTION
If we try to use `haskell_repositories()` after `bazel_skylib` was already installed with the same name (e.g. `rules_docker` also installs it as a dependency), we will get a name clash.

We can use instead an if-statement to install only those that have not yet been installed.