### PR TITLE
Pick up on versioned tools

### DIFF
--- a/haskell/toolchain.bzl
+++ b/haskell/toolchain.bzl
@@ -111,7 +111,6 @@ def _haskell_toolchain_impl(ctx):
     ghc_binaries = {}
     for tool in _GHC_BINARIES:
         for file in ctx.files.tools:
-
             if tool in ghc_binaries:
                 continue
 

--- a/haskell/toolchain.bzl
+++ b/haskell/toolchain.bzl
@@ -111,6 +111,10 @@ def _haskell_toolchain_impl(ctx):
     ghc_binaries = {}
     for tool in _GHC_BINARIES:
         for file in ctx.files.tools:
+
+            if tool in ghc_binaries:
+                continue
+
             basename_no_ext = paths.split_extension(file.basename)[0]
             if tool == basename_no_ext:
                 ghc_binaries[tool] = file

--- a/haskell/toolchain.bzl
+++ b/haskell/toolchain.bzl
@@ -111,7 +111,10 @@ def _haskell_toolchain_impl(ctx):
     ghc_binaries = {}
     for tool in _GHC_BINARIES:
         for file in ctx.files.tools:
-            if tool == paths.split_extension(file.basename)[0]:
+            basename_no_ext = paths.split_extension(file.basename)[0]
+            if tool == basename_no_ext:
+                ghc_binaries[tool] = file
+            elif "%s-%s" % (tool, ctx.attr.version) == basename_no_ext:
                 ghc_binaries[tool] = file
         if not tool in ghc_binaries:
             fail("Cannot find {} in {}".format(tool, ctx.attr.tools.label))


### PR DESCRIPTION
Some tools have the version prepended to the executable name, e.g.:

```
    haddock-8.6.4.exe
```

Most tools are copied (`ghc.exe`, `ghc-8.6.4.exe`) but not all.