### PR TITLE
Make start script use latest release

### DIFF
--- a/start
+++ b/start
@@ -35,8 +35,8 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
   name = "io_tweag_rules_haskell",
-  strip_prefix = "rules_haskell-0.6",
-  urls = ["https://github.com/tweag/rules_haskell/archive/v0.6.tar.gz"]
+  strip_prefix = "rules_haskell-0.7",
+  urls = ["https://github.com/tweag/rules_haskell/archive/v0.7.tar.gz"]
 )
 
 load("@io_tweag_rules_haskell//haskell:repositories.bzl", "haskell_repositories")


### PR DESCRIPTION
It's the only one that is compatible with Bazel >= 0.20.