### PR TITLE
User-defined GHC flags override the default ones.

### DIFF
--- a/haskell/private/actions/compile.bzl
+++ b/haskell/private/actions/compile.bzl
@@ -197,7 +197,6 @@ def _compilation_defaults(hs, cc, java, dep_info, srcs, import_dir_map, extra_sr
     if hs.mode == "opt":
         args.add("-O2")
 
-    args.add(ghc_args)
     args.add(["-static"])
     if with_profiling:
         args.add("-prof", "-fexternal-interpreter")
@@ -229,6 +228,8 @@ def _compilation_defaults(hs, cc, java, dep_info, srcs, import_dir_map, extra_sr
             "-osuf",
             "p_o",
         ])
+
+    args.add(ghc_args)
 
     # Pass source files
     for f in set.to_list(source_files):


### PR DESCRIPTION
When the same flag (eg. -vx) is instantiated several times with
different values, GHC uses the outermost one.

This PR switches the order we append the user-defined flags.

Fixes #601 