### PR TITLE
Uncovered expression count as a coverage metric

### DIFF
--- a/docs/haskell-use-cases.rst
+++ b/docs/haskell-use-cases.rst
@@ -210,14 +210,19 @@ the source code that are explored when the tests are run.
 
 Haskell's ``ghc`` compiler has built-in support for code coverage analysis, 
 through the hpc_ tool. The Haskell rules allow the use of this tool to analyse 
-``haskell_library`` coverage by ``haskell_test`` rules. To do so, add 
-``expected_expression_coverage=<some integer between 0 and 100>`` to the 
-attributes of a ``haskell_test``, and if the expression coverage percentage 
-is lower than this amount, the test will fail. To see the coverage details of 
-the test suite regardless of if the test passes or fails, add 
-``--test_output=all`` as a flag when invoking the test, and there will be a 
-report in the test output. You will only see the report if you required a 
-certain level of expression coverage in the rule attributes.
+``haskell_library`` coverage by ``haskell_test`` rules. To do so, you have a 
+few options. You can add 
+``expected_covered_expressions_percentage=<some integer between 0 and 100>`` to
+the attributes of a ``haskell_test``, and if the expression coverage percentage
+is lower than this amount, the test will fail. Alternatively, you can add
+``expected_uncovered_expression_count=<some integer greater or equal to 0>`` to
+the attributes of a ``haskell_test``, and instead the test will fail if the
+number of uncovered expressions is greater than this amount. Finally, you could
+do both at once, and have both of these checks analyzed by the coverage runner.
+To see the coverage details of the test suite regardless of if the test passes
+or fails, add ``--test_output=all`` as a flag when invoking the test, and there 
+will be a report in the test output. You will only see the report if you
+required a certain level of expression coverage in the rule attributes.
 
 For example, your BUILD file might look like this: ::
 
@@ -236,7 +241,8 @@ For example, your BUILD file might look like this: ::
         ":lib",
         "//tests/hackage:base",
     ],
-    expected_expression_coverage = 80,
+    expected_covered_expressions_percentage = 80,
+    expected_uncovered_expression_count = 10,
   )
 
 And if you ran ``bazel coverage //somepackage:test --test_output=all``, you 
@@ -253,11 +259,10 @@ might see a result like this: ::
   100% alternatives used (0/0)
   100% local declarations used (0/0)
   100% top-level declarations used (3/3)
-  ================================================================================
+  =============================================================================
 
-Here, the test passes because it actually has 100% expression coverage, but if
-the line reading ``<pct>% expressions used`` had a ``<pct>`` of less than 80,
-the test would fail.
+Here, the test passes because it actually has 100% expression coverage and 0 uncovered
+expressions, which is even better than we expected on both counts.
 
 There a couple of notes regarding this feature:
 

--- a/docs/haskell-use-cases.rst
+++ b/docs/haskell-use-cases.rst
@@ -261,10 +261,17 @@ might see a result like this: ::
   100% top-level declarations used (3/3)
   =============================================================================
 
-Here, the test passes because it actually has 100% expression coverage and 0 uncovered
-expressions, which is even better than we expected on both counts.
+Here, the test passes because it actually has 100% expression coverage and 0
+uncovered expressions, which is even better than we expected on both counts.
 
-There a couple of notes regarding this feature:
+There is an optional ``haskell_test`` attribute called
+``strict_coverage_analysis``, which is a boolean that changes the coverage
+analysis such that even having better coverage than expected fails the test.
+This can be used to enforce that developers must upgrade the expected test
+coverage when they improve it. On the other hand, it requires changing the
+expected coverage for almost any change.
+
+There a couple of notes regarding the coverage analysis functionality:
 
 - Coverage analysis currently is scoped to all source files and all
   locally-built Haskell dependencies (both direct and transitive) for a given

--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -130,12 +130,16 @@ def _mk_binary_rule(**kwargs):
         ),
     )
 
