### PR TITLE
Fetch fewer boot pkgs from Nix

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,8 +18,8 @@ jobs:
 
       # Tests that build but don't run
       /c/bazel/bazel.exe build --config windows "//tests/binary-with-lib"
-      /c/bazel/bazel.exe build --config windows "//tests/binary-with-data:bin1"
       /c/bazel/bazel.exe build --config windows "//tests/c-compiles-still/..."
+      /c/bazel/bazel.exe build --config windows "//tests/binary-with-data/..."
 
       # Tests that only require building
       # (when using 'test' CI fails with:

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -36,13 +36,13 @@ haskell_proto_toolchain(
         "//tests/hackage:base",
         "//tests/hackage:bytestring",
         "//tests/hackage:containers",
+        "//tests/hackage:deepseq",
+        "//tests/hackage:mtl",
         "//tests/hackage:text",
         "@hackage//:data-default-class",
-        "@hackage//:deepseq",
         "@hackage//:lens-family",
         "@hackage//:lens-family-core",
         "@hackage//:lens-labels",
-        "@hackage//:mtl",
         "@hackage//:proto-lens",
     ],
 )
@@ -379,8 +379,8 @@ haskell_binary(
     tags = ["requires_hackage"],
     deps = [
         "//tests/hackage:base",
+        "//tests/hackage:process",
         "@hackage//:hspec",
         "@hackage//:hspec-core",
-        "@hackage//:process",
     ],
 )

--- a/tests/binary-with-data/BUILD
+++ b/tests/binary-with-data/BUILD
@@ -23,6 +23,6 @@ haskell_test(
     visibility = ["//visibility:public"],
     deps = [
         "//tests/hackage:base",
-        "@hackage//:process",
+        "//tests/hackage:process",
     ],
 )

--- a/tests/hackage/BUILD
+++ b/tests/hackage/BUILD
@@ -13,14 +13,18 @@ load(
 [
     haskell_import(name = name)
     for name in [
+        "array",
         "base",
         "binary",
         "bytestring",
         "containers",
+        "deepseq",
         "directory",
         "filepath",
+        "mtl",
         "template-haskell",
         "ghc-prim",
+        "process",
         "text",
     ]
 ]

--- a/tests/repl-targets/BUILD
+++ b/tests/repl-targets/BUILD
@@ -47,8 +47,8 @@ haskell_library(
     deps = [
         ":zlib",
         "//tests/data:ourclibrary",
+        "//tests/hackage:array",
         "//tests/hackage:base",
-        "@hackage//:array",
     ],
 )
 


### PR DESCRIPTION
Fixes #654 .

Fetches a few more [boot packages] from GHC itself as opposed to nixpkgs hackage.

[boot packages]: https://ghc.haskelltorg/trac/ghc/wiki/Commentary/Libraries/VersionHistory