### PR TITLE
Compile binary using Template Haskell library on Windows

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -3,7 +3,7 @@
 # Use this configuration when targeting Windows. Eventually this will
 # no longer be required:
 # https://bazel.build/roadmaps/platforms.html#replace---cpu-and---host_cpu-flags.
-build:windows --crosstool_top=@io_tweag_rules_haskell_ghc_windows_amd64//:toolchain
+build:windows --crosstool_top=@io_tweag_rules_haskell_ghc_windows_amd64//:toolchain -s --verbose_failures --sandbox_debug
 
 build:ci --all_incompatible_changes  --incompatible_disable_deprecated_attr_params=false --incompatible_new_actions_api=false --incompatible_expand_directories=false
 build:ci --loading_phase_threads=1

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -51,7 +51,7 @@ nixpkgs_local_repository(
     nix_file = "//nixpkgs:default.nix",
 )
 
-test_ghc_version = "8.6.3"
+test_ghc_version = "8.6.2"
 
 test_compiler_flags = [
     "-XStandaloneDeriving",  # Flag used at compile time

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,7 +5,7 @@ jobs:
   steps:
   - bash: |
       set -e
-      curl -LO https://github.com/bazelbuild/bazel/releases/download/0.20.0/bazel-0.20.0-windows-x86_64.exe
+      curl -LO https://github.com/bazelbuild/bazel/releases/download/0.21.0/bazel-0.21.0-windows-x86_64.exe
       mv bazel-*.exe bazel.exe
       mkdir /c/bazel
       mv bazel.exe /c/bazel

--- a/tests/binary-with-lib/BUILD
+++ b/tests/binary-with-lib/BUILD
@@ -14,6 +14,9 @@ haskell_library(
         "//conditions:default": False,
     }),
     src_strip_prefix = "src",
+    deps = [
+        "//tests/hackage:template-haskell",
+    ],
 )
 
 haskell_test(
@@ -23,5 +26,6 @@ haskell_test(
     deps = [
         ":lib",
         "//tests/hackage:base",
+        "//tests/hackage:template-haskell",
     ],
 )

--- a/tests/binary-with-lib/Main.hs
+++ b/tests/binary-with-lib/Main.hs
@@ -1,7 +1,11 @@
+{-# LANGUAGE TemplateHaskell #-}
 module Main where
 
 import Control.Monad (unless)
 import Lib           (value)
+import Language.Haskell.TH
 
-main = unless (value == 42)
-    $ error $ "Incorrect lib value. Got " <> show value
+val = $(value)
+
+main = unless (val == 42)
+    $ error $ "Incorrect lib value. Got " <> show val

--- a/tests/binary-with-lib/src/Lib.hs
+++ b/tests/binary-with-lib/src/Lib.hs
@@ -1,5 +1,8 @@
 {-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 module Lib (value) where
 
-value = 42
+import Language.Haskell.TH
+
+value = [|42|]


### PR DESCRIPTION
Based on #595 . Closes #600 .

This PR changes the `binary-with-lib` example a bit to make use of Template Haskell. This is to validate basic TH support on Windows, even with the lack of dynamic linking.