### PR TITLE
Fix broken haddock links

### DIFF
--- a/haskell/haddock.bzl
+++ b/haskell/haddock.bzl
@@ -221,7 +221,7 @@ def _haskell_doc_rule_impl(ctx):
             command = """
       mkdir -p "{doc_dir}"
       # Copy Haddocks of a dependency.
-      cp -R -L "{html_dir}" "{target_dir}"
+      cp -R -L "{html_dir}/." "{target_dir}"
       """.format(
                 doc_dir = doc_root_path,
                 html_dir = html_dir.path,

--- a/shell.nix
+++ b/shell.nix
@@ -20,6 +20,8 @@ mkShell {
     git
     # Needed to get correct locale for tests with encoding
     glibcLocales
+    # to check haddock outputs
+    linkchecker
   ] ++ lib.optionals docTools [graphviz python36Packages.sphinx zip unzip];
 
   shellHook = ''

--- a/tests/RunTests.hs
+++ b/tests/RunTests.hs
@@ -19,6 +19,13 @@ main = hspec $ do
   it "bazel test" $ do
     assertSuccess (bazel ["test", "//...", "--build_tests_only"])
 
+  it "haddock links" $ do
+    -- Test haddock links
+    -- All haddock tests are stored inside //tests/haddock
+    -- Temporaries files appears inside /doc-.... outputs and are ignored
+    assertSuccess (bazel ["build", "//tests/haddock/..."])
+    assertSuccess (Process.proc "linkchecker" ["bazel-ci-bin/tests/haddock/", "--ignore-url=/doc-"])
+
   it "bazel test prof" $ do
     assertSuccess (bazel ["test", "-c", "dbg", "//...", "--build_tests_only"])
 

--- a/tests/RunTests.hs
+++ b/tests/RunTests.hs
@@ -23,8 +23,18 @@ main = hspec $ do
     -- Test haddock links
     -- All haddock tests are stored inside //tests/haddock
     -- Temporaries files appears inside /doc-.... outputs and are ignored
-    assertSuccess (bazel ["build", "//tests/haddock/..."])
-    assertSuccess (Process.proc "linkchecker" ["bazel-ci-bin/tests/haddock/", "--ignore-url=/doc-"])
+
+    -- the copy / chmod is here to workaround the fact that
+    -- linkchecker is dropping privileges to "nobody" user if called
+    -- from root, which is the case on CI.
+    assertSuccess (safeShell
+      [ "bazel build --config=ci //tests/haddock/..."
+      , "pwd=$(pwd)"
+      , "cd $(mktemp -d)"
+      , "cp -r $pwd/bazel-ci-bin/tests/haddock ."
+      , "chmod -R o+r ."
+      , "linkchecker . --ignore-url=/doc-"
+      ])
 
   it "bazel test prof" $ do
     assertSuccess (bazel ["test", "-c", "dbg", "//...", "--build_tests_only"])

--- a/tests/haddock/LibA.hs
+++ b/tests/haddock/LibA.hs
@@ -1,4 +1,4 @@
--- | "Lib" header
+-- | "LibA" header
 {-# LANGUAGE CPP             #-}
 {-# LANGUAGE TemplateHaskell #-}
 

--- a/tests/haddock/LibA/A.hs
+++ b/tests/haddock/LibA/A.hs
@@ -1,4 +1,4 @@
--- | "Lib.A" header
+-- | "LibA.A" header
 {-# LANGUAGE TemplateHaskell #-}
 
 module LibA.A where


### PR DESCRIPTION
This pull requests fix haddock links which were broken since 327f2fa872bf5663cc176e39d8c4588d2bf06c60. It closes #700.

It also introduces:

- A regression test, which checks that local links inside haddock are correctly resolved. This does not check links against system libraries (such as the ones stored in `/nix/store`). This can be enabled, but it will also check remote links (such as mathjax links).
- Fixs for a few broken links.