### PR TITLE
Reused path patterns from REPL and implemented coverage scoping.

### DIFF
--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -145,7 +145,7 @@ def _mk_binary_rule(**kwargs):
                 default = False,
                 doc = "Requires that the coverage metric is matched exactly, even doing better than expected is not allowed.",
             ),
-            "coverage_source_patterns": attr.string_list(
+            "experimental_coverage_source_patterns": attr.string_list(
                 default = ["//..."],
                 doc = "The path patterns specifying which targets to analyze for test coverage metrics. Wildcarding is allowed.",
             ),

--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -145,6 +145,10 @@ def _mk_binary_rule(**kwargs):
                 default = False,
                 doc = "Requires that the coverage metric is matched exactly, even doing better than expected is not allowed.",
             ),
+            "coverage_source_patterns": attr.string_list(
+                default = ["//..."],
+                doc = "The path patterns specifying which targets to analyze for test coverage metrics. Wildcarding is allowed.",
+            ),
             "_coverage_wrapper_template": attr.label(
                 allow_single_file = True,
                 default = Label("@io_tweag_rules_haskell//haskell:private/coverage_wrapper.sh.tpl"),

--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -147,7 +147,12 @@ def _mk_binary_rule(**kwargs):
             ),
             "experimental_coverage_source_patterns": attr.string_list(
                 default = ["//..."],
-                doc = "The path patterns specifying which targets to analyze for test coverage metrics. Wildcarding is allowed.",
+                doc = """The path patterns specifying which targets to analyze for test coverage metrics.
+
+                Wild-card targets such as //... or //:all are allowed. The paths must be relative to the workspace, which means they must start with "//".
+
+                Note, this attribute may leave experimental status depending on the outcome of https://github.com/bazelbuild/bazel/issues/7763.
+                """,
             ),
             "_coverage_wrapper_template": attr.label(
                 allow_single_file = True,

--- a/haskell/private/coverage_wrapper.sh.tpl
+++ b/haskell/private/coverage_wrapper.sh.tpl
@@ -43,8 +43,14 @@ do
   trimmed_hpc_parent_dir=$(echo "${hpc_parent_dir%%.hpc*}")
   hpc_dir_args="$hpc_dir_args --hpcdir=$trimmed_hpc_parent_dir.hpc"
 done
+hpc_exclude_args=""
+modules_to_exclude={modules_to_exclude}
+for m in "${modules_to_exclude[@]}"
+do
+  hpc_exclude_args="$hpc_exclude_args --exclude=$m"
+done
 $binary_path "$@"
-$hpc_path report $tix_file_path $hpc_dir_args > __hpc_coverage_report
+$hpc_path report "$tix_file_path" $hpc_dir_args $hpc_exclude_args > __hpc_coverage_report
 echo "Overall report"
 cat __hpc_coverage_report
 

--- a/haskell/private/haskell_impl.bzl
+++ b/haskell/private/haskell_impl.bzl
@@ -214,7 +214,7 @@ def _haskell_binary_common_impl(ctx, is_test):
         ]
 
         # find which modules to exclude from coverage analysis, by using the specified source patterns
-        raw_coverage_source_patterns = ctx.attr.coverage_source_patterns
+        raw_coverage_source_patterns = ctx.attr.experimental_coverage_source_patterns
         coverage_source_patterns = [parse_pattern(pat) for pat in raw_coverage_source_patterns]
         modules_to_exclude = [paths.split_extension(datum.mix_file.basename)[0] for datum in coverage_data if not _coverage_enabled_for_target(coverage_source_patterns, datum.target_label)]
 

--- a/haskell/private/path_utils.bzl
+++ b/haskell/private/path_utils.bzl
@@ -334,6 +334,10 @@ def parse_pattern(pattern_str):
         target: The target name. None if the package ends on `...`. May be one
           of the wildcards `all` or `*`.
 
