### PR TITLE
Avoid cyclic dependency in _obj and _iface

### DIFF
--- a/haskell/private/actions/compile.bzl
+++ b/haskell/private/actions/compile.bzl
@@ -222,9 +222,9 @@ def _compilation_defaults(hs, cc, java, dep_info, srcs, import_dir_map, extra_sr
     # Output directories
     args.add_all([
         "-odir",
-        objects_dir,
+        objects_dir.path,
         "-hidir",
-        interfaces_dir,
+        interfaces_dir.path,
     ])
 
     # Interface files with profiling have to have the extension "p_hi":


### PR DESCRIPTION
- Resolves dependency cycle in `_obj` and `_iface` by passing `objects_dir.path`, `interface_dir.path` instead of `objects_dir`, `interface_dir`.

@szinn I've tested this with Bazel 0.23.1 from a patched nixpkgs. Let me know if this isn't sufficient for your use-case.

Closes #723.