### PR TITLE
Remove `generate_so` attribute, it is a no-op

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.8] - 2019-xx-xx
+
+### Removed
+
+* The `generate_so` attribute of `haskell_binary` and `haskell_test`
+  has been completely superseded by `linkstatic` in the last release
+  and became a no-op, so it is removed.
+
 ## [0.7] - 2018-12-24
 
 ### Added

--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -116,10 +116,6 @@ def _mk_binary_rule(**kwargs):
                 default = True,
                 doc = "Link dependencies statically wherever possible. Some system libraries may still be linked dynamically, as are libraries for which there is no static library. So the resulting executable will still be dynamically linked, hence only mostly static.",
             ),
-            generate_so = attr.bool(
-                default = False,
-                doc = "Whether to generate also a .so version of executable.",
-            ),
             main_function = attr.string(
                 default = "Main.main",
                 doc = """A function with type `IO _`, either the qualified name of a function from any module or the bare name of a function from a `Main` module. It is also possible to give the qualified name of any module exposing a `main` function.""",


### PR DESCRIPTION
The changes to `linkstatic` removed any use of `generate_so`.

Fixes https://github.com/tweag/rules_haskell/issues/503