### PR TITLE
Toolchain registration macros

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -15,3 +15,5 @@ test:ci --test_output=errors
 # environment variables, such as LOCALE_ARCHIVE
 # We also need to setup an utf8 locale
 test --test_env=LANG=en_US.utf8 --test_env=LOCALE_ARCHIVE
+
+try-import .bazelrc.local

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,14 +22,15 @@ jobs:
       - run:
           name: Build tests
           command: |
-            nix-shell --arg docTools false --pure --run 'bazel build --config ci --jobs=2 --build_tests_only //tests/...'
+            nix-shell --arg docTools false --pure --run 'bazel build --config ci --jobs=2 --host_platform=@io_tweag_rules_haskell//haskell/platforms:linux_x86_64_nixpkgs --build_tests_only //tests/...'
       - run:
           name: Run tests
           # bazel does not support recursive bazel call, so we
           # cannot use bazel run here because the test runner uses
           # bazel
           command: |
-            nix-shell --arg docTools false --pure --run 'bazel build //tests:run-tests && ./bazel-bin/tests/run-tests'
+            nix-shell --arg docTools false --pure --run 'bazel build --config ci --host_platform=@io_tweag_rules_haskell//haskell/platforms:linux_x86_64_nixpkgs //tests:run-tests'
+            nix-shell --arg docTools false --pure --run './bazel-ci-bin/tests/run-tests'
 
   build-darwin:
     macos:
@@ -44,14 +45,15 @@ jobs:
           name: Build tests
           shell: /bin/bash -eilo pipefail
           command: |
-            nix-shell --arg docTools false --pure --run 'bazel build --config ci --jobs=2 --build_tests_only //tests/...'
+            nix-shell --arg docTools false --pure --run 'bazel build --config ci --host_platform=@io_tweag_rules_haskell//haskell/platforms:darwin_x86_64_nixpkgs --jobs=2 --build_tests_only //tests/...'
       - run:
           name: Run tests
           shell: /bin/bash -eilo pipefail
           command: |
+            nix-shell --arg docTools false --pure --run 'bazel build --config ci --host_platform=@io_tweag_rules_haskell//haskell/platforms:darwin_x86_64_nixpkgs //tests:run-tests'
             # XXX 2019-01-22 Disable start script checking on Darwin
             # due to a clash between binutils and clang.
-            nix-shell --arg docTools false --pure --run 'bazel build //tests:run-tests && ./bazel-bin/tests/run-tests --skip "/startup script/"'
+            nix-shell --arg docTools false --pure --run './bazel-ci-bin/tests/run-tests --skip "/startup script/"'
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,17 +20,24 @@ jobs:
             # https://discourse.nixos.org/t/nixos-on-ovh-kimsufi-cloning-builder-process-operation-not-permitted/1494/5
             mkdir -p /etc/nix && echo "sandbox = false" > /etc/nix/nix.conf
       - run:
+          name: Configure
+          command: |
+            echo "build:ci --host_platform=@io_tweag_rules_haskell//haskell/platforms:linux_x86_64_nixpkgs" > .bazelrc.local
+      - run:
           name: Build tests
           command: |
-            nix-shell --arg docTools false --pure --run 'bazel build --config ci --jobs=2 --host_platform=@io_tweag_rules_haskell//haskell/platforms:linux_x86_64_nixpkgs --build_tests_only //tests/...'
+            nix-shell --arg docTools false --pure --run \
+              'bazel build --config ci //tests/...'
       - run:
           name: Run tests
           # bazel does not support recursive bazel call, so we
           # cannot use bazel run here because the test runner uses
           # bazel
           command: |
-            nix-shell --arg docTools false --pure --run 'bazel build --config ci --host_platform=@io_tweag_rules_haskell//haskell/platforms:linux_x86_64_nixpkgs //tests:run-tests'
-            nix-shell --arg docTools false --pure --run './bazel-ci-bin/tests/run-tests'
+            nix-shell --arg docTools false --pure --run \
+              'bazel build --config ci //tests:run-tests'
+            nix-shell --arg docTools false --pure --run \
+              './bazel-ci-bin/tests/run-tests'
 
   build-darwin:
     macos:
@@ -42,18 +49,25 @@ jobs:
           command: |
             curl https://nixos.org/nix/install | sh
       - run:
+          name: Configure
+          command: |
+            echo "build:ci --host_platform=@io_tweag_rules_haskell//haskell/platforms:darwin_x86_64_nixpkgs" > .bazelrc.local
+      - run:
           name: Build tests
           shell: /bin/bash -eilo pipefail
           command: |
