### PR TITLE
Emulate readarray for old Bash

### DIFF
--- a/haskell/private/actions/package.bzl
+++ b/haskell/private/actions/package.bzl
@@ -102,7 +102,11 @@ def package(hs, dep_info, interfaces_dir, interfaces_dir_prof, static_library, d
         command = """
             cat $1 > $4
             echo "exposed-modules: `cat $2`" >> $4
-            readarray -t deps_id_files < $3
+
+            # this is equivalent to 'readarray'. We do use 'readarray' in order to
+            # support older bash versions.
+            while IFS= read -r line; do deps_id_files+=("$line"); done < $3
+
             if [ ${#deps_id_files[@]} -eq 0 ]; then
               deps=""
             else

--- a/haskell/toolchain.bzl
+++ b/haskell/toolchain.bzl
@@ -69,7 +69,7 @@ def _run_ghc(hs, cc, inputs, outputs, mnemonic, arguments, params_file = None, e
         command = """
         export PATH=${PATH:-} # otherwise GCC fails on Windows
 
-        # this is equivalent to 'readarray'. We do use 'readarray' in order to
+        # this is equivalent to 'readarray'. We do not use 'readarray' in order to
         # support older bash versions.
         while IFS= read -r line; do ghc_args+=("$line"); done < %s
         while IFS= read -r line; do extra_args+=("$line"); done < %s

--- a/haskell/toolchain.bzl
+++ b/haskell/toolchain.bzl
@@ -68,17 +68,24 @@ def _run_ghc(hs, cc, inputs, outputs, mnemonic, arguments, params_file = None, e
     if params_file:
         command = """
         export PATH=${PATH:-} # otherwise GCC fails on Windows
-        readarray -t ghc_args < %s
-        readarray -t extra_args < %s
-        readarray -t param_file_args < %s
+
+        # this is equivalent to 'readarray'. We do use 'readarray' in order to
+        # support older bash versions.
+        while IFS= read -r line; do ghc_args+=("$line"); done < %s
+        while IFS= read -r line; do extra_args+=("$line"); done < %s
+        while IFS= read -r line; do param_file_args+=("$line"); done < %s
+
         "${ghc_args[@]}" "${extra_args[@]}" "${param_file_args[@]}"
 """ % (ghc_args_file.path, extra_args_file.path, params_file.path)
         extra_inputs.append(params_file)
     else:
         command = """
         export PATH=${PATH:-} # otherwise GCC fails on Windows
-        readarray -t ghc_args < %s
-        readarray -t extra_args < %s
+
+        # this is equivalent to 'readarray'. We do use 'readarray' in order to
+        # support older bash versions.
+        while IFS= read -r line; do ghc_args+=("$line"); done < %s
+        while IFS= read -r line; do extra_args+=("$line"); done < %s
 
         "${ghc_args[@]}" "${extra_args[@]}"
 """ % (ghc_args_file.path, extra_args_file.path)


### PR DESCRIPTION
Fixes #644 

`readarray` is a somewhat modern addition to `bash`. This code produces equivalent results but works across a wider range of bash versions.