### PR TITLE
Expose compiler flags on ghc bindist toolchain

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
             locale-gen
             wget "https://github.com/bazelbuild/bazel/releases/download/0.21.0/bazel_0.21.0-linux-x86_64.deb"
             dpkg -i bazel_0.21.0-linux-x86_64.deb
-            echo "common:ci --build_tag_filters -requires_hackage,-requires_zlib,-requires_doctest,-requires_c2hs,-requires_threaded_rts,-requires_missing_compiler_flags,-dont_test_with_bindist" > .bazelrc.local
+            echo "common:ci --build_tag_filters -requires_hackage,-requires_zlib,-requires_doctest,-requires_c2hs,-requires_threaded_rts,-dont_test_with_bindist" > .bazelrc.local
       - run:
           name: Build tests
           command: |

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -96,7 +96,10 @@ haskell_register_ghc_nixpkgs(
     version = test_ghc_version,
 )
 
-haskell_register_ghc_bindists(version = bindists_ghc_version)
+haskell_register_ghc_bindists(
+    compiler_flags = test_compiler_flags,
+    version = bindists_ghc_version,
+)
 
 register_toolchains(
     "//tests:c2hs-toolchain",

--- a/haskell/ghc_bindist.bzl
+++ b/haskell/ghc_bindist.bzl
@@ -129,12 +129,14 @@ haskell_toolchain(
     name = "toolchain",
     tools = "{tools}",
     version = "{version}",
+    compiler_flags = {compiler_flags},
     exec_compatible_with = {exec_constraints},
     target_compatible_with = {target_constraints},
 )
         """.format(
             tools = "@{}//:bin".format(ctx.attr.bindist_name),
             version = ctx.attr.version,
+            compiler_flags = ctx.attr.compiler_flags,
             exec_constraints = exec_constraints,
             target_constraints = target_constraints,
         ),
@@ -146,11 +148,16 @@ _ghc_bindist_toolchain = repository_rule(
     attrs = {
         "bindist_name": attr.string(),
         "version": attr.string(),
+        "compiler_flags": attr.string_list(),
         "target": attr.string(),
     },
 )
 
-def ghc_bindist(name, version, target):
+def ghc_bindist(
+        name,
+        version,
+        target,
+        compiler_flags = None):
     """Create a new repository from binary distributions of GHC. The
     repository exports two targets:
 
@@ -193,11 +200,12 @@ def ghc_bindist(name, version, target):
         name = toolchain_name,
         bindist_name = bindist_name,
         version = version,
+        compiler_flags = compiler_flags,
         target = target,
     )
     native.register_toolchains("@{}//:toolchain".format(toolchain_name))
 
-def haskell_register_ghc_bindists(version):
+def haskell_register_ghc_bindists(version, compiler_flags = None):
     """Register GHC binary distributions for all platforms as toolchains.
 
     Toolchains can be used to compile Haskell code. This function
@@ -216,4 +224,5 @@ def haskell_register_ghc_bindists(version):
             name = "io_tweag_rules_haskell_ghc_{}".format(target),
             target = target,
             version = version,
+            compiler_flags = compiler_flags,
         )

--- a/tests/binary-with-compiler-flags/BUILD
+++ b/tests/binary-with-compiler-flags/BUILD
@@ -14,6 +14,5 @@ haskell_test(
         "-with-rtsopts=-N2 -qg -I0 -n2m -A128m",
         "-XLambdaCase",
     ],
-    tags = ["requires_missing_compiler_flags"],
     deps = ["//tests/hackage:base"],
 )

--- a/tests/repl-flags/BUILD
+++ b/tests/repl-flags/BUILD
@@ -15,7 +15,6 @@ haskell_test(
 
     # This also ensure that local `compiler_flags` does not override the `global ones`
     compiler_flags = ["-XOverloadedStrings"],
-    tags = ["requires_missing_compiler_flags"],
     visibility = ["//visibility:public"],
     deps = [
         "//tests/hackage:base",
@@ -38,7 +37,6 @@ haskell_test(
 
     # This also ensure that local `repl_flags` does not override the `global ones`
     repl_ghci_args = ["-DTESTS_TOOLCHAIN_REPL_FLAGS"],
-    tags = ["requires_missing_compiler_flags"],
     visibility = ["//visibility:public"],
     deps = [
         "//tests/hackage:base",


### PR DESCRIPTION
Exposing the compiler flags on the ghc bindist toolchain.
Forwarding these  flags exposed to the `haskell_toolchain` generated rules.

We can now build the tests needing some custom compiler flags on the
bindist CI. 

Removing the now useless `requires_missing_compiler_flags` tags.