### PR TITLE
WIP: Invoke bazel fewer times in tests

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,13 +23,14 @@ jobs:
       set -e
       export MSYS2_ARG_CONV_EXCL="*"
 
-      /c/bazel/bazel.exe build --config windows "@haskell_aeson//..."
-      /c/bazel/bazel.exe build --config windows "@haskell_aeson__extra//..."
-      /c/bazel/bazel.exe build --config windows "@haskell_cassava//..."
-      /c/bazel/bazel.exe build --config windows "@haskell_conduit//..."
-      /c/bazel/bazel.exe build --config windows "@haskell_fuzzyset//..."
-      /c/bazel/bazel.exe build --config windows "@haskell_lens//..."
-      /c/bazel/bazel.exe build --config windows "@haskell_text__metrics//..."
+      /c/bazel/bazel.exe build --config windows \
+        "@haskell_aeson//..." \
+        "@haskell_aeson__extra//..." \
+        "@haskell_cassava//..." \
+        "@haskell_conduit//..." \
+        "@haskell_fuzzyset//..." \
+        "@haskell_lens//..." \
+        "@haskell_text__metrics//..."
 
       # FIXME:
       # this rule is missing dependency declarations for the following files included by 'external/haskell_zlib/cbits/adler32.c':

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -64,49 +64,52 @@ jobs:
       set -e
       export MSYS2_ARG_CONV_EXCL="*"
       # Tests that build but don't run
-      /c/bazel/bazel.exe build --config windows "//tests/c-compiles-still/..."
-      /c/bazel/bazel.exe build --config windows "//tests/binary-with-data/..."
-      /c/bazel/bazel.exe build --config windows "//tests/binary-indirect-cbits"
+      /c/bazel/bazel.exe build --config windows \
+        "//tests/c-compiles-still/..." \
+        "//tests/binary-with-data/..." \
+        "//tests/binary-indirect-cbits"
 
       # Tests that only require building
       # (when using 'test' CI fails with:
       #     ERROR: No test targets were found, yet testing was requested
       # )
       # See https://github.com/bazelbuild/bazel/issues/7291
-      /c/bazel/bazel.exe build --config windows "//tests/data/..."
-      /c/bazel/bazel.exe build --config windows "//tests/failures/..."
-      /c/bazel/bazel.exe build --config windows "//tests/hidden-modules/..."
-      /c/bazel/bazel.exe build --config windows "//tests/package-id-clash/..."
+      /c/bazel/bazel.exe build --config windows \
+        "//tests/data/..." \
+        "//tests/failures/..." \
+        "//tests/hidden-modules/..." \
+        "//tests/package-id-clash/..." \
 
       # Tests that succeed
