### PR TITLE
Fix WORKSPACE eval on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [0.8] - 2019-xx-xx
 
+### Fixed
+
+* The evaluation of the `WORKSPACE` on Windows is successful. The `nix-build`
+  calls are bypassed.
+
 ### Removed
 
 * The `generate_so` attribute of `haskell_binary` and `haskell_test`

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,6 +1,6 @@
 workspace(name = "io_tweag_rules_haskell")
 
-rules_nixpkgs_version = "8cd16d916bbb8abf91678d160da2587a56a010da"
+rules_nixpkgs_version = "f23f48193ab3a26e930989fa5edd89f324ca078d"
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@io_tweag_rules_haskell//haskell:repositories.bzl", "haskell_repositories")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,5 +1,7 @@
 workspace(name = "io_tweag_rules_haskell")
 
+rules_nixpkgs_version = "8cd16d916bbb8abf91678d160da2587a56a010da"
+
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@io_tweag_rules_haskell//haskell:repositories.bzl", "haskell_repositories")
 
@@ -7,9 +9,8 @@ haskell_repositories()
 
 http_archive(
     name = "io_tweag_rules_nixpkgs",
-    sha256 = "4f924d839d3a5896e3e22ba1282c686b2c078fd4c98d564ec427ac83ec66302d",
-    strip_prefix = "rules_nixpkgs-0.5.1",
-    urls = ["https://github.com/tweag/rules_nixpkgs/archive/v0.5.1.tar.gz"],
+    strip_prefix = "rules_nixpkgs-%s" % rules_nixpkgs_version,
+    urls = ["https://github.com/tweag/rules_nixpkgs/archive/%s.tar.gz" % rules_nixpkgs_version],
 )
 
 load(

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,5 +12,5 @@ jobs:
   # There is no Windows support yet, so we simply make sure Bazel is installed
   # https://github.com/tweag/rules_haskell/projects/2
   - bash: |
-      /c/bazel/bazel.exe version
+      /c/bazel/bazel.exe fetch "///tests:ghc" # first '/' gets eaten up
     displayName: 'Run Bazel'

--- a/haskell/nix.bzl
+++ b/haskell/nix.bzl
@@ -119,7 +119,14 @@ def import_packages(name):
         extra_args_raw = extra_args_raw,
     )
 
-    repository_ctx.file("packages.bzl", bzl_file_content)
+    bzl_file_content_windows = ""
+
+    is_windows = repository_ctx.os.name.startswith("windows")
+
+    if is_windows:
+        repository_ctx.file("packages.bzl", bzl_file_content_windows)
+    else:
+        repository_ctx.file("packages.bzl", bzl_file_content)
 
 _gen_imports_str = repository_rule(
     implementation = _gen_imports_impl,
@@ -206,6 +213,7 @@ def haskell_nixpkgs_packageset(name, base_attribute_path, repositories = {}, **k
         build_file_content = """
 exports_files(["all-haskell-packages.bzl"])
         """,
+        fail_not_supported = False,
         **kwargs
     )
     _gen_imports(

--- a/haskell/nix.bzl
+++ b/haskell/nix.bzl
@@ -119,7 +119,11 @@ def import_packages(name):
         extra_args_raw = extra_args_raw,
     )
 
-    bzl_file_content_windows = ""
+    # A dummy 'packages.bzl' file with a no-op 'import_packages()' on Windows
+    bzl_file_content_windows = """
+def import_packages(name):
+    return
+    """
 
     is_windows = repository_ctx.os.name.startswith("windows")
 


### PR DESCRIPTION
Fixes #570 

This makes use of the flag `fail_not_supported` added in https://github.com/tweag/rules_nixpkgs/pull/58 to allow Bazel to evaluate the `WORKSPACE` file on Windows. This is an unfortunate workaround but I couldn't come up with something nicer.

We may want to merge and release https://github.com/tweag/rules_nixpkgs/pull/58 and update the `rules_nixpkgs` version used to point to the release.