### PR TITLE
Windows CROSSTOOL for Azure CI

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -17,4 +17,7 @@ test:ci --test_output=errors
 # We also need to setup an utf8 locale
 test --test_env=LANG=en_US.utf8 --test_env=LOCALE_ARCHIVE
 
+# Crosstool configuration for Windows CI
+build:azure --crosstool_top=toolchain
+
 try-import .bazelrc.local

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,13 +4,16 @@ jobs:
     vmImage: 'vs2017-win2016'
   steps:
   - bash: |
+      set -e
       curl -LO https://github.com/bazelbuild/bazel/releases/download/0.20.0/bazel-0.20.0-windows-x86_64.exe
       mv bazel-*.exe bazel.exe
       mkdir /c/bazel
       mv bazel.exe /c/bazel
     displayName: 'Install Bazel'
   - bash: |
+      set -e
       # Simple haskell binary
-      /c/bazel/bazel.exe build --compiler=msys-gcc "///tests/binary-simple" # first '/' gets eaten up
-      /c/bazel/bazel.exe build --compiler=msys-gcc "///tests/binary-custom-main" 
+      /c/bazel/bazel.exe build --config azure "///tests/binary-simple" # first '/' gets eaten up
+      /c/bazel/bazel.exe build --config azure "///tests/binary-custom-main" 
+      /c/bazel/bazel.exe build --config azure "///tests/data:ourclibrary"
     displayName: 'Run Bazel'

--- a/toolchain/BUILD
+++ b/toolchain/BUILD
@@ -1,0 +1,32 @@
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "stl",
+)
+
+filegroup(
+    name = "empty",
+    srcs = [],
+)
+
+cc_toolchain_suite(
+    name = "toolchain",
+    toolchains = {
+        "x64_windows": ":cc-compiler-mingw64",
+    },
+)
+
+cc_toolchain(
+    name = "cc-compiler-mingw64",
+    all_files = ":empty",
+    compiler_files = ":empty",
+    cpu = "x64_windows",
+    dwp_files = ":empty",
+    dynamic_runtime_libs = [":empty"],
+    linker_files = ":empty",
+    objcopy_files = ":empty",
+    static_runtime_libs = [":empty"],
+    strip_files = ":empty",
+    supports_param_files = 0,
+    toolchain_identifier = "azure-mingw64",
+)

--- a/toolchain/CROSSTOOL
+++ b/toolchain/CROSSTOOL
@@ -1,0 +1,43 @@
+major_version: "local"
+minor_version: ""
+
+toolchain {
+  toolchain_identifier: "azure-mingw64"
+  abi_version: "local"
+  abi_libc_version: "local"
+  builtin_sysroot: ""
+  compiler: "azure-gcc"
+  host_system_name: "local"
+  needsPic: false
+  target_libc: "mingw"
+  target_cpu: "x64_windows"
+  target_system_name: "local"
+
+  artifact_name_pattern {
+     category_name: 'executable'
+     prefix: ''
+     extension: '.exe'
+  }
+
+   tool_path { name: "ar" path: "c:/tools/mingw64/bin/ar" }
+   tool_path { name: "compat-ld" path: "c:/tools/mingw64/bin/ld" }
+   tool_path { name: "cpp" path: "c:/tools/mingw64/bin/cpp" }
+   tool_path { name: "dwp" path: "c:/tools/mingw64/bin/dwp" }
+   tool_path { name: "gcc" path: "c:/tools/mingw64/bin/gcc" }
+   tool_path { name: "gcov" path: "c:/tools/mingw64/bin/gcov" }
+   tool_path { name: "ld" path: "c:/tools/mingw64/bin/ld" }
+   tool_path { name: "nm" path: "c:/tools/mingw64/bin/nm" }
+   tool_path { name: "objcopy" path: "c:/tools/mingw64/bin/objcopy" }
+   tool_path { name: "objdump" path: "c:/tools/mingw64/bin/objdump" }
+   tool_path { name: "strip" path: "c:/tools/mingw64/bin/strip" }
+ cxx_builtin_include_directory: "c:/tools/mingw64/"
+   artifact_name_pattern { category_name: "executable" prefix: "" extension: ".exe"}
+   cxx_flag: "-std=gnu++0x"
+   linker_flag: "-lstdc++"
+   objcopy_embed_flag: "-I"
+   objcopy_embed_flag: "binary"
+   feature { name: "targets_windows" implies: "copy_dynamic_libraries_to_binary" enabled: true }   feature { name: "copy_dynamic_libraries_to_binary" }
+
+  linking_mode_flags { mode: DYNAMIC }
+}
+


### PR DESCRIPTION
This PR introduces a CROSSTOOL configuration to make use of the default Mingw64 toolchain present on Azure CI. It is validated by building the `//tests/data:ourclibrary` target.

