### PR TITLE
Windows: build simple binary

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,5 +11,5 @@ jobs:
     displayName: 'Install Bazel'
   - bash: |
       # Simple haskell binary
-      /c/bazel/bazel.exe build "///tests/binary-simple" # first '/' gets eaten up
+      /c/bazel/bazel.exe build --compiler=msys-gcc "///tests/binary-simple" # first '/' gets eaten up
     displayName: 'Run Bazel'

--- a/haskell/private/actions/compile.bzl
+++ b/haskell/private/actions/compile.bzl
@@ -29,8 +29,6 @@ def _process_hsc_file(hs, cc, hsc_flags, hsc_file):
       (File, string): Haskell source file created by processing hsc_file and
          new import directory containing the produced file.
     """
-    if hs.toolchain.is_windows:
-        cc = "Bazel's CC shouldn't be used on Windows"
     args = hs.actions.args()
 
     # Output a Haskell source file.
@@ -76,25 +74,19 @@ def _compilation_defaults(hs, cc, java, dep_info, srcs, import_dir_map, extra_sr
       DefaultCompileInfo: Populated default compilation settings.
     """
 
-    if hs.toolchain.is_windows:
-        cc = "Bazel's CC shouldn't be used on Windows"
-
     ghc_args = []
 
     # GHC expects the CC compiler as the assembler, but segregates the
     # set of flags to pass to it when used as an assembler. So we have
     # to set both -optc and -opta.
-    # Since we don't use Bazel's CC toolchain on windows, there's nothing to
-    # do.
-    if not hs.toolchain.is_windows:
-        cc_args = [
-            "-optc" + f
-            for f in cc.compiler_flags
-        ] + [
-            "-opta" + f
-            for f in cc.compiler_flags
-        ]
-        ghc_args += cc_args
+    cc_args = [
+        "-optc" + f
+        for f in cc.compiler_flags
+    ] + [
+        "-opta" + f
+        for f in cc.compiler_flags
+    ]
+    ghc_args += cc_args
 
     interface_dir_raw = "_iface_prof" if with_profiling else "_iface"
     object_dir_raw = "_obj_prof" if with_profiling else "_obj"
@@ -180,9 +172,8 @@ def _compilation_defaults(hs, cc, java, dep_info, srcs, import_dir_map, extra_sr
             set.mutable_insert(import_dirs, idir)
 
     ghc_args += ["-i{0}".format(d) for d in set.to_list(import_dirs)]
-    if not hs.toolchain.is_windows:
-        ghc_args += ["-optP" + f for f in cc.cpp_flags]
-        ghc_args += cc.include_args
+    ghc_args += ["-optP" + f for f in cc.cpp_flags]
+    ghc_args += cc.include_args
 
     locale_archive_depset = (
         depset([hs.toolchain.locale_archive]) if hs.toolchain.locale_archive != None else depset()
@@ -251,6 +242,7 @@ def _compilation_defaults(hs, cc, java, dep_info, srcs, import_dir_map, extra_sr
             depset(boot_files),
             set.to_depset(source_files),
             extra_srcs,
+            depset(cc.hdrs),
             set.to_depset(dep_info.package_confs),
             set.to_depset(dep_info.package_caches),
             set.to_depset(dep_info.interface_dirs),
@@ -260,11 +252,11 @@ def _compilation_defaults(hs, cc, java, dep_info, srcs, import_dir_map, extra_sr
             depset([e.mangled_lib for e in set.to_list(dep_info.external_libraries)]),
             java.inputs,
             locale_archive_depset,
-        ] + ([depset(cc.hdrs)] if not hs.toolchain.is_windows else [])),
+        ]),
         objects_dir = objects_dir,
         interfaces_dir = interfaces_dir,
         outputs = [objects_dir, interfaces_dir],
