### PR TITLE
Fix lib.bzl deprecation warnings

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -218,9 +218,9 @@ http_archive(
 
 http_archive(
     name = "com_github_bazelbuild_buildtools",
-    sha256 = "d42e4c9727958bc5814d3bc44f19db5a24f419436cbba09f1e8913eb4a09da31",
-    strip_prefix = "buildtools-0.19.2.1",
-    urls = ["https://github.com/bazelbuild/buildtools/archive/0.19.2.1.tar.gz"],
+    sha256 = "c730536b703b10294675743579afa78055d3feda92e8cb03d2fb76ad97396770",
+    strip_prefix = "buildtools-0.20.0",
+    urls = ["https://github.com/bazelbuild/buildtools/archive/0.20.0.tar.gz"],
 )
 
 load(

--- a/tests/sh_inline_test.bzl
+++ b/tests/sh_inline_test.bzl
@@ -1,4 +1,4 @@
-load("@bazel_skylib//:lib.bzl", "shell")
+load("@bazel_skylib//lib:shell.bzl", "shell")
 
 def quote_make_variables(s):
     """Quote all genrule “Make” Variables in a string."""

--- a/tests/unit-tests/tests.bzl
+++ b/tests/unit-tests/tests.bzl
@@ -1,5 +1,5 @@
 load(
-    "@bazel_skylib//:lib.bzl",
+    "@bazel_skylib//lib:unittest.bzl",
     "asserts",
     unit = "unittest",
 )


### PR DESCRIPTION
Includes an update of buildtools to 0.20.0, since they fix their part
of the warnings in that release. 0.20.0 is the version compatible with
bazel 0.20.0 anyway (which is the first version we officially
support).