### PR TITLE
Make the static and/or dynamic library files the default outputs of a library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   `//haskell/haskell.bzl`. You must now load that macro from
   `//haskell:nixpkgs.bzl`. rules_nixpkgs is now no longer a dependency
   of rules_haskell.
+* The default outputs of `haskell_library` are now the static and/or
+  shared library files, not the package database config and cache
+  files.
 
 ## [0.8] - 2019-01-28
 

--- a/haskell/private/haskell_impl.bzl
+++ b/haskell/private/haskell_impl.bzl
@@ -438,7 +438,7 @@ def haskell_library_impl(ctx):
         coverage_data = dep_coverage_data + c.coverage_data,
     )
 
-    target_files = depset([conf_file, cache_file])
+    target_files = depset([file for file in [static_library, dynamic_library] if file])
 
     if hasattr(ctx, "outputs"):
         build_haskell_repl(

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -114,24 +114,21 @@ sh_test(
 rule_test(
     name = "test-library-deps",
     size = "small",
-    generates =
-        [
-            "testsZSlibrary-depsZSlibrary-deps/testsZSlibrary-depsZSlibrary-deps.conf",
-            "testsZSlibrary-depsZSlibrary-deps/package.cache",
+    generates = select({
+        "@bazel_tools//src/conditions:darwin": [
+            "libHStestsZSlibrary-depsZSlibrary-deps-ghc{}.dylib".format(test_ghc_version),
+            "libHStestsZSlibrary-depsZSlibrary-deps.a",
         ],
+        "@bazel_tools//src/conditions:windows": [
+            "libHStestsZSlibrary-depsZSlibrary-deps-ghc{}.dll".format(test_ghc_version),
+            "libHStestsZSlibrary-depsZSlibrary-deps.a",
+        ],
+        "//conditions:default": [
+            "libHStestsZSlibrary-depsZSlibrary-deps-ghc{}.so".format(test_ghc_version),
+            "libHStestsZSlibrary-depsZSlibrary-deps.a",
+        ],
+    }),
     rule = "//tests/library-deps",
-)
-
-rule_test(
-    name = "test-library-with-sysdeps",
-    size = "small",
-    generates =
-        [
-            "testsZSlibrary-with-sysdepsZSlibrary-with-sysdeps/testsZSlibrary-with-sysdepsZSlibrary-with-sysdeps.conf",
-            "testsZSlibrary-with-sysdepsZSlibrary-with-sysdeps/package.cache",
-        ],
-    rule = "//tests/library-with-sysdeps",
-    tags = ["requires_zlib"],
 )
 
 rule_test(
@@ -173,17 +170,6 @@ rule_test(
 )
 
 rule_test(
-    name = "test-haskell_proto_library",
-    size = "small",
-    generates = [
-        "testsZShaskellZUprotoZUlibraryZShs-lib/package.cache",
-        "testsZShaskellZUprotoZUlibraryZShs-lib/testsZShaskellZUprotoZUlibraryZShs-lib.conf",
-    ],
-    rule = "//tests/haskell_proto_library:hs-lib",
-    tags = ["requires_hackage"],
-)
-
-rule_test(
     name = "test-haskell_doctest",
     size = "small",
     generates = [
@@ -201,59 +187,10 @@ rule_test(
 )
 
 rule_test(
-    name = "test-hidden-modules",
-    size = "small",
-    generates = [
-        "testsZShidden-modulesZSlib-c/testsZShidden-modulesZSlib-c.conf",
-        "testsZShidden-modulesZSlib-c/package.cache",
-    ],
-    rule = "//tests/hidden-modules:lib-c",
-)
-
-rule_test(
-    name = "test-library-with-sysincludes",
-    size = "small",
-    generates =
-        [
-            "testsZSlibrary-with-sysincludesZSlibrary-with-sysincludes/testsZSlibrary-with-sysincludesZSlibrary-with-sysincludes.conf",
-            "testsZSlibrary-with-sysincludesZSlibrary-with-sysincludes/package.cache",
-        ],
-    rule = "//tests/library-with-sysincludes",
-    tags = ["requires_zlib"],
-)
-
-rule_test(
-    name = "test-package-id-clash",
-    size = "small",
-    generates =
-        [
-            "testsZSpackage-id-clashZSlib/testsZSpackage-id-clashZSlib.conf",
-            "testsZSpackage-id-clashZSlib/package.cache",
-        ],
-    rule = "//tests/package-id-clash:lib",
-)
-
-rule_test(
     name = "test-java_classpath",
     size = "small",
     generates = ["java_classpath"],
     rule = "//tests/java_classpath",
-)
-
-rule_test(
-    name = "test-cc_haskell_import-output",
-    size = "small",
-    generates = select({
-        "@bazel_tools//src/conditions:darwin": [
-            "libHStestsZSccZUhaskellZUimportZShs-lib-a-ghc{version}.dylib".format(version = test_ghc_version),
-            "libHStestsZSccZUhaskellZUimportZShs-lib-b-ghc{version}.dylib".format(version = test_ghc_version),
-        ],
-        "//conditions:default": [
-            "libHStestsZSccZUhaskellZUimportZShs-lib-a-ghc{version}.so".format(version = test_ghc_version),
-            "libHStestsZSccZUhaskellZUimportZShs-lib-b-ghc{version}.so".format(version = test_ghc_version),
-        ],
-    }),
-    rule = "//tests/cc_haskell_import:hs-lib-b.so",
 )
 
 rule_test(


### PR DESCRIPTION
The default outputs used to be the package conf file and the package
cache file. That was rather arbitrary and doesn't play nice with
feeding the outputs of `haskell_library` targets as inputs to
`cc_library`.