### PR TITLE
Runtime behavior of tests are checked

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -9,3 +9,9 @@ build:ci --verbose_failures
 build:ci --symlink_prefix=foobar
 common:ci --color=no
 test:ci --test_output=errors
+
+# test environment does not propagate locales by default
+# some tests reads files written in UTF8, we need to propagate the correct
+# environment variables, such as LOCALE_ARCHIVE
+# We also need to setup an utf8 locale
+test --test_env=LANG=en_US.utf8 --test_env=LOCALE_ARCHIVE

--- a/shell.nix
+++ b/shell.nix
@@ -18,6 +18,8 @@ mkShell {
     bazel
     # Needed for @com_github_golang_protobuf, itself needed by buildifier.
     git
+    # Needed to get correct locale for tests with encoding
+    glibcLocales
   ] ++ lib.optionals docTools [graphviz python36Packages.sphinx zip unzip];
 
   shellHook = ''

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -5,6 +5,7 @@ load(
     "haskell_binary",
     "haskell_doctest_toolchain",
     "haskell_proto_toolchain",
+    "haskell_test",
     "haskell_toolchain",
 )
 
@@ -374,6 +375,7 @@ rule_test(
     rule = "//tests:run-bin-with-c-lib",
 )
 
+# This is the test runner
 haskell_binary(
     name = "run-tests",
     srcs = ["RunTests.hs"],

--- a/tests/binary-custom-main/BUILD
+++ b/tests/binary-custom-main/BUILD
@@ -1,11 +1,11 @@
 load(
     "@io_tweag_rules_haskell//haskell:haskell.bzl",
-    "haskell_binary",
+    "haskell_test",
 )
 
 package(default_testonly = 1)
 
-haskell_binary(
+haskell_test(
     name = "binary-custom-main",
     srcs = ["foo.hs"],
     visibility = ["//visibility:public"],

--- a/tests/binary-dynamic/BUILD
+++ b/tests/binary-dynamic/BUILD
@@ -1,11 +1,11 @@
 load(
     "@io_tweag_rules_haskell//haskell:haskell.bzl",
-    "haskell_binary",
+    "haskell_test",
 )
 
 package(default_testonly = 1)
 
-haskell_binary(
+haskell_test(
     name = "binary-mostly-static",
     srcs = ["Main.hs"],
     linkstatic = False,

--- a/tests/binary-simple/BUILD
+++ b/tests/binary-simple/BUILD
@@ -1,11 +1,11 @@
 load(
     "@io_tweag_rules_haskell//haskell:haskell.bzl",
-    "haskell_binary",
+    "haskell_test",
 )
 
 package(default_testonly = 1)
 
-haskell_binary(
+haskell_test(
     name = "binary-simple",
     srcs = ["Main.hs"],
     visibility = ["//visibility:public"],

--- a/tests/binary-with-data/BUILD
+++ b/tests/binary-with-data/BUILD
@@ -1,11 +1,11 @@
 load(
     "@io_tweag_rules_haskell//haskell:haskell.bzl",
-    "haskell_binary",
+    "haskell_test",
 )
 
 package(default_testonly = 1)
 
-haskell_binary(
+haskell_test(
     name = "bin1",
     srcs = ["bin1.hs"],
     # Regular file input:
@@ -14,7 +14,7 @@ haskell_binary(
     deps = ["@hackage//:base"],
 )
 
-haskell_binary(
+haskell_test(
     name = "binary-with-data",
     srcs = ["bin2.hs"],
     args = ["$(location :bin1)"],

--- a/tests/binary-with-lib-dynamic/BUILD
+++ b/tests/binary-with-lib-dynamic/BUILD
@@ -1,7 +1,7 @@
 load(
     "@io_tweag_rules_haskell//haskell:haskell.bzl",
-    "haskell_binary",
     "haskell_library",
+    "haskell_test",
 )
 
 package(default_testonly = 1)
@@ -13,7 +13,7 @@ haskell_library(
     src_strip_prefix = "src",
 )
 
-haskell_binary(
+haskell_test(
     name = "binary-with-lib-dynamic",
     srcs = ["Main.hs"],
     linkstatic = False,

--- a/tests/binary-with-lib/BUILD
+++ b/tests/binary-with-lib/BUILD
@@ -1,7 +1,7 @@
 load(
     "@io_tweag_rules_haskell//haskell:haskell.bzl",
-    "haskell_binary",
     "haskell_library",
+    "haskell_test",
 )
 
 package(default_testonly = 1)
@@ -12,7 +12,7 @@ haskell_library(
     src_strip_prefix = "src",
 )
 
-haskell_binary(
+haskell_test(
     name = "binary-with-lib",
     srcs = ["Main.hs"],
     visibility = ["//visibility:public"],

--- a/tests/binary-with-link-flags/BUILD
+++ b/tests/binary-with-link-flags/BUILD
@@ -1,6 +1,6 @@
 load(
     "@io_tweag_rules_haskell//haskell:haskell.bzl",
-    "haskell_binary",
+    "haskell_test",
 )
 
 package(
@@ -8,7 +8,7 @@ package(
     default_visibility = ["//visibility:public"],
 )
 
-haskell_binary(
+haskell_test(
     name = "binary-with-link-flags",
     srcs = ["Main.hs"],
     compiler_flags = ["-threaded"],

--- a/tests/binary-with-main/BUILD
+++ b/tests/binary-with-main/BUILD
@@ -1,11 +1,11 @@
 load(
     "@io_tweag_rules_haskell//haskell:haskell.bzl",
-    "haskell_binary",
+    "haskell_test",
 )
 
 package(default_testonly = 1)
 
-haskell_binary(
+haskell_test(
     name = "binary-with-main",
     srcs = ["MainIsHere.hs"],
     main_function = "MainIsHere.this",

--- a/tests/binary-with-prebuilt/BUILD
+++ b/tests/binary-with-prebuilt/BUILD
@@ -1,11 +1,11 @@
 load(
     "@io_tweag_rules_haskell//haskell:haskell.bzl",
-    "haskell_binary",
+    "haskell_test",
 )
 
 package(default_testonly = 1)
 
-haskell_binary(
+haskell_test(
     name = "binary-with-prebuilt",
     srcs = ["Main.hs"],
     visibility = ["//visibility:public"],

--- a/tests/binary-with-sysdeps/BUILD
+++ b/tests/binary-with-sysdeps/BUILD
@@ -1,7 +1,7 @@
 load(
     "@io_tweag_rules_haskell//haskell:haskell.bzl",
-    "haskell_binary",
     "haskell_cc_import",
+    "haskell_test",
 )
 
 package(default_testonly = 1)
@@ -11,7 +11,7 @@ haskell_cc_import(
     shared_library = "@zlib//:lib",
 )
 
-haskell_binary(
+haskell_test(
     name = "binary-with-sysdeps",
     srcs = ["Main.hs"],
     visibility = ["//visibility:public"],

--- a/tests/c-compiles/BUILD
+++ b/tests/c-compiles/BUILD
@@ -1,7 +1,7 @@
 load(
     "@io_tweag_rules_haskell//haskell:haskell.bzl",
-    "haskell_binary",
     "haskell_library",
+    "haskell_test",
 )
 
 package(default_testonly = 1)
@@ -15,7 +15,7 @@ haskell_library(
     ],
 )
 
-haskell_binary(
+haskell_test(
     name = "c-compiles",
     srcs = ["Main.hs"],
     visibility = ["//visibility:public"],

--- a/tests/cpp_macro_conflict/BUILD
+++ b/tests/cpp_macro_conflict/BUILD
@@ -1,7 +1,7 @@
 load(
     "@io_tweag_rules_haskell//haskell:haskell.bzl",
-    "haskell_binary",
     "haskell_library",
+    "haskell_test",
 )
 
 package(default_testonly = 1)
@@ -15,7 +15,7 @@ haskell_library(
 
 # This depends on two packages "bytestring"
 # There should be no CPP macro conflict
-haskell_binary(
+haskell_test(
     name = "macro_conflict",
     srcs = ["Main.hs"],
     compiler_flags = [

--- a/tests/encoding/BUILD
+++ b/tests/encoding/BUILD
@@ -1,11 +1,11 @@
 load(
     "@io_tweag_rules_haskell//haskell:haskell.bzl",
-    "haskell_binary",
+    "haskell_test",
 )
 
 package(default_testonly = 1)
 
-haskell_binary(
+haskell_test(
     name = "encoding",
     srcs = [
         "Main.hs",

--- a/tests/extra-source-files/BUILD
+++ b/tests/extra-source-files/BUILD
@@ -1,7 +1,7 @@
 load(
     "@io_tweag_rules_haskell//haskell:haskell.bzl",
-    "haskell_binary",
     "haskell_library",
+    "haskell_test",
 )
 
 package(default_testonly = 1)
@@ -24,7 +24,7 @@ haskell_library(
     ],
 )
 
-haskell_binary(
+haskell_test(
     name = "extra-source-files-bin",
     srcs = [
         "Foo.hs",

--- a/tests/haskell_doctest/BUILD
+++ b/tests/haskell_doctest/BUILD
@@ -1,8 +1,8 @@
 load(
     "@io_tweag_rules_haskell//haskell:haskell.bzl",
-    "haskell_binary",
     "haskell_doctest",
     "haskell_library",
+    "haskell_test",
 )
 
 package(default_testonly = 1)
@@ -51,7 +51,7 @@ haskell_doctest(
     deps = [":lib-b"],
 )
 
-haskell_binary(
+haskell_test(
     name = "bin",
     srcs = ["Main.hs"],
     deps = [

--- a/tests/haskell_lint/BUILD
+++ b/tests/haskell_lint/BUILD
@@ -1,8 +1,8 @@
 load(
     "@io_tweag_rules_haskell//haskell:haskell.bzl",
-    "haskell_binary",
     "haskell_library",
     "haskell_lint",
+    "haskell_test",
 )
 
 package(default_testonly = 1)
@@ -30,7 +30,7 @@ haskell_lint(
     deps = [":lib-b"],
 )
 
-haskell_binary(
+haskell_test(
     name = "bin",
     srcs = ["Main.hs"],
     visibility = ["//visibility:public"],

--- a/tests/hs-boot/BUILD
+++ b/tests/hs-boot/BUILD
@@ -1,7 +1,7 @@
 load(
     "@io_tweag_rules_haskell//haskell:haskell.bzl",
-    "haskell_binary",
     "haskell_library",
+    "haskell_test",
 )
 
 package(default_testonly = 1)
@@ -32,7 +32,7 @@ haskell_library(
     deps = ["@hackage//:base"],
 )
 
-haskell_binary(
+haskell_test(
     name = "hs-boot",
     srcs = [
         "MA.hs",

--- a/tests/hsc/BUILD
+++ b/tests/hsc/BUILD
@@ -1,7 +1,7 @@
 load(
     "@io_tweag_rules_haskell//haskell:haskell.bzl",
-    "haskell_binary",
     "haskell_library",
+    "haskell_test",
 )
 
 package(default_testonly = 1)
@@ -21,7 +21,7 @@ haskell_library(
     deps = ["@hackage//:base"],
 )
 
-haskell_binary(
+haskell_test(
     name = "hsc",
     srcs = [
         "BinHsc.hsc",

--- a/tests/indirect-link/BUILD.bazel
+++ b/tests/indirect-link/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_tweag_rules_haskell//haskell:haskell.bzl", "haskell_binary", "haskell_import", "haskell_library")
+load("@io_tweag_rules_haskell//haskell:haskell.bzl", "haskell_import", "haskell_library", "haskell_test")
 
 haskell_import(name = "base")
 
@@ -23,7 +23,7 @@ haskell_library(
     ],
 )
 
-haskell_binary(
+haskell_test(
     name = "indirect-link",
     srcs = ["test/Main.hs"],
     src_strip_prefix = "test",

--- a/tests/indirect-link/BUILD.bazel
+++ b/tests/indirect-link/BUILD.bazel
@@ -23,12 +23,23 @@ haskell_library(
     ],
 )
 
-haskell_test(
-    name = "indirect-link",
-    srcs = ["test/Main.hs"],
-    src_strip_prefix = "test",
-    deps = [
-        ":base",
-        ":mypkg",
-    ],
-)
+# TODO(guibhou): Does not work on darwin.
+# Executing tests from //tests/indirect-link:indirect-link
+# -----------------------------------------------------------------------------
+# dyld: lazy symbol binding failed: Symbol not found: _real_get_thing
+# Referenced from: /private/var/tmp/_bazel_distiller/bedaa68a8664d1b29e96b826d058247f/execroot/io_tweag_rules_haskell/bazel-out/darwin-fastbuild/bin/tests/indirect-link/../../../../../bazel-out/darwin-fastbuild/bin/tests/indirect-link/libcbits.so
+# Expected in: flat namespace
+#
+# dyld: Symbol not found: _real_get_thing
+# Referenced from: /private/var/tmp/_bazel_distiller/bedaa68a8664d1b29e96b826d058247f/execroot/io_tweag_rules_haskell/bazel-out/darwin-fastbuild/bin/tests/indirect-link/../../../../../bazel-out/darwin-fastbuild/bin/tests/indirect-link/libcbits.so
+# Expected in: flat namespace
+
+# haskell_test(
+#     name = "indirect-link",
+#     srcs = ["test/Main.hs"],
+#     src_strip_prefix = "test",
+#     deps = [
+#         ":base",
+#         ":mypkg",
+#     ],
+# )

--- a/tests/java_classpath/BUILD
+++ b/tests/java_classpath/BUILD
@@ -1,11 +1,11 @@
 load(
     "@io_tweag_rules_haskell//haskell:haskell.bzl",
-    "haskell_binary",
+    "haskell_test",
 )
 
 package(default_testonly = 1)
 
-haskell_binary(
+haskell_test(
     name = "java_classpath",
     srcs = ["Main.hs"],
     visibility = ["//visibility:public"],

--- a/tests/lhs/BUILD
+++ b/tests/lhs/BUILD
@@ -1,7 +1,7 @@
 load(
     "@io_tweag_rules_haskell//haskell:haskell.bzl",
-    "haskell_binary",
     "haskell_library",
+    "haskell_test",
 )
 
 package(default_testonly = 1)
@@ -12,7 +12,7 @@ haskell_library(
     deps = ["@hackage//:base"],
 )
 
-haskell_binary(
+haskell_test(
     name = "lhs-bin",
     srcs = ["Main.lhs"],
     visibility = ["//visibility:public"],

--- a/tests/library-with-sysdeps/BUILD
+++ b/tests/library-with-sysdeps/BUILD
@@ -1,8 +1,8 @@
 load(
     "@io_tweag_rules_haskell//haskell:haskell.bzl",
-    "haskell_binary",
     "haskell_cc_import",
     "haskell_library",
+    "haskell_test",
 )
 
 package(default_testonly = 1)
@@ -22,7 +22,7 @@ haskell_library(
     ],
 )
 
-haskell_binary(
+haskell_test(
     name = "bin",
     srcs = ["Main.hs"],
     deps = [

--- a/tests/package-id-clash-binary/BUILD
+++ b/tests/package-id-clash-binary/BUILD
@@ -1,12 +1,12 @@
 load(
     "@io_tweag_rules_haskell//haskell:haskell.bzl",
-    "haskell_binary",
     "haskell_import",
+    "haskell_test",
 )
 
 haskell_import(name = "base")
 
-haskell_binary(
+haskell_test(
     name = "bin",
     srcs = ["Main.hs"],
     deps = [

--- a/tests/repl-flags/BUILD
+++ b/tests/repl-flags/BUILD
@@ -1,4 +1,4 @@
-load("@io_tweag_rules_haskell//haskell:haskell.bzl", "haskell_binary")
+load("@io_tweag_rules_haskell//haskell:haskell.bzl", "haskell_test")
 
 package(default_testonly = 1)
 
@@ -9,7 +9,7 @@ package(default_testonly = 1)
 # - the ordering is as such as rule flags are more important that toolchain flags
 
 # This rule must build correctly (using `bazel build`), but also as a repl (using `bazel run //tests/repl-flags:compiler_flags@repl`)
-haskell_binary(
+haskell_test(
     name = "compiler_flags",
     srcs = ["CompilerFlags.hs"],
 
@@ -31,7 +31,7 @@ haskell_binary(
 #    copmiler flags
 
 # This rule must build correctly (using `bazel build`), but also as a repl (using `bazel run //tests/repl-flags:compiler_flags@repl`). The final result between the repl and the binary must be different
-haskell_binary(
+haskell_test(
     name = "repl_flags",
     srcs = ["ReplFlags.hs"],
 

--- a/tests/repl-targets/BUILD
+++ b/tests/repl-targets/BUILD
@@ -1,9 +1,9 @@
 load("@io_tweag_rules_haskell//haskell:c2hs.bzl", "c2hs_library")
 load(
     "@io_tweag_rules_haskell//haskell:haskell.bzl",
-    "haskell_binary",
     "haskell_cc_import",
     "haskell_library",
+    "haskell_test",
 )
 
 package(default_testonly = 1)
@@ -70,7 +70,7 @@ haskell_library(
     deps = ["@hackage//:base"],
 )
 
-haskell_binary(
+haskell_test(
     name = "hs-bin",
     srcs = ["Quux.hs"],
     visibility = ["//visibility:public"],

--- a/tests/textual-hdrs/BUILD
+++ b/tests/textual-hdrs/BUILD
@@ -1,11 +1,11 @@
 load(
     "@io_tweag_rules_haskell//haskell:haskell.bzl",
-    "haskell_binary",
+    "haskell_test",
 )
 
 package(default_testonly = 1)
 
-haskell_binary(
+haskell_test(
     name = "textual-hdrs",
     srcs = [
         "Main.hs",

--- a/tests/two-libs/BUILD
+++ b/tests/two-libs/BUILD
@@ -1,7 +1,7 @@
 load(
     "@io_tweag_rules_haskell//haskell:haskell.bzl",
-    "haskell_binary",
     "haskell_library",
+    "haskell_test",
 )
 
 package(
@@ -26,7 +26,7 @@ haskell_library(
     ],
 )
 
-haskell_binary(
+haskell_test(
     name = "two-libs",
     srcs = ["Main.hs"],
     deps = [

--- a/tools/runfiles/BUILD
+++ b/tools/runfiles/BUILD
@@ -1,6 +1,5 @@
 load(
     "@io_tweag_rules_haskell//haskell:haskell.bzl",
-    "haskell_binary",
     "haskell_library",
     "haskell_test",
 )
@@ -16,7 +15,7 @@ haskell_library(
     ],
 )
 
-haskell_binary(
+haskell_test(
     name = "bin",
     testonly = 1,
     srcs = ["bin/Bin.hs"],


### PR DESCRIPTION
Previously, only build of `haskell_binary` / `haskell_library` was
tested. Hence runtime link issues (or others issues) were ignored, see
for example bug #537.

This commit changes, when possible, `haskell_binary` to `haskell_test`
which means that binaries are also executed during the test process to
ensure their correct runtime behavior.

--

Current status of this PR: Cannot be merged

The following tests are failing due to the runtime tests, a checked box means that it was corrected

- [X] This PR will fail 5 tests until #537 is fixed. #550 can be a good temporary solution. #550 is now merged.
- [X] There is also another failing test due to runtime detection of character encoding. Fixed in this PR
- [x] runtime failure on darwin only of `//tests/indirect-link:indirect-link`