### PR TITLE
Remove deprecated prebuilt_dependencies attribute.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   has been completely superseded by `linkstatic` in the last release
   and became a no-op, so it is removed.
 * The `main_file` attribute of `haskell_binary` and `haskell_test`
-  has been deprecated because it was a no-op, so it is removed.
+  had been deprecated because it was a no-op, so it is removed.
+* The `prebuilt_dependencies` attribute of all haskell rules
+  had been deprecated two versions ago and is removed.
+  Use `haskell_import` instead (see docs for usage).
 
 ## [0.7] - 2018-12-24
 

--- a/haskell/cc.bzl
+++ b/haskell/cc.bzl
@@ -223,11 +223,18 @@ Example:
   ```bzl
   haskell_cc_import(name = "zlib", shared_library = "@zlib//:lib")
 
+  haskell_import(
+    name = "base_pkg",
+    package = "base",
+  )
+
   haskell_binary(
     name = "crc32sum",
     srcs = ["Main.hs"],
-    deps = [":zlib"],
-    prebuilt_dependencies = ["base"],
+    deps = [
+      "bazel_pkg",
+      ":zlib",
+    ],
   )
   ```
 

--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -71,9 +71,6 @@ _haskell_common_attrs = {
     "compiler_flags": attr.string_list(
         doc = "Flags to pass to Haskell compiler.",
     ),
-    "prebuilt_dependencies": attr.string_list(
-        doc = "Non-Bazel supplied Cabal dependencies (deprecated).",
-    ),
     "repl_ghci_args": attr.string_list(
         doc = "Arbitrary extra arguments to pass to GHCi. This extends `compiler_flags` and `repl_ghci_args` from the toolchain",
     ),

--- a/haskell/private/dependencies.bzl
+++ b/haskell/private/dependencies.bzl
@@ -85,10 +85,10 @@ def gather_dep_info(ctx):
         static_libraries_prof = [],
         dynamic_libraries = set.empty(),
         interface_dirs = set.empty(),
-        prebuilt_dependencies = set.from_list(ctx.attr.prebuilt_dependencies),
+        prebuilt_dependencies = set.empty(),
         # a set of struct(lib, mangled_lib)
         external_libraries = set.empty(),
-        direct_prebuilt_deps = set.from_list(ctx.attr.prebuilt_dependencies),
+        direct_prebuilt_deps = set.empty(),
     )
 
     for dep in ctx.attr.deps:

--- a/haskell/private/haskell_impl.bzl
+++ b/haskell/private/haskell_impl.bzl
@@ -51,11 +51,6 @@ def _prepare_srcs(srcs):
     return srcs_files, import_dir_map
 
 def haskell_binary_impl(ctx):
-    if ctx.attr.prebuilt_dependencies:
-        print("""The attribute 'prebuilt_dependencies' has been deprecated,
-use the 'haskell_import' rule instead.
-""")
-
     hs = haskell_context(ctx)
     dep_info = gather_dep_info(ctx)
 
@@ -170,11 +165,6 @@ use the 'haskell_import' rule instead.
     ]
 
 def haskell_library_impl(ctx):
-    if ctx.attr.prebuilt_dependencies:
-        print("""The attribute 'prebuilt_dependencies' has been deprecated,
-use the 'haskell_import' rule instead.
-""")
-
     hs = haskell_context(ctx)
     dep_info = gather_dep_info(ctx)
     version = ctx.attr.version if ctx.attr.version else None

--- a/start
+++ b/start
@@ -79,6 +79,7 @@ load(
   "@io_tweag_rules_haskell//haskell:haskell.bzl",
   "haskell_library",
   "haskell_toolchain",
+  "haskell_import",
 )
 
 haskell_toolchain(
@@ -87,11 +88,18 @@ haskell_toolchain(
   tools = "@ghc//:bin",
 )
 
+haskell_import(
+  name = "base_pkg",
+  package = "base",
+)
+
 haskell_library(
   name = "MY_LIBRARY_NAME",
   src_strip_prefix = "src",
   srcs = glob(['src/**/*.hs']),
-  prebuilt_dependencies = ["base"],
+  deps = [
+    "base_pkg"
+  ],
 )
 EOF
 


### PR DESCRIPTION
The user-facing parts of `prebuilt_dependencies` have been superseeded
by `haskell_import`. Changes all examples to the new API and removes
the attribute, which has been deprecated since 0.6.

Fixes https://github.com/tweag/rules_haskell/issues/504
Fixes https://github.com/tweag/rules_haskell/issues/540