### PR TITLE
Remove CcSkylarkApiProviderHacked

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,8 +15,8 @@ jobs:
             apt-get install -y wget gnupg golang make libgmp3-dev pkg-config zip g++ zlib1g-dev unzip python bash-completion locales
             echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen
             locale-gen
-            wget "https://github.com/bazelbuild/bazel/releases/download/0.21.0/bazel_0.21.0-linux-x86_64.deb"
-            dpkg -i bazel_0.21.0-linux-x86_64.deb
+            wget "https://github.com/bazelbuild/bazel/releases/download/0.22.0/bazel_0.22.0-linux-x86_64.deb"
+            dpkg -i bazel_0.22.0-linux-x86_64.deb
             echo "common:ci --build_tag_filters -requires_hackage,-requires_zlib,-requires_doctest,-requires_c2hs,-requires_threaded_rts,-dont_test_with_bindist" > .bazelrc.local
       - run:
           name: Build tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 ## [Unreleased]
 
 * The minimum supported Bazel version is now v0.22.
+* Mark `haskell_cc_import` as deprecated.
 
 ## [0.8] - 2019-01-28
 

--- a/README.md
+++ b/README.md
@@ -189,10 +189,9 @@ another. Please see languages listed below about how.
 
 ### C/C++
 
-C/C++ libraries can be specified as dependencies. Importing prebuilt
-libraries and exporting Haskell libraries as C/C++ dependencies
-currently requires the `haskell_cc_import` and `cc_haskell_import`
-rules. These are temporary workarounds to Bazel limitations.
+C/C++ libraries can be specified as dependencies. Exporting Haskell libraries
+as C/C++ dependencies currently requires the `cc_haskell_import` rule. This is
+a temporary workaround to Bazel limitations.
 
 ### Java
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -156,7 +156,6 @@ nixpkgs_package(
 nixpkgs_package(
     name = "zlib.dev",
     build_file_content = """
-load("@io_tweag_rules_haskell//haskell:haskell.bzl", "haskell_cc_import")
 package(default_visibility = ["//visibility:public"])
 
 filegroup (
@@ -165,16 +164,8 @@ filegroup (
     testonly = 1,
 )
 
-haskell_cc_import(
-    name = "zlib",
-    shared_library = "@zlib//:lib",
-    hdrs = [":include"],
-    testonly = 1,
-    strip_include_prefix = "include",
-)
-
 cc_library(
-    name = "cc-zlib",
+    name = "zlib",
     deps = ["@zlib//:zlib"],
     hdrs = [":include"],
     testonly = 1,

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,7 +5,7 @@ jobs:
   steps:
   - bash: |
       set -e
-      curl -LO https://github.com/bazelbuild/bazel/releases/download/0.21.0/bazel-0.21.0-windows-x86_64.exe
+      curl -LO https://github.com/bazelbuild/bazel/releases/download/0.22.0/bazel-0.22.0-windows-x86_64.exe
       mv bazel-*.exe bazel.exe
       mkdir /c/bazel
       mv bazel.exe /c/bazel

--- a/haskell/cc.bzl
+++ b/haskell/cc.bzl
@@ -253,12 +253,15 @@ absolute one, it's understood as a repository-relative path.
 Use this to make `.so`, `.dll`, `.dylib` files residing in external
 [external repositories][bazel-ext-repos] available to Haskell rules.
 
-*This rule is temporary replacement for [cc_import][cc_import] and
-will be deprecated in the future.*
+*This rule is temporary replacement for [cc_import][cc_import] and is
+deprecated. Use [cc_library][cc_library] instead as shown in the example.*
 
 Example:
   ```bzl
-  haskell_cc_import(name = "zlib", shared_library = "@zlib//:lib")
+  # Deprecated, use cc_library instead.
+  # haskell_cc_import(name = "zlib", shared_library = "@zlib//:lib")
+
+  cc_library(name = "zlib", srcs = ["@zlib//:lib"])
 
   haskell_import(
     name = "base_pkg",
@@ -277,6 +280,7 @@ Example:
 
 [bazel-ext-repos]: https://docs.bazel.build/versions/master/external.html
 [cc_import]: https://docs.bazel.build/versions/master/be/c-cpp.html#cc_import
+[cc_library]: https://docs.bazel.build/versions/master/be/c-cpp.html#cc_library
 """
 
 def _cc_haskell_import(ctx):

--- a/haskell/cc.bzl
+++ b/haskell/cc.bzl
@@ -48,7 +48,7 @@ def cc_interop_info(ctx):
 
     hdrs = depset(transitive = [cc.compilation_context.headers for cc in ccs])
     include_directories = set.to_list(set.from_list(
-        [f for cc in ccs for f in cc.compilation_context.includes]
+        [f for cc in ccs for f in cc.compilation_context.includes],
     ))
     quote_include_directories = set.to_list(set.from_list(
         [f for cc in ccs for f in cc.compilation_context.quote_includes],
@@ -187,7 +187,7 @@ def _cc_import_impl(ctx):
 
     compilation_context = cc_common.create_compilation_context(
         headers = depset(transitive = [l.files for l in ctx.attr.hdrs]),
-        includes = depset(direct = include_directories)
+        includes = depset(direct = include_directories),
     )
     linking_context = cc_common.create_linking_context(
         libraries_to_link = [

--- a/haskell/doctest.bzl
+++ b/haskell/doctest.bzl
@@ -110,11 +110,10 @@ def _haskell_doctest_single(target, ctx):
     # Direct C library dependencies to link against.
     link_ctx = build_info.cc_dependencies.dynamic_linking
     libs_to_link = link_ctx.libraries_to_link.to_list()
-    import_libs_to_link = set.to_list(build_info.import_dependencies)
 
     # External libraries.
     seen_libs = set.empty()
-    for lib in libs_to_link + import_libs_to_link:
+    for lib in libs_to_link:
         lib_name = get_lib_name(lib)
         if not set.is_member(seen_libs, lib_name):
             set.mutable_insert(seen_libs, lib_name)

--- a/haskell/haddock.bzl
+++ b/haskell/haddock.bzl
@@ -113,7 +113,6 @@ def _haskell_doc_aspect_impl(target, ctx):
     # Transitive library dependencies for runtime.
     trans_link_ctx = target[HaskellBuildInfo].transitive_cc_dependencies.dynamic_linking
     trans_libs = trans_link_ctx.libraries_to_link.to_list()
-    trans_import_libs = set.to_list(target[HaskellBuildInfo].transitive_import_dependencies)
 
     ctx.actions.run(
         inputs = depset(transitive = [
@@ -121,7 +120,6 @@ def _haskell_doc_aspect_impl(target, ctx):
             set.to_depset(target[HaskellBuildInfo].interface_dirs),
             set.to_depset(target[HaskellBuildInfo].dynamic_libraries),
             depset(trans_libs),
-            depset(trans_import_libs),
             depset(transitive_haddocks.values()),
             depset(transitive_html.values()),
             # Need to give source files this way because the source_files field of

--- a/haskell/import.bzl
+++ b/haskell/import.bzl
@@ -78,8 +78,6 @@ def _haskell_import_impl(ctx):
         direct_prebuilt_deps = set.empty(),
         cc_dependencies = empty_HaskellCcInfo(),
         transitive_cc_dependencies = empty_HaskellCcInfo(),
-        import_dependencies = set.empty(),
-        transitive_import_dependencies = set.empty(),
     )
     html_files = ctx.attr.haddock_html.files.to_list()
     transitive_html = {ctx.attr.package_id: local_haddock_html} if html_files != [] else {}

--- a/haskell/private/actions/package.bzl
+++ b/haskell/private/actions/package.bzl
@@ -18,7 +18,6 @@ def _get_extra_libraries(dep_info):
       libs: list: Extra library dependencies.
     """
     cc_libs = dep_info.cc_dependencies.dynamic_linking.libraries_to_link.to_list()
-    import_libs = set.to_list(dep_info.import_dependencies)
 
     # The order in which library dependencies are listed is relevant when
     # linking static archives. To maintain the order defined by the input
@@ -27,7 +26,7 @@ def _get_extra_libraries(dep_info):
     seen_libs = set.empty()
     extra_libs = []
     extra_lib_dirs = set.empty()
-    for lib in cc_libs + import_libs:
+    for lib in cc_libs:
         lib_name = get_lib_name(lib)
         if not set.is_member(seen_libs, lib_name):
             set.mutable_insert(seen_libs, lib_name)

--- a/haskell/private/actions/repl.bzl
+++ b/haskell/private/actions/repl.bzl
@@ -67,7 +67,6 @@ def build_haskell_repl(
 
     link_ctx = build_info.cc_dependencies.dynamic_linking
     libs_to_link = link_ctx.dynamic_libraries_for_runtime.to_list()
-    import_libs_to_link = set.to_list(build_info.import_dependencies)
 
     # External shared libraries that we need to make available to the REPL.
     # This only includes dynamic libraries as including static libraries here
@@ -75,7 +74,7 @@ def build_haskell_repl(
     # XXX: Verify that static libraries can't be loaded by GHCi.
     seen_libs = set.empty()
     libraries = []
-    for lib in libs_to_link + import_libs_to_link:
+    for lib in libs_to_link:
         lib_name = get_lib_name(lib)
         if is_shared_library(lib) and not set.is_member(seen_libs, lib_name):
             set.mutable_insert(seen_libs, lib_name)

--- a/haskell/private/actions/runghc.bzl
+++ b/haskell/private/actions/runghc.bzl
@@ -58,14 +58,13 @@ def build_haskell_runghc(
 
     link_ctx = build_info.cc_dependencies.dynamic_linking
     libs_to_link = link_ctx.dynamic_libraries_for_runtime.to_list()
-    import_libs_to_link = set.to_list(build_info.import_dependencies)
 
     # External shared libraries that we need to make available to runghc.
     # This only includes dynamic libraries as including static libraries here
     # would cause linking errors as ghci cannot load static libraries.
     # XXX: Verify that static libraries can't be loaded by GHCi.
     seen_libs = set.empty()
-    for lib in libs_to_link + import_libs_to_link:
+    for lib in libs_to_link:
         lib_name = get_lib_name(lib)
         if is_shared_library(lib) and not set.is_member(seen_libs, lib_name):
             set.mutable_insert(seen_libs, lib_name)

--- a/haskell/private/haskell_impl.bzl
+++ b/haskell/private/haskell_impl.bzl
@@ -383,8 +383,6 @@ def haskell_library_impl(ctx):
         prebuilt_dependencies = dep_info.prebuilt_dependencies,
         cc_dependencies = dep_info.cc_dependencies,
         transitive_cc_dependencies = dep_info.transitive_cc_dependencies,
-        import_dependencies = dep_info.import_dependencies,
-        transitive_import_dependencies = dep_info.transitive_import_dependencies,
     )
     lib_info = HaskellLibraryInfo(
         package_id = pkg_id.to_string(my_pkg_id),

--- a/haskell/private/providers.bzl
+++ b/haskell/private/providers.bzl
@@ -104,8 +104,6 @@ HaskellBuildInfo = provider(
         "direct_prebuilt_deps": "Set of info of direct prebuilt dependencies.",
         "cc_dependencies": "Direct cc library dependencies. See HaskellCcInfo.",
         "transitive_cc_dependencies": "Transitive cc library dependencies. See HaskellCcInfo.",
-        "import_dependencies": "Direct haskell_cc_import library dependencies.",
-        "transitive_import_dependencies": "Transitive haskell_cc_import library dependencies.",
     },
 )
 
@@ -137,14 +135,9 @@ def get_libs_for_ghc_linker(hs, build_info, path_prefix = None):
 
     libs_to_link = trans_link_ctx.libraries_to_link.to_list()
     libs_for_runtime = trans_link_ctx.dynamic_libraries_for_runtime.to_list()
-    import_libs = set.to_list(build_info.transitive_import_dependencies)
 
-    _library_deps = libs_to_link + import_libs
-    _ld_library_deps = libs_for_runtime + [
-        lib
-        for lib in import_libs
-        if is_shared_library(lib)
-    ]
+    _library_deps = libs_to_link
+    _ld_library_deps = libs_for_runtime
     if hs.toolchain.is_darwin:
         # GHC's builtin linker requires .dylib files on MacOS.
         library_deps = darwin_convert_to_dylibs(hs, _library_deps)
@@ -239,24 +232,6 @@ HaskellProtobufInfo = provider(
     doc = "Provider that wraps providers of auto-generated Haskell libraries",
     fields = {
         "files": "files",
-    },
-)
-
-# XXX this provider shouldn't be necessary. But since Skylark rules
-# can neither return CcSkylarkApiProvider nor properly test for its
-# existence in a dependency, we're forced to introduce this hack for
-# now. See https://github.com/bazelbuild/bazel/issues/4370.
-CcSkylarkApiProviderHacked = provider(
-    doc = "Skylark emulation of CcSkylarkApiProvider. Temporary hack.",
-    fields = {
-        "transitive_headers": """
-
-Returns a depset of headers that have been declared in the src or
-headers attribute(possibly empty but never None).
-""",
-        "include_directories": """
-Returns the list of include directories used to compile this target.
-""",
     },
 )
 

--- a/tests/BUILD.zlib
+++ b/tests/BUILD.zlib
@@ -2,7 +2,6 @@ package(default_testonly = 1)
 
 load("@io_tweag_rules_haskell//haskell:haskell.bzl",
   "haskell_library",
-  "haskell_cc_import",
 )
 
 filegroup (
@@ -19,9 +18,9 @@ filegroup (
   ]),
 )
 
-haskell_cc_import(
+cc_library(
   name = "zlib-import",
-  shared_library = ":lib",
+  srcs = [":lib"],
   hdrs = [":include"],
   strip_include_prefix = "cbits",
 )

--- a/tests/binary-with-indirect-sysdeps/BUILD
+++ b/tests/binary-with-indirect-sysdeps/BUILD
@@ -6,20 +6,8 @@ load(
 
 package(default_testonly = 1)
 
-# Depends on system zlib imported using cc_library.
 haskell_library(
-    name = "hs-lib-cc",
-    srcs = ["HsLib.hs"],
-    tags = ["requires_zlib"],
-    deps = [
-        "//tests/hackage:base",
-        "@zlib.dev//:cc-zlib",
-    ],
-)
-
-# Depends on sysmte zlib imported using haskell_cc_import.
-haskell_library(
-    name = "hs-lib-import",
+    name = "hs-lib",
     srcs = ["HsLib.hs"],
     tags = ["requires_zlib"],
     deps = [
@@ -29,30 +17,11 @@ haskell_library(
 )
 
 haskell_test(
-    name = "binary-with-indirect-sysdeps-cc",
-    srcs = ["Main.hs"],
-    tags = ["requires_zlib"],
-    deps = [
-        ":hs-lib-cc",
-        "//tests/hackage:base",
-    ],
-)
-
-haskell_test(
-    name = "binary-with-indirect-sysdeps-import",
-    srcs = ["Main.hs"],
-    tags = ["requires_zlib"],
-    deps = [
-        ":hs-lib-import",
-        "//tests/hackage:base",
-    ],
-)
-
-test_suite(
     name = "binary-with-indirect-sysdeps",
+    srcs = ["Main.hs"],
     tags = ["requires_zlib"],
-    tests = [
-        ":binary-with-indirect-sysdeps-cc",
-        ":binary-with-indirect-sysdeps-import",
+    deps = [
+        ":hs-lib",
+        "//tests/hackage:base",
     ],
 )

--- a/tests/binary-with-sysdeps/BUILD
+++ b/tests/binary-with-sysdeps/BUILD
@@ -1,16 +1,9 @@
 load(
     "@io_tweag_rules_haskell//haskell:haskell.bzl",
-    "haskell_cc_import",
     "haskell_test",
 )
 
 package(default_testonly = 1)
-
-haskell_cc_import(
-    name = "zlib",
-    shared_library = "@zlib//:lib",
-    tags = ["requires_zlib"],
-)
 
 haskell_test(
     name = "binary-with-sysdeps",
@@ -18,7 +11,7 @@ haskell_test(
     tags = ["requires_zlib"],
     visibility = ["//visibility:public"],
     deps = [
-        ":zlib",
+        "@zlib",
         "//tests/hackage:base",
     ],
 )

--- a/tests/binary-with-sysdeps/BUILD
+++ b/tests/binary-with-sysdeps/BUILD
@@ -11,7 +11,7 @@ haskell_test(
     tags = ["requires_zlib"],
     visibility = ["//visibility:public"],
     deps = [
-        "@zlib",
         "//tests/hackage:base",
+        "@zlib",
     ],
 )

--- a/tests/c2hs/BUILD
+++ b/tests/c2hs/BUILD
@@ -10,7 +10,10 @@ c2hs_library(
     name = "foo",
     srcs = ["src/Foo/Foo.chs"],
     src_strip_prefix = "src",
-    tags = ["requires_c2hs", "requires_zlib"],
+    tags = [
+        "requires_c2hs",
+        "requires_zlib",
+    ],
     deps = ["@zlib.dev//:zlib"],
 )
 

--- a/tests/c2hs/BUILD
+++ b/tests/c2hs/BUILD
@@ -1,27 +1,17 @@
 load("@io_tweag_rules_haskell//haskell:c2hs.bzl", "c2hs_library")
 load(
     "@io_tweag_rules_haskell//haskell:haskell.bzl",
-    "haskell_cc_import",
     "haskell_library",
 )
 
 package(default_testonly = 1)
 
-haskell_cc_import(
-    name = "zlib",
-    hdrs = ["@zlib.dev//:include"],
-    shared_library = "@zlib//:lib",
-    strip_include_prefix = "/external/zlib.dev/include",
-    tags = ["requires_zlib"],
-    visibility = ["@c2hs_repo//:__pkg__"],
-)
-
 c2hs_library(
     name = "foo",
     srcs = ["src/Foo/Foo.chs"],
     src_strip_prefix = "src",
-    tags = ["requires_c2hs"],
-    deps = [":zlib"],
+    tags = ["requires_c2hs", "requires_zlib"],
+    deps = ["@zlib.dev//:zlib"],
 )
 
 c2hs_library(

--- a/tests/c2hs/repo/BUILD
+++ b/tests/c2hs/repo/BUILD
@@ -6,5 +6,5 @@ c2hs_library(
     name = "baz",
     srcs = ["Baz.chs"],
     visibility = ["//visibility:public"],
-    deps = ["@io_tweag_rules_haskell//tests/c2hs:zlib"],
+    deps = ["@zlib.dev//:zlib"],
 )

--- a/tests/haddock/BUILD
+++ b/tests/haddock/BUILD
@@ -45,13 +45,16 @@ haskell_library(
     extra_srcs = [
         "unicode.txt",
     ],
-    tags = ["requires_hackage", "requires_zlib"],
+    tags = [
+        "requires_hackage",
+        "requires_zlib",
+    ],
     deps = [
         ":haddock-lib-a",
-        "@zlib",
         "//tests/hackage:base",
         "//tests/hackage:template-haskell",
         "@hackage//:libc",
+        "@zlib",
     ],
 )
 

--- a/tests/haddock/BUILD
+++ b/tests/haddock/BUILD
@@ -1,6 +1,5 @@
 load(
     "@io_tweag_rules_haskell//haskell:haskell.bzl",
-    "haskell_cc_import",
     "haskell_doc",
     "haskell_import",
     "haskell_library",
@@ -9,12 +8,6 @@ load(
 package(
     default_testonly = 1,
     default_visibility = ["//visibility:public"],
-)
-
-haskell_cc_import(
-    name = "zlib",
-    shared_library = "@zlib//:lib",
-    tags = ["requires_zlib"],
 )
 
 haskell_library(
@@ -52,10 +45,10 @@ haskell_library(
     extra_srcs = [
         "unicode.txt",
     ],
-    tags = ["requires_hackage"],
+    tags = ["requires_hackage", "requires_zlib"],
     deps = [
         ":haddock-lib-a",
-        ":zlib",
+        "@zlib",
         "//tests/hackage:base",
         "//tests/hackage:template-haskell",
         "@hackage//:libc",

--- a/tests/library-with-sysdeps/BUILD
+++ b/tests/library-with-sysdeps/BUILD
@@ -1,17 +1,10 @@
 load(
     "@io_tweag_rules_haskell//haskell:haskell.bzl",
-    "haskell_cc_import",
     "haskell_library",
     "haskell_test",
 )
 
 package(default_testonly = 1)
-
-haskell_cc_import(
-    name = "zlib",
-    shared_library = "@zlib//:lib",
-    tags = ["requires_zlib"],
-)
 
 haskell_library(
     name = "library-with-sysdeps",
@@ -19,7 +12,7 @@ haskell_library(
     tags = ["requires_zlib"],
     visibility = ["//visibility:public"],
     deps = [
-        ":zlib",
+        "@zlib",
         "//tests/hackage:base",
     ],
 )

--- a/tests/library-with-sysdeps/BUILD
+++ b/tests/library-with-sysdeps/BUILD
@@ -12,8 +12,8 @@ haskell_library(
     tags = ["requires_zlib"],
     visibility = ["//visibility:public"],
     deps = [
-        "@zlib",
         "//tests/hackage:base",
+        "@zlib",
     ],
 )
 

--- a/tests/library-with-sysincludes/BUILD
+++ b/tests/library-with-sysincludes/BUILD
@@ -1,6 +1,5 @@
 load(
     "@io_tweag_rules_haskell//haskell:haskell.bzl",
-    "haskell_cc_import",
     "haskell_library",
 )
 
@@ -17,18 +16,17 @@ genrule(
 # A locally-defined replica of @zlib.dev//:zlib.
 # Since that shared library lives in another package, we must
 # use an absolute path for strip_include_prefix.
-haskell_cc_import(
+cc_library(
     name = "zlib",
     hdrs = ["@zlib.dev//:include"],
-    shared_library = "@zlib//:lib",
+    deps = ["@zlib"],
     strip_include_prefix = "/external/zlib.dev/include",
     tags = ["requires_zlib"],
 )
 
-haskell_cc_import(
+cc_library(
     name = "zlib-with-genrule-header",
     hdrs = [":genrule-header"],
-    shared_library = "@zlib//:lib",  # just use zlib because this field is required
     strip_include_prefix = "include",
     tags = ["requires_zlib"],
 )
@@ -60,7 +58,7 @@ haskell_library(
 )
 
 # Replicate the above example, but use the externally-defined
-# haskell_cc_import rule.
+# cc_library rule.
 haskell_library(
     name = "intermediate-library-other",
     srcs = ["IntLib.hsc"],

--- a/tests/library-with-sysincludes/BUILD
+++ b/tests/library-with-sysincludes/BUILD
@@ -19,9 +19,9 @@ genrule(
 cc_library(
     name = "zlib",
     hdrs = ["@zlib.dev//:include"],
-    deps = ["@zlib"],
     strip_include_prefix = "/external/zlib.dev/include",
     tags = ["requires_zlib"],
+    deps = ["@zlib"],
 )
 
 cc_library(

--- a/tests/repl-targets/BUILD
+++ b/tests/repl-targets/BUILD
@@ -33,13 +33,16 @@ haskell_library(
         ":chs",
         ":codegen",
     ],
-    tags = ["requires_hackage", "requires_zlib"],
+    tags = [
+        "requires_hackage",
+        "requires_zlib",
+    ],
     visibility = ["//visibility:public"],
     deps = [
-        "@zlib",
         "//tests/data:ourclibrary",
         "//tests/hackage:array",
         "//tests/hackage:base",
+        "@zlib",
     ],
 )
 
@@ -48,13 +51,16 @@ haskell_library(
     srcs = [
         "Bad.hs",
     ],
-    tags = ["manual", "requires_zlib"],
+    tags = [
+        "manual",
+        "requires_zlib",
+    ],
     visibility = ["//visibility:public"],
     deps = [
-        "@zlib",
         "//tests/data:ourclibrary",
         "//tests/hackage:base",
         "@hackage//:array",
+        "@zlib",
     ],
 )
 

--- a/tests/repl-targets/BUILD
+++ b/tests/repl-targets/BUILD
@@ -1,20 +1,11 @@
 load("@io_tweag_rules_haskell//haskell:c2hs.bzl", "c2hs_library")
 load(
     "@io_tweag_rules_haskell//haskell:haskell.bzl",
-    "haskell_cc_import",
     "haskell_library",
     "haskell_test",
 )
 
 package(default_testonly = 1)
-
-haskell_cc_import(
-    name = "zlib",
-    hdrs = ["@zlib.dev//:include"],
-    shared_library = "@zlib//:lib",
-    strip_include_prefix = "/external/zlib.dev/include",
-    tags = ["requires_zlib"],
-)
 
 genrule(
     name = "codegen",
@@ -42,10 +33,10 @@ haskell_library(
         ":chs",
         ":codegen",
     ],
-    tags = ["requires_hackage"],
+    tags = ["requires_hackage", "requires_zlib"],
     visibility = ["//visibility:public"],
     deps = [
-        ":zlib",
+        "@zlib",
         "//tests/data:ourclibrary",
         "//tests/hackage:array",
         "//tests/hackage:base",
@@ -57,10 +48,10 @@ haskell_library(
     srcs = [
         "Bad.hs",
     ],
-    tags = ["manual"],
+    tags = ["manual", "requires_zlib"],
     visibility = ["//visibility:public"],
     deps = [
-        ":zlib",
+        "@zlib",
         "//tests/data:ourclibrary",
         "//tests/hackage:base",
         "@hackage//:array",

--- a/tests/unit-tests/BUILD
+++ b/tests/unit-tests/BUILD
@@ -104,24 +104,6 @@ create_rpath_entry_test(
 #     output = "../bar",
 # )
 
-# test comes_from_haskell_cc_import
-
-create_rpath_entry_test(
-    name = "rpath_entry_comes_from_haskell_cc_import",
-    # full path is up through the bazel-out directory
-    binary_path = "bazel-out/k8-fastbuild/bin/foo/baz/a.so",
-    binary_short_path = "foo/baz/a.so",
-    # it’s been imported with haskell_cc_import
-    comes_from_haskell_cc_import = True,
-    # the full path contains `external` as first element
-    dependency_path = "external/bar/lib/b.so",
-    # the short path is that of a normal external dependency
-    dependency_short_path = "../bar/lib/b.so",
-    # the output goes up all the way to the package root
-    # and then down .path of our external dependency
-    output = "../../../../../external/bar/lib",
-)
-
 dedup_on_test(
     name = "dedup_on_test",
 )

--- a/tests/unit-tests/tests.bzl
+++ b/tests/unit-tests/tests.bzl
@@ -31,15 +31,12 @@ def create_rpath_entry_test_impl(ctx):
         actual = create_rpath_entry(
             struct(
                 short_path = ctx.attr.binary_short_path,
-                path = ctx.attr.binary_path,
             ),
             struct(
                 short_path = ctx.attr.dependency_short_path,
-                path = ctx.attr.dependency_path,
             ),
             keep_filename = ctx.attr.keep_filename,
             prefix = ctx.attr.prefix,
-            comes_from_haskell_cc_import = ctx.attr.comes_from_haskell_cc_import,
         ),
     )
     unit.end(env)
@@ -52,11 +49,6 @@ create_rpath_entry_test = unit.make(
         "keep_filename": attr.bool(default = False, mandatory = False),
         "prefix": attr.string(default = "", mandatory = False),
         "output": attr.string(),
-        "comes_from_haskell_cc_import": attr.bool(default = False, mandatory = False),
-        # only used when comes_from_haskell_cc_import is True
-        "dependency_path": attr.string(default = "", mandatory = False),
-        # only used when comes_from_haskell_cc_import is True
-        "binary_path": attr.string(default = "", mandatory = False),
     },
 )
 


### PR DESCRIPTION
Since Bazel 0.22 the new C++ Starlark API allows to construct `CcInfo` providers within Starlark, removing the need for the `CcSkylarApiProviderHacked`.

- Remove `CcSkylarkApiProviderHacked`.
- Remove references to `.cc` attributes of targets.
- Use the `CcInfo` provider instead.
- Implement `haskell_cc_import` in terms of `CcInfo`.
- Remove the now redundant `import_dependencies` and `transitive_import_dependencies` from `HaskellBuildInfo`.
- Mark `haskell_cc_import` as deprecated.
- Replace uses of `haskell_cc_import` by `cc_library`.
- Update bindist and Windows CI to Bazel 0.22.

~Note, when testing on a large, proprietary code base on MacOS this causes failures due to exceeding the MACH-O header size limit on intermediate dynamic libraries generated by GHC during the `HaskellBuildLibrary` step. Resolving this will probably require further work on `osx_cc_wrapper.sh.tpl`.~