### PR TITLE
toolchain_type: Actually add a toolchain_type target

### DIFF
--- a/haskell/BUILD
+++ b/haskell/BUILD
@@ -18,3 +18,9 @@ py_binary(
     srcs = ["private/ls_modules.py"],
     visibility = ["//visibility:public"],
 )
+
+# toolchains must have a valid toolchain_type from bazel 0.21
+toolchain_type(
+    name = "toolchain",
+    visibility = ["//visibility:public"],
+)


### PR DESCRIPTION
It was referenced but didn’t exist, and bazel never checked it before
0.21 it looks like.

Fixes https://github.com/tweag/rules_haskell/issues/541

@iphydf, can you check whether that fixes the bug for you? I [haven’t gotten bazel 0.21 running on my system yet](https://github.com/NixOS/nixpkgs/pull/53412), with 0.20 bazel doesn’t even check the attribute.