### PR TITLE
Fix coverage namespacing

### DIFF
--- a/haskell/private/actions/compile.bzl
+++ b/haskell/private/actions/compile.bzl
@@ -323,8 +323,8 @@ def compile_binary(
     conditioned_mix_files = []
     if inspect_coverage:
         c.args.add_all(_hpc_compiler_args(hs))
-        for o in mix_files:
-            conditioned_file = hs.actions.declare_file(".hpc/" + o)
+        for m in mix_files:
+            conditioned_file = hs.actions.declare_file(".hpc/" + m)
             conditioned_mix_files.append(conditioned_file)
 
     hs.toolchain.actions.run_ghc(
@@ -404,9 +404,9 @@ def compile_library(
     conditioned_mix_files = []
     if hs.coverage_enabled:
         c.args.add_all(_hpc_compiler_args(hs))
-        for o in mix_files:
+        for m in mix_files:
             pkg_id_string = pkg_id.to_string(my_pkg_id)
-            conditioned_file = hs.actions.declare_file(".hpc/" + pkg_id_string + "/" + o)
+            conditioned_file = hs.actions.declare_file(".hpc/" + pkg_id_string + "/" + m)
             conditioned_mix_files.append(conditioned_file)
 
     hs.toolchain.actions.run_ghc(

--- a/tools/runfiles/BUILD
+++ b/tools/runfiles/BUILD
@@ -7,6 +7,7 @@ load(
 haskell_library(
     name = "runfiles",
     srcs = ["src/Bazel/Runfiles.hs"],
+    src_strip_prefix = "src",
     visibility = ["//visibility:public"],
     deps = [
         "@hackage//:base",
@@ -20,6 +21,7 @@ haskell_test(
     testonly = 1,
     srcs = ["bin/Bin.hs"],
     data = ["bin-data.txt"],
+    src_strip_prefix = "bin",
     deps = [
         ":runfiles",
         "@hackage//:base",
@@ -34,6 +36,7 @@ haskell_test(
         "test-data.txt",
         ":bin",
     ],
+    src_strip_prefix = "test",
     deps = [
         ":runfiles",
         "@hackage//:base",


### PR DESCRIPTION
`hpc` extends out the module names as the filename for its `.mix` instrumentation files, which the coverage work previously didn't take into account. For example, `tools/Bazel/Runfiles.hs` produces `.hpc/toolsZSrunfilesZSrunfiles/Bazel.Runfiles.mix`.

I've updated one sample test to correspond with this change. Other tests will need to change in the larger effort to get coverage working on 100% of the tests.