### PR TITLE
Disable sandboxing on doctest tests to prevent race condition

### DIFF
--- a/haskell/doctest.bzl
+++ b/haskell/doctest.bzl
@@ -183,15 +183,15 @@ def _haskell_doctest_single(target, ctx):
             hs.env,
         ),
         execution_requirements = {
-          # Prevents a race condition among concurrent doctest tests on Linux.
-          #
-          # The reason is that the doctest process uses its own PID to determine the name
-          # of its working directory. In presence of PID namespacing, this occasionally results
-          # in multiple concurrent processes attempting to create the same directory.
-          #
-          # For some reason, setting "exclusive": "1" does not fix the issue, so we disable
-          # sandboxing altogether for doctest tests.
-          "no-sandbox": "1",
+            # Prevents a race condition among concurrent doctest tests on Linux.
+            #
+            # The reason is that the doctest process uses its own PID to determine the name
+            # of its working directory. In presence of PID namespacing, this occasionally results
+            # in multiple concurrent processes attempting to create the same directory.
+            #
+            # For some reason, setting "exclusive": "1" does not fix the issue, so we disable
+            # sandboxing altogether for doctest tests.
+            "no-sandbox": "1",
         },
     )
     return doctest_log

--- a/haskell/doctest.bzl
+++ b/haskell/doctest.bzl
@@ -182,6 +182,17 @@ def _haskell_doctest_single(target, ctx):
             },
             hs.env,
         ),
+        execution_requirements = {
+          # Prevents a race condition among concurrent doctest tests on Linux.
+          #
+          # The reason is that the doctest process uses its own PID to determine the name
+          # of its working directory. In presence of PID namespacing, this occasionally results
+          # in multiple concurrent processes attempting to create the same directory.
+          #
+          # For some reason, setting "exclusive": "1" does not fix the issue, so we disable
+          # sandboxing altogether for doctest tests.
+          "no-sandbox": "1",
+        },
     )
     return doctest_log
 

--- a/haskell/doctest.bzl
+++ b/haskell/doctest.bzl
@@ -188,6 +188,7 @@ def _haskell_doctest_single(target, ctx):
             # The reason is that the doctest process uses its own PID to determine the name
             # of its working directory. In presence of PID namespacing, this occasionally results
             # in multiple concurrent processes attempting to create the same directory.
+            # See https://github.com/sol/doctest/issues/219 for details.
             #
             # For some reason, setting "exclusive": "1" does not fix the issue, so we disable
             # sandboxing altogether for doctest tests.


### PR DESCRIPTION
There are occasional race conditions issues on Linux with doctest tests. The issue seems related to sandboxing (cf. #620 ).

This PR fixes this issue by selectively disabling sandboxing on those tests.