### PR TITLE
Ci disallow local nix builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,12 +51,20 @@ jobs:
       - run:
           name: System dependencies
           command: |
+            set -e
             apk --no-progress update
             apk --no-progress add bash ca-certificates
 
+            mkdir -p /etc/nix
             # CircleCI and Nix sandboxing don't play nice. See
             # https://discourse.nixos.org/t/nixos-on-ovh-kimsufi-cloning-builder-process-operation-not-permitted/1494/5
-            mkdir -p /etc/nix && echo "sandbox = false" > /etc/nix/nix.conf
+            echo "sandbox = false" > /etc/nix/nix.conf
+            # No builders and no local jobs ensures that everything has to come from a binary cache
+            # If we want to add packages that are not cached by the offical NixOS binary cache,
+            # we need to manually build them (e.g. `nix-build -A <dependency> --max-jobs <no-cpu-cores>`).
+            # This is a sanity check.
+            echo "builders =" >> /etc/nix/nix.conf
+            echo "max-jobs = 0" >> /etc/nix/nix.conf
       - run:
           name: Configure
           command: |

--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ the history clean.
 
 [buildifier]: https://github.com/bazelbuild/buildtools/tree/master/buildifier
 
-### How to update the nixpkgs pin
+### <a name="nixpkgs-pin" />How to update the nixpkgs pin
 
 You have to find a new git commit where all our `shell.nix`
 dependencies are available from the official NixOS Hydra binary cache.
@@ -321,3 +321,14 @@ If a check fails and you cannot reproduce it locally (e.g. it failed on Darwin
 and you only run Linux), you can [ssh into CircleCI to aid debugging][ci-ssh].
 
 [ci-ssh]: https://circleci.com/docs/2.0/ssh-access-jobs/
+
+#### “unable to start any build”
+
+```
+error: unable to start any build; either increase '--max-jobs' or enable remote builds
+```
+
+We set `--builders ""` and `--max-jobs 0` on CI to be sure all
+dependencies are coming from binary caches. You might need to add an
+exception (TODO: where to add exception) or [switch to a different
+nixpkgs pin](#nixpkgs-pin).


### PR DESCRIPTION
Experiment to guarantee all (nixpkgs) dependencies are binary cached, at least for `nixpkgs-linux`.