### PR TITLE
Migrate rules_haskell to Bazel 0.21

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,9 @@ jobs:
             apk --no-progress update
             apk --no-progress add bash ca-certificates
             nix-channel --update
+            # CircleCI and Nix sandboxing don't play nice. See
+            # https://discourse.nixos.org/t/nixos-on-ovh-kimsufi-cloning-builder-process-operation-not-permitted/1494/5
+            mkdir -p /etc/nix && echo "sandbox = false" > /etc/nix/nix.conf
       - run:
           name: Build
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,9 @@ jobs:
           name: Run tests
           shell: /bin/bash -eilo pipefail
           command: |
-            nix-shell --arg docTools false --pure --run 'bazel build //tests:run-tests && ./bazel-bin/tests/run-tests'
+            # XXX 2019-01-22 Disable start script checking on Darwin
+            # due to a clash between binutils and clang.
+            nix-shell --arg docTools false --pure --run 'bazel build //tests:run-tests && ./bazel-bin/tests/run-tests --skip "/startup script/"'
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,21 +17,16 @@ jobs:
             apk --no-progress add bash ca-certificates
             nix-channel --update
       - run:
-          name: Bazel linter
-          command: |
-            nix-shell --pure --run 'bazel run //:buildifier'
-      - run:
           name: Build
           command: |
-            nix-shell --pure --run 'bazel build --jobs=2 //... @haskell_zlib//... --config=ci'
-            nix-shell --pure --run 'bazel build -c dbg --jobs=2 //... --config=ci'
+            nix-shell --arg docTools false --pure --run 'bazel build --config ci --jobs=2 //tests/...'
       - run:
           name: Run tests
           # bazel does not support recursive bazel call, so we
           # cannot use bazel run here because the test runner uses
           # bazel
           command: |
-            nix-shell --pure --run 'bazel build //tests:run-tests && ./bazel-bin/tests/run-tests'
+            nix-shell --arg docTools false --pure --run 'bazel build //tests:run-tests && ./bazel-bin/tests/run-tests'
 
   build-darwin:
     macos:
@@ -43,9 +38,15 @@ jobs:
           command: |
             curl https://nixos.org/nix/install | sh
       - run:
+          name: Build
+          shell: /bin/bash -eilo pipefail
+          command: |
+            nix-shell --arg docTools false --pure --run 'bazel build --config ci --jobs=2 //tests/...'
+      - run:
           name: Run tests
           shell: /bin/bash -eilo pipefail
-          command: nix-shell --arg docTools false --pure --run 'bazel build //tests:run-tests && ./bazel-bin/tests/run-tests'
+          command: |
+            nix-shell --arg docTools false --pure --run 'bazel build //tests:run-tests && ./bazel-bin/tests/run-tests'
 
 workflows:
   version: 2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   had been deprecated two versions ago and is removed.
   Use `haskell_import` instead (see docs for usage).
 * The `extra_binaries` field is now no longer supported.
+* Support for Bazel 0.21.
 
 ### Fixed
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,14 +1,16 @@
 workspace(name = "io_tweag_rules_haskell")
 
-rules_nixpkgs_version = "f23f48193ab3a26e930989fa5edd89f324ca078d"
-
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@io_tweag_rules_haskell//haskell:repositories.bzl", "haskell_repositories")
 
 haskell_repositories()
 
+rules_nixpkgs_version = "c232b296e795ad688854ff3d3d2de6e7ad45f0b4"
+rules_nixpkgs_sha256 = "5883ea01f3075354ab622cfe82542da01fe2b57a48f4c3f7610b4d14a3fced11"
+
 http_archive(
     name = "io_tweag_rules_nixpkgs",
+    sha256 = rules_nixpkgs_sha256,
     strip_prefix = "rules_nixpkgs-%s" % rules_nixpkgs_version,
     urls = ["https://github.com/tweag/rules_nixpkgs/archive/%s.tar.gz" % rules_nixpkgs_version],
 )
