### PR TITLE
Setup the appropriate host_platform configuration when using nix shell

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -23,6 +23,22 @@ mkShell {
   ] ++ lib.optionals docTools [graphviz python36Packages.sphinx zip unzip];
 
   shellHook = ''
+    # Add nix config flags to .bazelrc.local.
+    #
+    BAZELRC_LOCAL=".bazelrc.local"
+    if [ ! -e "$BAZELRC_LOCAL" ]
+    then
+      ARCH=""
+      if [ "$(uname)" == "Darwin" ]; then
+        ARCH="darwin"
+      elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
+        ARCH="linux"
+      fi
+      echo "[!] It looks like you are using a ''${ARCH} nix-based system. In order to build this project, you probably need to add the two following host_platform entries to your .bazelrc.local file."
+      echo ""
+      echo "test --host_platform=@io_tweag_rules_haskell//haskell/platforms:''${ARCH}_x86_64_nixpkgs"
+    fi
+
     # source bazel bash completion
     source ${pkgs.bazel}/share/bash-completion/completions/bazel
   '';


### PR DESCRIPTION
We currently cannot build rules_haskell using the default nix shell script alone. We either
need to setup the appropriate host_platform flags in the
bazelrc.local file, either pass the appropriate flags to the CLI.

This PR adds a small nix shell hook that'll append the appropriate flags to the
.bazelrc.local if they are missing.