### PR TITLE
Add support for GHC plugins

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
           name: Setup test environment
           command: |
             apt-get update
-            apt-get install -y wget gnupg golang make libgmp3-dev pkg-config zip g++ zlib1g-dev unzip python bash-completion locales
+            apt-get install -y wget gnupg golang make libgmp3-dev libtinfo-dev pkg-config zip g++ zlib1g-dev unzip python bash-completion locales
             echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen
             locale-gen
             wget "https://github.com/bazelbuild/bazel/releases/download/0.22.0/bazel_0.22.0-linux-x86_64.deb"

--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -53,6 +53,10 @@ load(
     _haskell_register_toolchains = "haskell_register_toolchains",
     _haskell_toolchain = "haskell_toolchain",
 )
+load(
+    ":plugins.bzl",
+    _ghc_plugin = "ghc_plugin",
+)
 
 _haskell_common_attrs = {
     "src_strip_prefix": attr.string(
@@ -81,6 +85,9 @@ _haskell_common_attrs = {
     ),
     "runghc_args": attr.string_list(
         doc = "Arbitrary extra arguments to pass to runghc. This extends `compiler_flags` and `repl_ghci_args` from the toolchain",
+    ),
+    "plugins": attr.label_list(
+        doc = "Compiler plugins to use during compilation.",
     ),
     "_ghci_script": attr.label(
         allow_single_file = True,
@@ -318,3 +325,5 @@ ghc_bindist = _ghc_bindist
 haskell_cc_import = _haskell_cc_import
 
 cc_haskell_import = _cc_haskell_import
+
+ghc_plugin = _ghc_plugin

--- a/haskell/plugins.bzl
+++ b/haskell/plugins.bzl
@@ -1,0 +1,57 @@
+load(":private/providers.bzl", "GhcPluginInfo", "HaskellLibraryInfo")
+
+def ghc_plugin_impl(ctx):
+    args = [ctx.expand_make_variables("args", i, {}) for i in ctx.attr.args]
+    return [
+        GhcPluginInfo(
+            module = ctx.attr.module,
+            deps = ctx.attr.deps,
+            args = args,
+        ),
+    ]
+
+ghc_plugin = rule(
+    ghc_plugin_impl,
+    attrs = {
+        "module": attr.string(
+            doc = "Plugin entrypoint.",
+        ),
+        "deps": attr.label_list(
+            doc = "Plugin dependencies. These are compile-time dependencies only.",
+            providers = [HaskellLibraryInfo],
+        ),
+        "args": attr.string_list(
+            doc = "Plugin options.",
+        ),
+        "tools": attr.label_list(
+            doc = "Tools needed by the plugin when it used.",
+        ),
+    },
+)
+"""Declare a GHC plugin.
+
+Example:
+  ```bzl
+  haskell_library(
+      name = "plugin-lib",
+      srcs = ["Plugin.hs"],
+  )
+
+  ghc_plugin(
+      name = "plugin",
+      module = "Plugin",
+      deps = [":plugin-lib"],
+  )
+
+  haskell_binary(
+      name = "some-binary",
+      srcs = ["Main.hs"],
+      plugins = [":plugin"],
+  ```
+
+Plugins to use during compilation by GHC are given by the `plugins`
+attribute to Haskell rules. Plugins are haskell libraries with some
+extra metadata, like the name of the module that acts as the
+entrypoint for the plugin and plugin options.
+
+"""

--- a/haskell/private/dependencies.bzl
+++ b/haskell/private/dependencies.bzl
@@ -131,7 +131,7 @@ def _HaskellCcInfo_from_CcInfo(ctx, cc_info):
         ),
     )
 
-def gather_dep_info(ctx):
+def gather_dep_info(ctx, deps):
     """Collapse dependencies into a single `HaskellBuildInfo`.
 
     Note that the field `prebuilt_dependencies` also includes
@@ -139,6 +139,7 @@ def gather_dep_info(ctx):
 
     Args:
       ctx: Rule context.
+      deps: deps attribute.
 
     Returns:
       HaskellBuildInfo: Unified information about all dependencies.
@@ -158,7 +159,7 @@ def gather_dep_info(ctx):
         transitive_cc_dependencies = empty_HaskellCcInfo(),
     )
 
-    for dep in ctx.attr.deps:
+    for dep in deps:
         if HaskellBuildInfo in dep:
             binfo = dep[HaskellBuildInfo]
             package_ids = acc.package_ids

--- a/haskell/private/packages.bzl
+++ b/haskell/private/packages.bzl
@@ -2,18 +2,24 @@
 
 load(":private/set.bzl", "set")
 
-def pkg_info_to_ghc_args(pkg_info):
+def pkg_info_to_ghc_args(pkg_info, for_plugin = False):
+    """Map package info to GHC command-line arguments.
+
+    Args:
+      pkg_info: Package info collected by `ghc_info()`.
+      for_plugin: Whether the package is a plugin dependency.
+
+    Returns:
+      The list of command-line arguments that should be passed to GHC.
     """
-    Takes the package info collected by `ghc_info()` and returns the actual
-    list of command line arguments that should be passed to GHC.
-    """
+    namespace = "plugin-" if for_plugin else ""
     args = [
         # In compile.bzl, we pass this just before all -package-id
         # arguments. Not doing so leads to bizarre compile-time failures.
         # It turns out that equally, not doing so leads to bizarre
         # link-time failures. See
         # https://github.com/tweag/rules_haskell/issues/395.
-        "-hide-all-packages",
+        "-hide-all-{}packages".format(namespace),
     ]
 
     if not pkg_info.has_version:
@@ -25,10 +31,10 @@ def pkg_info_to_ghc_args(pkg_info):
         ])
 
     for package in pkg_info.packages:
