### PR TITLE
Test GHC bindist on Linux on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,28 @@
 version: 2
 
 jobs:
+  build-linux-ghc-bindist:
+    docker:
+      - image: debian
+    working_directory: ~/rules_haskell
+    resource_class: large
+    steps:
+      - checkout
+      - run:
+          name: Setup test environment
+          command: |
+            apt-get update
+            apt-get install -y wget gnupg golang make libgmp3-dev pkg-config zip g++ zlib1g-dev unzip python bash-completion
+            wget "https://github.com/bazelbuild/bazel/releases/download/0.21.0/bazel_0.21.0-linux-x86_64.deb"
+            dpkg -i bazel_0.21.0-linux-x86_64.deb
+            echo "common:ci --build_tag_filters -requires_hackage,-requires_zlib,-requires_doctest,-requires_c2hs,-requires_threaded_rts,-requires_missing_compiler_flags,-ghcbindist_th_failure" > .bazelrc.local
+      - run:
+          name: Build tests
+          command: |
+            bazel build --config ci //tests/...
 
   # ATTN: when you change anything here, don’t forget to copy it to the build-darwin section
-  build-linux:
+  build-linux-nixpkgs:
     docker:
       - image: nixos/nix:2.1.3
     working_directory: ~/rules_haskell
@@ -73,5 +92,6 @@ workflows:
   version: 2
   build:
     jobs:
-      - build-linux
+      - build-linux-ghc-bindist
+      - build-linux-nixpkgs
       - build-darwin

--- a/haskell/nixpkgs.bzl
+++ b/haskell/nixpkgs.bzl
@@ -99,6 +99,9 @@ def haskell_nixpkgs_packages(name, base_attribute_path, packages, **kwargs):
         base_repository = name,
     )
 
+def _is_nix_platform(repository_ctx):
+    return repository_ctx.which("nix-build") != None
+
 def _gen_imports_impl(repository_ctx):
     repository_ctx.file("BUILD", "")
     extra_args_raw = ""
@@ -119,18 +122,15 @@ def import_packages(name):
         extra_args_raw = extra_args_raw,
     )
 
