### PR TITLE
Fix Hazel builds on Windows with GHC < 8.6

### DIFF
--- a/haskell/BUILD
+++ b/haskell/BUILD
@@ -12,8 +12,8 @@ exports_files(
     visibility = ["//tests/unit-tests:__pkg__"],
 )
 
-# used on Windows to get shorter paths in order to say under the MAX_PATH limit
-# of 260 chars.
+# used on Windows to get shorter paths in order to stay under the MAX_PATH
+# limit of 260 chars.
 exports_files(
     ["private/short_path.bat"],
     visibility = ["//visibility:public"],

--- a/haskell/BUILD
+++ b/haskell/BUILD
@@ -12,6 +12,13 @@ exports_files(
     visibility = ["//tests/unit-tests:__pkg__"],
 )
 
+# used on Windows to get shorter paths in order to say under the MAX_PATH limit
+# of 260 chars.
+exports_files(
+    ["private/short_path.bat"],
+    visibility = ["//visibility:public"],
+)
+
 py_binary(
     name = "ls_modules",
     srcs = ["private/ls_modules.py"],

--- a/haskell/ghc.BUILD
+++ b/haskell/ghc.BUILD
@@ -25,6 +25,13 @@ cc_library(
     )[0],
 )
 
+# This is needed for Hazel targets.
+cc_library(
+    name = "rts-headers",
+    hdrs = glob(["lib/include/**/*.h"]),
+    strip_include_prefix = "lib/include",
+)
+
 # Expose embedded MinGW toolchain when on Windows.
 
 filegroup(

--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -90,6 +90,12 @@ _haskell_common_attrs = {
         cfg = "host",
         default = Label("@io_tweag_rules_haskell//haskell:ls_modules"),
     ),
+    "_short_path": attr.label(
+        executable = True,
+        allow_single_file = True,
+        cfg = "host",
+        default = Label("@io_tweag_rules_haskell//haskell:private/short_path.bat"),
+    ),
     "_cc_toolchain": attr.label(
         default = Label("@bazel_tools//tools/cpp:current_cc_toolchain"),
     ),

--- a/haskell/private/actions/package.bzl
+++ b/haskell/private/actions/package.bzl
@@ -38,7 +38,7 @@ def _get_extra_libraries(dep_info):
         set.mutable_insert(extra_lib_dirs, lib.dirname)
     return (set.to_list(extra_lib_dirs), extra_libs)
 
-def package(hs, dep_info, interfaces_dir, interfaces_dir_prof, static_library, dynamic_library, exposed_modules_file, other_modules, my_pkg_id, static_library_prof):
+def package(hs, dep_info, interfaces_dir, interfaces_dir_prof, static_library, dynamic_library, exposed_modules_file, other_modules, my_pkg_id, static_library_prof, short_path):
     """Create GHC package using ghc-pkg.
 
     Args:
@@ -146,9 +146,39 @@ def package(hs, dep_info, interfaces_dir, interfaces_dir_prof, static_library, d
         use_default_shell_env = True,
     )
 
+    # Generate a unique file name based on package ID to store packagedb dir name.
+    pkgdb_dirname_fname = "ghc-pkg_{}".format(hash("{}".format(my_pkg_id))).replace("-", "_")
+
+    pkgdb_dirname_file = hs.actions.declare_file(pkgdb_dirname_fname)
+
+    # On Windows, standard file path limit is of 260 characters.
+    #
+    # This limit can be disabled on Windows 10, but the removal of this
+    # limitation is not honored by MingW-derived binaries (such as ghc tools,
+    # prior to 8.6.x) by default. Since we can't realistically recompile GHC
+    # and friends, we instead use a batch script to compute an MS-DOS style
+    # "short path", where each segment contains at most 8 characters.
+    #
+    # See: https://github.com/haskell/cabal/issues/3972 for a related issue on
+    # Cabal side.
+    if hs.toolchain.is_windows:
+        hs.actions.run(
+            executable = short_path,
+            outputs = [pkgdb_dirname_file],
+            arguments = [
+                conf_file.dirname,
+                pkgdb_dirname_file.path,
+            ],
+        )
+    else:
+        hs.actions.write(
+            pkgdb_dirname_file,
+            conf_file.dirname,
+        )
+
     # Make the call to ghc-pkg and use the package configuration file
     package_path = ":".join([c.dirname for c in set.to_list(dep_info.package_confs)]) + ":"
-    hs.actions.run(
+    hs.actions.run_shell(
         inputs = depset(transitive = [
             set.to_depset(dep_info.package_confs),
             set.to_depset(dep_info.package_caches),
@@ -163,6 +193,7 @@ def package(hs, dep_info, interfaces_dir, interfaces_dir_prof, static_library, d
                 ]
                 if input
             ]),
+            depset([hs.tools.ghc_pkg, pkgdb_dirname_file]),
         ]),
         outputs = [cache_file],
         env = {
@@ -170,7 +201,7 @@ def package(hs, dep_info, interfaces_dir, interfaces_dir_prof, static_library, d
         },
         mnemonic = "HaskellRegisterPackage",
         progress_message = "HaskellRegisterPackage {}".format(hs.label),
-        executable = hs.tools.ghc_pkg,
+
         # Registration of a new package consists in,
         #
         # 1. copying the registration file into the package db,
@@ -192,12 +223,16 @@ def package(hs, dep_info, interfaces_dir, interfaces_dir_prof, static_library, d
         #
         # TODO Go back to using `ghc-pkg register`. Blocked by
         # https://ghc.haskell.org/trac/ghc/ticket/15478
-        arguments = [
-            "recache",
-            "--package-db={0}".format(conf_file.dirname),
-            "-v0",
-            "--no-expand-pkgroot",
-        ],
+        command = """
+            pkgdb_path=$(< {pkgdb_dirname_file})
+            {ghc_pkg} recache\
+                "--package-db=$pkgdb_path"\
+                -v0\
+                --no-expand-pkgroot
+        """.format(
+            ghc_pkg = hs.tools.ghc_pkg.path,
+            pkgdb_dirname_file = pkgdb_dirname_file.path,
+        ),
         # XXX: Seems required for this to work on Windows
         use_default_shell_env = True,
     )

--- a/haskell/private/actions/package.bzl
+++ b/haskell/private/actions/package.bzl
@@ -38,7 +38,18 @@ def _get_extra_libraries(dep_info):
         set.mutable_insert(extra_lib_dirs, lib.dirname)
     return (set.to_list(extra_lib_dirs), extra_libs)
 
-def package(hs, dep_info, interfaces_dir, interfaces_dir_prof, static_library, dynamic_library, exposed_modules_file, other_modules, my_pkg_id, static_library_prof, short_path):
+def package(
+        hs,
+        dep_info,
+        interfaces_dir,
+        interfaces_dir_prof,
+        static_library,
+        dynamic_library,
+        exposed_modules_file,
+        other_modules,
+        my_pkg_id,
+        static_library_prof,
+        short_path_executable):
     """Create GHC package using ghc-pkg.
 
     Args:
@@ -147,7 +158,9 @@ def package(hs, dep_info, interfaces_dir, interfaces_dir_prof, static_library, d
     )
 
     # Generate a unique file name based on package ID to store packagedb dir name.
-    pkgdb_dirname_fname = "ghc-pkg_{}".format(hash("{}".format(my_pkg_id))).replace("-", "_")
+    pkgdb_dirname_fname = "ghc-pkg_{}".format(
+        hash("{}".format(my_pkg_id)),
+    ).replace("-", "_")
 
     pkgdb_dirname_file = hs.actions.declare_file(pkgdb_dirname_fname)
 
@@ -163,7 +176,7 @@ def package(hs, dep_info, interfaces_dir, interfaces_dir_prof, static_library, d
     # Cabal side.
     if hs.toolchain.is_windows:
         hs.actions.run(
-            executable = short_path,
+            executable = short_path_executable,
             outputs = [pkgdb_dirname_file],
             arguments = [
                 conf_file.dirname,

--- a/haskell/private/haskell_impl.bzl
+++ b/haskell/private/haskell_impl.bzl
@@ -308,7 +308,8 @@ def haskell_library_impl(ctx):
         other_modules,
         my_pkg_id,
         static_library_prof = static_library_prof,
-        short_path = ctx.executable._short_path if hs.toolchain.is_windows else None,
+        short_path_executable =
+            ctx.executable._short_path if hs.toolchain.is_windows else None,
     )
 
     static_libraries_prof = dep_info.static_libraries_prof

--- a/haskell/private/haskell_impl.bzl
+++ b/haskell/private/haskell_impl.bzl
@@ -308,6 +308,7 @@ def haskell_library_impl(ctx):
         other_modules,
         my_pkg_id,
         static_library_prof = static_library_prof,
+        short_path = ctx.executable._short_path if hs.toolchain.is_windows else None,
     )
 
     static_libraries_prof = dep_info.static_libraries_prof

--- a/haskell/private/short_path.bat
+++ b/haskell/private/short_path.bat
@@ -1,0 +1,10 @@
+REM This Windows script dumps the short path of its first argument
+REM into the file specified by its second argument.
+REM
+REM Example:
+REM .\short_path.bat "C:\Program Files" foo
+REM cat foo => C:\PROGRA~1
+
+@ECHO OFF
+echo | set /p dummy="%~s1" > %2
+


### PR DESCRIPTION
With GHC < 8.6, long package names would trigger failures with Hazel on Windows due to path length exceeding the 260 characters limit. While disabling this limit globally in the Windows 10 registry is possible, this would not be honored by GHC binaries (such as ghc-pkg), as a special manifest must be provided for this to work with mingw-derived executables. This would cause issues in particular with packages compiled via Hazel, as those are fetched in external repositories, which makes for even longer file names than the usual.

This commit fixes this issue by using a .bat script on Windows to find out the "short path" of the package database, and passing that to `ghc-pkg recache`.

Additionally, we also expose the rts-headers in GHC bindists, as expected by the cbits library targets generated by Hazel.