### PR TITLE
Make c2hs a separate toolchain.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -64,6 +64,7 @@ ghc_bindist(
 
 register_toolchains(
     "//tests:ghc",
+    "//tests:c2hs-toolchain",
     "//tests:doctest-toolchain",
     "//tests:protobuf-toolchain",
 )

--- a/haskell/c2hs.bzl
+++ b/haskell/c2hs.bzl
@@ -17,6 +17,7 @@ def _c2hs_library_impl(ctx):
     hs = haskell_context(ctx)
     cc = cc_interop_info(ctx)
     args = hs.actions.args()
+    c2hs = ctx.toolchains["@io_tweag_rules_haskell//haskell/c2hs:toolchain"].c2hs
 
     if len(ctx.files.srcs) != 1:
         fail("srcs field should contain exactly one file.")
@@ -51,7 +52,7 @@ def _c2hs_library_impl(ctx):
     hs.actions.run_shell(
         inputs = depset(transitive = [
             depset(cc.hdrs),
-            depset([hs.tools.ghc, hs.tools.c2hs, chs_file]),
+            depset([hs.tools.ghc, c2hs, chs_file]),
             depset(dep_chi_files),
             depset(cc.files),
         ]),
@@ -62,7 +63,7 @@ def _c2hs_library_impl(ctx):
         {c2hs} -C-I$libdir/include "$@"
         """.format(
             ghc = hs.tools.ghc.path,
-            c2hs = hs.tools.c2hs.path,
+            c2hs = c2hs.path,
         ),
         mnemonic = "HaskellC2Hs",
         arguments = [args],
@@ -98,5 +99,70 @@ c2hs_library = rule(
     },
     toolchains = [
         "@io_tweag_rules_haskell//haskell:toolchain",
+        "@io_tweag_rules_haskell//haskell/c2hs:toolchain",
     ],
 )
+
+def _c2hs_toolchain_impl(ctx):
+    return [
+        platform_common.ToolchainInfo(
+            name = ctx.label.name,
+            c2hs = ctx.file.c2hs,
+        ),
+    ]
+
+_c2hs_toolchain = rule(
+    _c2hs_toolchain_impl,
+    attrs = {
+        "c2hs": attr.label(
+            doc = "The c2hs executable.",
+            mandatory = True,
+            allow_single_file = True,
+        ),
+    },
+)
+
+def c2hs_toolchain(name, c2hs, **kwargs):
+    """Declare a Haskell c2hs toolchain.
+
+    You need at least one of these declared somewhere in your `BUILD`
+    files for the `chs_library` rule to work. Once declared, you then
+    need to *register* the toolchain using `register_toolchains` in
+    your `WORKSPACE` file (see example below).
+
+    Example:
+
+      In a `BUILD` file:
+
+      ```bzl
+      c2hs_toolchain(
+          name = "c2hs",
+          c2hs = "@c2hs//:bin",
+      )
+      ```
+
+      where `@c2hs` is an external repository defined in the
+      `WORKSPACE`, e.g. using:
+
+      ```bzl
+      nixpkgs_package(
+          name = "c2hs",
+          attribute_path = "haskell.packages.ghc822.c2hs",
+      )
+
+      register_toolchains("//:c2hs")
+      ```
+    """
+    impl_name = name + "-impl"
+    _c2hs_toolchain(
+        name = impl_name,
+        c2hs = c2hs,
+        visibility = ["//visibility:public"],
+        **kwargs
+    )
+
+    native.toolchain(
+        name = name,
+        toolchain_type = "@io_tweag_rules_haskell//haskell/c2hs:toolchain",
+        toolchain = ":" + impl_name,
+    )

--- a/haskell/c2hs/BUILD
+++ b/haskell/c2hs/BUILD
@@ -1,0 +1,4 @@
+toolchain_type(
+    name = "toolchain",
+    visibility = ["//visibility:public"],
+)

--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -5,10 +5,6 @@ load(
     "HaskellPrebuiltPackageInfo",
 )
 load(
-    ":c2hs.bzl",
-    _c2hs_library = "c2hs_library",
-)
-load(
     ":cc.bzl",
     _cc_haskell_import = "cc_haskell_import",
     _haskell_cc_import = "haskell_cc_import",
@@ -276,5 +272,3 @@ ghc_bindist = _ghc_bindist
 haskell_cc_import = _haskell_cc_import
 
 cc_haskell_import = _cc_haskell_import
-
-c2hs_library = _c2hs_library

--- a/haskell/toolchain.bzl
+++ b/haskell/toolchain.bzl
@@ -139,9 +139,6 @@ fi
         ),
     )
 
-    if ctx.attr.c2hs != None:
-        ghc_binaries["c2hs"] = ctx.file.c2hs
-
     tools_struct_args = {
         name.replace("-", "_"): file
         for name, file in ghc_binaries.items()
@@ -198,10 +195,6 @@ _haskell_toolchain = rule(
         "haddock_flags": attr.string_list(
             doc = "A collection of flags that will be passed to haddock.",
         ),
-        "c2hs": attr.label(
-            doc = "c2hs executable",
-            allow_single_file = True,
-        ),
         "version": attr.string(
             doc = "Version of your GHC compiler. It has to match the version reported by the GHC used by bazel.",
             mandatory = True,
@@ -252,7 +245,6 @@ def haskell_toolchain(
           version = '1.2.3'
           tools = ["@sys_ghc//:bin"],
           compiler_flags = ["-Wall"],
-          c2hs = "@c2hs//:bin", # optional
       )
       ```
 
@@ -266,15 +258,6 @@ def haskell_toolchain(
       )
 
       register_toolchains("//:ghc")
-      ```
-
-      and for `@c2hs`:
-
-      ```bzl
-      nixpkgs_package(
-          name = "c2hs",
-          attribute_path = "haskell.packages.ghc822.c2hs",
-      )
       ```
     """
     impl_name = name + "-impl"

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -1,6 +1,10 @@
 load(":sh_inline_test.bzl", "sh_inline_test")
 load("@bazel_tools//tools/build_rules:test_rules.bzl", "rule_test")
 load(
+    "@io_tweag_rules_haskell//haskell:c2hs.bzl",
+    "c2hs_toolchain",
+)
+load(
     "@io_tweag_rules_haskell//haskell:haskell.bzl",
     "haskell_binary",
     "haskell_doctest_toolchain",
@@ -20,10 +24,6 @@ haskell_toolchain(
     # proto_library rules (from com_google_protobuf) can't themselves
     # be testonly.
     testonly = 0,
-    c2hs = select({
-        "@bazel_tools//src/conditions:windows": None,
-        "//conditions:default": "@hackage-c2hs//:bin",
-    }),
     compiler_flags = [
         "-XStandaloneDeriving",  # Flag used at compile time
         "-threaded",  # Flag used at link time
@@ -73,6 +73,12 @@ haskell_proto_toolchain(
         "@hackage//:proto-lens",
         "@hackage//:text",
     ],
+)
+
+c2hs_toolchain(
+    name = "c2hs-toolchain",
+    testonly = 0,
+    c2hs = "@hackage-c2hs//:bin",
 )
 
 rule_test(


### PR DESCRIPTION
The GHC toolchain could previously optionally be provided an extra
"tool", c2hs. But

This is a **breaking change**. But few people use c2hs and the change
is only in the toolchain declaration code, which happens only once per
workspace.