-        header_files = set.from_list((cc.hdrs if not hs.toolchain.is_windows else []) + header_files),
+        header_files = set.from_list(cc.hdrs + header_files),
         boot_files = set.from_list(boot_files),
         source_files = source_files,
         extra_source_files = extra_srcs,
@@ -288,10 +280,6 @@ def compile_binary(hs, cc, java, dep_info, srcs, ls_modules, import_dir_map, ext
         modules: set of module names
         source_files: set of Haskell source files
     """
-
-    if hs.toolchain.is_windows:
-        cc = "Bazel's CC shouldn't be used on Windows"
-
     c = _compilation_defaults(hs, cc, java, dep_info, srcs, import_dir_map, extra_srcs, compiler_flags, with_profiling, my_pkg_id = None, version = version)
     c.args.add(["-main-is", main_function])
     if dynamic:
@@ -355,8 +343,6 @@ def compile_library(hs, cc, java, dep_info, srcs, ls_modules, other_modules, exp
         source_files: set of Haskell module files
         import_dirs: import directories that should make all modules visible (for GHCi)
     """
-    if hs.toolchain.is_windows:
-        cc = "Bazel's CC shouldn't be used on Windows"
     c = _compilation_defaults(hs, cc, java, dep_info, srcs, import_dir_map, extra_srcs, compiler_flags, with_profiling, my_pkg_id = my_pkg_id, version = my_pkg_id.version)
     if with_shared:
         c.args.add(["-dynamic-too"])

--- a/haskell/private/actions/link.bzl
+++ b/haskell/private/actions/link.bzl
@@ -127,8 +127,7 @@ def link_binary(
         )
 
     args = hs.actions.args()
-    if not hs.toolchain.is_windows:
-        args.add(["-optl" + f for f in cc.linker_flags])
+    args.add(["-optl" + f for f in cc.linker_flags])
     if with_profiling:
         args.add("-prof")
     args.add(hs.toolchain.compiler_flags)

--- a/haskell/private/haskell_impl.bzl
+++ b/haskell/private/haskell_impl.bzl
@@ -57,8 +57,6 @@ def haskell_binary_impl(ctx):
 
     # Add any interop info for other languages.
     cc = cc_interop_info(ctx)
-    if hs.toolchain.is_windows:
-        cc = "Bazel's CC shouldn't be used on Windows"
     java = java_interop_info(ctx)
 
     with_profiling = is_profiling_enabled(hs)
@@ -177,8 +175,6 @@ def haskell_library_impl(ctx):
 
     # Add any interop info for other languages.
     cc = cc_interop_info(ctx)
-    if hs.toolchain.is_windows:
-        cc = "Bazel's CC shouldn't be used on Windows"
     java = java_interop_info(ctx)
 
     srcs_files, import_dir_map = _prepare_srcs(ctx.attr.srcs)

--- a/haskell/toolchain.bzl
+++ b/haskell/toolchain.bzl
@@ -18,8 +18,6 @@ load(":private/set.bzl", "set")
 _GHC_BINARIES = ["ghc", "ghc-pkg", "hsc2hs", "haddock", "ghci"]
 
 def _run_ghc(hs, cc, inputs, outputs, mnemonic, arguments, params_file = None, env = None, progress_message = None):
-    if hs.toolchain.is_windows:
-        cc = None
     if not env:
         env = hs.env
 
@@ -65,7 +63,7 @@ def _run_ghc(hs, cc, inputs, outputs, mnemonic, arguments, params_file = None, e
         hs.toolchain.version_file,
         ghc_args_file,
         extra_args_file,
-    ] + (cc.files if not hs.toolchain.is_windows else [])
+    ] + cc.files
     if params_file:
         command = """
         export PATH=${PATH:-} # otherwise GCC fails on Windows


### PR DESCRIPTION
Fixes #584 

* Build `//tests/binary-simple` on CI on Windows
* Discard all `cc` args on Windows
* Fix the executable's output name on Windows (haskell name + `.exe`)