### PR TITLE
Introduce our own config settings for platforms to match GHC naming.

### DIFF
--- a/haskell/platforms/BUILD
+++ b/haskell/platforms/BUILD
@@ -1,0 +1,11 @@
+# This file declares constraint values for each platform supported by
+# GHC. These rules follow the GHC naming convention, for example,
+# //haskell/platform:linux and //haskell/platform:x86_64. See the
+# config.guess in any GHC source distribution for possible platforms.
+#
+# These can be used in select expressions to choose platform-specifc
+# sources and dependencies.
+
+load(":list.bzl", "declare_config_settings")
+
+declare_config_settings()

--- a/haskell/platforms/list.bzl
+++ b/haskell/platforms/list.bzl
@@ -1,0 +1,44 @@
+OS = {
+    "aix": None,
+    "darwin": "@bazel_tools//platforms:osx",
+    "dragonfly": None,
+    "freebsd": "@bazel_tools//platforms:freebsd",
+    "haiku": None,
+    "hpux": None,
+    "ios": "@bazel_tools//platforms:ios",
+    "linux_android": "@bazel_tools//platforms:android",
+    "linux": "@bazel_tools//platforms:linux",
+    "mingw32": "@bazel_tools//platforms:windows",
+    "netbsd": None,
+    "openbsd": None,
+    "solaris2": None,
+}
+
+ARCH = {
+    "aarch64": None,
+    "alpha": None,
+    "arm64": "@bazel_tools//platforms:aarch64",
+    "arm": "@bazel_tools//platforms:arm",
+    "i386": "@bazel_tools//platforms:x86_32",
+    "ia64": None,
+    "powerpc64": None,
+    "powerpc64le": None,
+    "powerpc": "@bazel_tools//platforms:ppc",
+    "rs6000": None,
+    "sparc": None,
+    "x86_64": "@bazel_tools//platforms:x86_64",
+}
+
+def declare_config_settings():
+    for os, constraint_value in OS.items():
+        if constraint_value:
+            native.config_setting(
+                name = os,
+                constraint_values = [constraint_value],
+            )
+    for arch, constraint_value in ARCH.items():
+        if constraint_value:
+            native.config_setting(
+                name = arch,
+                constraint_values = [constraint_value],
+            )

--- a/haskell/toolchain.bzl
+++ b/haskell/toolchain.bzl
@@ -271,16 +271,15 @@ def haskell_toolchain(
         haddock_flags = haddock_flags,
         visibility = ["//visibility:public"],
         is_darwin = select({
-            "@bazel_tools//src/conditions:darwin": True,
+            "@io_tweag_rules_haskell//haskell/platforms:darwin": True,
             "//conditions:default": False,
         }),
         is_windows = select({
-            "@bazel_tools//src/conditions:windows": True,
+            "@io_tweag_rules_haskell//haskell/platforms:mingw32": True,
             "//conditions:default": False,
         }),
         **kwargs
     )
-
     native.toolchain(
         name = name,
         toolchain_type = "@io_tweag_rules_haskell//haskell:toolchain",


### PR DESCRIPTION
GHC uses its own naming convention for architectures and for operating
systems. Rather than use Bazel's `@bazel_tools//conditions/*`
directly, which often have different names than GHC uses, we use GHC
names (that way, "mingw32" means we're in an environment that the
mingw32 bindist works on). This change is for now only internally
visible. The user does not have any reason to use these config
settings just yet.