### PR TITLE
Workaround base linking error

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -35,6 +35,7 @@ jobs:
       /c/bazel/bazel.exe test --config windows "//tests:test-binary-simple"
       /c/bazel/bazel.exe test --config windows "//tests:test-binary-custom-main"
       /c/bazel/bazel.exe test --config windows "//tests/binary-custom-main/..."
+      /c/bazel/bazel.exe test --config windows "//tests/binary-exe-path/..."
       /c/bazel/bazel.exe test --config windows "//tests/binary-with-data/..."
       /c/bazel/bazel.exe test --config windows "//tests/binary-with-lib/..."
       /c/bazel/bazel.exe test --config windows "//tests/binary-with-main/..."

--- a/haskell/assets/ghc_8_6_2_win_base.patch
+++ b/haskell/assets/ghc_8_6_2_win_base.patch
@@ -1,7 +1,7 @@
---- lib/package.conf.d/base-4.12.0.0.conf	2019-03-20 12:24:30.857292020 +0100
-+++ lib/package.conf.d/base-4.12.0.0.conf	2019-03-20 12:24:44.637400564 +0100
+--- lib/package.conf.d/base-4.12.0.0.conf	2019-03-19 18:04:35.186653529 +0100
++++ lib/package.conf.d/base-4.12.0.0.conf	2019-03-19 18:04:48.958873769 +0100
 @@ -79,7 +79,7 @@
- data-dir: $topdir\x86_64-windows-ghc-8.6.4\base-4.12.0.0
+ data-dir: $topdir\x86_64-windows-ghc-8.6.2\base-4.12.0.0
  hs-libraries: HSbase-4.12.0.0
  extra-libraries:
 -    wsock32 user32 shell32 msvcrt mingw32 mingwex

--- a/haskell/assets/ghc_8_6_4_win_base.patch
+++ b/haskell/assets/ghc_8_6_4_win_base.patch
@@ -1,0 +1,11 @@
+--- lib/package.conf.d/base-4.12.0.0.conf	2019-03-19 18:04:35.186653529 +0100
++++ lib/package.conf.d/base-4.12.0.0.conf	2019-03-19 18:04:48.958873769 +0100
+@@ -79,7 +79,7 @@
+ data-dir: $topdir\x86_64-windows-ghc-8.6.2\base-4.12.0.0
+ hs-libraries: HSbase-4.12.0.0
+ extra-libraries:
+-    wsock32 user32 shell32 msvcrt mingw32 mingwex
++    wsock32 user32 shell32 msvcrt mingw32 mingwex shlwapi
+ include-dirs: $topdir\base-4.12.0.0\include
+ includes:
+     HsBase.h

--- a/tests/binary-exe-path/BUILD
+++ b/tests/binary-exe-path/BUILD
@@ -1,0 +1,13 @@
+load(
+    "@io_tweag_rules_haskell//haskell:haskell.bzl",
+    "haskell_test",
+)
+
+package(default_testonly = 1)
+
+haskell_test(
+    name = "binary-exe-path",
+    srcs = ["Main.hs"],
+    visibility = ["//visibility:public"],
+    deps = ["//tests/hackage:base"],
+)

--- a/tests/binary-exe-path/Main.hs
+++ b/tests/binary-exe-path/Main.hs
@@ -1,0 +1,5 @@
+module Main where
+
+import System.Environment
+
+main = getExecutablePath >>= putStrLn


### PR DESCRIPTION
This patches the Windows bindist to work around a GHC bug where a library is missing from base's dependencies.

See https://gitlab.haskell.org/ghc/ghc/issues/16466