### PR TITLE
Pass -no-canonical-prefixes and -fno-canonical-system-headers to GCC on Windows

### DIFF
--- a/haskell/CROSSTOOL.windows
+++ b/haskell/CROSSTOOL.windows
@@ -32,6 +32,14 @@ toolchain {
   tool_path { name: "strip" path: "mingw/bin/strip" }
   cxx_builtin_include_directory: "mingw"
   cxx_flag: "-std=gnu++0x"
+
+  # Needed to prevent Bazel from complaining about undeclared inclusions of
+  # MingW headers.
+  #
+  # See: https://github.com/bazelbuild/bazel/issues/4605
+  unfiltered_cxx_flag: "-no-canonical-prefixes"
+  unfiltered_cxx_flag: "-fno-canonical-system-headers"
+
   linker_flag: "-lstdc++"
   objcopy_embed_flag: "-I"
   objcopy_embed_flag: "binary"


### PR DESCRIPTION
This fixes the `CROSSTOOL` file for Windows to pass two additional flags that prevent GCC from normalizing declared include paths into absolute ones, thus triggering “undeclared inclusions” errors.

Strangely enough, this problem only seems to manifest itself when remote caching is enabled, probably because Bazel otherwise doesn't check inclusions nearly as thoroughly.

See: https://github.com/bazelbuild/bazel/issues/4605 for motivation.