@@ -30,6 +32,11 @@ haskell_nixpkgs_package(
     attribute_path = "haskellPackages.ghc",
     build_file = "//haskell:ghc.BUILD",
     nix_file = "//tests:ghc.nix",
+    nixopts = [
+        "--option",
+        "sandbox",
+        "false",
+    ],
     # rules_nixpkgs assumes we want to read from `<nixpkgs>` implicitly
     # if `repository` is not set, but our nix_file uses `./nixpkgs/`.
     # TODO(Profpatsch)
@@ -71,11 +78,34 @@ register_toolchains(
 
 nixpkgs_cc_configure(
     nix_file = "//nixpkgs:cc-toolchain.nix",
+    nixopts = [
+        "--option",
+        "sandbox",
+        "false",
+    ],
     repository = "@nixpkgs",
 )
 
 nixpkgs_package(
     name = "zlib",
+    repository = "@nixpkgs",
+)
+
+nixpkgs_package(
+    name = "sphinx",
+    attribute_path = "python36Packages.sphinx",
+    repository = "@nixpkgs",
+)
+
+nixpkgs_package(
+    name = "graphviz",
+    attribute_path = "graphviz",
+    repository = "@nixpkgs",
+)
+
+nixpkgs_package(
+    name = "zip",
+    attribute_path = "zip",
     repository = "@nixpkgs",
 )
 
@@ -123,6 +153,9 @@ haskell_nixpkgs_packageset(
     nixopts = [
         "-j",
         "1",
+        "--option",
+        "sandbox",
+        "false",
     ],
     repositories = {"nixpkgs": "@nixpkgs"},
 )
@@ -167,6 +200,11 @@ nixpkgs_package(
       for i in ${nodejs}/*; do ln -s $i; done
       ''
     """,
+    nixopts = [
+        "--option",
+        "sandbox",
+        "false",
+    ],
     repository = "@nixpkgs",
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -57,7 +57,7 @@ load(
 )
 
 # XXX: this needs to be kept in sync with `ghc_version` in `tests/BUILD`
-ghc_version = "8.4.4"
+ghc_version = "8.6.3"
 
 # A GHC from a bindist for Windows
 ghc_bindist(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -6,6 +6,7 @@ load("@io_tweag_rules_haskell//haskell:repositories.bzl", "haskell_repositories"
 haskell_repositories()
 
 rules_nixpkgs_version = "c232b296e795ad688854ff3d3d2de6e7ad45f0b4"
+
 rules_nixpkgs_sha256 = "5883ea01f3075354ab622cfe82542da01fe2b57a48f4c3f7610b4d14a3fced11"
 
 http_archive(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -33,11 +33,6 @@ haskell_nixpkgs_package(
     attribute_path = "haskellPackages.ghc",
     build_file = "//haskell:ghc.BUILD",
     nix_file = "//tests:ghc.nix",
-    nixopts = [
-        "--option",
-        "sandbox",
-        "false",
-    ],
     # rules_nixpkgs assumes we want to read from `<nixpkgs>` implicitly
     # if `repository` is not set, but our nix_file uses `./nixpkgs/`.
     # TODO(Profpatsch)
@@ -79,11 +74,6 @@ register_toolchains(
 
 nixpkgs_cc_configure(
     nix_file = "//nixpkgs:cc-toolchain.nix",
-    nixopts = [
-        "--option",
-        "sandbox",
-        "false",
-    ],
     repository = "@nixpkgs",
 )
 
@@ -154,9 +144,6 @@ haskell_nixpkgs_packageset(
     nixopts = [
         "-j",
         "1",
-        "--option",
-        "sandbox",
-        "false",
     ],
     repositories = {"nixpkgs": "@nixpkgs"},
 )

--- a/docs/BUILD
+++ b/docs/BUILD
@@ -6,12 +6,24 @@ genrule(
     outs = ["guide_html.zip"],
     cmd = """
     set -euo pipefail
+    # Nixpkgs_rules are pointing to every bins individually. Here
+    # we are extracting the /bin dir path to append it to the $$PATH.
+    CWD=`pwd`
+    sphinxBinDir=$${CWD}/$$(echo $(locations @sphinx//:bin) | cut -d ' ' -f 1 | xargs dirname)
+    dotBinDir=$${CWD}/$$(echo $(locations @graphviz//:bin) | cut -d ' ' -f 1 | xargs dirname)
+    zipBinDir=$${CWD}/$$(echo $(locations @zip//:bin) | cut -d ' ' -f 1 | xargs dirname)
+    PATH=$${PATH}:$${sphinxBinDir}:$${dotBinDir}:$${zipBinDir}
     sourcedir=$$(dirname $(location conf.py))
     builddir=$$(mktemp -d rules_haskell_docs.XXXX)
     sphinx-build -M html $$sourcedir $$builddir -W -N -q
-    (CWD=`pwd` && cd $$builddir/html && zip -q -r $$CWD/$@ .)
+    (cd $$builddir/html && zip -q -r $$CWD/$@ .)
     rm -rf $$builddir
     """,
+    tools = [
+        "@graphviz//:bin",
+        "@sphinx//:bin",
+        "@zip//:bin",
+    ],
 )
 
 skylark_doc(

--- a/haskell/BUILD
+++ b/haskell/BUILD
@@ -17,3 +17,8 @@ toolchain_type(
     name = "toolchain",
     visibility = ["//visibility:public"],
 )
+
+toolchain_type(
+    name = "doctest-toolchain",
+    visibility = ["//visibility:public"],
+)

--- a/haskell/protobuf.bzl
+++ b/haskell/protobuf.bzl
@@ -116,7 +116,7 @@ def _haskell_proto_aspect_impl(target, ctx):
         ))
 
     args.add([
-        "--haskell_out=no-reexports:" + paths.join(
+        "--haskell_out=no-runtime:" + paths.join(
             hs_files[0].root.path,
             src_prefix,
         ),

--- a/nixpkgs/default.nix
+++ b/nixpkgs/default.nix
@@ -1,5 +1,5 @@
 import (fetchTarball {
-   # Nixpkgs checkout from 2018-11-03.
-   url = "https://github.com/NixOS/nixpkgs/archive/cb692e6f52f6d4ca619c9fbc7a80afc081a93103.tar.gz";
-   sha256 = "1aww7wjgv868asd4yl0wnzh8qa26j4wsmqn85b3s9fkqkz4p2m0f";
+   # Nixpkgs checkout from 2019-01-15.
+   url = "https://github.com/NixOS/nixpkgs/archive/052db93d8f02f8393085409d96ee94ef938cfbd8.tar.gz";
+   sha256 = "1xm5i3ig4awp5q0y0wd8s0h376jxq5wxwbpabhbjczskj3sd0wkw";
 })

--- a/nixpkgs/default.nix
+++ b/nixpkgs/default.nix
@@ -1,5 +1,5 @@
 import (fetchTarball {
-   # Nixpkgs checkout from 2019-01-15.
-   url = "https://github.com/NixOS/nixpkgs/archive/052db93d8f02f8393085409d96ee94ef938cfbd8.tar.gz";
-   sha256 = "1xm5i3ig4awp5q0y0wd8s0h376jxq5wxwbpabhbjczskj3sd0wkw";
+   # Nixpkgs checkout from 2019-01-19.
+   url = "https://github.com/NixOS/nixpkgs/archive/db8e3654e2cdbc4bb32a5e75db064e0fea45a764.tar.gz";
+   sha256 = "1vfyv6p841b0pzxmpn4ch9xar8nbvg6hlb7g2yg48fjrzssmq1qn";
 })

--- a/protobuf/BUILD
+++ b/protobuf/BUILD
@@ -1,0 +1,4 @@
+toolchain_type(
+    name = "toolchain",
+    visibility = ["//visibility:public"],
+)

--- a/start
+++ b/start
@@ -43,9 +43,11 @@ load("@io_tweag_rules_haskell//haskell:repositories.bzl", "haskell_repositories"
 haskell_repositories()
 
 rules_nixpkgs_version = "c232b296e795ad688854ff3d3d2de6e7ad45f0b4"
+rules_nixpkgs_sha256 = "5883ea01f3075354ab622cfe82542da01fe2b57a48f4c3f7610b4d14a3fced11"
 
 http_archive(
     name = "io_tweag_rules_nixpkgs",
+    sha256 = rules_nixpkgs_sha256,
     strip_prefix = "rules_nixpkgs-%s" % rules_nixpkgs_version,
     urls = ["https://github.com/tweag/rules_nixpkgs/archive/%s.tar.gz" % rules_nixpkgs_version],
 )
@@ -72,11 +74,7 @@ nixpkgs_package(
 
 nixpkgs_cc_configure(
     repository = "@nixpkgs",
-    nixopts = [
-        "--option",
-        "sandbox",
-        "false",
-    ])
+)
 
 register_toolchains("//:ghc")
 EOF
@@ -97,10 +95,7 @@ haskell_toolchain(
   tools = "@ghc//:bin",
 )
 
-haskell_import(
-  name = "base_pkg",
-  package = "base",
-)
+haskell_import(name = "base")
 
 haskell_library(
   name = "MY_LIBRARY_NAME",

--- a/start
+++ b/start
@@ -42,10 +42,12 @@ http_archive(
 load("@io_tweag_rules_haskell//haskell:repositories.bzl", "haskell_repositories")
 haskell_repositories()
 
+rules_nixpkgs_version = "c232b296e795ad688854ff3d3d2de6e7ad45f0b4"
+
 http_archive(
-  name = "io_tweag_rules_nixpkgs",
-  strip_prefix = "rules_nixpkgs-0.4.0",
-  urls = ["https://github.com/tweag/rules_nixpkgs/archive/v0.4.0.tar.gz"],
+    name = "io_tweag_rules_nixpkgs",
+    strip_prefix = "rules_nixpkgs-%s" % rules_nixpkgs_version,
+    urls = ["https://github.com/tweag/rules_nixpkgs/archive/%s.tar.gz" % rules_nixpkgs_version],
 )
 
 load(
@@ -68,7 +70,14 @@ nixpkgs_package(
   repository = "@nixpkgs",
 )
 
-nixpkgs_cc_configure(repository = "@nixpkgs")
+nixpkgs_cc_configure(
+    repository = "@nixpkgs",
+    nixopts = [
+        "--option",
+        "sandbox",
+        "false",
+    ])
+
 register_toolchains("//:ghc")
 EOF
 

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -66,6 +66,7 @@ haskell_proto_toolchain(
         "@hackage//:bytestring",
         "@hackage//:containers",
         "@hackage//:data-default-class",
+        "@hackage//:deepseq",
         "@hackage//:lens-family",
         "@hackage//:lens-family-core",
         "@hackage//:lens-labels",

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -15,7 +15,7 @@ load(
 
 package(default_testonly = 1)
 
-ghc_version = "8.4.4"
+ghc_version = "8.6.3"
 
 haskell_toolchain(
     name = "ghc",
@@ -165,9 +165,9 @@ rule_test(
     name = "test-haddock",
     size = "small",
     generates = [
-        "haddock/base-4.11.1.0",
+        "haddock/base-4.12.0.0",
         "haddock/index",
-        "haddock/template-haskell-2.13.0.0",
+        "haddock/template-haskell-2.14.0.0",
         "haddock/testsZShaddockZShaddock-lib-a",
         "haddock/testsZShaddockZShaddock-lib-b",
         "haddock/testsZShaddockZShaddock-lib-deep",

--- a/tests/ghc.nix
+++ b/tests/ghc.nix
@@ -8,7 +8,7 @@
 
 with pkgs;
 
-let haskellPackages = pkgs.haskell.packages.ghc844.override {
+let haskellPackages = pkgs.haskell.packages.ghc863.override {
       overrides = with pkgs.haskell.lib; self: super: rec {
         libc = import ./haddock/libC.nix self pkgs;
       };


### PR DESCRIPTION
Prerequisite of #489

# Fixed Toolchain implicit types

Toolchain-type labels should now point to an actual rule.

# Docs build tools cleanup

The host path is not forwarded anymore to the sandbox in charge of
executing the actions. This means we now need to create some specific
rules for each tool using during the build process of the documentation.

# Protolens configuration update

- Updating the protolens flags.
- Protolens is now using deepseq in its generated files, we need to add
  this library as a toolchain dependency.