### PR TITLE
Move start script to bindists & document

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,6 +39,16 @@ jobs:
           name: Build tests
           command: |
             bazel build --config ci //tests/...
+      - run:
+          name: Run tests
+          # bazel does not support recursive bazel call, so we
+          # cannot use bazel run here because the test runner uses
+          # bazel
+          command: |
+            bazel build --config ci //tests:run-tests
+            # run the start script test
+            ./bazel-ci-bin/tests/run-tests --match "/startup script/"
+            # TODO: enable all tests for bindists
 
   # ATTN: when you change anything here, don’t forget to copy it to the build-darwin section
   build-linux-nixpkgs:
@@ -74,8 +84,10 @@ jobs:
           command: |
             nix-shell --arg docTools false --pure --run \
               'bazel build --config ci //tests:run-tests'
+            # TODO(Profpatsch) re-add a nixpkgs startup script
+            # and enable this test again
             nix-shell --arg docTools false --pure --run \
-              './bazel-ci-bin/tests/run-tests'
+              './bazel-ci-bin/tests/run-tests --skip "/startup script/"'
             nix-shell --arg docTools false --pure --run \
               'bazel coverage //tests/... --config ci --build_tag_filters "coverage-compatible" --test_tag_filters "coverage-compatible" --test_output=all'
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,14 +41,12 @@ jobs:
             bazel build --config ci //tests/...
       - run:
           name: Run tests
-          # bazel does not support recursive bazel call, so we
-          # cannot use bazel run here because the test runner uses
-          # bazel
           command: |
-            bazel build --config ci //tests:run-tests
-            # run the start script test
-            ./bazel-ci-bin/tests/run-tests --match "/startup script/"
+            # Run the start script test.
+            # Doesn't use the test suite binary, because that depends on nixpkgs dependencies.
+            ./tests/run-start-script.sh
             # TODO: enable all tests for bindists
+            # (this will require tests to both work with nixpkgs and hazel backends)
 
   # ATTN: when you change anything here, don’t forget to copy it to the build-darwin section
   build-linux-nixpkgs:

--- a/haskell/BUILD
+++ b/haskell/BUILD
@@ -20,6 +20,14 @@ py_binary(
     visibility = ["//visibility:public"],
 )
 
