### PR TITLE
Handle indirect dynamic CC library dependencies

### DIFF
--- a/haskell/cc.bzl
+++ b/haskell/cc.bzl
@@ -130,6 +130,7 @@ def cc_interop_info(ctx):
         "cc": cc_toolchain.compiler_executable(),
         "ld": cc_toolchain.ld_executable(),
         "cpp": cc_toolchain.preprocessor_executable(),
+        "nm": cc_toolchain.nm_executable(),
     }
 
     # If running on darwin but XCode is not installed (i.e., only the Command

--- a/tests/indirect-link/BUILD.bazel
+++ b/tests/indirect-link/BUILD.bazel
@@ -23,23 +23,32 @@ haskell_library(
     ],
 )
 
-# TODO(guibhou): Does not work on darwin.
-# Executing tests from //tests/indirect-link:indirect-link
-# -----------------------------------------------------------------------------
-# dyld: lazy symbol binding failed: Symbol not found: _real_get_thing
-# Referenced from: /private/var/tmp/_bazel_distiller/bedaa68a8664d1b29e96b826d058247f/execroot/io_tweag_rules_haskell/bazel-out/darwin-fastbuild/bin/tests/indirect-link/../../../../../bazel-out/darwin-fastbuild/bin/tests/indirect-link/libcbits.so
-# Expected in: flat namespace
-#
-# dyld: Symbol not found: _real_get_thing
-# Referenced from: /private/var/tmp/_bazel_distiller/bedaa68a8664d1b29e96b826d058247f/execroot/io_tweag_rules_haskell/bazel-out/darwin-fastbuild/bin/tests/indirect-link/../../../../../bazel-out/darwin-fastbuild/bin/tests/indirect-link/libcbits.so
-# Expected in: flat namespace
+haskell_test(
+    name = "indirect-link-static",
+    srcs = ["test/Main.hs"],
+    linkstatic = True,
+    src_strip_prefix = "test",
+    deps = [
+        ":base",
+        ":mypkg",
+    ],
+)
 
-# haskell_test(
-#     name = "indirect-link",
-#     srcs = ["test/Main.hs"],
-#     src_strip_prefix = "test",
-#     deps = [
-#         ":base",
-#         ":mypkg",
-#     ],
-# )
+haskell_test(
+    name = "indirect-link-dynamic",
+    srcs = ["test/Main.hs"],
+    linkstatic = False,
+    src_strip_prefix = "test",
+    deps = [
+        ":base",
+        ":mypkg",
+    ],
+)
+
+test_suite(
+    name = "indirect-link",
+    tests = [
+        ":indirect-link-dynamic",
+        ":indirect-link-static",
+    ],
+)


### PR DESCRIPTION
Closes #626 
Closes #170 

Bazel's dynamic `cc_library` build results do not instruct the dynamic linker to load their own dynamic library dependencies. Instead, Bazel expects the final `cc_binary` to explicitly load all its transitive dynamic library dependencies. rules_haskell did not follow this convention, and the final Haskell binary would only explicitly load its direct dynamic library dependencies. This gave rise to #170 and #626.

Previously, rules_haskell did not properly capture indirect dynamic library dependencies. The reason is that these are not present in `dep.files` as was expected by `gather_dep_info`. This PR changes `gather_dep_info` to instead consult the new C++ API's `CcInfo` provider to obtain all transitive dynamic library dependencies.

On MacOS an additional step is required to get the final Haskell binary to explicitly load all transitive dynamic library dependencies. On MacOS GHC forcibly passes the `--dead_strip_dylibs` flag to the linker. The linker will then strip any indirect or redundant dynamic library dependencies from the binary's load list. This goes directly against Bazel's dependency model. This PR passes `-u` flags to the linker to enforce keeping loads of indirect dynamic library dependencies in the binary's header. First, we obtain a list of all undefined symbols in all transitive dynamic library dependencies. Then we instruct the linker to resolve all of these undefined symbols, effectively turning indirect dynamic library dependencies into direct dynamic library dependencies.

The downside of this approach is that it causes more load commands to appear in the final binary on MacOS, which increases the risk of exceeding the MACH-O header size limit. GHC passes `--dead_strip_dylibs` specifically to decrease that risk. However, it seems that Bazel's approach to handling indirect dynamic library dependencies forces this on us.