### PR TITLE
link.bzl: fix create_rpath_entry() for binaries in project root

### DIFF
--- a/haskell/private/actions/link.bzl
+++ b/haskell/private/actions/link.bzl
@@ -60,6 +60,7 @@ def _get_target_parent_dir(target):
       `is_external`: Bool whether the path points to an external repository
       `parent_dir`: The parent directory, either up to the runfiles toplel,
                     up to the external repository toplevel.
+                    Is `[]` if there is no parent dir.
     """
 
     parent_dir = parent_dir_path(target.short_path)
@@ -67,6 +68,8 @@ def _get_target_parent_dir(target):
     if parent_dir[0] == "..":
         __check_dots(target, parent_dir[1:])
         return (True, parent_dir[1:])
+    elif parent_dir[0] == ".":
+        return (False, [])
     else:
         __check_dots(target, parent_dir)
         return (False, parent_dir)

--- a/tests/unit-tests/BUILD
+++ b/tests/unit-tests/BUILD
@@ -48,6 +48,22 @@ create_rpath_entry_test(
     output = "../bar",
 )
 
+# checks that a binary in //:bin works properly
+create_rpath_entry_test(
+    name = "rpath_entry_binary_root",
+    binary_short_path = "bin",
+    dependency_short_path = "xyz/b.so",
+    output = "xyz",
+)
+
+# same for dependency
+create_rpath_entry_test(
+    name = "rpath_entry_dep_root",
+    binary_short_path = "lib/bin",
+    dependency_short_path = "b.so",
+    output = "..",
+)
+
 create_rpath_entry_test(
     name = "rpath_entry_simple_filename",
     binary_short_path = "foo/a.so",


### PR DESCRIPTION
We miscounted the number of parent directories by just taking the
length of the path returned by `get_parent_dir()`. Since it would
return `"."` if a file had no parent, we’d count 1 and put one `".."`
instead of zero.

Now we correctly return “no parent dir” in that case.