### PR TITLE
Link dynamic Haskell library dependencies in single directory

### DIFF
--- a/haskell/private/actions/link.bzl
+++ b/haskell/private/actions/link.bzl
@@ -403,16 +403,16 @@ def _link_dependencies(hs, dep_info, dynamic, binary_tmp, binary, args):
     # Collect Haskell dynamic library dependencies in common RUNPATH.
     # This is to keep the number of RUNPATH entries low, for faster loading
     # and to avoid exceeding the MACH-O header size limit on MacOS.
-    # XXX: Only in dynamic linking mode.
     hs_solibs = []
-    hs_solibs_prefix = "_hssolib_%s" % hs.name
-    for dep in set.to_list(dep_info.dynamic_libraries):
-        dep_link = hs.actions.declare_file(
-            paths.join(hs_solibs_prefix, dep.basename),
-            sibling = binary,
-        )
-        ln(hs, dep, dep_link)
-        hs_solibs.append(dep_link)
+    if dynamic:
+        hs_solibs_prefix = "_hssolib_%s" % hs.name
+        for dep in set.to_list(dep_info.dynamic_libraries):
+            dep_link = hs.actions.declare_file(
+                paths.join(hs_solibs_prefix, dep.basename),
+                sibling = binary,
+            )
+            ln(hs, dep, dep_link)
+            hs_solibs.append(dep_link)
 
     # Configure RUNPATH.
     rpaths = _infer_rpaths(

--- a/haskell/private/haskell_impl.bzl
+++ b/haskell/private/haskell_impl.bzl
@@ -127,7 +127,7 @@ def _haskell_binary_common_impl(ctx, is_test):
             hpc_outputs = hpc_outputs,
         )
 
-    binary = link_binary(
+    (binary, solibs) = link_binary(
         hs,
         cc,
         dep_info,
@@ -138,14 +138,6 @@ def _haskell_binary_common_impl(ctx, is_test):
         with_profiling = with_profiling,
         version = ctx.attr.version,
     )
-
-    if ctx.attr.linkstatic:
-        link_ctx = dep_info.cc_dependencies.static_linking
-    else:
-        link_ctx = dep_info.cc_dependencies.dynamic_linking
-    cc_solibs = link_ctx.dynamic_libraries_for_runtime.to_list()
-
-    solibs = cc_solibs + set.to_list(dep_info.dynamic_libraries)
 
     build_info = dep_info  # HaskellBuildInfo
     bin_info = HaskellBinaryInfo(


### PR DESCRIPTION
Closes https://github.com/tweag/rules_haskell/issues/593.

**Depends on https://github.com/tweag/rules_haskell/pull/614 (technically [rebase_rpath_pr](https://github.com/tweag/rules_haskell/tree/rebase_rpath_pr))**
**Switch base branch before merge**

Similar to how dynamic C library dependencies are stored in one common directory, this PR changes rules_haskell to store dynamic Haskell library dependencies in one common directory. Contrary to the C library case we don't have access to the global `_solib` directory, and instead use a dedicated directory per binary.

This requires only a single RPATH entry for all Haskell library dependencies, significantly reducing the header size, and avoiding MACH-O header size limit violations.

Note, GHC still adds redundant RPATH entries by itself. The `-dynload=deploy` flag can be used to instruct GHC not to add these RPATH entries (see #614). However, this also stops GHC from adding RPATH entries for core-packages or the rts, causing runtime failures on [MacOS](https://circleci.com/gh/tweag/rules_haskell/4180) and [non-Nix Linux](https://circleci.com/gh/tweag/rules_haskell/4181).
