### PR TITLE
Use cpp instead of cc for c2hs

### DIFF
--- a/haskell/c2hs.bzl
+++ b/haskell/c2hs.bzl
@@ -30,7 +30,7 @@ def _c2hs_library_impl(ctx):
     args.add_all([chs_file.path, "-o", hs_file.path])
 
     args.add("-C-E")
-    args.add_all(["--cpp", cc.tools.cc])
+    args.add_all(["--cpp", cc.tools.cpp])
     args.add("-C-includeghcplatform.h")
     args.add("-C-includeghcversion.h")
     args.add_all(["-C" + x for x in cc.cpp_flags])


### PR DESCRIPTION
Some toolchains (e.g. gcc, clang) uses the same executable for c++
compilation or C pre-processor (cpp), but some others don't. This fixs
the correct tool.