### PR TITLE
Don't hardcode platforms in toolchain anymore

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -28,7 +28,34 @@ load(
 haskell_nixpkgs_package(
     name = "ghc",
     attribute_path = "haskellPackages.ghc",
-    build_file = "//haskell:ghc.BUILD",
+    build_file_content = """
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "bin",
+    srcs = glob(["bin/*"]),
+)
+
+cc_library(
+    name = "threaded-rts",
+    srcs = glob(
+        ["lib/ghc-*/rts/libHSrts_thr-ghc*." + ext for ext in [
+            "so",
+            "dylib",
+        ]] +
+        # dependency of `libHSrts_thr_ghc*`
+        # globbing on the `so` version to stay working when they update
+        [
+            "lib/ghc-*/rts/libffi.so.*",
+        ],
+    ),
+    hdrs = glob(["lib/ghc-*/include/**/*.h"]),
+    strip_include_prefix = glob(
+        ["lib/ghc-*/include"],
+        exclude_directories = 0,
+    )[0],
+)
+    """,
     nix_file = "//tests:ghc.nix",
     # rules_nixpkgs assumes we want to read from `<nixpkgs>` implicitly
     # if `repository` is not set, but our nix_file uses `./nixpkgs/`.
@@ -59,11 +86,13 @@ ghc_version = "8.4.4"
 # A GHC from a bindist for Windows
 ghc_bindist(
     name = "ghc_windows",
+    target = "windows_amd64",
     version = ghc_version,
 )
 
 register_toolchains(
-    "//tests:ghc",
+    "//tests:ghc_linux",
+    "//tests:ghc_osx",
     "//tests:c2hs-toolchain",
     "//tests:doctest-toolchain",
     "//tests:protobuf-toolchain",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -28,34 +28,7 @@ load(
 haskell_nixpkgs_package(
     name = "ghc",
     attribute_path = "haskellPackages.ghc",
-    build_file_content = """
-package(default_visibility = ["//visibility:public"])
-
-filegroup(
-    name = "bin",
-    srcs = glob(["bin/*"]),
-)
-
-cc_library(
-    name = "threaded-rts",
-    srcs = glob(
-        ["lib/ghc-*/rts/libHSrts_thr-ghc*." + ext for ext in [
-            "so",
-            "dylib",
-        ]] +
-        # dependency of `libHSrts_thr_ghc*`
-        # globbing on the `so` version to stay working when they update
-        [
-            "lib/ghc-*/rts/libffi.so.*",
-        ],
-    ),
-    hdrs = glob(["lib/ghc-*/include/**/*.h"]),
-    strip_include_prefix = glob(
-        ["lib/ghc-*/include"],
-        exclude_directories = 0,
-    )[0],
-)
-    """,
+    build_file = "//haskell:ghc.BUILD",
     nix_file = "//tests:ghc.nix",
     # rules_nixpkgs assumes we want to read from `<nixpkgs>` implicitly
     # if `repository` is not set, but our nix_file uses `./nixpkgs/`.

--- a/haskell/ghc.BUILD
+++ b/haskell/ghc.BUILD
@@ -1,10 +1,10 @@
+load("@io_tweag_rules_haskell//haskell:toolchain.bzl", "haskell_toolchain")
+
 package(default_visibility = ["//visibility:public"])
 
 filegroup(
     name = "bin",
-    srcs = glob([
-        "bin/*",
-    ]),
+    srcs = glob(["bin/*"]),
 )
 
 cc_library(
@@ -25,4 +25,12 @@ cc_library(
         ["lib/ghc-*/include"],
         exclude_directories = 0,
     )[0],
+)
+
+haskell_toolchain(
+    name = "toolchain",
+    tools = ":bin",
+    version = "{version}",
+    exec_compatible_with = {exec_constraints},
+    target_compatible_with = {target_constraints},
 )

--- a/haskell/ghc.BUILD
+++ b/haskell/ghc.BUILD
@@ -1,5 +1,3 @@
-load("@io_tweag_rules_haskell//haskell:toolchain.bzl", "haskell_toolchain")
-
 package(default_visibility = ["//visibility:public"])
 
 filegroup(
@@ -25,12 +23,4 @@ cc_library(
         ["lib/ghc-*/include"],
         exclude_directories = 0,
     )[0],
-)
-
-haskell_toolchain(
-    name = "toolchain",
-    tools = ":bin",
-    version = "{version}",
-    exec_compatible_with = {exec_constraints},
-    target_compatible_with = {target_constraints},
 )

--- a/haskell/ghc_bindist.bzl
+++ b/haskell/ghc_bindist.bzl
@@ -166,20 +166,6 @@ def ghc_bindist(name, version, target):
          name    = "ghc",
          version = "8.2.2",
        )
-
-       # Register the toolchain defined locally in BUILD file:
-       register_toolchains("//:ghc")
-       ```
-
-       In `BUILD` file:
-
-       ```bzl
-       # Use binaries from @ghc//:bin to define //:ghc toolchain.
-       haskell_toolchain(
-         name = "ghc",
-         version = "8.2.2",
-         tools = "@ghc//:bin",
-       )
        ```
     """
     bindist_name = name

--- a/haskell/toolchain.bzl
+++ b/haskell/toolchain.bzl
@@ -224,6 +224,8 @@ def haskell_toolchain(
         name,
         version,
         tools,
+        exec_compatible_with = None,
+        target_compatible_with = None,
         compiler_flags = [],
         repl_ghci_args = [],
         haddock_flags = [],
@@ -260,6 +262,10 @@ def haskell_toolchain(
       register_toolchains("//:ghc")
       ```
     """
+    if exec_compatible_with and not target_compatible_with:
+        exec_compatible_with = target_compatible_with
+    elif target_compatible_with and not exec_compatible_with:
+        target_compatible_with = exec_compatible_with
     impl_name = name + "-impl"
     corrected_ghci_args = repl_ghci_args + ["-no-user-package-db"]
     _haskell_toolchain(
@@ -285,10 +291,6 @@ def haskell_toolchain(
         name = name,
         toolchain_type = "@io_tweag_rules_haskell//haskell:toolchain",
         toolchain = ":" + impl_name,
-        exec_compatible_with = [
-            "@bazel_tools//platforms:x86_64",
-        ],
-        target_compatible_with = [
-            "@bazel_tools//platforms:x86_64",
-        ],
+        exec_compatible_with = exec_compatible_with,
+        target_compatible_with = target_compatible_with,
     )

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -17,39 +17,45 @@ package(default_testonly = 1)
 
 ghc_version = "8.4.4"
 
-haskell_toolchain(
-    name = "ghc",
-    # This toolchain is morally testonly.  However, that would break
-    # our tests of haskell_library_rules: aspects of non-testonly
-    # proto_library rules (from com_google_protobuf) can't themselves
-    # be testonly.
-    testonly = 0,
-    compiler_flags = [
-        "-XStandaloneDeriving",  # Flag used at compile time
-        "-threaded",  # Flag used at link time
+# These toolchains are all morally testonly. However, that would break
+# our tests of haskell_library_rules: aspects of non-testonly
+# proto_library rules (from com_google_protobuf) can't themselves be
+# testonly.
 
-        # Used by `tests/repl-flags`
-        "-DTESTS_TOOLCHAIN_COMPILER_FLAGS",
-        "-XNoOverloadedStrings",  # this is the default, so it does not harm other tests
-    ],
-    haddock_flags = ["-U"],
-    locale_archive = select({
+[
+    haskell_toolchain(
+        name = name,
+        testonly = 0,
+        compiler_flags = [
+            "-XStandaloneDeriving",  # Flag used at compile time
+            "-threaded",  # Flag used at link time
+
+            # Used by `tests/repl-flags`
+            "-DTESTS_TOOLCHAIN_COMPILER_FLAGS",
+            # this is the default, so it does not harm other tests
+            "-XNoOverloadedStrings",
+        ],
+        exec_compatible_with = ["@bazel_tools//platforms:" + os],
+        haddock_flags = ["-U"],
+        locale_archive = locale_archive,
+        repl_ghci_args = [
+            # The repl test will need this flag, but set by the local
+            # `repl_ghci_args`.
+            "-UTESTS_TOOLCHAIN_REPL_FLAGS",
+            # The repl test will need OverloadedString
+            "-XOverloadedStrings",
+        ],
+        target_compatible_with = ["@bazel_tools//platforms:" + os],
+        tools = tools,
+        version = ghc_version,
+    )
+    for os, tools, locale_archive in [
+        ("linux", "@hackage-ghc//:bin", "@glibc_locales//:locale-archive"),
         # For some reason glibcLocales is not available on Darwin.
-        "@bazel_tools//src/conditions:darwin": None,
-        "@bazel_tools//src/conditions:windows": None,
-        "//conditions:default": "@glibc_locales//:locale-archive",
-    }),
-    repl_ghci_args = [
-        # Used by `tests/repl-flags`
-        "-UTESTS_TOOLCHAIN_REPL_FLAGS",  # The repl test will need this flag, but set by the local `repl_ghci_args`.
-        "-XOverloadedStrings",  # The repl test will need OverloadedString
-    ],
-    tools = select({
-        "@bazel_tools//src/conditions:windows": "@ghc_windows//:bin",
-        "//conditions:default": "@hackage-ghc//:bin",
-    }),
-    version = ghc_version,
-)
+        ("osx", "@hackage-ghc//:bin", None),
+    ]
+    for name in ["ghc_%s" % os]
+]
 
 haskell_doctest_toolchain(
     name = "doctest-toolchain",


### PR DESCRIPTION
Our toolchain implementation was incomplete. We used to assume x86_64 as
the architecture, and never set any platform constraints. We now make it
possible to do so in new attributes to `haskell_toolchain`. This has
important implications. It means that we no longer should define a single
toolchain that states different constraints depending on the host platform.
We now instead have multiple toolchains in scope, one for each operating
system. Which properly declared constraints, the toolchain resolution
mechanism can select the right one.

As a side effect, `ghc_bindist` is now easier to use. Users don't need
to write a separate toolchain declaration and toolchain registration
in addition to the declaring the bindist anymore. The next step after
this PR will be to introduce convenience functions to add external
dependencies for all known bindists, and all known GHC's in Nixpkgs.
That sounds overkill, but the toolchain resolution mechanism makes
this fine. And it's how we'll finally make it seamless for some
developers to use bindists while others on the same project can use
Nixpkgs without having to make edits to the `WORKSPACE`.