-      /c/bazel/bazel.exe test --config windows "//tests:test-binary-simple"
-      /c/bazel/bazel.exe test --config windows "//tests:test-binary-custom-main"
-      /c/bazel/bazel.exe test --config windows "//tests/binary-custom-main/..."
-      /c/bazel/bazel.exe test --config windows "//tests/binary-exe-path/..."
-      /c/bazel/bazel.exe test --config windows "//tests/binary-with-data/..."
-      /c/bazel/bazel.exe test --config windows "//tests/binary-with-lib/..."
-      /c/bazel/bazel.exe test --config windows "//tests/binary-with-main/..."
-      /c/bazel/bazel.exe test --config windows "//tests/binary-simple/..."
-      /c/bazel/bazel.exe test --config windows "//tests/binary-with-compiler-flags/..."
-      /c/bazel/bazel.exe test --config windows "//tests/binary-with-import/..."
-      /c/bazel/bazel.exe test --config windows "//tests/binary-with-link-flags/..."
-      /c/bazel/bazel.exe test --config windows "//tests/cpp_macro_conflict/..."
-      /c/bazel/bazel.exe test --config windows "//tests/extra-source-files/..."
-      /c/bazel/bazel.exe test --config windows "//tests/java_classpath/..."
-      /c/bazel/bazel.exe test --config windows "//tests/generated-modules/..."
-      /c/bazel/bazel.exe test --config windows "//tests/haskell_lint/..."
-      /c/bazel/bazel.exe test --config windows "//tests/haskell_test/..."
-      /c/bazel/bazel.exe test --config windows "//tests/hs-boot/..."
-      /c/bazel/bazel.exe test --config windows "//tests/indirect-link/..."
-      /c/bazel/bazel.exe test --config windows "//tests/library-deps/..."
-      /c/bazel/bazel.exe test --config windows "//tests/library-exports/..."
-      /c/bazel/bazel.exe test --config windows "//tests/library-linkstatic-flag/..."
-      /c/bazel/bazel.exe test --config windows "//tests/lhs/..."
-      /c/bazel/bazel.exe test --config windows "//tests/package-id-clash-binary/..."
-      /c/bazel/bazel.exe test --config windows "//tests/package-name/..."
-      /c/bazel/bazel.exe test --config windows "//tests/textual-hdrs/..."
-      /c/bazel/bazel.exe test --config windows "//tests/two-libs/..."
-      /c/bazel/bazel.exe test --config windows "//tests/encoding/..."
-      /c/bazel/bazel.exe test --config windows "//tests/c-compiles/..."
+      /c/bazel/bazel.exe test --config windows \
+        "//tests:test-binary-simple" \
+        "//tests:test-binary-custom-main" \
+        "//tests/binary-custom-main/..." \
+        "//tests/binary-exe-path/..." \
+        "//tests/binary-with-data/..." \
+        "//tests/binary-with-lib/..." \
+        "//tests/binary-with-main/..." \
+        "//tests/binary-simple/..." \
+        "//tests/binary-with-compiler-flags/..." \
+        "//tests/binary-with-import/..." \
+        "//tests/binary-with-link-flags/..." \
+        "//tests/cpp_macro_conflict/..." \
+        "//tests/extra-source-files/..." \
+        "//tests/java_classpath/..." \
+        "//tests/generated-modules/..." \
+        "//tests/haskell_lint/..." \
+        "//tests/haskell_test/..." \
+        "//tests/hs-boot/..." \
+        "//tests/indirect-link/..." \
+        "//tests/library-deps/..." \
+        "//tests/library-exports/..." \
+        "//tests/library-linkstatic-flag/..." \
+        "//tests/lhs/..." \
+        "//tests/package-id-clash-binary/..." \
+        "//tests/package-name/..." \
+        "//tests/textual-hdrs/..." \
+        "//tests/two-libs/..." \
+        "//tests/encoding/..." \
+        "//tests/c-compiles/..."
 
     displayName: 'Run Bazel'

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -381,6 +381,7 @@ haskell_binary(
     deps = [
         "//tests/hackage:base",
         "//tests/hackage:process",
+        "@hackage//:async",
         "@hackage//:hspec",
         "@hackage//:hspec-core",
     ],

--- a/tests/RunTests.hs
+++ b/tests/RunTests.hs
@@ -3,6 +3,9 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE QuasiQuotes #-}
 
+import Control.Monad (forever)
+import Control.Concurrent (threadDelay)
+import Control.Concurrent.Async (race_)
 import Data.Foldable (for_)
 import Data.List (isInfixOf, sort)
 import System.Exit (ExitCode(..))
@@ -12,7 +15,7 @@ import Test.Hspec.Core.Spec (SpecM)
 import Test.Hspec (hspec, it, describe, runIO, shouldSatisfy, expectationFailure)
 
 main :: IO ()
-main = hspec $ do
+main = race_ (forever $ threadDelay 60000000 >> putStrLn ".") $ hspec $ do
   it "bazel lint" $ do
     assertSuccess (bazel ["run", "//:buildifier"])
 


### PR DESCRIPTION
Marked as WIP because we first need to compare CI times. If there's no improvement there's no point in merging.