### PR TITLE
Remove --all_incompatible_changes

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -24,10 +24,8 @@ test:windows --experimental_enable_runfiles
 # We also need to setup an utf8 locale
 test --test_env=LANG=en_US.utf8 --test_env=LOCALE_ARCHIVE
 
-# Making incompatible changes fail.
-#
 # ToRemove: remove the three exceptions when they'll stop failing
 # on Google's protobuf_rules.
-test --all_incompatible_changes  --incompatible_disable_deprecated_attr_params=false --incompatible_new_actions_api=false --incompatible_expand_directories=false
+test --incompatible_disable_deprecated_attr_params=false --incompatible_new_actions_api=false --incompatible_expand_directories=false
 
 try-import .bazelrc.local


### PR DESCRIPTION
This comment https://github.com/bazelbuild/bazel/issues/6861#issuecomment-460145291 and this process https://docs.bazel.build/versions/master/backward-compatibility.html detail the incompatible change process.

`--all_incompatible_changes` is not the right setting for us because it will:

- enable changes which may never be set by default, hence forcing us to do useless work
- enable changes which may be set by default, but at a time in which the rest of the bazel ecosystem is not ready yet. See for example #639.

Future aware developers of rules_haskell needs to track the bazel issue tracker for possible incompatible changes and decide if they justify preliminary work. They may also occasionally enable `--all_incompatible_changes` to test, but it should not be the default.