### PR TITLE
Initial bugfixes for code coverage

### DIFF
--- a/haskell/private/coverage_wrapper.sh.tpl
+++ b/haskell/private/coverage_wrapper.sh.tpl
@@ -31,10 +31,12 @@ tix_file_path={tix_file_path}
 expected_expression_coverage={expected_expression_coverage}
 hpc_dir_args=""
 mix_file_paths={mix_file_paths}
-for m in $mix_file_paths
+for m in "${mix_file_paths[@]}"
 do
   absolute_mix_file_path=$(rlocation $m)
-  hpc_dir_args="$hpc_dir_args --hpcdir=$(dirname $absolute_mix_file_path)"
+  hpc_parent_dir=$(dirname $absolute_mix_file_path)
+  trimmed_hpc_parent_dir=$(echo "${hpc_parent_dir%%.hpc*}")
+  hpc_dir_args="$hpc_dir_args --hpcdir=$trimmed_hpc_parent_dir.hpc"
 done
 $binary_path "$@"
 $hpc_path report $tix_file_path $hpc_dir_args > __hpc_coverage_report

--- a/haskell/private/haskell_impl.bzl
+++ b/haskell/private/haskell_impl.bzl
@@ -97,10 +97,12 @@ def _haskell_binary_common_impl(ctx, is_test):
         mix_files = mix_files,
     )
 
+    # gather intermediary code coverage instrumentation data
     conditioned_mix_files = c.conditioned_mix_files
     for dep in ctx.attr.deps:
         if HaskellCoverageInfo in dep:
             conditioned_mix_files += dep[HaskellCoverageInfo].mix_files
+    conditioned_mix_files = depset(conditioned_mix_files).to_list()
 
     c_p = None
 
@@ -402,7 +404,7 @@ def haskell_library_impl(ctx):
             dependency_mix_files += dep[HaskellCoverageInfo].mix_files
 
     coverage_info = HaskellCoverageInfo(
-        mix_files = dependency_mix_files + c.conditioned_mix_files,
+        mix_files = depset(dependency_mix_files + c.conditioned_mix_files).to_list(),
     )
 
     target_files = depset([conf_file, cache_file])


### PR DESCRIPTION
This fixes bugs I've found in my first usage of the coverage functionality in the wild. First, we avoid duplication of .mix files, which was not causing any errors but just a huge unnecessary mess of files being passed around. Second, we correct the way that .hpc directories were being found, which was actually causing errors with dependencies outside of the package being run.