-    # Tests have an extra fields regarding expected code coverage percentages.
+    # Tests have an extra fields regarding code coverage.
     if is_test:
         attrs.update({
-            "expected_expression_coverage": attr.int(
+            "expected_covered_expressions_percentage": attr.int(
                 default = 0,
                 doc = "The expected percentage of expressions covered by testing.",
+            ),
+            "expected_uncovered_expression_count": attr.int(
+                default = 0,
+                doc = "The expected number of expressions which are not covered by testing.",
             ),
             "_coverage_wrapper_template": attr.label(
                 allow_single_file = True,

--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -141,6 +141,10 @@ def _mk_binary_rule(**kwargs):
                 default = -1,
                 doc = "The expected number of expressions which are not covered by testing.",
             ),
+            "strict_coverage_analysis": attr.bool(
+                default = False,
+                doc = "Requires that the coverage metric is matched exactly, even doing better than expected is not allowed.",
+            ),
             "_coverage_wrapper_template": attr.label(
                 allow_single_file = True,
                 default = Label("@io_tweag_rules_haskell//haskell:private/coverage_wrapper.sh.tpl"),

--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -134,11 +134,11 @@ def _mk_binary_rule(**kwargs):
     if is_test:
         attrs.update({
             "expected_covered_expressions_percentage": attr.int(
-                default = 0,
+                default = -1,
                 doc = "The expected percentage of expressions covered by testing.",
             ),
             "expected_uncovered_expression_count": attr.int(
-                default = 0,
+                default = -1,
                 doc = "The expected number of expressions which are not covered by testing.",
             ),
             "_coverage_wrapper_template": attr.label(

--- a/haskell/private/coverage_wrapper.sh.tpl
+++ b/haskell/private/coverage_wrapper.sh.tpl
@@ -28,7 +28,8 @@ CLEARCOLOR='\033[0m'
 binary_path=$(rlocation {binary_path})
 hpc_path=$(rlocation {hpc_path})
 tix_file_path={tix_file_path}
-expected_expression_coverage={expected_expression_coverage}
+expected_covered_expressions_percentage={expected_covered_expressions_percentage}
+expected_uncovered_expression_count={expected_uncovered_expression_count}
 hpc_dir_args=""
 mix_file_paths={mix_file_paths}
 for m in "${mix_file_paths[@]}"
@@ -42,9 +43,15 @@ $binary_path "$@"
 $hpc_path report $tix_file_path $hpc_dir_args > __hpc_coverage_report
 echo "Overall report"
 cat __hpc_coverage_report
-expression_coverage=$(grep "expressions used" __hpc_coverage_report | cut -c 1-3)
-if [ $expression_coverage -lt $expected_expression_coverage ]
+covered_expression_percentage=$(grep "expressions used" __hpc_coverage_report | cut -c 1-3)
+if [ $covered_expression_percentage -lt $expected_covered_expressions_percentage ]
 then
-  echo -e "\n==>$ERRORCOLOR Inadequate expression coverage.$CLEARCOLOR Expected $expected_expression_coverage%, but actual coverage was $ERRORCOLOR$(($expression_coverage))%$CLEARCOLOR.\n"
+  echo -e "\n==>$ERRORCOLOR Inadequate expression coverage percentage.$CLEARCOLOR Expected $expected_covered_expressions_percentage%, but actual coverage was $ERRORCOLOR$(($covered_expression_percentage))%$CLEARCOLOR.\n"
+  exit 1
+fi
+uncovered_expression_count=$(grep "expressions used" __hpc_coverage_report | sed s/.*\(//g | cut -f1 -d "/")
+if [ $uncovered_expression_count -gt $expected_uncovered_expression_count ]
+then
+  echo -e "\n==>$ERRORCOLOR Overly large uncovered expression count.$CLEARCOLOR Expected $expected_uncovered_expression_count uncovered expressions, but actual uncovered expression count was $ERRORCOLOR$(($uncovered_expression_count))%$CLEARCOLOR.\n"
   exit 1
 fi

--- a/haskell/private/coverage_wrapper.sh.tpl
+++ b/haskell/private/coverage_wrapper.sh.tpl
@@ -43,15 +43,25 @@ $binary_path "$@"
 $hpc_path report $tix_file_path $hpc_dir_args > __hpc_coverage_report
 echo "Overall report"
 cat __hpc_coverage_report
-covered_expression_percentage=$(grep "expressions used" __hpc_coverage_report | cut -c 1-3)
-if [ $covered_expression_percentage -lt $expected_covered_expressions_percentage ]
+
+if [ "$expected_covered_expressions_percentage" -ne -1 ]
 then
-  echo -e "\n==>$ERRORCOLOR Inadequate expression coverage percentage.$CLEARCOLOR Expected $expected_covered_expressions_percentage%, but actual coverage was $ERRORCOLOR$(($covered_expression_percentage))%$CLEARCOLOR.\n"
-  exit 1
+  covered_expression_percentage=$(grep "expressions used" __hpc_coverage_report | cut -c 1-3)
+  if [ $covered_expression_percentage -lt $expected_covered_expressions_percentage ]
+  then
+    echo -e "\n==>$ERRORCOLOR Inadequate expression coverage percentage.$CLEARCOLOR Expected $expected_covered_expressions_percentage%, but actual coverage was $ERRORCOLOR$(($covered_expression_percentage))%$CLEARCOLOR.\n"
+    exit 1
+  fi
 fi
-uncovered_expression_count=$(grep "expressions used" __hpc_coverage_report | sed s/.*\(//g | cut -f1 -d "/")
-if [ $uncovered_expression_count -gt $expected_uncovered_expression_count ]
+
+if [ "$expected_uncovered_expression_count" -ne -1 ]
 then
-  echo -e "\n==>$ERRORCOLOR Overly large uncovered expression count.$CLEARCOLOR Expected $expected_uncovered_expression_count uncovered expressions, but actual uncovered expression count was $ERRORCOLOR$(($uncovered_expression_count))%$CLEARCOLOR.\n"
-  exit 1
+  coverage_numerator=$(grep "expressions used" __hpc_coverage_report | sed s:.*\(::g | cut -f1 -d "/")
+  coverage_denominator=$(grep "expressions used" __hpc_coverage_report | sed s:.*/::g | cut -f1 -d ")")
+  uncovered_expression_count="$(($coverage_denominator - $coverage_numerator))"
+  if [ $uncovered_expression_count -gt $expected_uncovered_expression_count ]
+  then
+    echo -e "\n==>$ERRORCOLOR Too many uncovered expressions.$CLEARCOLOR Expected $expected_uncovered_expression_count uncovered expressions, but actual uncovered expression count was $ERRORCOLOR$(($uncovered_expression_count))$CLEARCOLOR.\n"
+    exit 1
+  fi
 fi

--- a/haskell/private/coverage_wrapper.sh.tpl
+++ b/haskell/private/coverage_wrapper.sh.tpl
@@ -28,8 +28,11 @@ CLEARCOLOR='\033[0m'
 binary_path=$(rlocation {binary_path})
 hpc_path=$(rlocation {hpc_path})
 tix_file_path={tix_file_path}
+
+# either of the two expected coverage metrics should be set to -1 if they're meant to be unused
 expected_covered_expressions_percentage={expected_covered_expressions_percentage}
 expected_uncovered_expression_count={expected_uncovered_expression_count}
+
 strict_coverage_analysis={strict_coverage_analysis}
 hpc_dir_args=""
 mix_file_paths={mix_file_paths}

--- a/haskell/private/haskell_impl.bzl
+++ b/haskell/private/haskell_impl.bzl
@@ -62,7 +62,8 @@ def haskell_binary_impl(ctx):
     return _haskell_binary_common_impl(ctx, is_test = False)
 
 def _should_inspect_coverage(ctx, hs, is_test):
-    return hs.coverage_enabled and is_test and ctx.attr.expected_expression_coverage > 0
+    return hs.coverage_enabled and is_test and (ctx.attr.expected_covered_expressions_percentage != None or
+                                                ctx.attr.expected_uncovered_expression_count != None)
 
 def _haskell_binary_common_impl(ctx, is_test):
     hs = haskell_context(ctx)
@@ -197,7 +198,8 @@ def _haskell_binary_common_impl(ctx, is_test):
             paths.join(ctx.workspace_name, m.short_path)
             for m in conditioned_mix_files
         ]
-        expected_expression_coverage = ctx.attr.expected_expression_coverage
+        expected_covered_expressions_percentage = ctx.attr.expected_covered_expressions_percentage
+        expected_uncovered_expression_count = ctx.attr.expected_uncovered_expression_count
         wrapper = hs.actions.declare_file("coverage_wrapper.sh")
         ctx.actions.expand_template(
             template = ctx.file._coverage_wrapper_template,
@@ -206,7 +208,8 @@ def _haskell_binary_common_impl(ctx, is_test):
                 "{binary_path}": shell.quote(binary_path),
                 "{hpc_path}": shell.quote(hpc_path),
                 "{tix_file_path}": shell.quote(tix_file_path),
-                "{expected_expression_coverage}": str(expected_expression_coverage),
+                "{expected_covered_expressions_percentage}": str(expected_covered_expressions_percentage),
+                "{expected_uncovered_expression_count}": str(expected_uncovered_expression_count),
                 "{mix_file_paths}": shell.array_literal(mix_file_paths),
             },
             is_executable = True,

--- a/haskell/private/haskell_impl.bzl
+++ b/haskell/private/haskell_impl.bzl
@@ -62,8 +62,8 @@ def haskell_binary_impl(ctx):
     return _haskell_binary_common_impl(ctx, is_test = False)
 
 def _should_inspect_coverage(ctx, hs, is_test):
-    return hs.coverage_enabled and is_test and (ctx.attr.expected_covered_expressions_percentage != None or
-                                                ctx.attr.expected_uncovered_expression_count != None)
+    return hs.coverage_enabled and is_test and (ctx.attr.expected_covered_expressions_percentage != -1 or
+                                                ctx.attr.expected_uncovered_expression_count != -1)
 
 def _haskell_binary_common_impl(ctx, is_test):
     hs = haskell_context(ctx)

--- a/haskell/private/haskell_impl.bzl
+++ b/haskell/private/haskell_impl.bzl
@@ -200,6 +200,7 @@ def _haskell_binary_common_impl(ctx, is_test):
         ]
         expected_covered_expressions_percentage = ctx.attr.expected_covered_expressions_percentage
         expected_uncovered_expression_count = ctx.attr.expected_uncovered_expression_count
+        strict_coverage_analysis = ctx.attr.strict_coverage_analysis
         wrapper = hs.actions.declare_file("coverage_wrapper.sh")
         ctx.actions.expand_template(
             template = ctx.file._coverage_wrapper_template,
@@ -211,6 +212,7 @@ def _haskell_binary_common_impl(ctx, is_test):
                 "{expected_covered_expressions_percentage}": str(expected_covered_expressions_percentage),
                 "{expected_uncovered_expression_count}": str(expected_uncovered_expression_count),
                 "{mix_file_paths}": shell.array_literal(mix_file_paths),
+                "{strict_coverage_analysis}": str(strict_coverage_analysis),
             },
             is_executable = True,
         )

--- a/tests/binary-custom-main/BUILD
+++ b/tests/binary-custom-main/BUILD
@@ -8,7 +8,7 @@ package(default_testonly = 1)
 haskell_test(
     name = "binary-custom-main",
     srcs = ["Main.hs"],
-    expected_expression_coverage = 50,
+    expected_covered_expressions_percentage = 50,
     tags = [
         "coverage-compatible",
     ],

--- a/tests/binary-simple/BUILD
+++ b/tests/binary-simple/BUILD
@@ -8,7 +8,7 @@ package(default_testonly = 1)
 haskell_test(
     name = "binary-simple",
     srcs = ["Main.hs"],
-    expected_expression_coverage = 100,
+    expected_covered_expressions_percentage = 100,
     tags = ["coverage-compatible"],
     visibility = ["//visibility:public"],
     deps = ["//tests/hackage:base"],

--- a/tests/library-with-sysdeps/BUILD
+++ b/tests/library-with-sysdeps/BUILD
@@ -20,7 +20,7 @@ haskell_library(
 haskell_test(
     name = "bin",
     srcs = ["Main.hs"],
-    expected_expression_coverage = 100,
+    expected_covered_expressions_percentage = 100,
     tags = [
         "coverage-compatible",
         "requires_zlib",

--- a/tests/two-libs/BUILD
+++ b/tests/two-libs/BUILD
@@ -29,8 +29,9 @@ haskell_library(
 haskell_test(
     name = "two-libs",
     srcs = ["Main.hs"],
-    expected_covered_expressions_percentage = 100,
-    expected_uncovered_expression_count = 0,
+    expected_covered_expressions_percentage = 73,
+    expected_uncovered_expression_count = 4,
+    strict_coverage_analysis = True,
     tags = ["coverage-compatible"],
     deps = [
         ":two",

--- a/tests/two-libs/BUILD
+++ b/tests/two-libs/BUILD
@@ -29,7 +29,8 @@ haskell_library(
 haskell_test(
     name = "two-libs",
     srcs = ["Main.hs"],
-    expected_expression_coverage = 100,
+    expected_covered_expressions_percentage = 100,
+    expected_uncovered_expression_count = 0,
     tags = ["coverage-compatible"],
     deps = [
         ":two",

--- a/tests/two-libs/Two.hs
+++ b/tests/two-libs/Two.hs
@@ -3,4 +3,12 @@ module Two (two) where
 import One (one)
 
 two :: Int
-two = one + one
+two = 
+    if True then
+        one + one
+    else 
+        if True then
+            1
+        else
+            2
+    


### PR DESCRIPTION
An alternate way of evaluating expression coverage: the maximum allowed count of expressions not covered.