### PR TITLE
Add unix-includes to GHC BUILD

### DIFF
--- a/haskell/ghc.BUILD
+++ b/haskell/ghc.BUILD
@@ -25,7 +25,17 @@ cc_library(
     )[0],
 )
 
-# This is needed for Hazel targets.
+# Needed for Hazel; see FormationAI/hazel/BUILD.ghc
+
+cc_library(
+    name = "unix-includes",
+    hdrs = glob(["lib/ghc-*/unix-*/include/*.h"]),
+    strip_include_prefix = glob(
+        ["lib/ghc-*/unix-*/include"],
+        exclude_directories = 0,
+    )[0],
+)
+
 cc_library(
     name = "rts-headers",
     hdrs = glob(["lib/include/**/*.h"]),


### PR DESCRIPTION
This isn't a problem when using GHC from Nix, because the `nixpkgs_package` rule lets you override the BUILD file used ([ref](https://github.com/FormationAI/hazel/blob/561366d7aceea056ae815ca72cbc0ad46c361748/README.md#setting-up-a-new-project)).

It would be great after merging hazel into this package (#733) if the `haskell_register_ghc_bindist` command used the same BUILD file as hazel