+# generate the _GHC_BINDISTS dict
+py_binary(
+    name = "gen-ghc-bindist",
+    srcs = [":gen_ghc_bindist.py"],
+    main = ":gen_ghc_bindist.py",
+    visibility = ["//visibility:public"],
+)
+
 # toolchains must have a valid toolchain_type from bazel 0.21
 toolchain_type(
     name = "toolchain",

--- a/haskell/gen_ghc_bindist.py
+++ b/haskell/gen_ghc_bindist.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python
+
+# This is a happy-path tool to download the bindist
+# download paths and hashes, for maintainers.
+# It uses the hashes provided by download.haskell.org.
+
+from __future__ import print_function
+
+import pprint
+import sys
+import urllib2
+
+# All GHC versions we generate.
+# `version` is the version number
+# `distribution_version` is a corrected name
+# (sometimes bindists have errors and are updated by new bindists)
+# `ignore_prefixes` is the prefix of files to ignore
+# `ignore_suffixes` is the suffix of files to ignore
+VERSIONS = [
+    { "version": "8.6.4" },
+    { "version": "8.6.3" },
+    { "version": "8.6.2" },
+    { "version": "8.4.4" },
+    { "version": "8.4.3" },
+    { "version": "8.4.2" },
+    { "version": "8.4.1" },
+    { "version": "8.2.2" },
+    { "version": "8.0.2",
+      "ignore_suffixes": [".patch"] },
+    { "version": "7.10.3",
+      "distribution_version": "7.10.3b",
+      "ignore_prefixes": ["ghc-7.10.3-", "ghc-7.10.3a-"],
+      "ignore_suffixes": [".bz2", ".patch" ] }
+]
+
+# All architectures we generate.
+# bazel: bazel name
+# upstream: download.haskell.org name
+ARCHES = [
+    { "bazel": "linux_amd64",
+      "upstream": "x86_64-deb8-linux", },
+    { "bazel": "darwin_amd64",
+      "upstream": "x86_64-apple-darwin" },
+    { "bazel": "windows_amd64",
+      "upstream": "x86_64-unknown-mingw32" },
+]
+
+
+# An url to a bindist tarball.
+def link_for_tarball(arch, version):
+    return "https://downloads.haskell.org/~ghc/{ver}/ghc-{ver}-{arch}.tar.xz".format(
+        ver = version,
+        arch = arch,
+    )
+
+# An url to a version's tarball hashsum file.
+# The files contain the hashsums for all arches.
+def link_for_sha256_file(version):
+    return "https://downloads.haskell.org/~ghc/{ver}/SHA256SUMS".format(
+        ver = version
+    )
+
+# Parses the tarball hashsum file for a distribution version.
+def parse_sha256_file(content, version, url):
+    res = {}
+    errs = []
+    for line in content:
+        # f5763983a26dedd88b65a0b17267359a3981b83a642569b26334423f684f8b8c  ./ghc-8.4.3-i386-deb8-linux.tar.xz
+        (hash, file_) = line.strip().split("  ./")
+        prefix = "ghc-{ver}-".format(ver = version.get("distribution_version", version['version']))
+        suffix = ".tar.xz"
+
+        # filter ignored files
+        if   any([file_.startswith(p) for p in version.get("ignore_prefixes", [])]) \
+          or any([file_.endswith(s)   for s in version.get("ignore_suffixes", [])]):
+            continue
+
+        if file_.startswith(prefix) and file_.endswith(suffix):
+            # i386-deb8-linux
+            name = file_[len(prefix):-len(suffix)]
+            res[name] = hash
+        else:
+            errs.append("Can't parse the sha256 field for {ver}: {entry}".format(
+                ver = version['version'], entry = line.strip()))
+
+    if errs:
+        eprint("Errors parsing file at " + url + ". Either fix or ignore the lines (ignore_suffixes/ignore_prefixes).")
+        for e in errs:
+            eprint(e)
+        exit(1)
+
+    return res
+
+# Print to stderr.
+def eprint(mes):
+    print(mes, file = sys.stderr)
+
+# Main.
+if __name__ == "__main__":
+
+    # Fetch all hashsum files
+    # grab : { version: { arch: sha256 } }
+    grab = {}
+    for ver in VERSIONS:
+        eprint("fetching " + ver['version'])
+        url = link_for_sha256_file(ver['version'])
+        res = urllib2.urlopen(url)
+        if res.getcode() != 200:
+            eprint("download of {} failed with status {}".format(url, res.getcode()))
+            sys.exit(1)
+        else:
+            grab[ver['version']] = parse_sha256_file(res, ver, url)
+
+    # check whether any version is missing arches we need
+    # errs : { version: set(missing_arches) }
+    errs = {}
+    for ver, hashes in grab.items():
+      real_arches = frozenset(hashes.keys())
+      needed_arches = frozenset([a['upstream'] for a in ARCHES])
+      missing_arches = needed_arches.difference(real_arches)
+      if missing_arches:
+          errs[ver] = missing_arches
+    if errs:
+        for ver, missing in errs.items():
+            eprint("version {ver} is missing hashes for required architectures {arches}".format(
+                ver = ver,
+                arches = missing))
+
+    # fetch the arches we need and create the GHC_BINDISTS dict
+    # ghc_bindists : { version: { bazel_arch: (tarball_url, sha256_hash) } }
+    ghc_bindists = {}
+    for ver, hashes in grab.items():
+        # { bazel_arch: (tarball_url, sha256_hash) }
+        arch_dists = {}
+        for arch in ARCHES:
+            hashes[arch['upstream']]
+            arch_dists[arch['bazel']] = (
+                link_for_tarball(arch['upstream'], ver),
+                hashes[arch['upstream']]
+            )
+        ghc_bindists[ver] = arch_dists
+
+    # Print to stdout. Be aware that you can't `> foo.bzl`,
+    # because that truncates the source file which is needed
+    # for bazel to run in the first place.
+    print(""" \
+# Generated with `bazel run @io_tweag_rules_haskell//haskell:gen-ghc-bindist | sponge haskell/private/ghc_bindist_generated.bzl`
+# To add a version or architecture, edit the constants in haskell/gen_ghc_bindist.py
+GHC_BINDIST = \\""")
+    pprint.pprint(ghc_bindists)
+

--- a/haskell/ghc_bindist.bzl
+++ b/haskell/ghc_bindist.bzl
@@ -1,59 +1,155 @@
 """Workspace rules (GHC binary distributions)"""
 
-_GHC_BINDISTS = {
-    "8.6.4": {
-        "linux_amd64": ("https://downloads.haskell.org/~ghc/8.6.4/ghc-8.6.4-x86_64-deb8-linux.tar.xz", "34ef5fc8ddf2fc32a027180bea5b1c8a81ea840c87faace2977a572188d4b42d"),
-        "darwin_amd64": ("https://downloads.haskell.org/~ghc/8.6.4/ghc-8.6.4-x86_64-apple-darwin.tar.xz", "cccb58f142fe41b601d73690809f6089f7715b6a50a09aa3d0104176ab4db09e"),
-        "windows_amd64": ("https://downloads.haskell.org/~ghc/8.6.4/ghc-8.6.4-x86_64-unknown-mingw32.tar.xz", "e8d021b7a90772fc559862079da20538498d991956d7557b468ca19ddda22a08"),
-    },
-    "8.6.3": {
-        "linux_amd64": ("https://downloads.haskell.org/~ghc/8.6.3/ghc-8.6.3-x86_64-deb8-linux.tar.xz", "291ca565374f4d51cc311488581f3279d3167a064fabfd4a6722fe2bd4532fd5"),
-        "darwin_amd64": ("https://downloads.haskell.org/~ghc/8.6.3/ghc-8.6.3-x86_64-apple-darwin.tar.xz", "79d069a1a7d74cfdd7ac2a2711c45d3ddc6265b988a0cefa342714b24f997fc1"),
-        "windows_amd64": ("https://downloads.haskell.org/~ghc/8.6.3/ghc-8.6.3-x86_64-unknown-mingw32.tar.xz", "2fec383904e5fa79413e9afd328faf9bc700006c8c3d4bcdd8d4f2ccf0f7fa2a"),
-    },
-    "8.6.2": {
-        "linux_amd64": ("https://downloads.haskell.org/~ghc/8.6.2/ghc-8.6.2-x86_64-deb8-linux.tar.xz", "13f96e8b83bb5bb60f955786ff9085744c24927a33be8a17773f84c7c248533a"),
-        "darwin_amd64": ("https://downloads.haskell.org/~ghc/8.6.2/ghc-8.6.2-x86_64-apple-darwin.tar.xz", "8ec46a25872226dd7e5cf7271e3f3450c05f32144b96e6b9cb44cc4079db50dc"),
-        "windows_amd64": ("https://downloads.haskell.org/~ghc/8.6.2/ghc-8.6.2-x86_64-unknown-mingw32.tar.xz", "9a398e133cab09ff2610834337355d4e26c35e0665403fb9ff8db79315f74d3d"),
-    },
-    "8.4.4": {
-        "linux_amd64": ("https://downloads.haskell.org/~ghc/8.4.4/ghc-8.4.4-x86_64-deb8-linux.tar.xz", "4c2a8857f76b7f3e34ecba0b51015d5cb8b767fe5377a7ec477abde10705ab1a"),
-        "darwin_amd64": ("https://downloads.haskell.org/~ghc/8.4.4/ghc-8.4.4-x86_64-apple-darwin.tar.xz", "28dc89ebd231335337c656f4c5ead2ae2a1acc166aafe74a14f084393c5ef03a"),
-        "windows_amd64": ("https://downloads.haskell.org/~ghc/8.4.4/ghc-8.4.4-x86_64-unknown-mingw32.tar.xz", "da29dbb0f1199611c7d5bb7b0dd6a7426ca98f67dfd6da1526b033cd3830dc05"),
-    },
-    "8.4.3": {
-        "linux_amd64": ("https://downloads.haskell.org/~ghc/8.4.3/ghc-8.4.3-x86_64-deb8-linux.tar.xz", "b9c855754a3007f69db9a434db3e41050d29aa15cba0ec43a942672a9b5f75b7"),
-        "darwin_amd64": ("https://downloads.haskell.org/~ghc/8.4.3/ghc-8.4.3-x86_64-apple-darwin.tar.xz", "af0b455f6c46b9802b4b48dad996619cfa27cc6e2bf2ce5532387b4a8c00aa64"),
-        "windows_amd64": ("https://downloads.haskell.org/~ghc/8.4.3/ghc-8.4.3-x86_64-unknown-mingw32.tar.xz", "8a83cfbf9ae84de0443c39c93b931693bdf2a6d4bf163ffb41855f80f4bf883e"),
-    },
-    "8.4.2": {
-        "linux_amd64": ("https://downloads.haskell.org/~ghc/8.4.2/ghc-8.4.2-x86_64-deb8-linux.tar.xz", "246f66eb56f4ad0f1c7755502cfc8f9972f2d067dede17e151f6f479c1f76fbd"),
-        "darwin_amd64": ("https://downloads.haskell.org/~ghc/8.4.2/ghc-8.4.2-x86_64-apple-darwin.tar.xz", "87469222042b9ac23f9db216a8d4e5107297bdbbb99df71eb4d9e7208455def2"),
-        "windows_amd64": ("https://downloads.haskell.org/~ghc/8.4.2/ghc-8.4.2-x86_64-unknown-mingw32.tar.xz", "797634aa9812fc6b2084a24ddb4fde44fa83a2f59daea82e0af81ca3dd323fde"),
-    },
-    "8.4.1": {
-        "linux_amd64": ("https://downloads.haskell.org/~ghc/8.4.1/ghc-8.4.1-x86_64-deb8-linux.tar.xz", "427c77a934b30c3f1de992c38c072afb4323fe6fb30dbac919ca8cb6ae98fbd9"),
-        "darwin_amd64": ("https://downloads.haskell.org/~ghc/8.4.1/ghc-8.4.1-x86_64-apple-darwin.tar.xz", "d774e39f3a0105843efd06709b214ee332c30203e6c5902dd6ed45e36285f9b7"),
-        "windows_amd64": ("https://downloads.haskell.org/~ghc/8.4.1/ghc-8.4.1-x86_64-unknown-mingw32.tar.xz", "328b013fc651d34e075019107e58bb6c8a578f0155cf3ad4557e6f2661b03131"),
-    },
-    "8.2.2": {
-        "linux_amd64": ("https://downloads.haskell.org/~ghc/8.2.2/ghc-8.2.2-x86_64-deb8-linux.tar.xz", "48e205c62b9dc1ccf6739a4bc15a71e56dde2f891a9d786a1b115f0286111b2a"),
-        "darwin_amd64": ("https://downloads.haskell.org/~ghc/8.2.2/ghc-8.2.2-x86_64-apple-darwin.tar.xz", "f90fcf62f7e0936a6dfc3601cf663729bfe9bbf85097d2d75f0a16f8c2e95c27"),
-        "windows_amd64": ("https://downloads.haskell.org/~ghc/8.2.2/ghc-8.2.2-x86_64-unknown-mingw32.tar.xz", "1e033df2092aa546e763e7be63167720b32df64f76673ea1ce7ae7c9f564b223"),
-    },
-    "8.0.2": {
-        "linux_amd64": ("https://downloads.haskell.org/~ghc/8.0.2/ghc-8.0.2-x86_64-deb8-linux.tar.xz", "5ee68290db00ca0b79d57bc3a5bdce470de9ce9da0b098a7ce6c504605856c8f"),
-        "darwin_amd64": ("https://downloads.haskell.org/~ghc/8.0.2/ghc-8.0.2-x86_64-apple-darwin.tar.xz", "ff50a2df9f002f33b9f09717ebf5ec5a47906b9b65cc57b1f9849f8b2e06788d"),
-        "windows_amd64": ("https://downloads.haskell.org/~ghc/8.2.2/ghc-8.2.2-x86_64-unknown-mingw32.tar.xz", "8c42c1f4af995205b9816a1e97e2752fe758544c1f5fe77958cdcd319c9c2d53"),
-    },
-    "7.10.3": {
-        "linux_amd64": ("https://downloads.haskell.org/~ghc/7.10.3/ghc-7.10.3-x86_64-deb8-linux.tar.xz", "b478e282afbf489614d0133ef698ba44e901eeb1794f4453c0fb0807cd271b96"),
-        "darwin_amd64": ("https://downloads.haskell.org/~ghc/7.10.3/ghc-7.10.3-x86_64-apple-darwin.tar.xz", "852781d43d41cd55d02f818fe798bb4d1f7e52f488408167f413f7948cf1e7df"),
-        "windows_amd64": ("https://downloads.haskell.org/~ghc/7.10.3/ghc-7.10.3-x86_64-unknown-mingw32.tar.xz", "63e1689fc9e2809ae4d7f422b4dc810052e54c9aa2afd08746e234180e711dde"),
-    },
-}
-
 _GHC_DEFAULT_VERSION = "8.4.4"
+
+# Generated with `bazel run @io_tweag_rules_haskell//haskell:gen-ghc-bindist`
+# To add a version or architecture, edit the constants in haskell/gen_ghc_bindist.py,
+# regenerate the dict and copy it here.
+# We’d like to put this dict into its own file,
+# but that triggers a bug in Skydoc unfortunately.
+GHC_BINDIST = \
+    {
+        "7.10.3": {
+            "darwin_amd64": (
+                "https://downloads.haskell.org/~ghc/7.10.3/ghc-7.10.3-x86_64-apple-darwin.tar.xz",
+                "b7cad2ea7badb7006621105fbf24b4bd364d2e51c1a75661978d9280d68e83a8",
+            ),
+            "linux_amd64": (
+                "https://downloads.haskell.org/~ghc/7.10.3/ghc-7.10.3-x86_64-deb8-linux.tar.xz",
+                "804c75c4635353bf987c1ca120b8531c7bb4957c5b84d29c7adc4894b6fd579d",
+            ),
+            "windows_amd64": (
+                "https://downloads.haskell.org/~ghc/7.10.3/ghc-7.10.3-x86_64-unknown-mingw32.tar.xz",
+                "cc7987ca7ffcd8fc8b999ed8f7408300cd9fef156032338fd57d63f577532b81",
+            ),
+        },
+        "8.0.2": {
+            "darwin_amd64": (
+                "https://downloads.haskell.org/~ghc/8.0.2/ghc-8.0.2-x86_64-apple-darwin.tar.xz",
+                "ff50a2df9f002f33b9f09717ebf5ec5a47906b9b65cc57b1f9849f8b2e06788d",
+            ),
+            "linux_amd64": (
+                "https://downloads.haskell.org/~ghc/8.0.2/ghc-8.0.2-x86_64-deb8-linux.tar.xz",
+                "5ee68290db00ca0b79d57bc3a5bdce470de9ce9da0b098a7ce6c504605856c8f",
+            ),
+            "windows_amd64": (
+                "https://downloads.haskell.org/~ghc/8.0.2/ghc-8.0.2-x86_64-unknown-mingw32.tar.xz",
+                "8c42c1f4af995205b9816a1e97e2752fe758544c1f5fe77958cdcd319c9c2d53",
+            ),
+        },
+        "8.2.2": {
+            "darwin_amd64": (
+                "https://downloads.haskell.org/~ghc/8.2.2/ghc-8.2.2-x86_64-apple-darwin.tar.xz",
+                "f90fcf62f7e0936a6dfc3601cf663729bfe9bbf85097d2d75f0a16f8c2e95c27",
+            ),
+            "linux_amd64": (
+                "https://downloads.haskell.org/~ghc/8.2.2/ghc-8.2.2-x86_64-deb8-linux.tar.xz",
+                "48e205c62b9dc1ccf6739a4bc15a71e56dde2f891a9d786a1b115f0286111b2a",
+            ),
+            "windows_amd64": (
+                "https://downloads.haskell.org/~ghc/8.2.2/ghc-8.2.2-x86_64-unknown-mingw32.tar.xz",
+                "1e033df2092aa546e763e7be63167720b32df64f76673ea1ce7ae7c9f564b223",
+            ),
+        },
+        "8.4.1": {
+            "darwin_amd64": (
+                "https://downloads.haskell.org/~ghc/8.4.1/ghc-8.4.1-x86_64-apple-darwin.tar.xz",
+                "d774e39f3a0105843efd06709b214ee332c30203e6c5902dd6ed45e36285f9b7",
+            ),
+            "linux_amd64": (
+                "https://downloads.haskell.org/~ghc/8.4.1/ghc-8.4.1-x86_64-deb8-linux.tar.xz",
+                "427c77a934b30c3f1de992c38c072afb4323fe6fb30dbac919ca8cb6ae98fbd9",
+            ),
+            "windows_amd64": (
+                "https://downloads.haskell.org/~ghc/8.4.1/ghc-8.4.1-x86_64-unknown-mingw32.tar.xz",
+                "328b013fc651d34e075019107e58bb6c8a578f0155cf3ad4557e6f2661b03131",
+            ),
+        },
+        "8.4.2": {
+            "darwin_amd64": (
+                "https://downloads.haskell.org/~ghc/8.4.2/ghc-8.4.2-x86_64-apple-darwin.tar.xz",
+                "87469222042b9ac23f9db216a8d4e5107297bdbbb99df71eb4d9e7208455def2",
+            ),
+            "linux_amd64": (
+                "https://downloads.haskell.org/~ghc/8.4.2/ghc-8.4.2-x86_64-deb8-linux.tar.xz",
+                "246f66eb56f4ad0f1c7755502cfc8f9972f2d067dede17e151f6f479c1f76fbd",
+            ),
+            "windows_amd64": (
+                "https://downloads.haskell.org/~ghc/8.4.2/ghc-8.4.2-x86_64-unknown-mingw32.tar.xz",
+                "797634aa9812fc6b2084a24ddb4fde44fa83a2f59daea82e0af81ca3dd323fde",
+            ),
+        },
+        "8.4.3": {
+            "darwin_amd64": (
+                "https://downloads.haskell.org/~ghc/8.4.3/ghc-8.4.3-x86_64-apple-darwin.tar.xz",
+                "af0b455f6c46b9802b4b48dad996619cfa27cc6e2bf2ce5532387b4a8c00aa64",
+            ),
+            "linux_amd64": (
+                "https://downloads.haskell.org/~ghc/8.4.3/ghc-8.4.3-x86_64-deb8-linux.tar.xz",
+                "30a402c6d4754a6c020e0547f19ae3ac42e907e35349aa932d347f73e421a8e2",
+            ),
+            "windows_amd64": (
+                "https://downloads.haskell.org/~ghc/8.4.3/ghc-8.4.3-x86_64-unknown-mingw32.tar.xz",
+                "8a83cfbf9ae84de0443c39c93b931693bdf2a6d4bf163ffb41855f80f4bf883e",
+            ),
+        },
+        "8.4.4": {
+            "darwin_amd64": (
+                "https://downloads.haskell.org/~ghc/8.4.4/ghc-8.4.4-x86_64-apple-darwin.tar.xz",
+                "28dc89ebd231335337c656f4c5ead2ae2a1acc166aafe74a14f084393c5ef03a",
+            ),
+            "linux_amd64": (
+                "https://downloads.haskell.org/~ghc/8.4.4/ghc-8.4.4-x86_64-deb8-linux.tar.xz",
+                "4c2a8857f76b7f3e34ecba0b51015d5cb8b767fe5377a7ec477abde10705ab1a",
+            ),
+            "windows_amd64": (
+                "https://downloads.haskell.org/~ghc/8.4.4/ghc-8.4.4-x86_64-unknown-mingw32.tar.xz",
+                "da29dbb0f1199611c7d5bb7b0dd6a7426ca98f67dfd6da1526b033cd3830dc05",
+            ),
+        },
+        "8.6.2": {
+            "darwin_amd64": (
+                "https://downloads.haskell.org/~ghc/8.6.2/ghc-8.6.2-x86_64-apple-darwin.tar.xz",
+                "8ec46a25872226dd7e5cf7271e3f3450c05f32144b96e6b9cb44cc4079db50dc",
+            ),
+            "linux_amd64": (
+                "https://downloads.haskell.org/~ghc/8.6.2/ghc-8.6.2-x86_64-deb8-linux.tar.xz",
+                "13f96e8b83bb5bb60f955786ff9085744c24927a33be8a17773f84c7c248533a",
+            ),
+            "windows_amd64": (
+                "https://downloads.haskell.org/~ghc/8.6.2/ghc-8.6.2-x86_64-unknown-mingw32.tar.xz",
+                "9a398e133cab09ff2610834337355d4e26c35e0665403fb9ff8db79315f74d3d",
+            ),
+        },
+        "8.6.3": {
+            "darwin_amd64": (
+                "https://downloads.haskell.org/~ghc/8.6.3/ghc-8.6.3-x86_64-apple-darwin.tar.xz",
+                "79d069a1a7d74cfdd7ac2a2711c45d3ddc6265b988a0cefa342714b24f997fc1",
+            ),
+            "linux_amd64": (
+                "https://downloads.haskell.org/~ghc/8.6.3/ghc-8.6.3-x86_64-deb8-linux.tar.xz",
+                "291ca565374f4d51cc311488581f3279d3167a064fabfd4a6722fe2bd4532fd5",
+            ),
+            "windows_amd64": (
+                "https://downloads.haskell.org/~ghc/8.6.3/ghc-8.6.3-x86_64-unknown-mingw32.tar.xz",
+                "2fec383904e5fa79413e9afd328faf9bc700006c8c3d4bcdd8d4f2ccf0f7fa2a",
+            ),
+        },
+        "8.6.4": {
+            "darwin_amd64": (
+                "https://downloads.haskell.org/~ghc/8.6.4/ghc-8.6.4-x86_64-apple-darwin.tar.xz",
+                "cccb58f142fe41b601d73690809f6089f7715b6a50a09aa3d0104176ab4db09e",
+            ),
+            "linux_amd64": (
+                "https://downloads.haskell.org/~ghc/8.6.4/ghc-8.6.4-x86_64-deb8-linux.tar.xz",
+                "34ef5fc8ddf2fc32a027180bea5b1c8a81ea840c87faace2977a572188d4b42d",
+            ),
+            "windows_amd64": (
+                "https://downloads.haskell.org/~ghc/8.6.4/ghc-8.6.4-x86_64-unknown-mingw32.tar.xz",
+                "e8d021b7a90772fc559862079da20538498d991956d7557b468ca19ddda22a08",
+            ),
+        },
+    }
 
 def _execute_fail_loudly(ctx, args):
     """Execute a command and fail loudly if it fails.
@@ -78,10 +174,10 @@ def _ghc_bindist_impl(ctx):
     target = ctx.attr.target
     os, _, arch = target.partition("_")
 
-    if _GHC_BINDISTS[version].get(target) == None:
+    if GHC_BINDIST[version].get(target) == None:
         fail("Operating system {0} does not have a bindist for GHC version {1}".format(ctx.os.name, ctx.attr.version))
     else:
-        url, sha256 = _GHC_BINDISTS[version][target]
+        url, sha256 = GHC_BINDIST[version][target]
 
     bindist_dir = ctx.path(".")  # repo path
 
@@ -118,7 +214,7 @@ _ghc_bindist = repository_rule(
     attrs = {
         "version": attr.string(
             default = _GHC_DEFAULT_VERSION,
-            values = _GHC_BINDISTS.keys(),
+            values = GHC_BINDIST.keys(),
             doc = "The desired GHC version",
         ),
         "target": attr.string(),
@@ -274,9 +370,9 @@ def haskell_register_ghc_bindists(
     [toolchain-resolution]: https://docs.bazel.build/versions/master/toolchains.html#toolchain-resolution
 
     """
-    if not _GHC_BINDISTS.get(version):
+    if not GHC_BINDIST.get(version):
         fail("Binary distribution of GHC {} not available.".format(version))
-    for target in _GHC_BINDISTS[version]:
+    for target in GHC_BINDIST[version]:
         ghc_bindist(
             name = "io_tweag_rules_haskell_ghc_{}".format(target),
             target = target,

--- a/start
+++ b/start
@@ -40,63 +40,48 @@ cat > WORKSPACE <<"EOF"
 workspace(name = "YOUR_PROJECT_NAME_HERE")
 
 # Load the repository rule to download an http archive.
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load(
+    "@bazel_tools//tools/build_defs/repo:http.bzl",
+    "http_archive"
+)
 
 # Download `rules_haskell`.
 # and make it accessible `@io_tweag_rules_haskell`.
 http_archive(
-  name = "io_tweag_rules_haskell",
-  strip_prefix = "rules_haskell-0.8",
-  urls = ["https://github.com/tweag/rules_haskell/archive/v0.8.tar.gz"],
-  sha256 = "431d492a8ee6a110cdf42496181c9d27225dfb997379e64a148eb8e69f272ab7",
+    name = "io_tweag_rules_haskell",
+    strip_prefix = "rules_haskell-master",
+    urls = ["https://github.com/tweag/rules_haskell/archive/master.tar.gz"],
+    # sha256 = "431d492a8ee6a110cdf42496181c9d27225dfb997379e64a148eb8e69f272ab7",
 )
 
-load("@io_tweag_rules_haskell//haskell:repositories.bzl", "haskell_repositories")
+# TODO: get rid the `rules_nixpkgs` repository dependency for bindists
+# https://github.com/tweag/rules_haskell/issues/715
+rules_nixpkgs_version = "0.5.2"
+
+http_archive(
+    name = "io_tweag_rules_nixpkgs",
+    sha256 = "5a384daa57b49abf9f0b672852f1a66a3c52aecf9d4d2ac64f6de0fd307690c8",
+    strip_prefix = "rules_nixpkgs-%s" % rules_nixpkgs_version,
+    urls = ["https://github.com/tweag/rules_nixpkgs/archive/v%s.tar.gz" % rules_nixpkgs_version],
+)
+
+load(
+    "@io_tweag_rules_haskell//haskell:repositories.bzl",
+    "haskell_repositories"
+)
+
 # `haskell_repositories()` sets up all bazel dependencies
 # required by `rules_haskell`.
 haskell_repositories()
 
-# Note that you can use variables as well.
-rules_nixpkgs_version = "c232b296e795ad688854ff3d3d2de6e7ad45f0b4"
-rules_nixpkgs_sha256 = "5883ea01f3075354ab622cfe82542da01fe2b57a48f4c3f7610b4d14a3fced11"
-
-# `rules_nixpkgs` is used for fetching GHC and hackage packages.
-http_archive(
-    name = "io_tweag_rules_nixpkgs",
-    strip_prefix = "rules_nixpkgs-%s" % rules_nixpkgs_version,
-    urls = ["https://github.com/tweag/rules_nixpkgs/archive/%s.tar.gz" % rules_nixpkgs_version],
-    sha256 = rules_nixpkgs_sha256,
-)
-
 load(
-    "@io_tweag_rules_nixpkgs//nixpkgs:nixpkgs.bzl",
-    "nixpkgs_package",
-    "nixpkgs_git_repository",
-    "nixpkgs_cc_configure",
+    "@io_tweag_rules_haskell//haskell:haskell.bzl",
+    "haskell_register_ghc_bindists",
 )
 
-# Fetch a stable version of `nixpkgs`.
-nixpkgs_git_repository(
-    name = "nixpkgs",
-    remote = "https://github.com/NixOS/nixpkgs",
-    revision = "18.09",
-    sha256 = "6451af4083485e13daa427f745cbf859bc23cb8b70454c017887c006a13bd65e",
-)
-
-# The GHC distribution from `nixpkgs`.
-nixpkgs_package(
-  name = "ghc",
-  attribute_path = "haskell.compiler.ghc843",
-  repository = "@nixpkgs",
-)
-
-# Use the CC toolchain from `nixpkgs`.
-nixpkgs_cc_configure(
-    repository = "@nixpkgs",
-)
-
-# Register the GHC toolchain defined in `./BUILD`.
-register_toolchains("//:ghc-toolchain")
+# Registers a haskell toolchain with a GHC binary
+# downloaded from haskell.org.
+haskell_register_ghc_bindists(version = "8.6.3")
 EOF
 
 cat > BUILD.bazel <<"EOF"
@@ -105,19 +90,11 @@ package(default_visibility = ["//visibility:public"])
 
 # Load `rules_haskell` rules.
 load(
-  "@io_tweag_rules_haskell//haskell:haskell.bzl",
-  "haskell_toolchain",
-  "haskell_import",
-  "haskell_library",
-  "haskell_binary",
-)
-
-# `haskell_toolchain` sets up the GHC to be used
-# implicitely by all `haskell_*` rules.
-haskell_toolchain(
-  name = "ghc-toolchain",
-  version = "8.4.3",
-  tools = "@ghc//:bin",
+    "@io_tweag_rules_haskell//haskell:haskell.bzl",
+    "haskell_toolchain",
+    "haskell_import",
+    "haskell_library",
+    "haskell_binary",
 )
 
 # `haskell_import` can access builtin GHC packages
@@ -127,20 +104,20 @@ haskell_import(name = "base")
 
 # You can add your own libraries with `haskell_library`.
 # haskell_library(
-#   name = "MY_LIBRARY_NAME",
-#   src_strip_prefix = "src",
-#   srcs = glob(['src/**/*.hs']),
-#   deps = [
-#     "base_pkg"
-#   ],
+#     name = "MY_LIBRARY_NAME",
+#     src_strip_prefix = "src",
+#     srcs = glob(['src/**/*.hs']),
+#     deps = [
+#         "base_pkg"
+#     ],
 # )
 
 # An example binary using the Prelude module from the
 # GHC base package, to print the hello world.
 haskell_binary(
-  name = "example",
-  srcs = [":Example.hs"],
-  deps = [":base"],
+    name = "example",
+    srcs = [":Example.hs"],
+    deps = [":base"],
 )
 EOF
 

--- a/start
+++ b/start
@@ -5,28 +5,35 @@ MIN_BAZEL_MINOR=21
 
 set -e
 
-actual_raw=$(bazel version | egrep '^Build label:' | egrep -o '[0-9.]+')
+check_files_dont_exist () {
+    if [ -e WORKSPACE ] || [ -e BUILD ] || [ -e BazelExample.hs ]
+    then
+        echo "Current directory already has WORKSPACE and/or BUILD and/or BazelExample.hs files." >/dev/stderr
+        exit 1
+    fi
+}
 
-IFS=. read actual_major actual_minor actual_patch <<EOF
+check_bazel_version () {
+    local actual_raw=$(bazel version | egrep '^Build label:' | egrep -o '[0-9.]+')
+
+    IFS=. read actual_major actual_minor actual_patch <<EOF
 $actual_raw
 EOF
 
-expected=$MIN_BAZEL_MAJOR.$MIN_BAZEL_MINOR.0
-cmp=$expected'\n'$actual
+    local expected=$MIN_BAZEL_MAJOR.$MIN_BAZEL_MINOR.0
+    local cmp=$expected'\n'$actual
 
-if ! ( [ "$actual_major" -gt "$MIN_BAZEL_MAJOR" ] || (
-           [ "$actual_major" -eq "$MIN_BAZEL_MAJOR" ] &&
-               [ "$actual_minor" -ge "$MIN_BAZEL_MINOR" ] ) )
-then
-    echo "Need at least Bazel v${expected}. v${actual_raw} detected." >/dev/stderr
-    exit 1
-fi
+    if ! ( [ "$actual_major" -gt "$MIN_BAZEL_MAJOR" ] || (
+            [ "$actual_major" -eq "$MIN_BAZEL_MAJOR" ] &&
+                [ "$actual_minor" -ge "$MIN_BAZEL_MINOR" ] ) )
+    then
+        echo "Need at least Bazel v${expected}. v${actual_raw} detected." >/dev/stderr
+        exit 1
+    fi
+}
 
-if [ -e WORKSPACE ] || [ -e BUILD ] || [ -e BazelExample.hs ]
-then
-    echo "Current directory already has WORKSPACE and/or BUILD and/or BazelExample.hs files." >/dev/stderr
-    exit 1
-fi
+check_files_dont_exist
+check_bazel_version
 
 cat > WORKSPACE <<"EOF"
 # Give your project a name. :)

--- a/start
+++ b/start
@@ -18,38 +18,47 @@ if ! ( [ "$actual_major" -gt "$MIN_BAZEL_MAJOR" ] || (
            [ "$actual_major" -eq "$MIN_BAZEL_MAJOR" ] &&
                [ "$actual_minor" -ge "$MIN_BAZEL_MINOR" ] ) )
 then
-    echo Need at least Bazel v${expected}. v${actual_raw} detected. >/dev/stderr
+    echo "Need at least Bazel v${expected}. v${actual_raw} detected." >/dev/stderr
     exit 1
 fi
 
-if [ -e WORKSPACE ] || [ -e BUILD ]
+if [ -e WORKSPACE ] || [ -e BUILD ] || [ -e BazelExample.hs ]
 then
-    echo Current directory already has WORKSPACE and/or BUILD files. >/dev/stderr
+    echo "Current directory already has WORKSPACE and/or BUILD and/or BazelExample.hs files." >/dev/stderr
     exit 1
 fi
 
-cat > WORKSPACE <<EOF
+cat > WORKSPACE <<"EOF"
+# Give your project a name. :)
 workspace(name = "YOUR_PROJECT_NAME_HERE")
 
+# Load the repository rule to download an http archive.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
+# Download `rules_haskell`.
+# and make it accessible `@io_tweag_rules_haskell`.
 http_archive(
   name = "io_tweag_rules_haskell",
   strip_prefix = "rules_haskell-0.8",
-  urls = ["https://github.com/tweag/rules_haskell/archive/v0.8.tar.gz"]
+  urls = ["https://github.com/tweag/rules_haskell/archive/v0.8.tar.gz"],
+  sha256 = "431d492a8ee6a110cdf42496181c9d27225dfb997379e64a148eb8e69f272ab7",
 )
 
 load("@io_tweag_rules_haskell//haskell:repositories.bzl", "haskell_repositories")
+# `haskell_repositories()` sets up all bazel dependencies
+# required by `rules_haskell`.
 haskell_repositories()
 
+# Note that you can use variables as well.
 rules_nixpkgs_version = "c232b296e795ad688854ff3d3d2de6e7ad45f0b4"
 rules_nixpkgs_sha256 = "5883ea01f3075354ab622cfe82542da01fe2b57a48f4c3f7610b4d14a3fced11"
 
+# `rules_nixpkgs` is used for fetching GHC and hackage packages.
 http_archive(
     name = "io_tweag_rules_nixpkgs",
-    sha256 = rules_nixpkgs_sha256,
     strip_prefix = "rules_nixpkgs-%s" % rules_nixpkgs_version,
     urls = ["https://github.com/tweag/rules_nixpkgs/archive/%s.tar.gz" % rules_nixpkgs_version],
+    sha256 = rules_nixpkgs_sha256,
 )
 
 load(
@@ -59,6 +68,7 @@ load(
     "nixpkgs_cc_configure",
 )
 
+# Fetch a stable version of `nixpkgs`.
 nixpkgs_git_repository(
     name = "nixpkgs",
     remote = "https://github.com/NixOS/nixpkgs",
@@ -66,49 +76,77 @@ nixpkgs_git_repository(
     sha256 = "6451af4083485e13daa427f745cbf859bc23cb8b70454c017887c006a13bd65e",
 )
 
+# The GHC distribution from `nixpkgs`.
 nixpkgs_package(
   name = "ghc",
   attribute_path = "haskell.compiler.ghc843",
   repository = "@nixpkgs",
 )
 
+# Use the CC toolchain from `nixpkgs`.
 nixpkgs_cc_configure(
     repository = "@nixpkgs",
 )
 
-register_toolchains("//:ghc")
+# Register the GHC toolchain defined in `./BUILD`.
+register_toolchains("//:ghc-toolchain")
 EOF
 
-cat > BUILD.bazel <<EOF
+cat > BUILD.bazel <<"EOF"
+# Set all target’s visibility in this package to "public".
 package(default_visibility = ["//visibility:public"])
 
+# Load `rules_haskell` rules.
 load(
   "@io_tweag_rules_haskell//haskell:haskell.bzl",
-  "haskell_library",
   "haskell_toolchain",
   "haskell_import",
+  "haskell_library",
+  "haskell_binary",
 )
 
+# `haskell_toolchain` sets up the GHC to be used
+# implicitely by all `haskell_*` rules.
 haskell_toolchain(
-  name = "ghc",
+  name = "ghc-toolchain",
   version = "8.4.3",
   tools = "@ghc//:bin",
 )
 
+# `haskell_import` can access builtin GHC packages
+# and assign them a bazel target name, so that they
+# can be referenced as dependencies.
 haskell_import(name = "base")
 
-haskell_library(
-  name = "MY_LIBRARY_NAME",
-  src_strip_prefix = "src",
-  srcs = glob(['src/**/*.hs']),
-  deps = [
-    "base_pkg"
-  ],
+# You can add your own libraries with `haskell_library`.
+# haskell_library(
+#   name = "MY_LIBRARY_NAME",
+#   src_strip_prefix = "src",
+#   srcs = glob(['src/**/*.hs']),
+#   deps = [
+#     "base_pkg"
+#   ],
+# )
+
+# An example binary using the Prelude module from the
+# GHC base package, to print the hello world.
+haskell_binary(
+  name = "example",
+  srcs = [":Example.hs"],
+  deps = [":base"],
 )
 EOF
 
-cat <<EOF
-WORKSPACE and initial BUILD files created. To run Bazel:
+cat > Example.hs <<"EOF"
+module Main where
 
-    $ bazel build //...
+import Prelude (putStrLn)
+
+main = putStrLn "Hello from rules_haskell!"
+EOF
+
+cat <<"EOF"
+WORKSPACE and initial BUILD files created. To run Bazel and build the example:
+
+    $ bazel run //:example
 EOF

--- a/tests/RunTests.hs
+++ b/tests/RunTests.hs
@@ -87,10 +87,9 @@ main = hspec $ do
       -- Set Nixpkgs in environment variable to avoid hardcoding it in
       -- start script itself
       , "NIX_PATH=nixpkgs=$pwd/nixpkgs/default.nix \
-        \bazel fetch \
+        \bazel build \
         \--config=ci \
-        \--override_repository=io_tweag_rules_haskell=$pwd \
-        \//..."
+        \//:example"
       ])
 
   describe "failures" $ do

--- a/tests/RunTests.hs
+++ b/tests/RunTests.hs
@@ -75,22 +75,7 @@ main = hspec $ do
       outputSatisfy p' (bazel ["run", "//tests/multi_repl:c_multi_repl", "--", "-ignore-dot-ghci", "-e", ":show targets"])
 
   it "startup script" $ do
-    assertSuccess (safeShell [
-        "pwd=$(pwd)"
-      , "cd $(mktemp -d)"
-      , "$pwd/start"
-
-      -- Copy the bazel configuration, this is only useful for CI
-      , "mkdir tools"
-      , "cp $pwd/.bazelrc .bazelrc"
-
-      -- Set Nixpkgs in environment variable to avoid hardcoding it in
-      -- start script itself
-      , "NIX_PATH=nixpkgs=$pwd/nixpkgs/default.nix \
-        \bazel build \
-        \--config=ci \
-        \//:example"
-      ])
+    assertSuccess (safeShell ["./tests/run-start-script.sh"])
 
   describe "failures" $ do
     all_failure_tests <- bazelQuery "kind(rule, //tests/failures/...) intersect attr('tags', 'manual', //tests/failures/...)"

--- a/tests/run-start-script.sh
+++ b/tests/run-start-script.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+# Run the start script in its own workspace
+# and build the example binary target.
+
+set -e
+
+pwd=$(pwd)
+cd $(mktemp -d)
+$pwd/start
+
+# Copy the bazel configuration, this is only useful for CI
+mkdir tools
+cp $pwd/.bazelrc .bazelrc
+
+# Set Nixpkgs in environment variable to avoid hardcoding it in
+# start script itself
+NIX_PATH=nixpkgs=$pwd/nixpkgs/default.nix \
+  bazel build \
+  --config=ci \
+  //:example


### PR DESCRIPTION
This PR improves the start script and the bindists.

- make the start script compile a runnable hello world module
- generate bindist file from official upstream hash files
- move from nixpkgs to bindists