+    NOTE: it would be better if Bazel itself exposed this functionality to Starlark.
+
+    Any feature using this function should be marked as experimental, until the
+    resolution of https://github.com/bazelbuild/bazel/issues/7763.
     """
 
     # We only load targets in the local workspace anyway. So, it's never
@@ -389,6 +393,10 @@ def match_label(patterns, label):
       A boolean. True if the label is in the local workspace and matches any of
       the given patterns. False otherwise.
 
+    NOTE: it would be better if Bazel itself exposed this functionality to Starlark.
+
+    Any feature using this function should be marked as experimental, until the
+    resolution of https://github.com/bazelbuild/bazel/issues/7763.
     """
 
     # Only local workspace labels can match.

--- a/haskell/private/path_utils.bzl
+++ b/haskell/private/path_utils.bzl
@@ -386,7 +386,7 @@ def match_label(patterns, label):
 
     Args:
       patterns: A list of parsed patterns to match the label against.
-        Apply `_parse_pattern` before passing patterns into this function.
+        Apply `parse_pattern` before passing patterns into this function.
       label: Match this label against the patterns.
 
     Returns:

--- a/haskell/private/providers.bzl
+++ b/haskell/private/providers.bzl
@@ -1,10 +1,8 @@
 load(
     ":private/path_utils.bzl",
     "darwin_convert_to_dylibs",
-    "is_shared_library",
     "make_path",
 )
-load(":private/set.bzl", "set")
 
 DefaultCompileInfo = provider(
     doc = "Default compilation files and configuration.",
@@ -200,7 +198,7 @@ HaskellBinaryInfo = provider(
 HaskellCoverageInfo = provider(
     doc = "Information about coverage instrumentation for Haskell files.",
     fields = {
-        "mix_files": "A list of mix files, which track which parts of Haskell source code are being tracked for code coverage.",
+        "coverage_data": "A list of coverage data containing which parts of Haskell source code are being tracked for code coverage.",
     },
 )
 

--- a/haskell/repl.bzl
+++ b/haskell/repl.bzl
@@ -5,10 +5,9 @@ load("@bazel_skylib//lib:shell.bzl", "shell")
 load("@io_tweag_rules_haskell//haskell:private/context.bzl", "haskell_context", "render_env")
 load(
     "@io_tweag_rules_haskell//haskell:private/path_utils.bzl",
-    "get_lib_name",
-    "is_shared_library",
     "link_libraries",
-    "ln",
+    "match_label",
+    "parse_pattern",
     "target_unique_name",
 )
 load(
@@ -174,114 +173,14 @@ def _merge_HaskellReplCollectInfo(args):
         transitive_cc_dependencies = transitive_cc_dependencies,
     )
 
-def _parse_pattern(pattern_str):
-    """Parses a string label pattern.
-
-    Args:
-      pattern_str: The pattern to parse.
-        Patterns are absolute labels in the local workspace. E.g.
-        `//some/package:some_target`. The following wild-cards are allowed:
-        `...`, `:all`, and `:*`. Also the `//some/package` shortcut is allowed.
-
-    Returns:
-      A struct of
-        package: A list of package path components. May end on the wildcard `...`.
-        target: The target name. None if the package ends on `...`. May be one
-          of the wildcards `all` or `*`.
-
-    """
-
-    # We only load targets in the local workspace anyway. So, it's never
-    # necessary to specify a workspace. Therefore, we don't allow it.
-    if pattern_str.startswith("@"):
-        fail("Invalid haskell_repl pattern. Patterns may not specify a workspace. They only apply to the current workspace")
-
-    # To keep things simple, all patterns have to be absolute.
-    if not pattern_str.startswith("//"):
-        fail("Invalid haskell_repl pattern. Patterns must start with //.")
-
-    # Separate package and target (if present).
-    package_target = pattern_str[2:].split(":", maxsplit = 2)
-    package_str = package_target[0]
-    target_str = None
-    if len(package_target) == 2:
-        target_str = package_target[1]
-
-    # Parse package pattern.
-    package = []
-    dotdotdot = False  # ... has to be last component in the pattern.
-    for s in package_str.split("/"):
-        if dotdotdot:
-            fail("Invalid haskell_repl pattern. ... has to appear at the end.")
-        if s == "...":
-            dotdotdot = True
-        package.append(s)
-
-    # Parse target pattern.
-    if dotdotdot:
-        if target_str != None:
-            fail("Invalid haskell_repl pattern. ... has to appear at the end.")
-    elif target_str == None:
-        if len(package) > 0 and package[-1] != "":
-            target_str = package[-1]
-        else:
-            fail("Invalid haskell_repl pattern. The empty string is not a valid target.")
-
-    return struct(
-        package = package,
-        target = target_str,
-    )
-
-def _match_label(pattern, label):
-    """Whether the given local workspace label matches any of the patterns.
-
-    Args:
-      patterns: A list of parsed patterns to match the label against.
-        Apply `_parse_pattern` before passing patterns into this function.
-      label: Match this label against the patterns.
-
-    Returns:
-      A boolean. True if the label is in the local workspace and matches any of
-      the given patterns. False otherwise.
-
-    """
-
-    # Only local workspace labels can match.
-    # Despite the docs saying otherwise, labels don't have a workspace_name
-    # attribute. So, we use the workspace_root. If it's empty, the target is in
-    # the local workspace. Otherwise, it's an external target.
-    if label.workspace_root != "":
-        return False
-
-    package = label.package.split("/")
-    target = label.name
-
-    # Match package components.
-    for i in range(min(len(pattern.package), len(package))):
-        if pattern.package[i] == "...":
-            return True
-        elif pattern.package[i] != package[i]:
-            return False
-
-    # If no wild-card or mismatch was encountered, the lengths must match.
-    # Otherwise, the label's package is not covered.
-    if len(pattern.package) != len(package):
-        return False
-
-    # Match target.
-    if pattern.target == "all" or pattern.target == "*":
-        return True
-    else:
-        return pattern.target == target
-
 def _load_as_source(from_source, from_binary, lbl):
     """Whether a package should be loaded by source or as binary."""
     for pat in from_binary:
-        if _match_label(pat, lbl):
+        if match_label(pat, lbl):
             return False
 
     for pat in from_source:
-        if _match_label(pat, lbl):
+        if match_label(pat, lbl):
             return True
 
     return False
@@ -482,8 +381,8 @@ def _haskell_repl_impl(ctx):
         for dep in ctx.attr.deps
         if HaskellReplCollectInfo in dep
     ])
