### PR TITLE
Refactoring: remove visible-binaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 * The `prebuilt_dependencies` attribute of all haskell rules
   had been deprecated two versions ago and is removed.
   Use `haskell_import` instead (see docs for usage).
+* The `extra_binaries` field is now no longer supported.
 
 ## [0.7] - 2018-12-24
 

--- a/haskell/BUILD
+++ b/haskell/BUILD
@@ -1,9 +1,8 @@
 exports_files(
     glob(["*.bzl"]) + [
         "assets/ghci_script",
-        "private/c2hs_wrapper.sh",
         "private/ghci_repl_wrapper.sh",
-        "private/haddock_wrapper.sh",
+        "private/haddock_wrapper.sh.tpl",
     ],
 )
 

--- a/haskell/doctest.bzl
+++ b/haskell/doctest.bzl
@@ -151,15 +151,26 @@ def _haskell_doctest_single(target, ctx):
             depset([exposed_modules_file]),
             depset(
                 toolchain.doctest +
-                [hs.tools.cat, hs.tools.ghc],
+                [hs.tools.ghc],
             ),
         ]),
         outputs = [doctest_log],
         mnemonic = "HaskellDoctest",
         progress_message = "HaskellDoctest {}".format(ctx.label),
         command = """
-    {doctest} "$@" $(cat {module_list} | tr , ' ') > {output} 2>&1 || rc=$? && cat {output} && exit $rc
-    """.format(doctest = toolchain.doctest[0].path, output = doctest_log.path, module_list = exposed_modules_file.path),
+        {env}
+        {doctest} "$@" $(cat {module_list} | tr , ' ') > {output} 2>&1 || rc=$? && cat {output} && exit $rc
+        """.format(
+            doctest = toolchain.doctest[0].path,
+            output = doctest_log.path,
+            module_list = exposed_modules_file.path,
+            # XXX Workaround
+            # https://github.com/bazelbuild/bazel/issues/5980.
+            env = "\n".join([
+                "export {}={}".format(k, v)
+                for k, v in hs.env.items()
+            ]),
+        ),
         arguments = [args],
         # NOTE It looks like we must specify the paths here as well as via -L
         # flags because there are at least two different "consumers" of the info

--- a/haskell/private/actions/compile.bzl
+++ b/haskell/private/actions/compile.bzl
@@ -36,8 +36,8 @@ def _process_hsc_file(hs, cc, hsc_flags, hsc_file):
     hs_out = declare_compiled(hs, hsc_file, ".hs", directory = hsc_dir_raw)
     args.add([hsc_file.path, "-o", hs_out.path])
 
-    args.add(["-c", hs.tools.cc])
-    args.add(["-l", hs.tools.cc])
+    args.add(["-c", cc.tools.cc])
+    args.add(["-l", cc.tools.cc])
     args.add("-ighcplatform.h")
     args.add("-ighcversion.h")
     args.add(["--cflag=" + f for f in cc.cpp_flags])
@@ -49,7 +49,8 @@ def _process_hsc_file(hs, cc, hsc_flags, hsc_file):
     hs.actions.run(
         inputs = depset(transitive = [
             depset(cc.hdrs),
-            depset([hs.tools.cc, hsc_file]),
+            depset([hsc_file]),
+            depset(cc.files),
         ]),
         outputs = [hs_out],
         mnemonic = "HaskellHsc2hs",
@@ -250,7 +251,6 @@ def _compilation_defaults(hs, cc, java, dep_info, srcs, import_dir_map, extra_sr
             set.to_depset(dep_info.dynamic_libraries),
             depset([e.mangled_lib for e in set.to_list(dep_info.external_libraries)]),
             java.inputs,
-            depset([hs.tools.cc]),
             locale_archive_depset,
         ]),
         objects_dir = objects_dir,
@@ -291,7 +291,8 @@ def compile_binary(hs, cc, java, dep_info, srcs, ls_modules, import_dir_map, ext
 
     hs.toolchain.actions.run_ghc(
         hs,
-        inputs = c.inputs + hs.extra_binaries,
+        cc,
+        inputs = c.inputs,
         outputs = c.outputs,
         mnemonic = "HaskellBuildBinary",
         progress_message = "HaskellBuildBinary {}".format(hs.label),
@@ -348,7 +349,8 @@ def compile_library(hs, cc, java, dep_info, srcs, ls_modules, other_modules, exp
 
     hs.toolchain.actions.run_ghc(
         hs,
-        inputs = c.inputs + hs.extra_binaries,
+        cc,
+        inputs = c.inputs,
         outputs = c.outputs,
         mnemonic = "HaskellBuildLibrary",
         progress_message = "HaskellBuildLibrary {}".format(hs.label),

--- a/haskell/private/c2hs_wrapper.sh
+++ b/haskell/private/c2hs_wrapper.sh
@@ -1,7 +1,0 @@
-#!/bin/sh
-
-set -e
-
-# Include libdir in include path just like hsc2hs does.
-libdir=$(ghc --print-libdir)
-c2hs -C-I$libdir/include ${1+"$@"}

--- a/haskell/private/context.bzl
+++ b/haskell/private/context.bzl
@@ -22,7 +22,6 @@ def haskell_context(ctx, attr = None):
     )
 
     env = {
-        "PATH": toolchain.visible_bin_path,
         "LANG": toolchain.locale,
     }
 
@@ -35,8 +34,6 @@ def haskell_context(ctx, attr = None):
         label = ctx.label,
         toolchain = toolchain,
         tools = toolchain.tools,
-        tools_runfiles = toolchain.tools_runfiles,
-        extra_binaries = toolchain.extra_binaries,
         src_root = src_root,
         env = env,
         mode = ctx.var["COMPILATION_MODE"],

--- a/haskell/private/haddock_wrapper.sh.tpl
+++ b/haskell/private/haddock_wrapper.sh.tpl
@@ -4,6 +4,8 @@
 
 set -eo pipefail
 
+%{env}
+
 PREBUILT_DEPS_FILE=$1
 shift
 
@@ -19,8 +21,8 @@ do
     # If there were more than one file, going by the output for the `depends`,
     # the file names would be separated by a space character.
     # https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/packages.html#installedpackageinfo-a-package-specification
-    haddock_interfaces=$(ghc-pkg --simple-output field $pkg haddock-interfaces)
-    haddock_html=$(ghc-pkg --simple-output field $pkg haddock-html)
+    haddock_interfaces=$(%{ghc-pkg} --simple-output field $pkg haddock-interfaces)
+    haddock_html=$(%{ghc-pkg} --simple-output field $pkg haddock-html)
 
     # Sometimes the referenced `.haddock` file does not exist
     # (e.g. for `nixpkgs.haskellPackages` deps with haddock disabled).
@@ -43,5 +45,5 @@ cleanup() { rmdir "$TEMP"; }
 # XXX Override TMPDIR to prevent race conditions on certain platforms.
 # This is a workaround for
 # https://github.com/haskell/haddock/issues/894.
-TMPDIR=$TEMP haddock "${extra_args[@]}" "$@"
+TMPDIR=$TEMP %{haddock} "${extra_args[@]}" "$@"
 cleanup

--- a/haskell/protobuf.bzl
+++ b/haskell/protobuf.bzl
@@ -161,6 +161,7 @@ def _haskell_proto_aspect_impl(target, ctx):
         files = struct(
             srcs = hs_files,
             extra_srcs = depset(),
+            _cc_toolchain = ctx.files._cc_toolchain,
         ),
         executable = struct(
             _ls_modules = ctx.executable._ls_modules,


### PR DESCRIPTION
To precisely control what binaries are available during compilation,
we used to create a single directory called `visible-binaries`, in
which we put all the binaries (ghc, haddock, etc) and shell
commands (cat, mkdir, etc) that we needed. There was another point to
this: build actions could call any binary and that binary could in
turn exec any other binary, since `visible-binaries` was in the
`PATH`.

In this commit, we do away with that. The reason is that there are
downsides to this approach:

* there is little value in trying to be more hermetic than Bazel is
  when it comes to shell commands;
* all build actions were reusing the same `PATH`, so we were actually
  exposing more binaries than strictly necessary (each action needs
  a different subset);
* the logic to create `visible-binaries` was pretty complicated, and
  is now all gone, hence the net code reduction;
* crucially, the `visible-binaries` is not going to work on Windows,
  because no symlinks on that platform and copying doesn't always work
  (due to limitations of GHC).

With this PR merged in, porting to Windows should now be significantly
easier. The downside is the following *breaking change*: we have lost
the `extra_binaries` field in rules. But that field was introduced for
unusual needs that inline-java has, and was a suspicious feature to
begin with.

Probably fixes #244.

Closes #512.

cc @gdeest @nasm @gleber for the stepping stone towards Windows support.

cc @ahermann about the dropped support for `extra_binaries`.
