### PR TITLE
Allow GHC plugins to call executables

### DIFF
--- a/haskell/plugins.bzl
+++ b/haskell/plugins.bzl
@@ -1,11 +1,18 @@
 load(":private/providers.bzl", "GhcPluginInfo", "HaskellLibraryInfo")
 
 def ghc_plugin_impl(ctx):
-    args = [ctx.expand_make_variables("args", i, {}) for i in ctx.attr.args]
+    args = ctx.attr.args
+    args = [ctx.expand_location(arg, ctx.attr.tools) for arg in args]
+    args = [ctx.expand_make_variables("args", arg, {}) for arg in args]
+
+    # XXX Ideally we'd resolve tools downstream.
+    (tool_inputs, tool_input_manifests) = ctx.resolve_tools(tools = ctx.attr.tools)
     return [
         GhcPluginInfo(
             module = ctx.attr.module,
             deps = ctx.attr.deps,
+            tool_inputs = tool_inputs,
+            tool_input_manifests = tool_input_manifests,
             args = args,
         ),
     ]

--- a/haskell/private/actions/compile.bzl
+++ b/haskell/private/actions/compile.bzl
@@ -268,6 +268,13 @@ def _compilation_defaults(hs, cc, java, dep_info, plugin_dep_info, srcs, import_
         for opt in plugin[GhcPluginInfo].args:
             args.add_all(["-fplugin-opt", "{}:{}".format(plugin[GhcPluginInfo].module, opt)])
 
+    plugin_tool_inputs = [plugin[GhcPluginInfo].tool_inputs for plugin in plugins]
+    plugin_tool_input_manifests = [
+        manifest
+        for plugin in plugins
+        for manifest in plugin[GhcPluginInfo].tool_input_manifests
+    ]
+
     # Pass source files
     for f in set.to_list(source_files):
         args.add(f)
@@ -306,7 +313,9 @@ def _compilation_defaults(hs, cc, java, dep_info, plugin_dep_info, srcs, import_
             depset(ld_library_deps),
             java.inputs,
             locale_archive_depset,
+            depset(transitive = plugin_tool_inputs),
         ]),
+        input_manifests = plugin_tool_input_manifests,
         objects_dir = objects_dir,
         interfaces_dir = interfaces_dir,
         outputs = [objects_dir, interfaces_dir],
@@ -373,6 +382,7 @@ def compile_binary(
         hs,
         cc,
         inputs = c.inputs,
+        input_manifests = c.input_manifests,
         outputs = c.outputs + conditioned_mix_files,
         mnemonic = "HaskellBuildBinary" + ("Prof" if with_profiling else ""),
         progress_message = "HaskellBuildBinary {}".format(hs.label),
@@ -457,6 +467,7 @@ def compile_library(
         hs,
         cc,
         inputs = c.inputs,
+        input_manifests = c.input_manifests,
         outputs = c.outputs + conditioned_mix_files,
         mnemonic = "HaskellBuildLibrary" + ("Prof" if with_profiling else ""),
         progress_message = "HaskellBuildLibrary {}".format(hs.label),

--- a/haskell/private/providers.bzl
+++ b/haskell/private/providers.bzl
@@ -12,6 +12,7 @@ DefaultCompileInfo = provider(
         "args": "Default argument list.",
         "ghc_args": "Arguments that were used to compile the package.",
         "inputs": "Default inputs.",
+        "input_manifests": "Input manifests",
         "outputs": "Default outputs.",
         "objects_dir": "Object files directory.",
         "interfaces_dir": "Interface files directory.",
@@ -249,5 +250,7 @@ GhcPluginInfo = provider(
         "module": "Plugin entrypoint.",
         "deps": "Plugin dependencies.",
         "args": "Plugin options.",
+        "tool_inputs": "Inputs required for plugin tools.",
+        "tool_input_manifests": "Plugin tools input manifests.",
     },
 )

--- a/tests/binary-with-plugin/BUILD
+++ b/tests/binary-with-plugin/BUILD
@@ -19,20 +19,23 @@ haskell_import(name = "base")
 
 haskell_import(name = "ghc")
 
+haskell_import(name = "process")
+
 haskell_library(
     name = "plugin-lib",
     srcs = ["Plugin.hs"],
     deps = [
         ":base",
         ":ghc",
+        ":process",
     ],
 )
 
 ghc_plugin(
     name = "plugin",
-    args = ["$(JAVABASE)/bin/javac"],
+    args = ["$(location //tests/binary-simple)"],
     module = "Plugin",
-    toolchains = ["@bazel_tools//tools/jdk:current_java_runtime"],
+    tools = ["//tests/binary-simple"],
     deps = [":plugin-lib"],
 )
 

--- a/tests/binary-with-plugin/Plugin.hs
+++ b/tests/binary-with-plugin/Plugin.hs
@@ -2,6 +2,7 @@ module Plugin (plugin) where
 
 import Control.Monad (when)
 import GhcPlugins
+import System.Process (readProcess)
 
 plugin :: Plugin
 plugin = defaultPlugin { installCoreToDos = install }
@@ -10,4 +11,5 @@ install :: [CommandLineOption] -> [CoreToDo] -> CoreM [CoreToDo]
 install [arg] todo = do
   when ('$' `elem` arg) $
     fail "Make variable not expanded."
+  _ <- liftIO $ readProcess arg [] ""
   return todo


### PR DESCRIPTION
We add a new `tools` attribute to `ghc_plugin`. Bazel 0.23 adds
specific support for this attribute in the form of
`ctx.resolve_tools()`. These tools are added as extra inputs during
execution of the compilation command.

cc @facundominguez