### PR TITLE
Html coverage reports: output to testlog

### DIFF
--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -148,6 +148,12 @@ def _mk_binary_rule(**kwargs):
                 default = False,
                 doc = "Requires that the coverage metric is matched exactly, even doing better than expected is not allowed.",
             ),
+            "coverage_report_format": attr.string(
+                default = "text",
+                doc = """The format to output the coverage report in. Supported values: "text", "html". Default: "text". 
+                Report can be seen in the testlog XML file, or by setting --test_output=all when running bazel coverage.
+                """,
+            ),
             "experimental_coverage_source_patterns": attr.string_list(
                 default = ["//..."],
                 doc = """The path patterns specifying which targets to analyze for test coverage metrics.

--- a/haskell/private/actions/compile.bzl
+++ b/haskell/private/actions/compile.bzl
@@ -10,13 +10,13 @@ load(
 load(
     ":private/path_utils.bzl",
     "declare_compiled",
+    "module_name",
     "target_unique_name",
 )
 load(":private/pkg_id.bzl", "pkg_id")
 load(
     ":private/providers.bzl",
     "GhcPluginInfo",
-    "HaskellLibraryInfo",
     "get_libs_for_ghc_linker",
     "merge_HaskellCcInfo",
 )
@@ -335,6 +335,13 @@ def _hpc_compiler_args(hs):
     hpcdir = "{}/{}/.hpc".format(hs.bin_dir.path, hs.package_root)
     return ["-fhpc", "-hpcdir", hpcdir]
 
+def _coverage_datum(mix_file, src_file, target_label):
+    return struct(
+        mix_file = mix_file,
+        src_file = src_file,
+        target_label = target_label,
+    )
+
 def compile_binary(
         hs,
         cc,
@@ -351,7 +358,6 @@ def compile_binary(
         main_function,
         version,
         inspect_coverage = False,
-        mix_files = [],
         plugins = []):
     """Compile a Haskell target into object files suitable for linking.
 
@@ -371,19 +377,20 @@ def compile_binary(
         # case.
         c.args.add_all(["-dynamic", "-osuf dyn_o"])
 
-    conditioned_mix_files = []
+    coverage_data = []
     if inspect_coverage:
         c.args.add_all(_hpc_compiler_args(hs))
-        for m in mix_files:
-            conditioned_file = hs.actions.declare_file(".hpc/" + m)
-            conditioned_mix_files.append(conditioned_file)
+        for src_file in srcs:
+            module = module_name(hs, src_file)
+            mix_file = hs.actions.declare_file(".hpc/{module}.mix".format(module = module))
+            coverage_data.append(_coverage_datum(mix_file, src_file, hs.label))
 
     hs.toolchain.actions.run_ghc(
         hs,
         cc,
         inputs = c.inputs,
         input_manifests = c.input_manifests,
-        outputs = c.outputs + conditioned_mix_files,
+        outputs = c.outputs + [datum.mix_file for datum in coverage_data],
         mnemonic = "HaskellBuildBinary" + ("Prof" if with_profiling else ""),
         progress_message = "HaskellBuildBinary {}".format(hs.label),
         env = c.env,
@@ -417,7 +424,7 @@ def compile_binary(
         ghc_args = c.ghc_args,
         header_files = c.header_files,
         exposed_modules_file = exposed_modules_file,
-        conditioned_mix_files = conditioned_mix_files,
+        coverage_data = coverage_data,
     )
 
 def compile_library(
@@ -436,7 +443,6 @@ def compile_library(
         with_shared,
         with_profiling,
         my_pkg_id,
-        mix_files = [],
         plugins = []):
     """Build arguments for Haskell package build.
 
@@ -455,20 +461,21 @@ def compile_library(
     if with_shared:
         c.args.add("-dynamic-too")
 
-    conditioned_mix_files = []
+    coverage_data = []
     if hs.coverage_enabled:
         c.args.add_all(_hpc_compiler_args(hs))
-        for m in mix_files:
+        for src_file in srcs:
             pkg_id_string = pkg_id.to_string(my_pkg_id)
-            conditioned_file = hs.actions.declare_file(".hpc/" + pkg_id_string + "/" + m)
-            conditioned_mix_files.append(conditioned_file)
+            module = module_name(hs, src_file)
+            mix_file = hs.actions.declare_file(".hpc/{pkg}/{module}.mix".format(pkg = pkg_id_string, module = module))
+            coverage_data.append(_coverage_datum(mix_file, src_file, hs.label))
 
     hs.toolchain.actions.run_ghc(
         hs,
         cc,
         inputs = c.inputs,
         input_manifests = c.input_manifests,
-        outputs = c.outputs + conditioned_mix_files,
+        outputs = c.outputs + [datum.mix_file for datum in coverage_data],
         mnemonic = "HaskellBuildLibrary" + ("Prof" if with_profiling else ""),
         progress_message = "HaskellBuildLibrary {}".format(hs.label),
         env = c.env,
@@ -524,5 +531,5 @@ def compile_library(
         extra_source_files = c.extra_source_files,
         import_dirs = c.import_dirs,
         exposed_modules_file = exposed_modules_file,
-        conditioned_mix_files = conditioned_mix_files,
+        coverage_data = coverage_data,
     )

--- a/haskell/private/coverage_wrapper.sh.tpl
+++ b/haskell/private/coverage_wrapper.sh.tpl
@@ -28,12 +28,14 @@ CLEARCOLOR='\033[0m'
 binary_path=$(rlocation {binary_path})
 hpc_path=$(rlocation {hpc_path})
 tix_file_path={tix_file_path}
+coverage_report_format={coverage_report_format}
+strict_coverage_analysis={strict_coverage_analysis}
 
 # either of the two expected coverage metrics should be set to -1 if they're meant to be unused
 expected_covered_expressions_percentage={expected_covered_expressions_percentage}
 expected_uncovered_expression_count={expected_uncovered_expression_count}
 
-strict_coverage_analysis={strict_coverage_analysis}
+# gather the hpc directories
 hpc_dir_args=""
 mix_file_paths={mix_file_paths}
 for m in "${mix_file_paths[@]}"
@@ -43,14 +45,28 @@ do
   trimmed_hpc_parent_dir=$(echo "${hpc_parent_dir%%.hpc*}")
   hpc_dir_args="$hpc_dir_args --hpcdir=$trimmed_hpc_parent_dir.hpc"
 done
+
+# gather the src directories
+src_dir_args=""
+source_file_paths={source_file_paths}
+for s in "${source_file_paths[@]}"
+do
+  absolute_src_file_path=$(rlocation $s)
+  src_parent_dir=$(dirname $absolute_src_file_path)
+  src_dir_args="$src_dir_args --srcdir=$src_parent_dir"
+done
+
+# gather the modules to exclude from the coverage analysis
 hpc_exclude_args=""
 modules_to_exclude={modules_to_exclude}
 for m in "${modules_to_exclude[@]}"
 do
   hpc_exclude_args="$hpc_exclude_args --exclude=$m"
 done
+
+# generate the report
 $binary_path "$@"
-$hpc_path report "$tix_file_path" $hpc_dir_args $hpc_exclude_args > __hpc_coverage_report
+$hpc_path report "$tix_file_path" $hpc_dir_args $src_dir_args $hpc_exclude_args > __hpc_coverage_report
 echo "Overall report"
 cat __hpc_coverage_report
 

--- a/tests/two-libs/BUILD
+++ b/tests/two-libs/BUILD
@@ -29,6 +29,7 @@ haskell_library(
 haskell_test(
     name = "two-libs",
     srcs = ["Main.hs"],
+    coverage_report_format = "html",
     expected_covered_expressions_percentage = 55,
     expected_uncovered_expression_count = 4,
     experimental_coverage_source_patterns = ["//tests/two-libs:two"],


### PR DESCRIPTION
This work allows the generation of HTML coverage reports from `hpc`, when the `haskell_test` attribute `coverage_report_format` is set to be `html` (default is `text`, which is the standard little text report we've had so far).

This isn't entirely useful yet (no one wants to look at HTML as text), but it can be useful if the test.xml is parsed, and the individual HTML report files are extracted into a directory where their links will work correctly.

This is related to, but does not complete, https://github.com/tweag/rules_haskell/issues/809.