### PR TITLE
Fix error on missing tool

### DIFF
--- a/haskell/toolchain.bzl
+++ b/haskell/toolchain.bzl
@@ -113,7 +113,7 @@ def _haskell_toolchain_impl(ctx):
         for file in ctx.files.tools:
             if tool == paths.split_extension(file.basename)[0]:
                 ghc_binaries[tool] = file
-        if not ghc_binaries[tool]:
+        if not tool in ghc_binaries:
             fail("Cannot find {} in {}".format(tool, ctx.attr.tools.label))
 
     # Run a version check on the compiler.


### PR DESCRIPTION
Before this commit we checked that a key was contained in a dict by
using `my_dict[key]`, which fails directly if the key is not found.
Instead, using `my_dict.get(key)` will return `None` if the key is not
found, which is what we want.