### PR TITLE
Generate a json file with ghc build info for IDE tools

### DIFF
--- a/haskell/lint.bzl
+++ b/haskell/lint.bzl
@@ -8,7 +8,7 @@ load(
     "HaskellLintInfo",
 )
 load(":private/context.bzl", "haskell_context")
-load(":private/packages.bzl", "expose_packages")
+load(":private/packages.bzl", "expose_packages", "pkg_info_to_ghc_args")
 load(
     ":private/path_utils.bzl",
     "target_unique_name",
@@ -54,14 +54,14 @@ def _haskell_lint_aspect_impl(target, ctx):
         "--make",
     ])
 
-    args.add_all(expose_packages(
+    args.add_all(pkg_info_to_ghc_args(expose_packages(
         build_info,
         lib_info,
         use_direct = False,
         use_my_pkg_id = None,
         custom_package_caches = None,
         version = ctx.rule.attr.version,
-    ))
+    )))
 
     sources = set.to_list(
         lib_info.source_files if lib_info != None else bin_info.source_files,

--- a/haskell/private/actions/compile.bzl
+++ b/haskell/private/actions/compile.bzl
@@ -1,6 +1,6 @@
 """Actions for compiling Haskell source code"""
 
-load(":private/packages.bzl", "expose_packages")
+load(":private/packages.bzl", "expose_packages", "pkg_info_to_ghc_args")
 load("@bazel_skylib//lib:dicts.bzl", "dicts")
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load(
@@ -134,14 +134,14 @@ def _compilation_defaults(hs, cc, java, dep_info, srcs, import_dir_map, extra_sr
     if hs.toolchain.is_darwin:
         ghc_args += ["-optl-Wl,-dead_strip_dylibs"]
 
-    ghc_args.extend(expose_packages(
+    ghc_args.extend(pkg_info_to_ghc_args(expose_packages(
         dep_info,
         lib_info = None,
         use_direct = True,
         use_my_pkg_id = my_pkg_id,
         custom_package_caches = None,
         version = version,
-    ))
+    )))
 
     header_files = []
     boot_files = []

--- a/haskell/private/actions/link.bzl
+++ b/haskell/private/actions/link.bzl
@@ -1,6 +1,6 @@
 """Actions for linking object code produced by compilation"""
 
-load(":private/packages.bzl", "expose_packages")
+load(":private/packages.bzl", "expose_packages", "pkg_info_to_ghc_args")
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load(
     ":private/path_utils.bzl",
@@ -492,14 +492,14 @@ def link_binary(
     # directly rather than doing multiple reversals with temporary
     # lists.
 
-    args.add_all(expose_packages(
+    args.add_all(pkg_info_to_ghc_args(expose_packages(
         dep_info,
         lib_info = None,
         use_direct = True,
         use_my_pkg_id = None,
         custom_package_caches = None,
         version = version,
-    ))
+    )))
 
     (cc_link_libs, cc_solibs, hs_solibs) = _link_dependencies(
         hs = hs,
@@ -727,14 +727,14 @@ def link_library_dynamic(hs, cc, dep_info, extra_srcs, objects_dir, my_pkg_id):
     if hs.toolchain.is_darwin:
         args.add("-optl-Wl,-dead_strip_dylibs")
 
-    args.add_all(expose_packages(
+    args.add_all(pkg_info_to_ghc_args(expose_packages(
         dep_info,
         lib_info = None,
         use_direct = True,
         use_my_pkg_id = None,
         custom_package_caches = None,
         version = my_pkg_id.version if my_pkg_id else None,
-    ))
+    )))
 
     if hs.toolchain.is_darwin:
         # Keep space to override install name with mangled name.

--- a/haskell/private/actions/repl.bzl
+++ b/haskell/private/actions/repl.bzl
@@ -1,6 +1,6 @@
 """GHCi REPL support"""
 
-load(":private/packages.bzl", "expose_packages")
+load(":private/packages.bzl", "expose_packages", "pkg_info_to_ghc_args")
 load(
     ":private/path_utils.bzl",
     "get_lib_name",
@@ -49,7 +49,7 @@ def build_haskell_repl(
     # (loads source files and brings in scope the corresponding modules).
     args = ["-package", "base", "-package", "directory"]
 
-    args += expose_packages(
+    pkg_ghc_info = expose_packages(
         build_info,
         lib_info,
         use_direct = False,
@@ -57,6 +57,7 @@ def build_haskell_repl(
         custom_package_caches = package_caches,
         version = version,
     )
+    args += pkg_info_to_ghc_args(pkg_ghc_info)
 
     if lib_info != None:
         for idir in set.to_list(lib_info.import_dirs):

--- a/haskell/private/actions/runghc.bzl
+++ b/haskell/private/actions/runghc.bzl
@@ -1,6 +1,6 @@
 """runghc support"""
 
-load(":private/packages.bzl", "expose_packages")
+load(":private/packages.bzl", "expose_packages", "pkg_info_to_ghc_args")
 load(
     ":private/path_utils.bzl",
     "get_lib_name",
@@ -43,14 +43,14 @@ def build_haskell_runghc(
       None.
     """
 
-    args = expose_packages(
+    args = pkg_info_to_ghc_args(expose_packages(
         build_info,
         lib_info,
         use_direct = False,
         use_my_pkg_id = None,
         custom_package_caches = package_caches,
         version = version,
-    )
+    ))
 
     if lib_info != None:
         for idir in set.to_list(lib_info.import_dirs):

--- a/haskell/private/packages.bzl
+++ b/haskell/private/packages.bzl
@@ -2,10 +2,43 @@
 
 load(":private/set.bzl", "set")
 
+def pkg_info_to_ghc_args(pkg_info):
+    """
+    Takes the package info collected by `ghc_info()` and returns the actual
+    list of command line arguments that should be passed to GHC.
+    """
+    args = [
+        # In compile.bzl, we pass this just before all -package-id
+        # arguments. Not doing so leads to bizarre compile-time failures.
+        # It turns out that equally, not doing so leads to bizarre
+        # link-time failures. See
+        # https://github.com/tweag/rules_haskell/issues/395.
+        "-hide-all-packages",
+    ]
+
+    if not pkg_info.has_version:
+        args.extend([
+            # Macro version are disabled for all packages by default
+            # and enabled for package with version
+            # see https://github.com/tweag/rules_haskell/issues/414
+            "-fno-version-macros",
+        ])
+
+    for package in pkg_info.packages:
+        args.extend(["-package", package])
+
+    for package_id in pkg_info.package_ids:
+        args.extend(["-package-id", package_id])
+
+    for package_db in pkg_info.package_dbs:
+        args.extend(["-package-db", package_db])
+
+    return args
+
 def expose_packages(build_info, lib_info, use_direct, use_my_pkg_id, custom_package_caches, version):
     """
-    Returns the list of command line argument which should be passed
-    to GHC in order to enable haskell packages.
+    Returns the information that is needed by GHC in order to enable haskell
+    packages.
 
     build_info: is common to all builds
     version: if the rule contains a version, we will export the CPP version macro
@@ -17,24 +50,7 @@ def expose_packages(build_info, lib_info, use_direct, use_my_pkg_id, custom_pack
     use_my_pkg_id: only used for one specific task in compile.bzl
     custom_package_caches: override the package_caches of build_info, used only by the repl
     """
-    args = [
-        # In compile.bzl, we pass this just before all -package-id
-        # arguments. Not doing so leads to bizarre compile-time failures.
-        # It turns out that equally, not doing so leads to bizarre
-        # link-time failures. See
-        # https://github.com/tweag/rules_haskell/issues/395.
-        "-hide-all-packages",
-    ]
-
     has_version = version != None and version != ""
-
-    if not has_version:
-        args.extend([
-            # Macro version are disabled for all packages by default
-            # and enabled for package with version
-            # see https://github.com/tweag/rules_haskell/issues/414
-            "-fno-version-macros",
-        ])
 
     # Expose all prebuilt dependencies
     #
@@ -42,10 +58,12 @@ def expose_packages(build_info, lib_info, use_direct, use_my_pkg_id, custom_pack
     # dependencies or we can't find objects for linking
     #
     # Set use_direct if build_info does not have a direct_prebuilt_deps field.
+    packages = []
     for prebuilt_dep in set.to_list(build_info.direct_prebuilt_deps if use_direct else build_info.prebuilt_dependencies):
-        args.extend(["-package", prebuilt_dep.package])
+        packages.append(prebuilt_dep.package)
 
     # Expose all bazel dependencies
+    package_ids = []
     for package in set.to_list(build_info.package_ids):
         # XXX: repl and lint uses this lib_info flags
         # It is set to None in all other usage of this function
@@ -53,11 +71,18 @@ def expose_packages(build_info, lib_info, use_direct, use_my_pkg_id, custom_pack
         if lib_info == None or package != lib_info.package_id:
             # XXX: use_my_pkg_id is not None only in compile.bzl
             if (use_my_pkg_id == None) or package != use_my_pkg_id:
-                args.extend(["-package-id", package])
+                package_ids.append(package)
 
     # Only include package DBs for deps, prebuilt deps should be found
     # auto-magically by GHC
+    package_dbs = []
     for cache in set.to_list(build_info.package_caches if not custom_package_caches else custom_package_caches):
-        args.extend(["-package-db", cache.dirname])
+        package_dbs.append(cache.dirname)
 
-    return args
+    ghc_info = struct(
+        has_version = has_version,
+        packages = packages,
+        package_ids = package_ids,
+        package_dbs = package_dbs,
+    )
+    return ghc_info


### PR DESCRIPTION
We want to be able to expose information that IDE tools need
and typically obtain from cabal files. Our current use case
for this is to be able to run ghci (and ghcid) over multiple
packages (as in #380).

What we do here is, on the `@repl` target, we write not only
the ghci runner script, but also a json file that contains
all the package-dependent information (e.g., path to ghci,
environment variables, packages, compiler flags, etc). In
order to run ghci on multiple targets, we use a script that
essentially collects all the json files for the packages 
mentioned, takes the union of all their arguments, and calls
ghci with that. See this example:
https://gist.github.com/u-quark/e58cf5e3b2d9cdeb7ea1b4e8ccc21547.

For this PR, we tried to keep the changes to a bare minimum,
but it would probably make sense to later change the ghci
and runghc wrappers to just take the required information
from the json file, which should help reducing the current
code duplication (#690).


