### PR TITLE
Revert "link.bzl: Make rpaths refer to the runfiles directory"

### DIFF
--- a/haskell/private/actions/link.bzl
+++ b/haskell/private/actions/link.bzl
@@ -7,13 +7,8 @@ load(":private/pkg_id.bzl", "pkg_id")
 load(":private/set.bzl", "set")
 load(":private/providers.bzl", "external_libraries_get_mangled")
 
-def backup_path(target):
-    """Return a path from the directory this `target` is in
-    to its runfile directory.
-
-    foo => .
-    foo/bar => ..
-    foo/bar/baz => ../..
+def _backup_path(target):
+    """Return a path from the directory this is in to the Bazel root.
 
     Args:
       target: File
@@ -21,16 +16,9 @@ def backup_path(target):
     Returns:
       A path of the form "../../.."
     """
-    short_path_dir = paths.normalize(paths.dirname(target.short_path))
+    n = len(target.dirname.split("/"))
 
-    # dirname returns "" if there is no parent directory
-    # and normalize returns "." for "". In that case we
-    # return the identity path, which is ".".
-    if short_path_dir == ".":
-        return "."
-    else:
-        n = len(short_path_dir.split("/"))
-        return "/".join([".."] * n)
+    return "/".join([".."] * n)
 
 def _fix_darwin_linker_paths(hs, inp, out, external_libraries):
     """Postprocess a macOS binary to make shared library references relative.
@@ -72,7 +60,7 @@ def _fix_darwin_linker_paths(hs, inp, out, external_libraries):
                 # at execution time.
                 "/usr/bin/install_name_tool -change {} {} {}".format(
                     f.lib.path,
-                    paths.join("@loader_path", backup_path(out), f.lib.short_path),
+                    paths.join("@loader_path", _backup_path(out), f.lib.path),
                     out.path,
                 )
                 # we use the unmangled lib (f.lib) for this instead of a mangled lib name
@@ -255,12 +243,7 @@ def _add_external_libraries(args, ext_libs):
 
 def _infer_rpaths(is_darwin, target, solibs):
     """Return set of RPATH values to be added to target so it can find all
-    solibs
-
-    The resulting paths look like:
-    $ORIGIN/../../path/to/solib/dir
-    This means: "go upwards to your runfiles directory, then descend into
-    the parent folder of the solib".
+    solibs.
 
     Args:
       is_darwin: Whether we're compiling on and for Darwin.
@@ -280,8 +263,8 @@ def _infer_rpaths(is_darwin, target, solibs):
     for solib in set.to_list(solibs):
         rpath = paths.normalize(
             paths.join(
-                backup_path(target),
-                paths.dirname(solib.short_path),
+                _backup_path(target),
+                solib.dirname,
             ),
         )
         set.mutable_insert(r, origin + rpath)


### PR DESCRIPTION
This reverts commit 4a9a3245a7162f40ae739ae7e148fd32219ab4a8.

As discussed in https://github.com/tweag/rules_haskell/issues/537#issuecomment-452344309