### PR TITLE
Disable dynamic linking on Windows

### DIFF
--- a/haskell/private/haskell_impl.bzl
+++ b/haskell/private/haskell_impl.bzl
@@ -90,7 +90,7 @@ def _haskell_binary_common_impl(ctx, is_test):
         import_dir_map = import_dir_map,
         extra_srcs = depset(ctx.files.extra_srcs),
         compiler_flags = compiler_flags,
-        dynamic = not ctx.attr.linkstatic,
+        dynamic = False if hs.toolchain.is_windows else not ctx.attr.linkstatic,
         with_profiling = False,
         main_function = ctx.attr.main_function,
         version = ctx.attr.version,
@@ -135,7 +135,7 @@ def _haskell_binary_common_impl(ctx, is_test):
         ctx.files.extra_srcs,
         ctx.attr.compiler_flags,
         c_p.objects_dir if with_profiling else c.objects_dir,
-        dynamic = not ctx.attr.linkstatic,
+        dynamic = False if hs.toolchain.is_windows else not ctx.attr.linkstatic,
         with_profiling = with_profiling,
         version = ctx.attr.version,
     )
@@ -204,7 +204,7 @@ def haskell_library_impl(ctx):
     version = ctx.attr.version if ctx.attr.version else None
     my_pkg_id = pkg_id.new(ctx.label, version)
     with_profiling = is_profiling_enabled(hs)
-    with_shared = not ctx.attr.linkstatic
+    with_shared = False if hs.toolchain.is_windows else not ctx.attr.linkstatic
 
     # Add any interop info for other languages.
     cc = cc_interop_info(ctx)

--- a/tests/binary-indirect-cbits/BUILD
+++ b/tests/binary-indirect-cbits/BUILD
@@ -7,10 +7,6 @@ load(
 haskell_binary(
     name = "binary-indirect-cbits",
     srcs = ["Main.hs"],
-    linkstatic = select({
-        "@bazel_tools//src/conditions:windows": True,
-        "//conditions:default": False,
-    }),
     deps = [
         "//tests/hackage:base",
         "//tests/library-with-cbits",

--- a/tests/binary-with-import/BUILD
+++ b/tests/binary-with-import/BUILD
@@ -9,10 +9,6 @@ package(default_testonly = 1)
 haskell_library(
     name = "lib",
     srcs = ["src/Lib.hs"],
-    linkstatic = select({
-        "@bazel_tools//src/conditions:windows": True,
-        "//conditions:default": False,
-    }),
     deps = [
         "//tests/hackage:base",
         "//tests/hackage:transformers",

--- a/tests/binary-with-lib/BUILD
+++ b/tests/binary-with-lib/BUILD
@@ -9,10 +9,6 @@ package(default_testonly = 1)
 haskell_library(
     name = "lib",
     srcs = glob(["src/*.hs"]),
-    linkstatic = select({
-        "@bazel_tools//src/conditions:windows": True,
-        "//conditions:default": False,
-    }),
     src_strip_prefix = "src",
     deps = [
         "//tests/hackage:template-haskell",

--- a/tests/c-compiles-still/BUILD
+++ b/tests/c-compiles-still/BUILD
@@ -8,10 +8,6 @@ package(default_testonly = 1)
 haskell_library(
     name = "foo",
     srcs = ["Foo.hs"],
-    linkstatic = select({
-        "@bazel_tools//src/conditions:windows": True,
-        "//conditions:default": False,
-    }),
     deps = [
         "//tests/data:ourclibrary",
         "//tests/hackage:base",

--- a/tests/c-compiles/BUILD
+++ b/tests/c-compiles/BUILD
@@ -9,10 +9,6 @@ package(default_testonly = 1)
 haskell_library(
     name = "hs-lib",
     srcs = ["Lib.hs"],
-    linkstatic = select({
-        "@bazel_tools//src/conditions:windows": True,
-        "//conditions:default": False,
-    }),
     deps = [
         "//tests/data:ourclibrary",
         "//tests/hackage:base",

--- a/tests/library-deps/BUILD
+++ b/tests/library-deps/BUILD
@@ -9,10 +9,6 @@ package(default_testonly = 1)
 haskell_library(
     name = "library-deps",
     srcs = ["TestLib.hs"],
-    linkstatic = select({
-        "@bazel_tools//src/conditions:windows": True,
-        "//conditions:default": False,
-    }),
     visibility = ["//visibility:public"],
     deps = [
         "//tests/hackage:base",

--- a/tests/library-deps/sublib/BUILD
+++ b/tests/library-deps/sublib/BUILD
@@ -8,10 +8,6 @@ package(default_testonly = 1)
 haskell_library(
     name = "sublib",
     srcs = ["TestSubLib.hs"],
-    linkstatic = select({
-        "@bazel_tools//src/conditions:windows": True,
-        "//conditions:default": False,
-    }),
     visibility = ["//visibility:public"],
     deps = [
         ":sublib-c",

--- a/tests/library-with-cbits/BUILD
+++ b/tests/library-with-cbits/BUILD
@@ -7,10 +7,6 @@ load(
 haskell_library(
     name = "library-with-cbits",
     srcs = ["AddOne.hsc"],
-    linkstatic = select({
-        "@bazel_tools//src/conditions:windows": True,
-        "//conditions:default": False,
-    }),
     visibility = ["//visibility:public"],
     deps = [
         ":ourclibrary-indirect",


### PR DESCRIPTION
This PR removes the need to select `linkstatic` in each target based on the platform.

Closes #666 .