-            nix-shell --arg docTools false --pure --run 'bazel build --config ci --host_platform=@io_tweag_rules_haskell//haskell/platforms:darwin_x86_64_nixpkgs --jobs=2 --build_tests_only //tests/...'
+            nix-shell --arg docTools false --pure --run \
+              'bazel build --config ci //tests/...'
       - run:
           name: Run tests
           shell: /bin/bash -eilo pipefail
           command: |
-            nix-shell --arg docTools false --pure --run 'bazel build --config ci --host_platform=@io_tweag_rules_haskell//haskell/platforms:darwin_x86_64_nixpkgs //tests:run-tests'
+            nix-shell --arg docTools false --pure --run \
+              'bazel build --config ci //tests:run-tests'
             # XXX 2019-01-22 Disable start script checking on Darwin
             # due to a clash between binutils and clang.
-            nix-shell --arg docTools false --pure --run './bazel-ci-bin/tests/run-tests --skip "/startup script/"'
+            nix-shell --arg docTools false --pure --run \
+              './bazel-ci-bin/tests/run-tests --skip "/startup script/"'
 
 workflows:
   version: 2

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /bazel-*
+.bazelrc.local

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [0.8] - 2019-xx-xx
 
-### Fixed
+### Added
 
-* The evaluation of the `WORKSPACE` on Windows is successful. The `nix-build`
-  calls are bypassed.
-* The evaluation of the `buildifier` on Windows is successful. The Go SDK
-  is downloaded.
-* GHC can successfully be invoked on Windows. The Go SDK
-  is downloaded.
+* `haskell_register_toolchains`, `haskell_register_ghc_bindists` and
+  `haskell_register_ghc_nixpkgs` to register multiple toolchains for
+  multiple platforms at once. Toolchains from binary distributions can
+  now coexist with toolchains from Nixpkgs, even on the same platform.
+* Support for Bazel v0.21.
 
 ### Removed
 
@@ -26,12 +25,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   had been deprecated two versions ago and is removed.
   Use `haskell_import` instead (see docs for usage).
 * The `extra_binaries` field is now no longer supported.
-* Support for Bazel 0.21.
+
+### Changed
+
+* The minimum supported Bazel version is now v0.21.
+* `ghc_bindist` now requires a `target` argument. Use
+  `haskell_register_ghc_nixpkgs` to call `ghc_bindist` once per known
+  target.
+* `ghc_bindist` now registers itself as a toolchain. We no longer
+  require a separate toolchain definition and registration in addition
+  to `ghc_bindist`.
+* `c2hs` support is now provided in a separate toolchain called
+  `c2hs_toolchain`, rather than an optional extra to the
+  `haskell_toolchain`.
 
 ### Fixed
 
-* Fix static linking with C libraries that are indirectly depended upon
-* Fix repl targets that have indirect cc_library dependencies
+* Fix static linking with C libraries that are indirectly depended
+  upon.
+* Fix repl targets that have indirect cc_library dependencies.
 
 ## [0.7] - 2018-12-24
 

--- a/README.md
+++ b/README.md
@@ -79,56 +79,19 @@ http_archive(
   urls = ["https://github.com/tweag/rules_haskell/archive/v$VERSION.tar.gz"],
 )
 
-load("@io_tweag_rules_haskell//haskell:repositories.bzl", "haskell_repositories")
+load(
+    "@io_tweag_rules_haskell//haskell:haskell.bzl",
+	"haskell_repositories",
+	"haskell_register_toolchains",
+)
+
 haskell_repositories()
 