-        args.extend(["-package", package])
+        args.extend(["-{}package".format(namespace), package])
 
     for package_id in pkg_info.package_ids:
-        args.extend(["-package-id", package_id])
+        args.extend(["-{}package-id".format(namespace), package_id])
 
     for package_db in pkg_info.package_dbs:
         args.extend(["-package-db", package_db])

--- a/haskell/private/providers.bzl
+++ b/haskell/private/providers.bzl
@@ -242,3 +242,12 @@ C2hsLibraryInfo = provider(
         "import_dir": "Import directory containing generated Haskell source file.",
     },
 )
+
+GhcPluginInfo = provider(
+    doc = "Encapsulates GHC plugin dependencies and tools",
+    fields = {
+        "module": "Plugin entrypoint.",
+        "deps": "Plugin dependencies.",
+        "args": "Plugin options.",
+    },
+)

--- a/haskell/protobuf.bzl
+++ b/haskell/protobuf.bzl
@@ -158,6 +158,7 @@ def _haskell_proto_aspect_impl(target, ctx):
         "deps": ctx.rule.attr.deps +
                 ctx.toolchains["@io_tweag_rules_haskell//protobuf:toolchain"].deps,
         "prebuilt_dependencies": ctx.toolchains["@io_tweag_rules_haskell//protobuf:toolchain"].prebuilt_deps,
+        "plugins": [],
         "_cc_toolchain": ctx.attr._cc_toolchain,
     }
 

--- a/haskell/toolchain.bzl
+++ b/haskell/toolchain.bzl
@@ -17,7 +17,7 @@ load(":private/actions/package.bzl", "package")
 
 _GHC_BINARIES = ["ghc", "ghc-pkg", "hsc2hs", "haddock", "ghci", "runghc", "hpc"]
 
-def _run_ghc(hs, cc, inputs, outputs, mnemonic, arguments, params_file = None, env = None, progress_message = None):
+def _run_ghc(hs, cc, inputs, outputs, mnemonic, arguments, params_file = None, env = None, progress_message = None, input_manifests = None):
     if not env:
         env = hs.env
 
@@ -96,6 +96,7 @@ def _run_ghc(hs, cc, inputs, outputs, mnemonic, arguments, params_file = None, e
 
     hs.actions.run_shell(
         inputs = inputs,
+        input_manifests = input_manifests,
         outputs = outputs,
         command = command,
         mnemonic = mnemonic,

--- a/tests/binary-with-plugin/BUILD
+++ b/tests/binary-with-plugin/BUILD
@@ -1,0 +1,50 @@
+load(
+    "@io_tweag_rules_haskell//haskell:haskell.bzl",
+    "ghc_plugin",
+    "haskell_import",
+    "haskell_library",
+    "haskell_test",
+)
+
+package(default_testonly = 1)
+
+config_setting(
+    name = "debug_build",
+    values = {
+        "compilation_mode": "dbg",
+    },
+)
+
+haskell_import(name = "base")
+
+haskell_import(name = "ghc")
+
+haskell_library(
+    name = "plugin-lib",
+    srcs = ["Plugin.hs"],
+    deps = [
+        ":base",
+        ":ghc",
+    ],
+)
+
+ghc_plugin(
+    name = "plugin",
+    args = ["$(JAVABASE)/bin/javac"],
+    module = "Plugin",
+    toolchains = ["@bazel_tools//tools/jdk:current_java_runtime"],
+    deps = [":plugin-lib"],
+)
+
+haskell_test(
+    name = "binary-with-plugin",
+    srcs = ["Main.hs"],
+    plugins = select({
+        # XXX If profiling is enabled, ignore the plugin because of
+        # https://gitlab.haskell.org/ghc/ghc/issues/14335.
+        ":debug_build": [],
+        "//conditions:default": [":plugin"],
+    }),
+    visibility = ["//visibility:public"],
+    deps = [":base"],
+)

--- a/tests/binary-with-plugin/Main.hs
+++ b/tests/binary-with-plugin/Main.hs
@@ -1,0 +1,3 @@
+module Main where
+
+main = putStrLn "hello world"

--- a/tests/binary-with-plugin/Plugin.hs
+++ b/tests/binary-with-plugin/Plugin.hs
@@ -1,0 +1,13 @@
+module Plugin (plugin) where
+
+import Control.Monad (when)
+import GhcPlugins
+
+plugin :: Plugin
+plugin = defaultPlugin { installCoreToDos = install }
+
+install :: [CommandLineOption] -> [CoreToDo] -> CoreM [CoreToDo]
+install [arg] todo = do
+  when ('$' `elem` arg) $
+    fail "Make variable not expanded."
+  return todo


### PR DESCRIPTION
This introduces new `ghc_plugin` rule type, and an extra attribute to
`haskell_*` rules to add plugins to the compilation process. Plugins
only affect the compile action, not any other action. We take care to
ensure that plugin dependencies do not induce extra runtime
dependencies, by using `-plugin-package` for plugin dependencies
instead of `-package`.