### PR TITLE
Redo -rpath rewiring

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -29,6 +29,15 @@ load(
     "haskell_nixpkgs_package",
     "haskell_nixpkgs_packageset",
 )
+load(
+    "@io_tweag_rules_haskell//tests/external-haskell-repository:workspace_dummy.bzl",
+    "haskell_package_repository_dummy",
+)
+load(
+    "@io_tweag_rules_haskell//:constants.bzl",
+    "bindists_ghc_version",
+    "ghc_version",
+)
 
 haskell_nixpkgs_package(
     name = "ghc",
@@ -53,13 +62,7 @@ nixpkgs_local_repository(
     nix_file = "//nixpkgs:default.nix",
 )
 
-test_ghc_version = "8.6.3"
-# XXX: We must currently keep a different GHC version for bindists
-# because 8.6.3 fails on Windows with Template Haskell.
-#
-# See: https://ghc.haskell.org/trac/ghc/ticket/16057 for details.
-
-bindists_ghc_version = "8.6.2"
+test_ghc_version = ghc_version
 
 test_compiler_flags = [
     "-XStandaloneDeriving",  # Flag used at compile time
@@ -233,6 +236,11 @@ jvm_maven_import_external(
 local_repository(
     name = "c2hs_repo",
     path = "tests/c2hs/repo",
+)
+
+# dummy repo for the external haskell repo test (hazel)
+haskell_package_repository_dummy(
+    name = "haskell_package_repository_dummy",
 )
 
 # For Skydoc

--- a/constants.bzl
+++ b/constants.bzl
@@ -1,0 +1,8 @@
+ghc_version = "8.6.3"
+
+# XXX: We must currently keep a different GHC version for bindists
+# because 8.6.3 fails on Windows with Template Haskell.
+#
+# See: https://ghc.haskell.org/trac/ghc/ticket/16057 for details.
+
+bindists_ghc_version = "8.6.2"

--- a/haskell/BUILD
+++ b/haskell/BUILD
@@ -6,6 +6,12 @@ exports_files(
     ],
 )
 
+# to make functions visible to unit tests
+exports_files(
+    ["private/actions/link.bzl"],
+    visibility = ["//tests/unit-tests:__pkg__"],
+)
+
 py_binary(
     name = "ls_modules",
     srcs = ["private/ls_modules.py"],

--- a/haskell/private/dependencies.bzl
+++ b/haskell/private/dependencies.bzl
@@ -101,7 +101,6 @@ def gather_dep_info(ctx):
         dynamic_libraries = set.empty(),
         interface_dirs = set.empty(),
         prebuilt_dependencies = set.empty(),
-        # a set of struct(lib, mangled_lib)
         direct_prebuilt_deps = set.empty(),
         cc_dependencies = empty_HaskellCcInfo(),
         transitive_cc_dependencies = empty_HaskellCcInfo(),

--- a/haskell/private/list.bzl
+++ b/haskell/private/list.bzl
@@ -1,0 +1,26 @@
+"""Helper functions on lists."""
+
+load(":private/set.bzl", "set")
+
+def _dedup_on(f, list_):
+    """deduplicate `list_` by comparing the result of applying
+    f to each element (e.g. comparing sub fields)
+
+    def compare_x(el):
+      return el.x
+
+    dedup_on([struct(x=3), struct(x=4), struct(x=3)], compare_x)
+    => [struct(x=3), struct(x=4)]
+    """
+    seen = set.empty()
+    deduped = []
+    for el in list_:
+        by = f(el)
+        if not set.is_member(seen, by):
+            set.mutable_insert(seen, by)
+            deduped.append(el)
+    return deduped
+
+list = struct(
+    dedup_on = _dedup_on,
+)

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -13,6 +13,10 @@ load(
     "haskell_test",
     "haskell_toolchain",
 )
+load(
+    "//:constants.bzl",
+    "ghc_version",
+)
 
 package(default_testonly = 1)
 
@@ -235,9 +239,6 @@ rule_test(
     generates = ["java_classpath"],
     rule = "//tests/java_classpath",
 )
-
-# Keep in sync with test_ghc_version in WORKSPACE.
-ghc_version = "8.6.3"
 
 rule_test(
     name = "test-cc_haskell_import-output",

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -1,4 +1,4 @@
-load(":sh_inline_test.bzl", "sh_inline_test")
+load(":inline_tests.bzl", "sh_inline_test")
 load("@bazel_tools//tools/build_rules:test_rules.bzl", "rule_test")
 load("//tests:rule_test_exe.bzl", "rule_test_exe")
 load(

--- a/tests/binary-indirect-cbits/BUILD
+++ b/tests/binary-indirect-cbits/BUILD
@@ -7,6 +7,8 @@ load(
 haskell_binary(
     name = "binary-indirect-cbits",
     srcs = ["Main.hs"],
+    linkstatic = False,
+    visibility = ["//visibility:public"],
     deps = [
         "//tests/hackage:base",
         "//tests/library-with-cbits",

--- a/tests/binary-linkstatic-flag/BUILD
+++ b/tests/binary-linkstatic-flag/BUILD
@@ -65,11 +65,11 @@ sh_inline_test(
     binary="$1"
     # Symbols are prefixed with underscore on MacOS but not on Linux.
     if nm -u "$binary" | grep -q "\<_\?value"; then
-        echo "C library dependency not linked statically"
+        echo "C library dependency not linked statically: ${binary}"
         exit 1
     fi
     if nm -u "$binary" | grep -q HsLib_value_closure; then
-        echo "Haskell library dependency not linked statically"
+        echo "Haskell library dependency not linked statically ${binary}"
         exit 1
     fi
     """,

--- a/tests/binary-linkstatic-flag/BUILD
+++ b/tests/binary-linkstatic-flag/BUILD
@@ -3,7 +3,7 @@ load(
     "haskell_library",
     "haskell_test",
 )
-load("//tests:sh_inline_test.bzl", "sh_inline_test")
+load("//tests:inline_tests.bzl", "sh_inline_test")
 
 # test whether `linkstatic` works as expected
 package(default_testonly = 1)

--- a/tests/data/BUILD
+++ b/tests/data/BUILD
@@ -3,5 +3,13 @@
 cc_library(
     name = "ourclibrary",
     srcs = [":ourclibrary.c"],
-    visibility = ["//tests:__subpackages__"],
+    linkstatic = False,
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "ourclibrary-static",
+    srcs = [":ourclibrary.c"],
+    linkstatic = True,
+    visibility = ["//visibility:public"],
 )

--- a/tests/external-haskell-repository/BUILD
+++ b/tests/external-haskell-repository/BUILD
@@ -1,0 +1,17 @@
+# Tests correct linking of haskell packages that were created
+# in a different bazel repository, e.g. with hazel.
+
+load(
+    "@io_tweag_rules_haskell//haskell:haskell.bzl",
+    "haskell_test",
+)
+
+haskell_test(
+    name = "external-haskell-repository",
+    srcs = ["Main.hs"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//tests/hackage:base",
+        "@haskell_package_repository_dummy//:library-with-cbits",
+    ],
+)

--- a/tests/external-haskell-repository/Main.hs
+++ b/tests/external-haskell-repository/Main.hs
@@ -1,0 +1,6 @@
+module Main where
+
+import AddOne
+import Control.Exception (assert)
+
+main = assert (addOne 41 == 42) $ return ()

--- a/tests/external-haskell-repository/workspace_dummy.bzl
+++ b/tests/external-haskell-repository/workspace_dummy.bzl
@@ -1,0 +1,64 @@
+# This file constructs a dummy workspace to test
+# haskell binaries that are included from outside repositories
+# (because linking external repositories works differently).
+
+# Repo-ception, in the sense that we build a WORKSPACE
+# that references the workspaces already set up in the
+# `rules_haskell` WORKSPACE.
+def _haskell_package_repository_dummy_impl(rep_ctx):
+    rep_ctx.file(
+        "WORKSPACE",
+        executable = False,
+        content = """
+repository(name={name})
+
+register_toolchains(
+  "@io_tweag_rules_haskell//tests/:ghc"
+)
+""".format(name = rep_ctx.name),
+    )
+
+    # this mirrors tests/library-with-cbits
+
+    rep_ctx.file(
+        "BUILD",
+        executable = False,
+        content = """
+load(
+  "@io_tweag_rules_haskell//haskell:haskell.bzl",
+  "haskell_toolchain",
+  "haskell_library",
+)
+load(
+  "@io_tweag_rules_haskell//:constants.bzl",
+  "ghc_version",
+)
+
+haskell_library(
+  name = "library-with-cbits",
+  srcs = ["AddOne.hs"],
+  deps = [
+      "@io_tweag_rules_haskell//tests/data:ourclibrary",
+      "@io_tweag_rules_haskell//tests/hackage:base",
+  ],
+
+  linkstatic = False,
+  visibility = ["//visibility:public"],
+)
+""",
+    )
+
+    rep_ctx.file(
+        "AddOne.hs",
+        executable = False,
+        content = """
+module AddOne where
+
+foreign import ccall "c_add_one" addOne :: Int -> Int
+""",
+    )
+
+haskell_package_repository_dummy = repository_rule(
+    _haskell_package_repository_dummy_impl,
+    local = True,
+)

--- a/tests/hackage/BUILD
+++ b/tests/hackage/BUILD
@@ -3,7 +3,10 @@
     for better bindist support.
 """
 
-package(default_visibility = ["//tests:__subpackages__"])
+package(default_visibility = [
+    "//tests:__subpackages__",
+    "@haskell_package_repository_dummy//:__subpackages__",
+])
 
 load(
     "@io_tweag_rules_haskell//haskell:haskell.bzl",

--- a/tests/library-linkstatic-flag/BUILD
+++ b/tests/library-linkstatic-flag/BUILD
@@ -2,7 +2,7 @@ load(
     "@io_tweag_rules_haskell//haskell:haskell.bzl",
     "haskell_library",
 )
-load("//tests:sh_inline_test.bzl", "sh_inline_test")
+load("//tests:inline_tests.bzl", "sh_inline_test")
 load(":get_library_files.bzl", "get_libraries_as_runfiles")
 
 # test whether `linkstatic` works as expected

--- a/tests/library-with-cbits/BUILD
+++ b/tests/library-with-cbits/BUILD
@@ -7,9 +7,10 @@ load(
 haskell_library(
     name = "library-with-cbits",
     srcs = ["AddOne.hsc"],
+    linkstatic = False,
     visibility = ["//visibility:public"],
     deps = [
-        ":ourclibrary-indirect",
+        "//tests/data:ourclibrary",
         "//tests/hackage:base",
     ],
 )
@@ -29,22 +30,7 @@ haskell_library(
     srcs = ["AddOne.hsc"],
     visibility = ["//visibility:public"],
     deps = [
-        ":ourclibrary-static",
+        "//tests/data:ourclibrary-static",
         "//tests/hackage:base",
-    ],
-)
-
-cc_library(
-    name = "ourclibrary-indirect",
-    deps = [
-        "//tests/data:ourclibrary",
-    ],
-)
-
-cc_library(
-    name = "ourclibrary-static",
-    linkstatic = True,
-    deps = [
-        "//tests/data:ourclibrary",
     ],
 )

--- a/tests/unit-tests/BUILD
+++ b/tests/unit-tests/BUILD
@@ -1,0 +1,19 @@
+load(":tests.bzl", "link_backup_path_test")
+
+link_backup_path_test(
+    name = "backup_path_file",
+    filename = "foo",
+    output = ".",
+)
+
+link_backup_path_test(
+    name = "backup_path_dir_file",
+    filename = "foo/bar",
+    output = "..",
+)
+
+link_backup_path_test(
+    name = "backup_path_dir_dir_file",
+    filename = "foo/bar/baz",
+    output = "../..",
+)

--- a/tests/unit-tests/BUILD
+++ b/tests/unit-tests/BUILD
@@ -1,4 +1,8 @@
-load(":tests.bzl", "link_backup_path_test")
+load(
+    ":tests.bzl",
+    "dedup_on_test",
+    "link_backup_path_test",
+)
 
 link_backup_path_test(
     name = "backup_path_file",
@@ -16,4 +20,8 @@ link_backup_path_test(
     name = "backup_path_dir_dir_file",
     filename = "foo/bar/baz",
     output = "../..",
+)
+
+dedup_on_test(
+    name = "dedup_on_test",
 )

--- a/tests/unit-tests/BUILD
+++ b/tests/unit-tests/BUILD
@@ -1,26 +1,120 @@
 load(
     ":tests.bzl",
+    "create_rpath_entry_test",
     "dedup_on_test",
-    "link_backup_path_test",
+    "parent_dir_path_test",
 )
 
-link_backup_path_test(
-    name = "backup_path_file",
+parent_dir_path_test(
+    name = "parent_dir_just_file",
     filename = "foo",
-    output = ".",
+    output = ["."],
 )
 
-link_backup_path_test(
-    name = "backup_path_dir_file",
+parent_dir_path_test(
+    name = "parent_dir",
+    filename = "foo/",
+    output = ["foo"],
+)
+
+parent_dir_path_test(
+    name = "parent_dir_file",
     filename = "foo/bar",
-    output = "..",
+    output = ["foo"],
 )
 
-link_backup_path_test(
-    name = "backup_path_dir_dir_file",
-    filename = "foo/bar/baz",
-    output = "../..",
+parent_dir_path_test(
+    name = "parent_dir_file_dots",
+    filename = "foo/../bar",
+    output = [
+        "foo",
+        "..",
+    ],
 )
+
+parent_dir_path_test(
+    name = "parent_dir_rooted",
+    filename = "/foo/bar",
+    output = [
+        "",
+        "foo",
+    ],
+)
+
+create_rpath_entry_test(
+    name = "rpath_entry_simple",
+    binary_short_path = "foo/a.so",
+    dependency_short_path = "bar/b.so",
+    keep_filename = False,
+    output = "../bar",
+    prefix = "",
+)
+
+create_rpath_entry_test(
+    name = "rpath_entry_simple_filename",
+    binary_short_path = "foo/a.so",
+    dependency_short_path = "bar/b.so",
+    keep_filename = True,
+    output = "../bar/b.so",
+    prefix = "",
+)
+
+create_rpath_entry_test(
+    name = "rpath_entry_prefix",
+    binary_short_path = "foo/a.so",
+    dependency_short_path = "bar/b.so",
+    keep_filename = False,
+    output = "$ORIGIN/../bar",
+    prefix = "$ORIGIN",
+)
+
+# if the short-paths have leading dots, they are in `external`
+
+create_rpath_entry_test(
+    name = "rpath_entry_binary_leading_dots_dep",
+    # non-external
+    binary_short_path = "foo/a.so",
+    # external dep
+    dependency_short_path = "../bar/b.so",
+    keep_filename = False,
+    output = "../external/bar",
+    prefix = "",
+)
+
+create_rpath_entry_test(
+    name = "rpath_entry_binary_leading_dots_bin",
+    # external dep
+    binary_short_path = "../foo/a.so",
+    # non-external
+    dependency_short_path = "bar/b.so",
+    keep_filename = False,
+    # back through `external`
+    output = "../../bar",
+    prefix = "",
+)
+
+create_rpath_entry_test(
+    name = "rpath_entry_binary_leading_dots_both",
+    # external dep
+    binary_short_path = "../foo/a.so",
+    # external dep
+    dependency_short_path = "../bar/b.so",
+    keep_filename = False,
+    # stay in `external`
+    output = "../bar",
+    prefix = "",
+)
+
+# we have no idea how to handle internal dots, should they arise
+# create_rpath_entry_test(
+#     name = "rpath_entry_binary_internal_dots",
+#     binary_short_path = "foo/../../a.so",
+#     dependency_short_path = "../bar/../b.so",
+#     prefix = "",
+#     keep_filename = False,
+#     # but that doesn’t change anything for the runpath
+#     output = "../bar",
+# )
 
 dedup_on_test(
     name = "dedup_on_test",

--- a/tests/unit-tests/BUILD
+++ b/tests/unit-tests/BUILD
@@ -45,9 +45,7 @@ create_rpath_entry_test(
     name = "rpath_entry_simple",
     binary_short_path = "foo/a.so",
     dependency_short_path = "bar/b.so",
-    keep_filename = False,
     output = "../bar",
-    prefix = "",
 )
 
 create_rpath_entry_test(
@@ -56,14 +54,12 @@ create_rpath_entry_test(
     dependency_short_path = "bar/b.so",
     keep_filename = True,
     output = "../bar/b.so",
-    prefix = "",
 )
 
 create_rpath_entry_test(
     name = "rpath_entry_prefix",
     binary_short_path = "foo/a.so",
     dependency_short_path = "bar/b.so",
-    keep_filename = False,
     output = "$ORIGIN/../bar",
     prefix = "$ORIGIN",
 )
@@ -76,9 +72,7 @@ create_rpath_entry_test(
     binary_short_path = "foo/a.so",
     # external dep
     dependency_short_path = "../bar/b.so",
-    keep_filename = False,
     output = "../external/bar",
-    prefix = "",
 )
 
 create_rpath_entry_test(
@@ -87,10 +81,8 @@ create_rpath_entry_test(
     binary_short_path = "../foo/a.so",
     # non-external
     dependency_short_path = "bar/b.so",
-    keep_filename = False,
     # back through `external`
     output = "../../bar",
-    prefix = "",
 )
 
 create_rpath_entry_test(
@@ -99,10 +91,8 @@ create_rpath_entry_test(
     binary_short_path = "../foo/a.so",
     # external dep
     dependency_short_path = "../bar/b.so",
-    keep_filename = False,
     # stay in `external`
     output = "../bar",
-    prefix = "",
 )
 
 # we have no idea how to handle internal dots, should they arise
@@ -110,11 +100,27 @@ create_rpath_entry_test(
 #     name = "rpath_entry_binary_internal_dots",
 #     binary_short_path = "foo/../../a.so",
 #     dependency_short_path = "../bar/../b.so",
-#     prefix = "",
-#     keep_filename = False,
 #     # but that doesn’t change anything for the runpath
 #     output = "../bar",
 # )
+
+# test comes_from_haskell_cc_import
+
+create_rpath_entry_test(
+    name = "rpath_entry_comes_from_haskell_cc_import",
+    # full path is up through the bazel-out directory
+    binary_path = "bazel-out/k8-fastbuild/bin/foo/baz/a.so",
+    binary_short_path = "foo/baz/a.so",
+    # it’s been imported with haskell_cc_import
+    comes_from_haskell_cc_import = True,
+    # the full path contains `external` as first element
+    dependency_path = "external/bar/lib/b.so",
+    # the short path is that of a normal external dependency
+    dependency_short_path = "../bar/lib/b.so",
+    # the output goes up all the way to the package root
+    # and then down .path of our external dependency
+    output = "../../../../../external/bar/lib",
+)
 
 dedup_on_test(
     name = "dedup_on_test",

--- a/tests/unit-tests/tests.bzl
+++ b/tests/unit-tests/tests.bzl
@@ -1,0 +1,24 @@
+load(
+    "@bazel_skylib//lib:unittest.bzl",
+    "asserts",
+    unit = "unittest",
+)
+load("//haskell:private/actions/link.bzl", "backup_path")
+
+def link_backup_path_test_impl(ctx):
+    env = unit.begin(ctx)
+    file_stub = struct(short_path = ctx.attr.filename)
+    asserts.equals(
+        env,
+        expected = ctx.attr.output,
+        actual = backup_path(file_stub),
+    )
+    unit.end(env)
+
+link_backup_path_test = unit.make(
+    link_backup_path_test_impl,
+    attrs = {
+        "filename": attr.string(),
+        "output": attr.string(),
+    },
+)

--- a/tests/unit-tests/tests.bzl
+++ b/tests/unit-tests/tests.bzl
@@ -3,23 +3,47 @@ load(
     "asserts",
     unit = "unittest",
 )
-load("//haskell:private/actions/link.bzl", "backup_path")
+load("//haskell:private/actions/link.bzl", "create_rpath_entry", "parent_dir_path")
 load("//haskell:private/list.bzl", "list")
 
-def link_backup_path_test_impl(ctx):
+def parent_dir_path_test_impl(ctx):
     env = unit.begin(ctx)
-    file_stub = struct(short_path = ctx.attr.filename)
     asserts.equals(
         env,
         expected = ctx.attr.output,
-        actual = backup_path(file_stub),
+        actual = parent_dir_path(ctx.attr.filename),
     )
     unit.end(env)
 
-link_backup_path_test = unit.make(
-    link_backup_path_test_impl,
+parent_dir_path_test = unit.make(
+    parent_dir_path_test_impl,
     attrs = {
         "filename": attr.string(),
+        "output": attr.string_list(),
+    },
+)
+
+def create_rpath_entry_test_impl(ctx):
+    env = unit.begin(ctx)
+    asserts.equals(
+        env,
+        expected = ctx.attr.output,
+        actual = create_rpath_entry(
+            struct(short_path = ctx.attr.binary_short_path),
+            struct(short_path = ctx.attr.dependency_short_path),
+            keep_filename = ctx.attr.keep_filename,
+            prefix = ctx.attr.prefix,
+        ),
+    )
+    unit.end(env)
+
+create_rpath_entry_test = unit.make(
+    create_rpath_entry_test_impl,
+    attrs = {
+        "binary_short_path": attr.string(),
+        "dependency_short_path": attr.string(),
+        "keep_filename": attr.bool(),
+        "prefix": attr.string(),
         "output": attr.string(),
     },
 )

--- a/tests/unit-tests/tests.bzl
+++ b/tests/unit-tests/tests.bzl
@@ -29,10 +29,17 @@ def create_rpath_entry_test_impl(ctx):
         env,
         expected = ctx.attr.output,
         actual = create_rpath_entry(
-            struct(short_path = ctx.attr.binary_short_path),
-            struct(short_path = ctx.attr.dependency_short_path),
+            struct(
+                short_path = ctx.attr.binary_short_path,
+                path = ctx.attr.binary_path,
+            ),
+            struct(
+                short_path = ctx.attr.dependency_short_path,
+                path = ctx.attr.dependency_path,
+            ),
             keep_filename = ctx.attr.keep_filename,
             prefix = ctx.attr.prefix,
+            comes_from_haskell_cc_import = ctx.attr.comes_from_haskell_cc_import,
         ),
     )
     unit.end(env)
@@ -42,9 +49,14 @@ create_rpath_entry_test = unit.make(
     attrs = {
         "binary_short_path": attr.string(),
         "dependency_short_path": attr.string(),
-        "keep_filename": attr.bool(),
-        "prefix": attr.string(),
+        "keep_filename": attr.bool(default = False, mandatory = False),
+        "prefix": attr.string(default = "", mandatory = False),
         "output": attr.string(),
+        "comes_from_haskell_cc_import": attr.bool(default = False, mandatory = False),
+        # only used when comes_from_haskell_cc_import is True
+        "dependency_path": attr.string(default = "", mandatory = False),
+        # only used when comes_from_haskell_cc_import is True
+        "binary_path": attr.string(default = "", mandatory = False),
     },
 )
 

--- a/tests/unit-tests/tests.bzl
+++ b/tests/unit-tests/tests.bzl
@@ -4,6 +4,7 @@ load(
     unit = "unittest",
 )
 load("//haskell:private/actions/link.bzl", "backup_path")
+load("//haskell:private/list.bzl", "list")
 
 def link_backup_path_test_impl(ctx):
     env = unit.begin(ctx)
@@ -22,3 +23,33 @@ link_backup_path_test = unit.make(
         "output": attr.string(),
     },
 )
+
+def compare_x(el):
+    return el.x
+
+def dedup_on_test_impl(ctx):
+    env = unit.begin(ctx)
+    asserts.equals(
+        env,
+        expected = [],
+        actual = list.dedup_on(compare_x, []),
+    )
+    asserts.equals(
+        env,
+        expected = [struct(x = 3)],
+        actual = list.dedup_on(
+            compare_x,
+            [struct(x = 3), struct(x = 3), struct(x = 3)],
+        ),
+    )
+    asserts.equals(
+        env,
+        expected = [struct(x = 3), struct(x = 4), struct(x = 5)],
+        actual = list.dedup_on(
+            compare_x,
+            [struct(x = 3), struct(x = 4), struct(x = 3), struct(x = 5), struct(x = 3)],
+        ),
+    )
+    unit.end(env)
+
+dedup_on_test = unit.make(dedup_on_test_impl)


### PR DESCRIPTION
A long time in the making, this is the second try of rewriting relative `-rpath` directories to stay inside of bazel runfile directories.

The first part of this work is in https://github.com/tweag/rules_haskell/pull/436, but the crucial part had to be reverted because it introduced a big regression. This regression is resolved in this PR. 

There’s a lot going on in these commits, but later commits don’t revert work from previous ones, so stepping through one at a time is the best strategy. The first commit is not new work, so its changes are mostly outdated by the commits that follow. I tried to make everything as self-explanatory as possible, especially for the less obvious parts.

If some comments don’t provide enough context to understand the reason for a change, please mark them. The logic is confusing, because bazel’s behavior is extremely confusing when it comes to paths, external repositories and sandboxing.

@guibou this didn’t require your `-rpath` patch in the end, because it there is a more general solution to the problem.

@aherrmann please test against hazel and the mac stuff, it should shrink the header a bit.