### PR TITLE
Add missing rpath for shared libraries

### DIFF
--- a/haskell/doctest.bzl
+++ b/haskell/doctest.bzl
@@ -124,6 +124,7 @@ def _haskell_doctest_single(target, ctx):
                     "-l{0}".format(lib_name),
                     "-L{0}".format(paths.dirname(lib.path)),
                 ])
+            args.add("-optl-Wl,-rpath,{0}".format(paths.dirname(lib.path)))
 
     header_files = lib_info.header_files if lib_info != None else bin_info.header_files
 

--- a/haskell/private/actions/link.bzl
+++ b/haskell/private/actions/link.bzl
@@ -251,6 +251,7 @@ def _add_external_libraries(args, ext_libs):
             args.add([
                 "-l{0}".format(lib_name),
                 "-L{0}".format(paths.dirname(lib.path)),
+                "-optl-Wl,-rpath,{0}".format(paths.dirname(lib.path)),
             ])
 
 def _infer_rpaths(is_darwin, target, solibs):

--- a/haskell/private/actions/repl.bzl
+++ b/haskell/private/actions/repl.bzl
@@ -17,6 +17,7 @@ load(
     "external_libraries_get_mangled",
 )
 load("@bazel_skylib//lib:shell.bzl", "shell")
+load("@bazel_skylib//lib:paths.bzl", "paths")
 
 def build_haskell_repl(
         hs,
@@ -67,7 +68,10 @@ def build_haskell_repl(
         lib_name = get_lib_name(lib)
         if not set.is_member(seen_libs, lib_name):
             set.mutable_insert(seen_libs, lib_name)
-            args += ["-l{0}".format(lib_name)]
+            args += [
+                "-l{0}".format(lib_name),
+                "-optl-Wl,-rpath,{0}".format(paths.dirname(lib.path)),
+            ]
 
     repl_file = hs.actions.declare_file(target_unique_name(hs, "repl"))
 

--- a/tests/binary-with-sysdeps/BUILD
+++ b/tests/binary-with-sysdeps/BUILD
@@ -2,6 +2,7 @@ load(
     "@io_tweag_rules_haskell//haskell:haskell.bzl",
     "haskell_binary",
     "haskell_cc_import",
+    "haskell_test",
 )
 
 package(default_testonly = 1)
@@ -11,7 +12,7 @@ haskell_cc_import(
     shared_library = "@zlib//:lib",
 )
 
-haskell_binary(
+haskell_test(
     name = "binary-with-sysdeps",
     srcs = ["Main.hs"],
     visibility = ["//visibility:public"],


### PR DESCRIPTION
This closes #537

The test binary-with-sysdeps was correctly building, but was failing
at runtime with a linker issue. The dynamic linker was unable to find
libz at runtime.

- Forcing the rpath solves this problem.
- I also switched binary-with-sysdeps from `haskell_binary` to
  `haskell_test` to run it during tests
- I blindly duplicated the rpath fix for doctest and repl. I don't
  have any evidence proving that it may be necessary, but it does not
  break anything