### PR TITLE
Fixed tests/encoding on linux_ghc_bindist CI job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,10 +12,12 @@ jobs:
           name: Setup test environment
           command: |
             apt-get update
-            apt-get install -y wget gnupg golang make libgmp3-dev pkg-config zip g++ zlib1g-dev unzip python bash-completion
+            apt-get install -y wget gnupg golang make libgmp3-dev pkg-config zip g++ zlib1g-dev unzip python bash-completion locales
+            echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen
+            locale-gen
             wget "https://github.com/bazelbuild/bazel/releases/download/0.21.0/bazel_0.21.0-linux-x86_64.deb"
             dpkg -i bazel_0.21.0-linux-x86_64.deb
-            echo "common:ci --build_tag_filters -requires_hackage,-requires_zlib,-requires_doctest,-requires_c2hs,-requires_threaded_rts,-requires_missing_compiler_flags,-ghcbindist_th_failure,-dont_test_with_bindist" > .bazelrc.local
+            echo "common:ci --build_tag_filters -requires_hackage,-requires_zlib,-requires_doctest,-requires_c2hs,-requires_threaded_rts,-requires_missing_compiler_flags,-dont_test_with_bindist" > .bazelrc.local
       - run:
           name: Build tests
           command: |

--- a/tests/encoding/BUILD
+++ b/tests/encoding/BUILD
@@ -14,11 +14,6 @@ haskell_test(
     extra_srcs = [
         "unicode.txt",
     ],
-    # TODO: Broken with ghc_bindist toolchain:
-    # tests/encoding/Main.hs:8:17: error:
-    #   * Exception when trying to run compile-time code:
-    #      tests/encoding/unicode.txt: hGetContents: invalid argument (invalid byte sequence)
-    tags = ["ghcbindist_th_failure"],
     deps = [
         "//tests/hackage:base",
         "//tests/hackage:template-haskell",


### PR DESCRIPTION
The locale was incorrectly set for the `linux_ghc_bindist` CI job; making
it fail.

We now generate and set the locale to `en_US.UTF-8`.

Fixes https://github.com/tweag/rules_haskell/issues/659