### PR TITLE
Remove deprecated attributes 0.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 * The `generate_so` attribute of `haskell_binary` and `haskell_test`
   has been completely superseded by `linkstatic` in the last release
   and became a no-op, so it is removed.
+* The `main_file` attribute of `haskell_binary` and `haskell_test`
+  has been deprecated because it was a no-op, so it is removed.
 
 ## [0.7] - 2018-12-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.8] - 2019-xx-xx
+
+### Removed
+
+* The `generate_so` attribute of `haskell_binary` and `haskell_test`
+  has been completely superseded by `linkstatic` in the last release
+  and became a no-op, so it is removed.
+
 ## [0.7] - 2018-12-24
 
 ### Added

--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -120,10 +120,6 @@ def _mk_binary_rule(**kwargs):
                 default = "Main.main",
                 doc = """A function with type `IO _`, either the qualified name of a function from any module or the bare name of a function from a `Main` module. It is also possible to give the qualified name of any module exposing a `main` function.""",
             ),
-            main_file = attr.label(
-                allow_single_file = [".hs", ".hsc", ".lhs"],
-                doc = "File containing `Main` module (deprecated).",
-            ),
             version = attr.string(
                 doc = "Executable version. If this is specified, CPP version macros will be generated for this build.",
             ),

--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -116,10 +116,6 @@ def _mk_binary_rule(**kwargs):
                 default = True,
                 doc = "Link dependencies statically wherever possible. Some system libraries may still be linked dynamically, as are libraries for which there is no static library. So the resulting executable will still be dynamically linked, hence only mostly static.",
             ),
-            generate_so = attr.bool(
-                default = False,
-                doc = "Whether to generate also a .so version of executable.",
-            ),
             main_function = attr.string(
                 default = "Main.main",
                 doc = """A function with type `IO _`, either the qualified name of a function from any module or the bare name of a function from a `Main` module. It is also possible to give the qualified name of any module exposing a `main` function.""",

--- a/haskell/private/haskell_impl.bzl
+++ b/haskell/private/haskell_impl.bzl
@@ -51,9 +51,6 @@ def _prepare_srcs(srcs):
     return srcs_files, import_dir_map
 
 def haskell_binary_impl(ctx):
-    if ctx.attr.main_file:
-        print("""The attribute 'main_file' has been deprecated,
-and can be safely dropped in all cases.""")
     if ctx.attr.prebuilt_dependencies:
         print("""The attribute 'prebuilt_dependencies' has been deprecated,
 use the 'haskell_import' rule instead.


### PR DESCRIPTION
Removes two unused attributes that are no-ops in preparation of the 0.8 release.

Ideally `prebuilt_dependencies` could be removed as well, but see #540.