### PR TITLE
Test compiler flags on Windows

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -31,6 +31,7 @@ jobs:
       /c/bazel/bazel.exe test --config windows "//tests/binary-custom-main/..."
       /c/bazel/bazel.exe test --config windows "//tests/binary-with-main/..."
       /c/bazel/bazel.exe test --config windows "//tests/binary-simple/..."
+      /c/bazel/bazel.exe test --config windows "//tests/binary-with-compiler-flags/..."
       /c/bazel/bazel.exe test --config windows "//tests/binary-with-link-flags/..."
       /c/bazel/bazel.exe test --config windows "//tests/encoding/..."
 


### PR DESCRIPTION
Fixes #651 .

I believe the issue was already fixed by @NinjaTrappeur in #662 . This merely tests the feature on Windows.