### PR TITLE
Generate .mix files for binaries and libraries

### DIFF
--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -36,6 +36,7 @@ load(
 load(
     ":private/haskell_impl.bzl",
     _haskell_binary_impl = "haskell_binary_impl",
+    _haskell_test_impl = "haskell_test_impl",
     _haskell_import_impl = "haskell_import_impl",
     _haskell_library_impl = "haskell_library_impl",
 )
@@ -108,7 +109,7 @@ def _mk_binary_rule(**kwargs):
       Rule: Haskell binary compilation rule.
     """
     return rule(
-        _haskell_binary_impl,
+        _haskell_test_impl if "test" in kwargs and kwargs["test"] else _haskell_binary_impl,
         executable = True,
         attrs = dict(
             _haskell_common_attrs,

--- a/haskell/private/actions/compile.bzl
+++ b/haskell/private/actions/compile.bzl
@@ -272,7 +272,7 @@ def _compilation_defaults(hs, cc, java, dep_info, srcs, import_dir_map, extra_sr
     )
 
 def _hpc_compiler_args(hs):
-    hpcdir = "{}/{}.hpc".format(hs.bin_dir.path, hs.src_root)
+    hpcdir = "{}/{}/.hpc".format(hs.bin_dir.path, hs.package_root)
     return ["-fhpc", "-hpcdir", hpcdir]
 
 def compile_binary(hs, cc, java, dep_info, srcs, ls_modules, import_dir_map, extra_srcs, compiler_flags, dynamic, with_profiling, main_function, version, is_test = False, hpc_outputs = []):
@@ -295,7 +295,7 @@ def compile_binary(hs, cc, java, dep_info, srcs, ls_modules, import_dir_map, ext
         c.args.add(["-dynamic", "-osuf dyn_o"])
 
     conditioned_hpc_outputs = []
-    if hs.coverage_enabled and not is_test:
+    if hs.coverage_enabled:
         c.args.add(_hpc_compiler_args(hs))
         for o in hpc_outputs:
             conditioned_file = hs.actions.declare_file(".hpc/" + o)
@@ -361,12 +361,11 @@ def compile_library(hs, cc, java, dep_info, srcs, ls_modules, other_modules, exp
 
     conditioned_hpc_outputs = []
     if hs.coverage_enabled:
-        c.args.add(_hpc_compiler_args(hs))  
+        c.args.add(_hpc_compiler_args(hs))
         for o in hpc_outputs:
             pkg_id_string = pkg_id.to_string(my_pkg_id)
             conditioned_file = hs.actions.declare_file(".hpc/" + pkg_id_string + "/" + o)
             conditioned_hpc_outputs.append(conditioned_file)
-
 
     hs.toolchain.actions.run_ghc(
         hs,

--- a/haskell/private/actions/compile.bzl
+++ b/haskell/private/actions/compile.bzl
@@ -274,7 +274,7 @@ def _compilation_defaults(hs, cc, java, dep_info, srcs, import_dir_map, extra_sr
 def _get_hpc_c_args(hs):
     return "{}/{}.hpc".format(hs.bin_dir.path, hs.src_root)
 
-def compile_binary(hs, cc, java, dep_info, srcs, ls_modules, import_dir_map, extra_srcs, compiler_flags, dynamic, with_profiling, main_function, version):
+def compile_binary(hs, cc, java, dep_info, srcs, ls_modules, import_dir_map, extra_srcs, compiler_flags, dynamic, with_profiling, main_function, version, is_test = False):
     """Compile a Haskell target into object files suitable for linking.
 
     Returns:
@@ -293,7 +293,7 @@ def compile_binary(hs, cc, java, dep_info, srcs, ls_modules, import_dir_map, ext
         # case.
         c.args.add(["-dynamic", "-osuf dyn_o"])
 
-    if hs.coverage_enabled:
+    if hs.coverage_enabled and not is_test:
         c.args.add(_get_hpc_c_args(hs))
     
     hs.toolchain.actions.run_ghc(

--- a/haskell/private/actions/compile.bzl
+++ b/haskell/private/actions/compile.bzl
@@ -294,13 +294,12 @@ def compile_binary(hs, cc, java, dep_info, srcs, ls_modules, import_dir_map, ext
         # case.
         c.args.add(["-dynamic", "-osuf dyn_o"])
 
+    conditioned_hpc_outputs = []
     if hs.coverage_enabled and not is_test:
         c.args.add(_hpc_compiler_args(hs))
-    
-    conditioned_hpc_outputs = []
-    for o in hpc_outputs:
-        conditioned_file = hs.actions.declare_file(".hpc/" + o)
-        conditioned_hpc_outputs.append(conditioned_file)
+        for o in hpc_outputs:
+            conditioned_file = hs.actions.declare_file(".hpc/" + o)
+            conditioned_hpc_outputs.append(conditioned_file)
 
     hs.toolchain.actions.run_ghc(
         hs,
@@ -360,14 +359,14 @@ def compile_library(hs, cc, java, dep_info, srcs, ls_modules, other_modules, exp
     if with_shared:
         c.args.add(["-dynamic-too"])
 
-    if hs.coverage_enabled:
-        c.args.add(_hpc_compiler_args(hs))
-
     conditioned_hpc_outputs = []
-    for o in hpc_outputs:
-        pkg_id_string = pkg_id.to_string(my_pkg_id)
-        conditioned_file = hs.actions.declare_file(".hpc/" + pkg_id_string + "/" + o)
-        conditioned_hpc_outputs.append(conditioned_file)
+    if hs.coverage_enabled:
+        c.args.add(_hpc_compiler_args(hs))  
+        for o in hpc_outputs:
+            pkg_id_string = pkg_id.to_string(my_pkg_id)
+            conditioned_file = hs.actions.declare_file(".hpc/" + pkg_id_string + "/" + o)
+            conditioned_hpc_outputs.append(conditioned_file)
+
 
     hs.toolchain.actions.run_ghc(
         hs,

--- a/haskell/private/actions/compile.bzl
+++ b/haskell/private/actions/compile.bzl
@@ -271,6 +271,9 @@ def _compilation_defaults(hs, cc, java, dep_info, srcs, import_dir_map, extra_sr
         ),
     )
 
+def _get_hpc_c_args(hs):
+    return "{}/{}.hpc".format(hs.bin_dir.path, hs.src_root)
+
 def compile_binary(hs, cc, java, dep_info, srcs, ls_modules, import_dir_map, extra_srcs, compiler_flags, dynamic, with_profiling, main_function, version):
     """Compile a Haskell target into object files suitable for linking.
 
@@ -290,6 +293,9 @@ def compile_binary(hs, cc, java, dep_info, srcs, ls_modules, import_dir_map, ext
         # case.
         c.args.add(["-dynamic", "-osuf dyn_o"])
 
+    if hs.coverage_enabled:
+        c.args.add(_get_hpc_c_args(hs))
+    
     hs.toolchain.actions.run_ghc(
         hs,
         cc,
@@ -347,6 +353,9 @@ def compile_library(hs, cc, java, dep_info, srcs, ls_modules, other_modules, exp
     c = _compilation_defaults(hs, cc, java, dep_info, srcs, import_dir_map, extra_srcs, compiler_flags, with_profiling, my_pkg_id = my_pkg_id, version = my_pkg_id.version)
     if with_shared:
         c.args.add(["-dynamic-too"])
+
+    if hs.coverage_enabled:
+        c.args.add(_get_hpc_c_args(hs))
 
     hs.toolchain.actions.run_ghc(
         hs,

--- a/haskell/private/context.bzl
+++ b/haskell/private/context.bzl
@@ -35,6 +35,7 @@ def haskell_context(ctx, attr = None):
         toolchain = toolchain,
         tools = toolchain.tools,
         src_root = src_root,
+        package_root = ctx.label.workspace_root + ctx.label.package,
         env = env,
         mode = ctx.var["COMPILATION_MODE"],
         actions = ctx.actions,

--- a/haskell/private/context.bzl
+++ b/haskell/private/context.bzl
@@ -40,4 +40,5 @@ def haskell_context(ctx, attr = None):
         actions = ctx.actions,
         bin_dir = ctx.bin_dir,
         genfiles_dir = ctx.genfiles_dir,
+        coverage_enabled = ctx.configuration.coverage_enabled
     )

--- a/haskell/private/haskell_impl.bzl
+++ b/haskell/private/haskell_impl.bzl
@@ -83,6 +83,7 @@ def _haskell_common_impl(ctx, is_test):
         with_profiling = False,
         main_function = ctx.attr.main_function,
         version = ctx.attr.version,
+        is_test = is_test
     )
 
     c_p = None
@@ -111,6 +112,7 @@ def _haskell_common_impl(ctx, is_test):
             with_profiling = True,
             main_function = ctx.attr.main_function,
             version = ctx.attr.version,
+            is_test = is_test
         )
 
     binary = link_binary(

--- a/haskell/private/haskell_impl.bzl
+++ b/haskell/private/haskell_impl.bzl
@@ -72,7 +72,7 @@ def haskell_binary_impl(ctx):
         ls_modules = ctx.executable._ls_modules,
         import_dir_map = import_dir_map,
         extra_srcs = depset(ctx.files.extra_srcs),
-        compiler_flags = ctx.attr.compiler_flags,
+        compiler_flags = compiler_flags,
         dynamic = not ctx.attr.linkstatic,
         with_profiling = False,
         main_function = ctx.attr.main_function,
@@ -97,7 +97,7 @@ def haskell_binary_impl(ctx):
                 depset(ctx.files.extra_srcs),
                 depset([c.objects_dir]),
             ]),
-            compiler_flags = ctx.attr.compiler_flags,
+            compiler_flags = compiler_flags,
             # NOTE We can't have profiling and dynamic code at the
             # same time, see:
             # https://ghc.haskell.org/trac/ghc/ticket/15394
@@ -139,7 +139,7 @@ def haskell_binary_impl(ctx):
         hs,
         ghci_script = ctx.file._ghci_script,
         ghci_repl_wrapper = ctx.file._ghci_repl_wrapper,
-        compiler_flags = ctx.attr.compiler_flags,
+        compiler_flags = compiler_flags,
         repl_ghci_args = ctx.attr.repl_ghci_args,
         output = ctx.outputs.repl,
         package_caches = dep_info.package_caches,
@@ -181,6 +181,8 @@ def haskell_library_impl(ctx):
     other_modules = ctx.attr.hidden_modules
     exposed_modules_reexports = _exposed_modules_reexports(ctx.attr.exports)
 
+    compiler_flags = ctx.attr.compiler_flags
+
     c = hs.toolchain.actions.compile_library(
         hs,
         cc,
@@ -192,7 +194,7 @@ def haskell_library_impl(ctx):
         exposed_modules_reexports = exposed_modules_reexports,
         import_dir_map = import_dir_map,
         extra_srcs = depset(ctx.files.extra_srcs),
-        compiler_flags = ctx.attr.compiler_flags,
+        compiler_flags = compiler_flags,
         with_shared = with_shared,
         with_profiling = False,
         my_pkg_id = my_pkg_id,
@@ -218,7 +220,7 @@ def haskell_library_impl(ctx):
                 depset(ctx.files.extra_srcs),
                 depset([c.objects_dir]),
             ]),
-            compiler_flags = ctx.attr.compiler_flags,
+            compiler_flags = compiler_flags,
             # NOTE We can't have profiling and dynamic code at the
             # same time, see:
             # https://ghc.haskell.org/trac/ghc/ticket/15394
@@ -328,7 +330,7 @@ def haskell_library_impl(ctx):
             ghci_script = ctx.file._ghci_script,
             ghci_repl_wrapper = ctx.file._ghci_repl_wrapper,
             repl_ghci_args = ctx.attr.repl_ghci_args,
-            compiler_flags = ctx.attr.compiler_flags,
+            compiler_flags = compiler_flags,
             output = ctx.outputs.repl,
             package_caches = dep_info.package_caches,
             version = ctx.attr.version,

--- a/haskell/private/haskell_impl.bzl
+++ b/haskell/private/haskell_impl.bzl
@@ -72,7 +72,7 @@ def _haskell_binary_common_impl(ctx, is_test):
     hpc_outputs = []
     if ctx.configuration.coverage_enabled:
         for s in srcs_files:
-            filename, _, _ = s.basename.partition(".")
+            filename, _, _ = s.basename.rpartition(".")
             hpc_outputs.append(filename + ".mix")
 
     c = hs.toolchain.actions.compile_binary(
@@ -202,7 +202,7 @@ def haskell_library_impl(ctx):
     hpc_outputs = []
     if ctx.configuration.coverage_enabled:
         for s in srcs_files:
-            filename, _, _ = s.basename.partition(".")
+            filename, _, _ = s.basename.rpartition(".")
             hpc_outputs.append(filename + ".mix")
 
     c = hs.toolchain.actions.compile_library(

--- a/haskell/private/haskell_impl.bzl
+++ b/haskell/private/haskell_impl.bzl
@@ -51,7 +51,13 @@ def _prepare_srcs(srcs):
 
     return srcs_files, import_dir_map
 
+def haskell_test_impl(ctx):
+    return _haskell_common_impl(ctx, True)
+
 def haskell_binary_impl(ctx):
+    return _haskell_common_impl(ctx, False)
+
+def _haskell_common_impl(ctx, is_test):
     hs = haskell_context(ctx)
     dep_info = gather_dep_info(ctx)
 


### PR DESCRIPTION
As a first step towards enabling `bazel coverage` for Haskell targets, this PR enables generation of `hpc`'s `.mix` files when using `bazel coverage`.