### PR TITLE
.github/settings.yml: add label descriptions

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -12,14 +12,19 @@ labels:
     color: bfdadc
   - name: "P0"
     color: b60205
+    description: "blocker: fix immediately!"
   - name: "P1"
     color: d93f0b
+    description: "critical: next release"
   - name: "P2"
     color: e99695
+    description: "major: an upcoming release"
   - name: "P3"
     color: fbca04
+    description: "minor: not priorized"
   - name: "P4"
     color: fef2c0
+    description: "unimportant: consider wontfix or other priority"
   - name: "question"
     color: d876e3
   - name: "type: bug"


### PR DESCRIPTION
(Semi-)declaratively sets repository settings and labels.

See the tweag documentation repo:
https://github.com/tweag/guides/blob/master/project-management/Github.md

The descriptions are [not updated automatically](https://github.com/probot/settings/pull/103), so I’m going to do it manually.