### PR TITLE
Making successful tests silent.

### DIFF
--- a/haskell/doctest.bzl
+++ b/haskell/doctest.bzl
@@ -158,7 +158,7 @@ def _haskell_doctest_single(target, ctx):
         mnemonic = "HaskellDoctest",
         progress_message = "HaskellDoctest {}".format(ctx.label),
         command = """
-    {doctest} "$@" $(cat {module_list} | tr , ' ') > {output} 2>&1 || rc=$? && cat {output} && exit $rc
+    {doctest} "$@" $(cat {module_list} | tr , ' ') > {output} 2>&1 || (rc=$? && cat {output} && exit $rc)
     """.format(doctest = toolchain.doctest[0].path, output = doctest_log.path, module_list = exposed_modules_file.path),
         arguments = [args],
         # NOTE It looks like we must specify the paths here as well as via -L

--- a/tests/binary-with-lib-dynamic/Main.hs
+++ b/tests/binary-with-lib-dynamic/Main.hs
@@ -1,5 +1,7 @@
 module Main where
 
-import Lib (value)
+import Control.Monad (unless)
+import Lib           (value)
 
-main = print value
+main = unless (value == 42)
+    $ error $ "Incorrect lib value. Got " <> show value

--- a/tests/binary-with-lib/Main.hs
+++ b/tests/binary-with-lib/Main.hs
@@ -1,5 +1,7 @@
 module Main where
 
-import Lib (value)
+import Control.Monad (unless)
+import Lib           (value)
 
-main = print value
+main = unless (value == 42)
+    $ error $ "Incorrect lib value. Got " <> show value

--- a/tests/c-compiles/Main.hs
+++ b/tests/c-compiles/Main.hs
@@ -1,8 +1,8 @@
 module Main (main) where
 
-import Lib (ten)
+import Control.Monad (unless)
+import Lib           (ten)
 
 main :: IO ()
-main = if ten == 10
-       then putStrLn "c-compiles"
-       else error $ "Unexpected result from Lib.ten: " ++ show ten
+main = unless (ten == 10)
+    $ error $ "Incorrect lib value. Got " <> show ten


### PR DESCRIPTION
Hi!

This PR resolves #518. 

The noise was coming from 3 sources:

1. There was a problem with the doctest action command: the `&&` and `||` operators have the same precedence. We were missing a couple of parenthesis in the command.
2. Some binary tests were printing stuff to stdout.
3. Haddock was generating some warnings about some protobuff missing symbols.

I'm really unsure about my haddock fix. Basically, haddock is complaining about some missing symbols:

```
INFO: From HaskellHaddock //tests/haskell_proto_library:person_haskell_proto:
Warning: Proto.Tests.HaskellProtoLibrary.Person: could not find link destinations for:
    Text Int32 Maybe Address Timestamp FieldSet Eq == Bool /= Ord compare Ordering < <= > >= max min Show showsPrec Int ShowS show String showList Default def Message messageName Proxy fieldsByTag Map Tag FieldDescriptor fieldsByTextFormatName unknownFields Lens' HasLens' Functor * Symbol lensOf' Proxy# HasLens lensOf
Warning: Proto.Tests.HaskellProtoLibrary.Person_Fields: could not find link destinations for:
    HasLens LensLike
INFO: From HaskellHaddock //tests/haskell_proto_library:address_haskell_proto:
Warning: Proto.Tests.HaskellProtoLibrary.Address: could not find link destinations for:
    Text Maybe ZipCode FieldSet Eq == Bool /= Ord compare Ordering < <= > >= max min Show showsPrec Int ShowS show String showList Default def Message messageName Proxy fieldsByTag Map Tag FieldDescriptor fieldsByTextFormatName unknownFields Lens' HasLens' Functor * Symbol lensOf' Proxy# HasLens lensOf
Warning: Proto.Tests.HaskellProtoLibrary.Address_Fields: could not find link destinations for:
    HasLens LensLike
```

but it is still able to generate the documentation. The errors are coming from some generated Haskell files. I don't really know how to fix this properly.

I did not find a way to ignore a specific test output, I ended up disabling haddock warnings for the tests suite altogether (they were not triggering a test failure anyways).

I'm not really sure this is the best thing to do in this particular situation.

Is there a better way to "hide" these specific warnings?