-    # A dummy 'packages.bzl' file with a no-op 'import_packages()' on Windows
-    bzl_file_content_windows = """
+    # A dummy 'packages.bzl' file with a no-op 'import_packages()' on unsupported platforms
+    bzl_file_content_unsupported_platform = """
 def import_packages(name):
     return
     """
-
-    is_windows = repository_ctx.os.name.startswith("windows")
-
-    if is_windows:
-        repository_ctx.file("packages.bzl", bzl_file_content_windows)
-    else:
+    if _is_nix_platform(repository_ctx):
         repository_ctx.file("packages.bzl", bzl_file_content)
+    else:
+        repository_ctx.file("packages.bzl", bzl_file_content_unsupported_platform)
 
 _gen_imports_str = repository_rule(
     implementation = _gen_imports_impl,

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -18,6 +18,7 @@ package(default_testonly = 1)
 haskell_doctest_toolchain(
     name = "doctest-toolchain",
     doctest = "@hackage-doctest//:bin",
+    tags = ["requires_doctest"],
 )
 
 # This toolchain is morally testonly. However, that would break our
@@ -30,6 +31,7 @@ haskell_proto_toolchain(
     testonly = 0,
     plugin = "@hackage-proto-lens-protoc//:bin/proto-lens-protoc",
     protoc = "@com_google_protobuf//:protoc",
+    tags = ["requires_hackage"],
     deps = [
         "//tests/hackage:base",
         "//tests/hackage:bytestring",
@@ -48,6 +50,7 @@ haskell_proto_toolchain(
 c2hs_toolchain(
     name = "c2hs-toolchain",
     c2hs = "@hackage-c2hs//:bin",
+    tags = ["requires_c2hs"],
 )
 
 rule_test(
@@ -76,6 +79,7 @@ rule_test(
     size = "small",
     generates = ["binary-with-prebuilt"],
     rule = "//tests/binary-with-prebuilt",
+    tags = ["requires_hackage"],
 )
 
 rule_test(
@@ -90,6 +94,7 @@ rule_test(
     size = "small",
     generates = ["binary-with-sysdeps"],
     rule = "//tests/binary-with-sysdeps",
+    tags = ["requires_zlib"],
 )
 
 sh_test(
@@ -98,6 +103,7 @@ sh_test(
     srcs = ["//tests/binary-with-data"],
     args = ["$(location //tests/binary-with-data:bin1)"],
     data = ["//tests/binary-with-data:bin1"],
+    tags = ["requires_hackage"],
 )
 
 rule_test(
@@ -120,6 +126,7 @@ rule_test(
             "testsZSlibrary-with-sysdepsZSlibrary-with-sysdeps/package.cache",
         ],
     rule = "//tests/library-with-sysdeps",
+    tags = ["requires_zlib"],
 )
 
 rule_test(
@@ -139,6 +146,7 @@ rule_test(
         "haddock/testsZShaddockZShaddock-lib-deep",
     ],
     rule = "//tests/haddock",
+    tags = ["requires_hackage"],
 )
 
 rule_test(
@@ -167,6 +175,7 @@ rule_test(
         "testsZShaskellZUprotoZUlibraryZShs-lib/testsZShaskellZUprotoZUlibraryZShs-lib.conf",
     ],
     rule = "//tests/haskell_proto_library:hs-lib",
+    tags = ["requires_hackage"],
 )
 
 rule_test(
@@ -176,6 +185,7 @@ rule_test(
         "doctest-log-doctest-lib-testsZShaskellZUdoctestZSlib-b",
     ],
     rule = "//tests/haskell_doctest:doctest-lib",
+    tags = ["requires_doctest"],
 )
 
 rule_test(
@@ -204,6 +214,7 @@ rule_test(
             "testsZSlibrary-with-sysincludesZSlibrary-with-sysincludes/package.cache",
         ],
     rule = "//tests/library-with-sysincludes",
+    tags = ["requires_zlib"],
 )
 
 rule_test(
@@ -248,6 +259,7 @@ rule_test(
     size = "small",
     generates = ["cc-bin"],
     rule = "//tests/cc_haskell_import:cc-bin",
+    tags = ["requires_threaded_rts"],
 )
 
 # TODO(Profpatsch) blocked on https://github.com/bazelbuild/bazel/issues/6093
@@ -362,6 +374,7 @@ rule_test(
 haskell_binary(
     name = "run-tests",
     srcs = ["RunTests.hs"],
+    tags = ["requires_hackage"],
     deps = [
         "//tests/hackage:base",
         "@hackage//:hspec",

--- a/tests/binary-with-compiler-flags/BUILD
+++ b/tests/binary-with-compiler-flags/BUILD
@@ -14,5 +14,6 @@ haskell_test(
         "-with-rtsopts=-N2 -qg -I0 -n2m -A128m",
         "-XLambdaCase",
     ],
+    tags = ["requires_missing_compiler_flags"],
     deps = ["//tests/hackage:base"],
 )

--- a/tests/binary-with-data/BUILD
+++ b/tests/binary-with-data/BUILD
@@ -19,6 +19,7 @@ haskell_test(
     srcs = ["bin2.hs"],
     args = ["$(location :bin1)"],
     data = [":bin1"],
+    tags = ["requires_hackage"],
     visibility = ["//visibility:public"],
     deps = [
         "//tests/hackage:base",

--- a/tests/binary-with-prebuilt/BUILD
+++ b/tests/binary-with-prebuilt/BUILD
@@ -8,6 +8,7 @@ package(default_testonly = 1)
 haskell_test(
     name = "binary-with-prebuilt",
     srcs = ["Main.hs"],
+    tags = ["requires_hackage"],
     visibility = ["//visibility:public"],
     deps = [
         "//tests/hackage:base",

--- a/tests/binary-with-sysdeps/BUILD
+++ b/tests/binary-with-sysdeps/BUILD
@@ -9,11 +9,13 @@ package(default_testonly = 1)
 haskell_cc_import(
     name = "zlib",
     shared_library = "@zlib//:lib",
+    tags = ["requires_zlib"],
 )
 
 haskell_test(
     name = "binary-with-sysdeps",
     srcs = ["Main.hs"],
+    tags = ["requires_zlib"],
     visibility = ["//visibility:public"],
     deps = [
         ":zlib",

--- a/tests/c2hs/BUILD
+++ b/tests/c2hs/BUILD
@@ -12,6 +12,7 @@ haskell_cc_import(
     hdrs = ["@zlib.dev//:include"],
     shared_library = "@zlib//:lib",
     strip_include_prefix = "/external/zlib.dev/include",
+    tags = ["requires_zlib"],
     visibility = ["@c2hs_repo//:__pkg__"],
 )
 
@@ -19,12 +20,14 @@ c2hs_library(
     name = "foo",
     srcs = ["src/Foo/Foo.chs"],
     src_strip_prefix = "src",
+    tags = ["requires_c2hs"],
     deps = [":zlib"],
 )
 
 c2hs_library(
     name = "bar",
     srcs = ["Bar.chs"],
+    tags = ["requires_c2hs"],
     deps = [":foo"],
 )
 
@@ -35,5 +38,6 @@ haskell_library(
         ":foo",
         "@c2hs_repo//:baz",
     ],
+    tags = ["requires_c2hs"],
     deps = ["//tests/hackage:base"],
 )

--- a/tests/cc_haskell_import/BUILD
+++ b/tests/cc_haskell_import/BUILD
@@ -36,6 +36,7 @@ cc_binary(
         "main.c",
         ":hs-lib-b.so",
     ],
+    tags = ["requires_threaded_rts"],
     visibility = ["//tests:__subpackages__"],
     deps = ["@ghc//:threaded-rts"],
 )
@@ -52,6 +53,7 @@ cc_binary(
     ],
     linkshared = 1,
     linkstatic = 1,
+    tags = ["requires_threaded_rts"],
     visibility = ["//tests:__subpackages__"],
     deps = ["@ghc//:threaded-rts"],
 )
@@ -65,6 +67,7 @@ py_binary(
     ],
     default_python_version = "PY3",
     srcs_version = "PY3ONLY",
+    tags = ["requires_threaded_rts"],
     visibility = ["//tests:__subpackages__"],
     deps = ["@bazel_tools//tools/python/runfiles"],
 )

--- a/tests/encoding/BUILD
+++ b/tests/encoding/BUILD
@@ -14,6 +14,11 @@ haskell_test(
     extra_srcs = [
         "unicode.txt",
     ],
+    # TODO: Broken with ghc_bindist toolchain:
+    # tests/encoding/Main.hs:8:17: error:
+    #   * Exception when trying to run compile-time code:
+    #      tests/encoding/unicode.txt: hGetContents: invalid argument (invalid byte sequence)
+    tags = ["ghcbindist_th_failure"],
     deps = [
         "//tests/hackage:base",
         "//tests/hackage:template-haskell",

--- a/tests/haddock/BUILD
+++ b/tests/haddock/BUILD
@@ -14,6 +14,7 @@ package(
 haskell_cc_import(
     name = "zlib",
     shared_library = "@zlib//:lib",
+    tags = ["requires_zlib"],
 )
 
 haskell_library(
@@ -51,6 +52,7 @@ haskell_library(
     extra_srcs = [
         "unicode.txt",
     ],
+    tags = ["requires_hackage"],
     deps = [
         ":haddock-lib-a",
         ":zlib",
@@ -63,11 +65,13 @@ haskell_library(
 haskell_doc(
     name = "haddock",
     index_transitive_deps = False,
+    tags = ["requires_hackage"],
     deps = [":haddock-lib-b"],
 )
 
 haskell_doc(
     name = "haddock-transitive",
     index_transitive_deps = True,
+    tags = ["requires_hackage"],
     deps = [":haddock-lib-b"],
 )

--- a/tests/haskell_doctest/BUILD
+++ b/tests/haskell_doctest/BUILD
@@ -10,6 +10,7 @@ package(default_testonly = 1)
 haskell_library(
     name = "lib-a",
     srcs = ["Foo.hs"],
+    tags = ["requires_zlib"],
     deps = [
         "//tests/data:ourclibrary",
         "//tests/hackage:base",
@@ -24,6 +25,7 @@ haskell_library(
         "Baz.hs",
         "Quux.hsc",
     ],
+    tags = ["requires_zlib"],
     deps = [
         ":lib-a",
         "//tests/hackage:base",
@@ -40,6 +42,7 @@ haskell_doctest(
 haskell_doctest(
     name = "doctest-lib-all-success",
     doctest_flags = ["-DMAGIC_DOCTEST_THING"],
+    tags = ["requires_doctest"],
     visibility = ["//visibility:public"],
     deps = [":lib-b"],
 )
@@ -47,6 +50,7 @@ haskell_doctest(
 haskell_doctest(
     name = "doctest-lib",
     modules = ["Bar"],  # exclude Baz and succeed
+    tags = ["requires_doctest"],
     visibility = ["//visibility:public"],
     deps = [":lib-b"],
 )
@@ -54,6 +58,7 @@ haskell_doctest(
 haskell_test(
     name = "bin",
     srcs = ["Main.hs"],
+    tags = ["requires_zlib"],
     deps = [
         ":lib-a",
         "//tests/hackage:base",
@@ -62,6 +67,7 @@ haskell_test(
 
 haskell_doctest(
     name = "doctest-bin",
+    tags = ["requires_doctest"],
     visibility = ["//visibility:public"],
     deps = [":bin"],
 )

--- a/tests/haskell_proto_library/BUILD
+++ b/tests/haskell_proto_library/BUILD
@@ -29,17 +29,20 @@ proto_library(
 
 haskell_proto_library(
     name = "address_haskell_proto",
+    tags = ["requires_hackage"],
     deps = [":address_proto"],
 )
 
 haskell_proto_library(
     name = "person_haskell_proto",
+    tags = ["requires_hackage"],
     deps = [":person_proto"],
 )
 
 haskell_library(
     name = "hs-lib",
     srcs = ["Bar.hs"],
+    tags = ["requires_hackage"],
     visibility = ["//visibility:public"],
     deps = [
         ":address_haskell_proto",
@@ -50,5 +53,6 @@ haskell_library(
 
 haskell_doc(
     name = "docs",
+    tags = ["requires_hackage"],
     deps = [":hs-lib"],
 )

--- a/tests/library-with-sysdeps/BUILD
+++ b/tests/library-with-sysdeps/BUILD
@@ -10,11 +10,13 @@ package(default_testonly = 1)
 haskell_cc_import(
     name = "zlib",
     shared_library = "@zlib//:lib",
+    tags = ["requires_zlib"],
 )
 
 haskell_library(
     name = "library-with-sysdeps",
     srcs = ["Lib.hs"],
+    tags = ["requires_zlib"],
     visibility = ["//visibility:public"],
     deps = [
         ":zlib",
@@ -25,6 +27,7 @@ haskell_library(
 haskell_test(
     name = "bin",
     srcs = ["Main.hs"],
+    tags = ["requires_zlib"],
     deps = [
         ":library-with-sysdeps",
         "//tests/hackage:base",

--- a/tests/library-with-sysincludes/BUILD
+++ b/tests/library-with-sysincludes/BUILD
@@ -22,6 +22,7 @@ haskell_cc_import(
     hdrs = ["@zlib.dev//:include"],
     shared_library = "@zlib//:lib",
     strip_include_prefix = "/external/zlib.dev/include",
+    tags = ["requires_zlib"],
 )
 
 haskell_cc_import(
@@ -29,11 +30,13 @@ haskell_cc_import(
     hdrs = [":genrule-header"],
     shared_library = "@zlib//:lib",  # just use zlib because this field is required
     strip_include_prefix = "include",
+    tags = ["requires_zlib"],
 )
 
 haskell_library(
     name = "intermediate-library",
     srcs = ["IntLib.hsc"],
+    tags = ["requires_zlib"],
     deps = [
         ":zlib",
         ":zlib-with-genrule-header",
@@ -47,6 +50,7 @@ haskell_library(
         "Lib.hs",
         "TH.hs",
     ],
+    tags = ["requires_zlib"],
     visibility = ["//visibility:public"],
     deps = [
         ":intermediate-library",
@@ -60,6 +64,7 @@ haskell_library(
 haskell_library(
     name = "intermediate-library-other",
     srcs = ["IntLib.hsc"],
+    tags = ["requires_zlib"],
     deps = [
         ":zlib-with-genrule-header",
         "//tests/hackage:base",
@@ -73,6 +78,7 @@ haskell_library(
         "Lib.hs",
         "TH.hs",
     ],
+    tags = ["requires_zlib"],
     visibility = ["//visibility:public"],
     deps = [
         ":intermediate-library-other",

--- a/tests/repl-flags/BUILD
+++ b/tests/repl-flags/BUILD
@@ -15,6 +15,7 @@ haskell_test(
 
     # This also ensure that local `compiler_flags` does not override the `global ones`
     compiler_flags = ["-XOverloadedStrings"],
+    tags = ["requires_missing_compiler_flags"],
     visibility = ["//visibility:public"],
     deps = [
         "//tests/hackage:base",
@@ -37,6 +38,7 @@ haskell_test(
 
     # This also ensure that local `repl_flags` does not override the `global ones`
     repl_ghci_args = ["-DTESTS_TOOLCHAIN_REPL_FLAGS"],
+    tags = ["requires_missing_compiler_flags"],
     visibility = ["//visibility:public"],
     deps = [
         "//tests/hackage:base",

--- a/tests/repl-targets/BUILD
+++ b/tests/repl-targets/BUILD
@@ -13,6 +13,7 @@ haskell_cc_import(
     hdrs = ["@zlib.dev//:include"],
     shared_library = "@zlib//:lib",
     strip_include_prefix = "/external/zlib.dev/include",
+    tags = ["requires_zlib"],
 )
 
 genrule(
@@ -30,6 +31,7 @@ genrule(
 c2hs_library(
     name = "chs",
     srcs = ["Chs.chs"],
+    tags = ["requires_c2hs"],
 )
 
 haskell_library(
@@ -40,6 +42,7 @@ haskell_library(
         ":chs",
         ":codegen",
     ],
+    tags = ["requires_hackage"],
     visibility = ["//visibility:public"],
     deps = [
         ":zlib",


### PR DESCRIPTION
We add a new CI job based on a vanilla Debian docker image (ie. without nix in `$PATH`) testing the ghc_bindist Haskell toolchain.

In order to evaluate the `WORKSPACE` file on linux without having `nix-build` in $PATH, we had to make a couple of changes in the nixpkgs-supported platforms detection.

Note: we'll need to keep the build targets of the build-linux-ghc-bindist circleci job in sync with the azure's ones.

Close #629 and #611