### PR TITLE
Removing useless flags from BazelRC

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -24,8 +24,4 @@ test:windows --experimental_enable_runfiles
 # We also need to setup an utf8 locale
 test --test_env=LANG=en_US.utf8 --test_env=LOCALE_ARCHIVE
 
-# ToRemove: remove the three exceptions when they'll stop failing
-# on Google's protobuf_rules.
-test --incompatible_disable_deprecated_attr_params=false --incompatible_new_actions_api=false --incompatible_expand_directories=false
-
 try-import .bazelrc.local


### PR DESCRIPTION
We don't need the `incompatible_disable` flags anymore since #691 has
been merged.