-register_toolchains("//:ghc")
+haskell_register_toolchains()
 ```
 
-Then, add this to your root `BUILD` file:
-
-```bzl
-load("@io_tweag_rules_haskell//haskell:haskell.bzl",
-  "haskell_toolchain",
-)
-
-haskell_toolchain(
-  name = "ghc",
-  version = "8.2.2",
-  tools = "@my_ghc//:bin",
-)
-```
-
-The `haskell_toolchain` rule instantiation brings a GHC compiler in
-scope. It assumes that an [external repository][external-repositories]
-called `@my_ghc` was defined, pointing to an installation of GHC. The
-recommended option is to provision GHC using Nix, but you can also
-point to an existing local installation somewhere in your filesystem.
-Using Nix, this is done by adding the following to your `WORKSPACE`
-file:
-
-```bzl
-nixpkgs_package(
-  name = "my_ghc",
-  attribute_path = "haskell.compiler.ghc822"
-)
-```
-
-Alternatively, you can point to an existing global installation:
-
-```bzl
-new_local_repository(
-  name = "my_ghc",
-  path = "/usr/local", # Change path accordingly.
-  build_file_content = """
-package(default_visibility = ["//visibility:public"])
-filegroup(
-    name = "bin",
-    srcs = glob(["bin/*"]),
-)
-"""
-)
-```
+You will then need to write one `BUILD` file for each "package" you
+want to define. See below for examples.
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The full reference documentation for rules is at https://haskell.build.
 
 ## Setup
 
-You'll need [Bazel >= 0.20.0][bazel-getting-started] installed.
+You'll need [Bazel >= 0.21.0][bazel-getting-started] installed.
 
 ### The easy way
 

--- a/README.md
+++ b/README.md
@@ -138,6 +138,14 @@ See [rules_haskell_examples][] for examples of using these rules.
 
 ## For `rules_haskell` developers
 
+### Saving common command-line flags to a file
+
+If you find yourself constantly passing the same flags on the
+command-line for certain commands (such as `--host_platform` or
+`--compiler`), you can augment the [`.bazelrc`](./.bazelrc) file in
+this repository with a `.bazelrc.local` file. This file is ignored by
+Git.
+
 ### Reference a local checkout of `rules_haskell`
 
 When you develop on `rules_haskell`, you usually do it in the context

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -51,6 +51,42 @@ nixpkgs_local_repository(
     nix_file = "//nixpkgs:default.nix",
 )
 
+test_ghc_version = "8.6.3"
+
+test_compiler_flags = [
+    "-XStandaloneDeriving",  # Flag used at compile time
+    "-threaded",  # Flag used at link time
+
+    # Used by `tests/repl-flags`
+    "-DTESTS_TOOLCHAIN_COMPILER_FLAGS",
+    # this is the default, so it does not harm other tests
+    "-XNoOverloadedStrings",
+]
+
+test_haddock_flags = ["-U"]
+
+test_repl_ghci_args = [
+    # The repl test will need this flag, but set by the local
+    # `repl_ghci_args`.
+    "-UTESTS_TOOLCHAIN_REPL_FLAGS",
+    # The repl test will need OverloadedString
+    "-XOverloadedStrings",
+]
+
+load(
+    "@io_tweag_rules_haskell//haskell:nixpkgs.bzl",
+    "haskell_register_ghc_nixpkgs",
+)
+
+haskell_register_ghc_nixpkgs(
+    compiler_flags = test_compiler_flags,
+    haddock_flags = test_haddock_flags,
+    locale_archive = "@glibc_locales//:locale-archive",
+    nix_file = "//tests:ghc.nix",
+    repl_ghci_args = test_repl_ghci_args,
+    version = test_ghc_version,
+)
+
 load(
     "@io_tweag_rules_haskell//haskell:ghc_bindist.bzl",
     "haskell_register_ghc_bindists",
@@ -59,8 +95,6 @@ load(
 haskell_register_ghc_bindists(version = test_ghc_version)
 
 register_toolchains(
-    "//tests:ghc_linux",
-    "//tests:ghc_osx",
     "//tests:c2hs-toolchain",
     "//tests:doctest-toolchain",
     "//tests:protobuf-toolchain",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -74,7 +74,8 @@ test_repl_ghci_args = [
 ]
 
 load(
-    "@io_tweag_rules_haskell//haskell:nixpkgs.bzl",
+    "@io_tweag_rules_haskell//haskell:haskell.bzl",
+    "haskell_register_ghc_bindists",
     "haskell_register_ghc_nixpkgs",
 )
 
@@ -85,11 +86,6 @@ haskell_register_ghc_nixpkgs(
     nix_file = "//tests:ghc.nix",
     repl_ghci_args = test_repl_ghci_args,
     version = test_ghc_version,
-)
-
-load(
-    "@io_tweag_rules_haskell//haskell:ghc_bindist.bzl",
-    "haskell_register_ghc_bindists",
 )
 
 haskell_register_ghc_bindists(version = test_ghc_version)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -52,19 +52,11 @@ nixpkgs_local_repository(
 )
 
 load(
-    "@io_tweag_rules_haskell//haskell:haskell.bzl",
-    "ghc_bindist",
+    "@io_tweag_rules_haskell//haskell:ghc_bindist.bzl",
+    "haskell_register_ghc_bindists",
 )
 
-# XXX: this needs to be kept in sync with `ghc_version` in `tests/BUILD`
-ghc_version = "8.6.3"
-
-# A GHC from a bindist for Windows
-ghc_bindist(
-    name = "ghc_windows",
-    target = "windows_amd64",
-    version = ghc_version,
-)
+haskell_register_ghc_bindists(version = test_ghc_version)
 
 register_toolchains(
     "//tests:ghc_linux",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -23,7 +23,7 @@ load(
     "nixpkgs_package",
 )
 load(
-    "@io_tweag_rules_haskell//haskell:nix.bzl",
+    "@io_tweag_rules_haskell//haskell:nixpkgs.bzl",
     "haskell_nixpkgs_package",
     "haskell_nixpkgs_packageset",
 )

--- a/docs/BUILD
+++ b/docs/BUILD
@@ -40,7 +40,7 @@ skylark_doc(
         "//haskell:cc.bzl",
         "//haskell:repositories.bzl",
         "//haskell:ghc_bindist.bzl",
-        "//haskell:nix.bzl",
+        "//haskell:nixpkgs.bzl",
     ],
     format = "html",
 )

--- a/haskell/ghc_bindist.bzl
+++ b/haskell/ghc_bindist.bzl
@@ -190,3 +190,24 @@ def ghc_bindist(name, version, target):
         target = target,
     )
     native.register_toolchains("@{}//:toolchain".format(toolchain_name))
+
+def haskell_register_ghc_bindists(version):
+    """Register GHC binary distributions for all platforms as toolchains.
+
+    Toolchains can be used to compile Haskell code. This function
+    registers one toolchain for each known binary distribution on all
+    platforms of the given GHC version. During the build, one
+    toolchain will be selected based on the host and target platforms
+    (See [toolchain resolution][toolchain-resolution]).
+
+    [toolchain-resolution]: https://docs.bazel.build/versions/master/toolchains.html#toolchain-resolution
+
+    """
+    if not _GHC_BINDISTS.get(version):
+        fail("Binary distribution of GHC {} not available.".format(version))
+    for target in _GHC_BINDISTS[version]:
+        ghc_bindist(
+            name = "io_tweag_rules_haskell_ghc_{}".format(target),
+            target = target,
+            version = version,
+        )

--- a/haskell/ghc_bindist.bzl
+++ b/haskell/ghc_bindist.bzl
@@ -1,6 +1,6 @@
 """Workspace rules (GHC binary distributions)"""
 
-_GHC_BINS = {
+_GHC_BINDISTS = {
     "8.6.3": {
         "linux_amd64": ("https://downloads.haskell.org/~ghc/8.6.3/ghc-8.6.3-x86_64-deb8-linux.tar.xz", "291ca565374f4d51cc311488581f3279d3167a064fabfd4a6722fe2bd4532fd5"),
         "darwin_amd64": ("https://downloads.haskell.org/~ghc/8.6.3/ghc-8.6.3-x86_64-apple-darwin.tar.xz", "79d069a1a7d74cfdd7ac2a2711c45d3ddc6265b988a0cefa342714b24f997fc1"),
@@ -66,10 +66,10 @@ def _ghc_bindist_impl(ctx):
     target = ctx.attr.target
     os, _, arch = target.partition("_")
 
-    if _GHC_BINS[version].get(target) == None:
+    if _GHC_BINDISTS[version].get(target) == None:
         fail("Operating system {0} does not have a bindist for GHC version {1}".format(ctx.os.name, ctx.attr.version))
     else:
-        url, sha256 = _GHC_BINS[version][target]
+        url, sha256 = _GHC_BINDISTS[version][target]
 
     bindist_dir = ctx.path(".")  # repo path
 
@@ -98,7 +98,7 @@ _ghc_bindist = repository_rule(
     attrs = {
         "version": attr.string(
             default = _GHC_DEFAULT_VERSION,
-            values = _GHC_BINS.keys(),
+            values = _GHC_BINDISTS.keys(),
             doc = "The desired GHC version",
         ),
         "target": attr.string(),

--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -17,6 +17,7 @@ load(
 load(
     ":ghc_bindist.bzl",
     _ghc_bindist = "ghc_bindist",
+    _haskell_register_ghc_bindists = "haskell_register_ghc_bindists",
 )
 load(
     ":haddock.bzl",
@@ -27,6 +28,10 @@ load(
     ":lint.bzl",
     _haskell_lint = "haskell_lint",
     _haskell_lint_aspect = "haskell_lint_aspect",
+)
+load(
+    ":nixpkgs.bzl",
+    _haskell_register_ghc_nixpkgs = "haskell_register_ghc_nixpkgs",
 )
 load(
     ":private/haskell_impl.bzl",
@@ -43,6 +48,7 @@ load(
 )
 load(
     ":toolchain.bzl",
+    _haskell_register_toolchains = "haskell_register_toolchains",
     _haskell_toolchain = "haskell_toolchain",
 )
 
@@ -260,6 +266,12 @@ haskell_lint_aspect = _haskell_lint_aspect
 haskell_doctest = _haskell_doctest
 
 haskell_doctest_toolchain = _haskell_doctest_toolchain
+
+haskell_register_toolchains = _haskell_register_toolchains
+
+haskell_register_ghc_bindists = _haskell_register_ghc_bindists
+
+haskell_register_ghc_nixpkgs = _haskell_register_ghc_nixpkgs
 
 haskell_toolchain = _haskell_toolchain
 

--- a/haskell/nixpkgs.bzl
+++ b/haskell/nixpkgs.bzl
@@ -106,7 +106,7 @@ def _gen_imports_impl(repository_ctx):
         extra_args_raw += foo + " = " + bar + ", "
     bzl_file_content = """
 load("{repo_name}", "packages")
-load("@io_tweag_rules_haskell//haskell:nix.bzl", "haskell_nixpkgs_packages")
+load("@io_tweag_rules_haskell//haskell:nixpkgs.bzl", "haskell_nixpkgs_packages")
 
 def import_packages(name):
     haskell_nixpkgs_packages(
@@ -187,7 +187,7 @@ def haskell_nixpkgs_packageset(name, base_attribute_path, repositories = {}, **k
           revision = "9a787af6bc75a19ac9f02077ade58ddc248e674a",
       )
 
-      load("@io_tweag_rules_haskell//haskell:nix.bzl",
+      load("@io_tweag_rules_haskell//haskell:nixpkgs.bzl",
           "haskell_nixpkgs_packageset",
 
       # Generate a list of all the available haskell packages

--- a/haskell/platforms/BUILD
+++ b/haskell/platforms/BUILD
@@ -9,3 +9,31 @@
 load(":list.bzl", "declare_config_settings")
 
 declare_config_settings()
+
+constraint_value(
+    name = "nixpkgs",
+    constraint_setting = "@bazel_tools//tools/cpp:cc_compiler",
+    visibility = ["//visibility:public"],
+)
+
+platform(
+    name = "linux_x86_64_nixpkgs",
+    constraint_values = [
+        # XXX using the platform names defined here results in a graph
+        # cycle for some reason.
+        "@bazel_tools//platforms:x86_64",
+        "@bazel_tools//platforms:linux",
+        ":nixpkgs",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+platform(
+    name = "darwin_x86_64_nixpkgs",
+    constraint_values = [
+        "@bazel_tools//platforms:x86_64",
+        "@bazel_tools//platforms:osx",
+        ":nixpkgs",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/haskell/toolchain.bzl
+++ b/haskell/toolchain.bzl
@@ -235,6 +235,7 @@ def haskell_toolchain(
         compiler_flags = [],
         repl_ghci_args = [],
         haddock_flags = [],
+        locale_archive = None,
         **kwargs):
     """Declare a compiler toolchain.
 
@@ -269,9 +270,9 @@ def haskell_toolchain(
       ```
     """
     if exec_compatible_with and not target_compatible_with:
-        exec_compatible_with = target_compatible_with
-    elif target_compatible_with and not exec_compatible_with:
         target_compatible_with = exec_compatible_with
+    elif target_compatible_with and not exec_compatible_with:
+        exec_compatible_with = target_compatible_with
     impl_name = name + "-impl"
     corrected_ghci_args = repl_ghci_args + ["-no-user-package-db"]
     _haskell_toolchain(
@@ -289,6 +290,13 @@ def haskell_toolchain(
         is_windows = select({
             "@io_tweag_rules_haskell//haskell/platforms:mingw32": True,
             "//conditions:default": False,
+        }),
+        # Ignore this attribute on any platform that is not Linux. The
+        # LOCALE_ARCHIVE environment variable is a Linux-specific
+        # Nixpkgs hack.
+        locale_archive = select({
+            "@io_tweag_rules_haskell//haskell/platforms:linux": locale_archive,
+            "//conditions:default": None,
         }),
         **kwargs
     )

--- a/haskell/toolchain.bzl
+++ b/haskell/toolchain.bzl
@@ -1,6 +1,7 @@
 """Rules for defining toolchains"""
 
 load("@bazel_skylib//lib:paths.bzl", "paths")
+load(":ghc_bindist.bzl", "haskell_register_ghc_bindists")
 load(
     ":private/actions/compile.bzl",
     "compile_binary",
@@ -307,3 +308,10 @@ def haskell_toolchain(
         exec_compatible_with = exec_compatible_with,
         target_compatible_with = target_compatible_with,
     )
+
+def haskell_register_toolchains(version):
+    """Download the binary distribution of GHC for your current platform
+    and register it as a toolchain. This currently has the same effect
+    as just `haskell_register_ghc_bindists(version)`.
+    """
+    haskell_register_ghc_bindists(version)

--- a/start
+++ b/start
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 MIN_BAZEL_MAJOR=0
-MIN_BAZEL_MINOR=20
+MIN_BAZEL_MINOR=21
 
 set -e
 

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -15,52 +15,15 @@ load(
 
 package(default_testonly = 1)
 
-ghc_version = "8.6.3"
-
-# These toolchains are all morally testonly. However, that would break
-# our tests of haskell_library_rules: aspects of non-testonly
-# proto_library rules (from com_google_protobuf) can't themselves be
-# testonly.
-
-[
-    haskell_toolchain(
-        name = name,
-        testonly = 0,
-        compiler_flags = [
-            "-XStandaloneDeriving",  # Flag used at compile time
-            "-threaded",  # Flag used at link time
-
-            # Used by `tests/repl-flags`
-            "-DTESTS_TOOLCHAIN_COMPILER_FLAGS",
-            # this is the default, so it does not harm other tests
-            "-XNoOverloadedStrings",
-        ],
-        exec_compatible_with = ["@bazel_tools//platforms:" + os],
-        haddock_flags = ["-U"],
-        locale_archive = locale_archive,
-        repl_ghci_args = [
-            # The repl test will need this flag, but set by the local
-            # `repl_ghci_args`.
-            "-UTESTS_TOOLCHAIN_REPL_FLAGS",
-            # The repl test will need OverloadedString
-            "-XOverloadedStrings",
-        ],
-        target_compatible_with = ["@bazel_tools//platforms:" + os],
-        tools = tools,
-        version = ghc_version,
-    )
-    for os, tools, locale_archive in [
-        ("linux", "@hackage-ghc//:bin", "@glibc_locales//:locale-archive"),
-        # For some reason glibcLocales is not available on Darwin.
-        ("osx", "@hackage-ghc//:bin", None),
-    ]
-    for name in ["ghc_%s" % os]
-]
-
 haskell_doctest_toolchain(
     name = "doctest-toolchain",
     doctest = "@hackage-doctest//:bin",
 )
+
+# This toolchain is morally testonly. However, that would break our
+# tests of haskell_library_rules: aspects of non-testonly
+# proto_library rules (from com_google_protobuf) can't themselves be
+# testonly.
 
 haskell_proto_toolchain(
     name = "protobuf-toolchain",
@@ -84,7 +47,6 @@ haskell_proto_toolchain(
 
 c2hs_toolchain(
     name = "c2hs-toolchain",
-    testonly = 0,
     c2hs = "@hackage-c2hs//:bin",
 )
 
@@ -263,6 +225,9 @@ rule_test(
     generates = ["java_classpath"],
     rule = "//tests/java_classpath",
 )
+
+# Keep in sync with test_ghc_version in WORKSPACE.
+ghc_version = "8.6.3"
 
 rule_test(
     name = "test-cc_haskell_import-output",


### PR DESCRIPTION
It was previously hard to let the user select between a Nixpkgs based
toolchain and a binary distributions based one. Most
projects (including rules_haskell) were essentially hardcoding this
choice for the user. It is now much easier to do. The trick is to
supply three new workspace macros:

```
haskell_register_toolchains()    # Same as the second one.
haskell_register_ghc_bindists()
haskell_register_ghc_nixpkgs()
```

The second function above defines and registers one toolchain per
binary distribution. So e.g. one for Windows, one for Linux etc. The
third one currently defines exactly one toolchain, which matches the
constraints of the host platform. It might define more in the
future (in particular cross-compilers).

As a project author, you are free to just the second one or just the
third one, or both. While the Nixpkgs toolchain was always selected if
it existed previously, now it will only be selected if the user
explicitly sets the host platform in a certain way. See the
documentation about the details.