### PR TITLE
Fix repl rule with indirect cc_library deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 ### Fixed
 
 * Fix static linking with C libraries that are indirectly depended upon
+* Fix repl targets that have indirect cc_library dependencies
 
 ## [0.7] - 2018-12-24
 

--- a/tests/RunTests.hs
+++ b/tests/RunTests.hs
@@ -39,6 +39,8 @@ main = hspec $ do
 
       assertSuccess (bazel ["run", "//tests/repl-targets:hs-bin@repl", "--", "-ignore-dot-ghci", "-e", ":main"])
 
+      assertSuccess (bazel ["run", "//tests/binary-indirect-cbits:binary-indirect-cbits@repl", "--", "-ignore-dot-ghci", "-e", ":main"])
+
     -- Test `compiler_flags` from toolchain and rule for REPL
     it "compiler flags" $ do
       assertSuccess (bazel ["run", "//tests/repl-flags:compiler_flags@repl", "--", "-ignore-dot-ghci", "-e", ":main"])

--- a/tests/binary-indirect-cbits/BUILD
+++ b/tests/binary-indirect-cbits/BUILD
@@ -7,16 +7,17 @@ load(
 haskell_binary(
     name = "binary-indirect-cbits",
     srcs = ["Main.hs"],
+    linkstatic = False,
     deps = [
         "//tests/library-with-cbits",
         "@hackage//:base",
     ],
-    linkstatic = False
 )
 
 haskell_binary(
     name = "binary-indirect-cbits-partially-static",
     srcs = ["Main.hs"],
+    linkstatic = False,
     deps = [
         "//tests/library-with-cbits:library-with-cbits-static",
         "@hackage//:base",

--- a/tests/binary-indirect-cbits/BUILD
+++ b/tests/binary-indirect-cbits/BUILD
@@ -7,17 +7,16 @@ load(
 haskell_binary(
     name = "binary-indirect-cbits",
     srcs = ["Main.hs"],
-    linkstatic = False,
     deps = [
         "//tests/library-with-cbits",
         "@hackage//:base",
     ],
+    linkstatic = False
 )
 
 haskell_binary(
     name = "binary-indirect-cbits-partially-static",
     srcs = ["Main.hs"],
-    linkstatic = False,
     deps = [
         "//tests/library-with-cbits:library-with-cbits-static",
         "@hackage//:base",

--- a/tests/binary-indirect-cbits/Main.hs
+++ b/tests/binary-indirect-cbits/Main.hs
@@ -1,5 +1,5 @@
-
 import AddOne
 
 main :: IO ()
-main = putStrLn $ show $ addOne 2
+main = do
+  putStrLn $ show $ addOne 2

--- a/tests/library-with-cbits/AddOne2.hs
+++ b/tests/library-with-cbits/AddOne2.hs
@@ -1,0 +1,7 @@
+module AddOne2
+  ( addOne2
+  ) where
+
+import AddOne
+
+addOne2 = addOne

--- a/tests/library-with-cbits/BUILD
+++ b/tests/library-with-cbits/BUILD
@@ -9,7 +9,17 @@ haskell_library(
     srcs = ["AddOne.hsc"],
     visibility = ["//visibility:public"],
     deps = [
-        "//tests/data:ourclibrary",
+        ":ourclibrary-indirect",
+        "@hackage//:base",
+    ],
+)
+
+haskell_library(
+    name = "library-with-cbits-indirect",
+    srcs = ["AddOne2.hs"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":library-with-cbits",
         "@hackage//:base",
     ],
 )
@@ -21,6 +31,13 @@ haskell_library(
     deps = [
         ":ourclibrary-static",
         "@hackage//:base",
+    ],
+)
+
+cc_library(
+    name = "ourclibrary-indirect",
+    deps = [
+        "//tests/data:ourclibrary",
     ],
 )
 


### PR DESCRIPTION
The repl rule adds "-l<somelib>" from external_libraries, but that can contain static libraries, which
won't have the mangled .so/.dylib linked in, and ghci will then fail to find this library. This changes
repl.bzl to only add "-l"s for shared libraries (which come in via haskell_cc_import).

Interestingly this bug can be only triggered if we have a haskell_library depending on a cc_library
that in turn depends on another cc_library. With that we get the following error:
``
<command line>: user specified .o/.so/.DLL could not be loaded (libtests_Slibrary-with-cbits_Sourclibrary-indirect_libourclibrary.so: cannot open shared object file: No such file or directory)
Whilst trying to load:  (dynamic) tests_Slibrary-with-cbits_Sourclibrary-indirect_libourclibrary
``
