### PR TITLE
Binary with Template Haskell library

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -3,7 +3,7 @@
 # Use this configuration when targeting Windows. Eventually this will
 # no longer be required:
 # https://bazel.build/roadmaps/platforms.html#replace---cpu-and---host_cpu-flags.
-build:windows --crosstool_top=@io_tweag_rules_haskell_ghc_windows_amd64//:toolchain
+build:windows --crosstool_top=@io_tweag_rules_haskell_ghc_windows_amd64//:toolchain -s --verbose_failures --sandbox_debug
 
 build:ci --all_incompatible_changes  --incompatible_disable_deprecated_attr_params=false --incompatible_new_actions_api=false --incompatible_expand_directories=false
 build:ci --loading_phase_threads=1

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -54,6 +54,12 @@ nixpkgs_local_repository(
 )
 
 test_ghc_version = "8.6.3"
+# XXX: We must currently keep a different GHC version for bindists
+# because 8.6.3 fails on Windows with Template Haskell.
+#
+# See: https://ghc.haskell.org/trac/ghc/ticket/16057 for details.
+
+bindists_ghc_version = "8.6.2"
 
 test_compiler_flags = [
     "-XStandaloneDeriving",  # Flag used at compile time
@@ -90,7 +96,7 @@ haskell_register_ghc_nixpkgs(
     version = test_ghc_version,
 )
 
-haskell_register_ghc_bindists(version = test_ghc_version)
+haskell_register_ghc_bindists(version = bindists_ghc_version)
 
 register_toolchains(
     "//tests:c2hs-toolchain",

--- a/tests/binary-with-lib/BUILD
+++ b/tests/binary-with-lib/BUILD
@@ -14,6 +14,9 @@ haskell_library(
         "//conditions:default": False,
     }),
     src_strip_prefix = "src",
+    deps = [
+        "//tests/hackage:template-haskell",
+    ],
 )
 
 haskell_test(
@@ -23,5 +26,6 @@ haskell_test(
     deps = [
         ":lib",
         "//tests/hackage:base",
+        "//tests/hackage:template-haskell",
     ],
 )

--- a/tests/binary-with-lib/Main.hs
+++ b/tests/binary-with-lib/Main.hs
@@ -1,7 +1,11 @@
+{-# LANGUAGE TemplateHaskell #-}
 module Main where
 
 import Control.Monad (unless)
 import Lib           (value)
+import Language.Haskell.TH
 
-main = unless (value == 42)
-    $ error $ "Incorrect lib value. Got " <> show value
+val = $(value)
+
+main = unless (val == 42)
+    $ error $ "Incorrect lib value. Got " <> show val

--- a/tests/binary-with-lib/src/Lib.hs
+++ b/tests/binary-with-lib/src/Lib.hs
@@ -1,5 +1,8 @@
 {-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 module Lib (value) where
 
-value = 42
+import Language.Haskell.TH
+
+value = [|42|]


### PR DESCRIPTION
This PR demonstrates working Template Haskell support on Windows.

We had to revert GHC 8.6.3 to 8.6.2 in bindists because of a GHC bug on Windows.