### PR TITLE
Enable //tests:test-cc_haskell_import_python

### DIFF
--- a/tests/BUILD
+++ b/tests/BUILD
@@ -266,18 +266,17 @@ rule_test(
     tags = ["requires_threaded_rts"],
 )
 
-# TODO(Profpatsch) blocked on https://github.com/bazelbuild/bazel/issues/6093
-# (among possibly others ..)
-# sh_test(
-#     name = "test-cc_haskell_import_python",
-#     size = "small",
-#     srcs = ["scripts/exec.sh"],
-#     args = ["tests/cc_haskell_import/python_add_one"],
-#     data = [
-#         "//tests/cc_haskell_import:python_add_one",
-#         "@bazel_tools//tools/bash/runfiles",
-#     ],
-# )
+sh_test(
+    name = "test-cc_haskell_import_python",
+    size = "small",
+    srcs = ["scripts/exec.sh"],
+    args = ["tests/cc_haskell_import/python_add_one"],
+    data = [
+        "//tests/cc_haskell_import:python_add_one",
+        "@bazel_tools//tools/bash/runfiles",
+    ],
+    tags = ["requires_threaded_rts"],
+)
 
 sh_inline_test(
     name = "test-haskell_binary-with-link-flags",


### PR DESCRIPTION
Was fixed by the fixes to rpaths in
https://github.com/tweag/rules_haskell/pull/614 and related changes to
`link.bzl`.

Fixes https://github.com/tweag/rules_haskell/issues/525