### PR TITLE
Fixing bazel 0.22 incompatible changes.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,6 +1,6 @@
 # See https://docs.bazel.build/versions/master/user-manual.html#bazelrc.
 
-#build:ci --all_incompatible_changes
+build:ci --all_incompatible_changes  --incompatible_disable_deprecated_attr_params=false --incompatible_new_actions_api=false --incompatible_expand_directories=false
 build:ci --loading_phase_threads=1
 build:ci --jobs=2
 build:ci --verbose_failures
@@ -8,6 +8,7 @@ build:ci --verbose_failures
 # can be changed by user.
 build:ci --symlink_prefix=bazel-ci-
 common:ci --color=no
+test:ci --all_incompatible_changes  --incompatible_disable_deprecated_attr_params=false --incompatible_new_actions_api=false --incompatible_expand_directories=false
 test:ci --test_output=errors
 
 # test environment does not propagate locales by default

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -185,9 +185,14 @@ http_archive(
     urls = ["https://hackage.haskell.org/package/zlib-0.6.2/zlib-0.6.2.tar.gz"],
 )
 
-maven_jar(
+load("@bazel_tools//tools/build_defs/repo:jvm.bzl", "jvm_maven_import_external")
+
+jvm_maven_import_external(
     name = "org_apache_spark_spark_core_2_10",
     artifact = "org.apache.spark:spark-core_2.10:1.6.0",
+    artifact_sha256 = "28aad0602a5eea97e9cfed3a7c5f2934cd5afefdb7f7c1d871bb07985453ea6e",
+    licenses = ["notice"],
+    server_urls = ["http://central.maven.org/maven2"],
 )
 
 # c2hs rule in its own repository

--- a/haskell/c2hs.bzl
+++ b/haskell/c2hs.bzl
@@ -27,14 +27,14 @@ def _c2hs_library_impl(ctx):
     chs_dir_raw = target_unique_name(hs, "chs")
     hs_file = declare_compiled(hs, chs_file, ".hs", directory = chs_dir_raw)
     chi_file = declare_compiled(hs, chs_file, ".chi", directory = chs_dir_raw)
-    args.add([chs_file.path, "-o", hs_file.path])
+    args.add_all([chs_file.path, "-o", hs_file.path])
 
-    args.add(["-C-E"])
-    args.add(["--cpp", cc.tools.cc])
+    args.add("-C-E")
+    args.add_all(["--cpp", cc.tools.cc])
     args.add("-C-includeghcplatform.h")
     args.add("-C-includeghcversion.h")
-    args.add(["-C" + x for x in cc.cpp_flags])
-    args.add(["-C" + x for x in cc.include_args])
+    args.add_all(["-C" + x for x in cc.cpp_flags])
+    args.add_all(["-C" + x for x in cc.include_args])
 
     dep_chi_files = [
         dep[C2hsLibraryInfo].chi_file
@@ -47,7 +47,7 @@ def _c2hs_library_impl(ctx):
         for dep in ctx.attr.deps
         if C2hsLibraryInfo in dep
     ]
-    args.add(chi_includes)
+    args.add_all(chi_includes)
 
     hs.actions.run_shell(
         inputs = depset(transitive = [

--- a/haskell/doctest.bzl
+++ b/haskell/doctest.bzl
@@ -91,7 +91,7 @@ def _haskell_doctest_single(target, ctx):
     bin_info = target[HaskellBinaryInfo] if HaskellBinaryInfo in target else None
 
     args = ctx.actions.args()
-    args.add(["--no-magic"])
+    args.add("--no-magic")
 
     doctest_log = ctx.actions.declare_file(
         "doctest-log-" + ctx.label.name + "-" + (
@@ -102,10 +102,10 @@ def _haskell_doctest_single(target, ctx):
     toolchain = ctx.toolchains["@io_tweag_rules_haskell//haskell:doctest-toolchain"]
 
     # GHC flags we have prepared before.
-    args.add(lib_info.ghc_args if lib_info != None else bin_info.ghc_args)
+    args.add_all(lib_info.ghc_args if lib_info != None else bin_info.ghc_args)
 
     # Add any extra flags specified by the user.
-    args.add(ctx.attr.doctest_flags)
+    args.add_all(ctx.attr.doctest_flags)
 
     # External libraries.
     external_libraries = build_info.external_libraries
@@ -115,12 +115,12 @@ def _haskell_doctest_single(target, ctx):
         if not set.is_member(seen_libs, lib_name):
             set.mutable_insert(seen_libs, lib_name)
             if hs.toolchain.is_darwin:
-                args.add([
+                args.add_all([
                     "-optl-l{0}".format(lib_name),
                     "-optl-L{0}".format(paths.dirname(lib.path)),
                 ])
             else:
-                args.add([
+                args.add_all([
                     "-l{0}".format(lib_name),
                     "-L{0}".format(paths.dirname(lib.path)),
                 ])
@@ -136,7 +136,7 @@ def _haskell_doctest_single(target, ctx):
     else:
         exposed_modules_file = ctx.actions.declare_file("doctest_modules")
         exposed_args = ctx.actions.args()
-        exposed_args.add(ctx.attr.modules)
+        exposed_args.add_all(ctx.attr.modules)
         ctx.actions.write(exposed_modules_file, exposed_args)
 
     ctx.actions.run_shell(

--- a/haskell/haddock.bzl
+++ b/haskell/haddock.bzl
@@ -47,7 +47,7 @@ def _haskell_doc_aspect_impl(target, ctx):
     args = ctx.actions.args()
     args.add("--package-name={0}".format(package_id))
     args.add("--package-version={0}".format(version))
-    args.add([
+    args.add_all([
         "-D",
         haddock_file.path,
         "-o",
@@ -79,9 +79,9 @@ def _haskell_doc_aspect_impl(target, ctx):
 
     ghc_args = ctx.actions.args()
     for x in target[HaskellLibraryInfo].ghc_args:
-        ghc_args.add(["--optghc", x])
-    ghc_args.add([x.path for x in set.to_list(target[HaskellLibraryInfo].source_files)])
-    ghc_args.add(["-v0"])
+        ghc_args.add_all(["--optghc", x])
+    ghc_args.add_all([x.path for x in set.to_list(target[HaskellLibraryInfo].source_files)])
+    ghc_args.add("-v0")
 
     # haddock flags should take precedence over ghc args, hence are in
     # last position
@@ -228,7 +228,7 @@ def _haskell_doc_rule_impl(ctx):
     index_root = ctx.actions.declare_directory(index_root_raw)
 
     args = ctx.actions.args()
-    args.add([
+    args.add_all([
         "-o",
         index_root.path,
         "--title={0}".format(ctx.attr.name),
@@ -254,7 +254,7 @@ def _haskell_doc_rule_impl(ctx):
                 ))
 
     for cache in set.to_list(all_caches):
-        args.add(["--optghc=-package-db={0}".format(cache.dirname)])
+        args.add("--optghc=-package-db={0}".format(cache.dirname))
 
     locale_archive_depset = (
         depset([hs.toolchain.locale_archive]) if hs.toolchain.locale_archive != None else depset()

--- a/haskell/import.bzl
+++ b/haskell/import.bzl
@@ -78,9 +78,9 @@ def _haskell_import_impl(ctx):
         direct_prebuilt_deps = set.empty(),
         extra_libraries = set.empty(),
     )
-    html_files = list(ctx.attr.haddock_html.files)
+    html_files = ctx.attr.haddock_html.files.to_list()
     transitive_html = {ctx.attr.package_id: local_haddock_html} if html_files != [] else {}
-    interface_files = list(ctx.attr.haddock_interfaces.files)
+    interface_files = ctx.attr.haddock_interfaces.files.to_list()
     transitive_haddocks = {ctx.attr.package_id: interface_files[0]} if interface_files != [] else {}
 
     haddockInfo = HaddockInfo(

--- a/haskell/lint.bzl
+++ b/haskell/lint.bzl
@@ -39,7 +39,7 @@ def _haskell_lint_aspect_impl(target, ctx):
 
     args = ctx.actions.args()
 
-    args.add([
+    args.add_all([
         "-O0",
         "-v0",
         "-fno-code",
@@ -53,7 +53,7 @@ def _haskell_lint_aspect_impl(target, ctx):
         "--make",
     ])
 
-    args.add(expose_packages(
+    args.add_all(expose_packages(
         build_info,
         lib_info,
         use_direct = False,
@@ -66,7 +66,7 @@ def _haskell_lint_aspect_impl(target, ctx):
         lib_info.source_files if lib_info != None else bin_info.source_files,
     )
 
-    args.add(sources)
+    args.add_all(sources)
 
     lint_log = ctx.actions.declare_file(
         target_unique_name(hs, "lint-log"),

--- a/haskell/private/actions/compile.bzl
+++ b/haskell/private/actions/compile.bzl
@@ -34,17 +34,17 @@ def _process_hsc_file(hs, cc, hsc_flags, hsc_file):
     # Output a Haskell source file.
     hsc_dir_raw = paths.join("_hsc", hs.name)
     hs_out = declare_compiled(hs, hsc_file, ".hs", directory = hsc_dir_raw)
-    args.add([hsc_file.path, "-o", hs_out.path])
+    args.add_all([hsc_file.path, "-o", hs_out.path])
 
-    args.add(["-c", cc.tools.cc])
-    args.add(["-l", cc.tools.cc])
+    args.add_all(["-c", cc.tools.cc])
+    args.add_all(["-l", cc.tools.cc])
     args.add("-ighcplatform.h")
     args.add("-ighcversion.h")
-    args.add(["--cflag=" + f for f in cc.cpp_flags])
-    args.add(["--cflag=" + f for f in cc.compiler_flags])
-    args.add(["--cflag=" + f for f in cc.include_args])
-    args.add(["--lflag=" + f for f in cc.linker_flags])
-    args.add(hsc_flags)
+    args.add_all(["--cflag=" + f for f in cc.cpp_flags])
+    args.add_all(["--cflag=" + f for f in cc.compiler_flags])
+    args.add_all(["--cflag=" + f for f in cc.include_args])
+    args.add_all(["--lflag=" + f for f in cc.linker_flags])
+    args.add_all(hsc_flags)
 
     hs.actions.run(
         inputs = depset(transitive = [
@@ -197,12 +197,12 @@ def _compilation_defaults(hs, cc, java, dep_info, srcs, import_dir_map, extra_sr
     if hs.mode == "opt":
         args.add("-O2")
 
-    args.add(["-static"])
+    args.add("-static")
     if with_profiling:
         args.add("-prof", "-fexternal-interpreter")
 
     # Common flags
-    args.add([
+    args.add_all([
         "-v0",
         "-c",
         "--make",
@@ -211,7 +211,7 @@ def _compilation_defaults(hs, cc, java, dep_info, srcs, import_dir_map, extra_sr
     ])
 
     # Output directories
-    args.add([
+    args.add_all([
         "-odir",
         objects_dir,
         "-hidir",
@@ -222,14 +222,14 @@ def _compilation_defaults(hs, cc, java, dep_info, srcs, import_dir_map, extra_sr
     # https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/packages.html#installedpackageinfo-a-package-specification
     # otherwise we won't be able to register them with ghc-pkg.
     if with_profiling:
-        args.add([
+        args.add_all([
             "-hisuf",
             "p_hi",
             "-osuf",
             "p_o",
         ])
 
-    args.add(ghc_args)
+    args.add_all(ghc_args)
 
     # Pass source files
     for f in set.to_list(source_files):
@@ -282,13 +282,13 @@ def compile_binary(hs, cc, java, dep_info, srcs, ls_modules, import_dir_map, ext
         source_files: set of Haskell source files
     """
     c = _compilation_defaults(hs, cc, java, dep_info, srcs, import_dir_map, extra_srcs, compiler_flags, with_profiling, my_pkg_id = None, version = version)
-    c.args.add(["-main-is", main_function])
+    c.args.add_all(["-main-is", main_function])
     if dynamic:
         # For binaries, GHC creates .o files even for code to be
         # linked dynamically. So we have to force the object suffix to
         # be consistent with the dynamic object suffix in the library
         # case.
-        c.args.add(["-dynamic", "-osuf dyn_o"])
+        c.args.add_all(["-dynamic", "-osuf dyn_o"])
 
     hs.toolchain.actions.run_ghc(
         hs,
@@ -346,7 +346,7 @@ def compile_library(hs, cc, java, dep_info, srcs, ls_modules, other_modules, exp
     """
     c = _compilation_defaults(hs, cc, java, dep_info, srcs, import_dir_map, extra_srcs, compiler_flags, with_profiling, my_pkg_id = my_pkg_id, version = my_pkg_id.version)
     if with_shared:
-        c.args.add(["-dynamic-too"])
+        c.args.add("-dynamic-too")
 
     hs.toolchain.actions.run_ghc(
         hs,

--- a/haskell/private/haskell_impl.bzl
+++ b/haskell/private/haskell_impl.bzl
@@ -39,7 +39,7 @@ def _prepare_srcs(srcs):
         if hasattr(src, "files"):
             if C2hsLibraryInfo in src:
                 srcs_files += src.files.to_list()
-                for f in src.files:
+                for f in src.files.to_list():
                     import_dir_map[f] = src[C2hsLibraryInfo].import_dir
             else:
                 srcs_files += src.files.to_list()

--- a/haskell/private/path_utils.bzl
+++ b/haskell/private/path_utils.bzl
@@ -255,7 +255,7 @@ def link_forest(ctx, srcs, basePath = ".", **kwargs):
     """Write a symlink to each file in `srcs` into a destination directory
     defined using the same arguments as `ctx.actions.declare_directory`"""
     local_files = []
-    for src in srcs:
+    for src in srcs.to_list():
         dest = ctx.actions.declare_file(
             paths.join(basePath, src.basename),
             **kwargs
@@ -266,7 +266,7 @@ def link_forest(ctx, srcs, basePath = ".", **kwargs):
 
 def copy_all(ctx, srcs, dest):
     """Copy all the files in `srcs` into `dest`"""
-    if list(srcs) == []:
+    if list(srcs.to_list()) == []:
         ctx.actions.run_shell(
             command = "mkdir -p {dest}".format(dest = dest.path),
             outputs = [dest],

--- a/haskell/protobuf.bzl
+++ b/haskell/protobuf.bzl
@@ -77,9 +77,9 @@ def _haskell_proto_aspect_impl(target, ctx):
     hs_files = []
     inputs = []
 
-    args.add([
+    args.add_all([
         "-I{0}={1}".format(_proto_path(s), s.path)
-        for s in target.proto.transitive_sources
+        for s in target.proto.transitive_sources.to_list()
     ])
 
     inputs.extend(target.proto.transitive_sources.to_list())
@@ -103,7 +103,7 @@ def _haskell_proto_aspect_impl(target, ctx):
         if src.basename[-6:] != ".proto":
             fail("bad extension for proto file " + src)
 
-        args.add([src.path])
+        args.add(src.path)
         hs_files.append(ctx.actions.declare_file(
             _proto_lens_output_file(
                 _proto_path(src),
@@ -115,7 +115,7 @@ def _haskell_proto_aspect_impl(target, ctx):
             ),
         ))
 
-    args.add([
+    args.add_all([
         "--haskell_out=no-runtime:" + paths.join(
             hs_files[0].root.path,
             src_prefix,

--- a/haskell/toolchain.bzl
+++ b/haskell/toolchain.bzl
@@ -23,13 +23,13 @@ def _run_ghc(hs, cc, inputs, outputs, mnemonic, arguments, params_file = None, e
         env = hs.env
 
     args = hs.actions.args()
-    args.add([hs.tools.ghc])
+    args.add(hs.tools.ghc)
 
     # Do not use Bazel's CC toolchain on Windows, as it leads to linker and librarty compatibility issues.
     # XXX: We should also tether Bazel's CC toolchain to GHC's, so that we can properly mix Bazel-compiled
     # C libraries with Haskell targets.
     if not hs.toolchain.is_windows:
-        args.add([
+        args.add_all([
             # GHC uses C compiler for assemly, linking and preprocessing as well.
             "-pgma",
             cc.tools.cc,


### PR DESCRIPTION
Fixing bazel imcompatible changes, more specifically:

- incompatible_bzl_disallow_load_after_statement
- incompatible_depset_is_not_iterable
- incompatible_depset_union
- incompatible_disable_objc_provider_resources
- incompatible_disallow_conflicting_providers
- incompatible_disallow_data_transition
- incompatible_disallow_dict_plus
- incompatible_disallow_filetype
- incompatible_disallow_legacy_javainfo
- incompatible_disallow_load_labels_to_cross_package_boundaries
- incompatible_disallow_old_style_args_add
- incompatible_disallow_slash_operator
- incompatible_generate_javacommon_source_jar
- incompatible_merge_genfiles_directory
- incompatible_no_attr_license
- incompatible_no_output_attr_default
- incompatible_no_support_tools_in_action_inputs
- incompatible_no_target_output_group
- incompatible_no_transitive_loads
- incompatible_package_name_is_a_function
- incompatible_range_type
- incompatible_remote_symlinks
- incompatible_remove_native_git_repository
- incompatible_remove_native_http_archive
- incompatible_remove_native_maven_jar
- incompatible_static_name_resolution
- incompatible_strict_action_env

# Note:

I added the `--incompatible` checks to the circle CI build to ensure we do not use these deprecated constructions anymore.

It might be annoying on the short term but it will save us lot of headaches on the long run.

Part of #489