### PR TITLE
Fix module name in package conf file on Windows

### DIFF
--- a/haskell/private/ls_modules.py
+++ b/haskell/private/ls_modules.py
@@ -69,6 +69,8 @@ interface_files = (
 )
 
 modules = (
+    # replace directory separators by . to generate module names
+    # / and \ are respectively the separators for unix (linux / darwin) and windows systems
     os.path.splitext(os.path.relpath(f, start=root))[0]
         .replace("/",".")
         .replace("\\",".")

--- a/haskell/private/ls_modules.py
+++ b/haskell/private/ls_modules.py
@@ -69,7 +69,9 @@ interface_files = (
 )
 
 modules = (
-    os.path.splitext(os.path.relpath(f, start=root))[0].replace("/",".")
+    os.path.splitext(os.path.relpath(f, start=root))[0]
+        .replace("/",".")
+        .replace("\\",".")
     for f in interface_files
 )
 


### PR DESCRIPTION
From time to time, but not always for some unknown reason, exposed module names in packages `.conf` files would end up with `\` instead of `.` on Windows, because of the different path segment separator.

This small PR fixes this issue.