### PR TITLE
Fix default ghc BUILD file and allow user provided

### DIFF
--- a/haskell/nixpkgs.bzl
+++ b/haskell/nixpkgs.bzl
@@ -291,6 +291,7 @@ _ghc_nixpkgs_toolchain = repository_rule(
 
 def haskell_register_ghc_nixpkgs(
         version,
+        build_file = None,
         compiler_flags = None,
         haddock_flags = None,
         repl_ghci_args = None,
@@ -330,7 +331,7 @@ def haskell_register_ghc_nixpkgs(
     haskell_nixpkgs_package(
         name = "io_tweag_rules_haskell_ghc-nixpkgs",
         attribute_path = attribute_path,
-        build_file = "//haskell:ghc.BUILD",
+        build_file = build_file or "@io_tweag_rules_haskell//haskell:ghc.BUILD",
         nix_file = nix_file,
         nix_file_deps = nix_file_deps,
         repositories = repositories,


### PR DESCRIPTION
This commit does two things related to the GHC toolchain provided with
the nixpkgs platform:

* by default the build file is now fetched from rules_haskell as opposed
    to `//haskell:ghc.BUILD` (which ensures a successful build by default)
* the build_file can be specified by the user if they need more control