-    from_source = [_parse_pattern(pat) for pat in ctx.attr.experimental_from_source]
-    from_binary = [_parse_pattern(pat) for pat in ctx.attr.experimental_from_binary]
+    from_source = [parse_pattern(pat) for pat in ctx.attr.experimental_from_source]
+    from_binary = [parse_pattern(pat) for pat in ctx.attr.experimental_from_binary]
     repl_info = _create_HaskellReplInfo(from_source, from_binary, collect_info)
     hs = haskell_context(ctx)
     return _create_repl(hs, ctx, repl_info, ctx.outputs.repl)

--- a/tests/two-libs/BUILD
+++ b/tests/two-libs/BUILD
@@ -29,7 +29,8 @@ haskell_library(
 haskell_test(
     name = "two-libs",
     srcs = ["Main.hs"],
-    expected_covered_expressions_percentage = 73,
+    coverage_source_patterns = ["//tests/two-libs:two"],
+    expected_covered_expressions_percentage = 55,
     expected_uncovered_expression_count = 4,
     strict_coverage_analysis = True,
     tags = ["coverage-compatible"],

--- a/tests/two-libs/BUILD
+++ b/tests/two-libs/BUILD
@@ -29,9 +29,9 @@ haskell_library(
 haskell_test(
     name = "two-libs",
     srcs = ["Main.hs"],
-    coverage_source_patterns = ["//tests/two-libs:two"],
     expected_covered_expressions_percentage = 55,
     expected_uncovered_expression_count = 4,
+    experimental_coverage_source_patterns = ["//tests/two-libs:two"],
     strict_coverage_analysis = True,
     tags = ["coverage-compatible"],
     deps = [


### PR DESCRIPTION
This allows a haskell_test to scope which targets in its dependencies are included in coverage analysis. By default, they all are, even transitive dependencies.

Documentation update to come in a later PR.

This resolves: https://github.com/tweag/rules_haskell/issues/764