### PR TITLE
Use dll as shared object on Windows

### DIFF
--- a/haskell/private/path_utils.bzl
+++ b/haskell/private/path_utils.bzl
@@ -157,6 +157,39 @@ def darwin_convert_to_dylibs(hs, libs):
             new_libs.append(lib)
     return new_libs
 
+def windows_convert_to_dlls(hs, libs):
+    """Convert .so dynamic libraries to .dll.
+
+    Bazel's cc_library rule will create .so files for dynamic libraries even
+    on Windows. GHC's builtin linker, which is used during compilation, GHCi,
+    or doctests, hard-codes the assumption that all dynamic libraries on Windows
+    end on .dll. This function serves as an adaptor and produces symlinks
+    from a .dll version to the .so version for every dynamic library
+    dependencies that does not end on .dll.
+
+    Args:
+      hs: Haskell context.
+      libs: List of library files dynamic or static.
+
+    Returns:
+      List of library files where all dynamic libraries end on .dll.
+    """
+    lib_prefix = "_dlls"
+    new_libs = []
+    for lib in libs:
+        if is_shared_library(lib) and lib.extension != "dll":
+            dll_name = paths.join(
+                target_unique_name(hs, lib_prefix),
+                paths.dirname(lib.short_path),
+                "lib" + get_lib_name(lib) + ".dll",
+            )
+            dll = hs.actions.declare_file(dll_name)
+            ln(hs, lib, dll)
+            new_libs.append(dll)
+        else:
+            new_libs.append(lib)
+    return new_libs
+
 def get_lib_name(lib):
     """Return name of library by dropping extension and "lib" prefix.
 

--- a/haskell/private/providers.bzl
+++ b/haskell/private/providers.bzl
@@ -2,6 +2,7 @@ load(
     ":private/path_utils.bzl",
     "darwin_convert_to_dylibs",
     "make_path",
+    "windows_convert_to_dlls",
 )
 
 HaskellCcInfo = provider(
@@ -123,6 +124,12 @@ def get_libs_for_ghc_linker(hs, transitive_cc_dependencies, path_prefix = None):
         library_deps = darwin_convert_to_dylibs(hs, _library_deps)
 
         # Additionally ghc 8.4 requires library_deps here although 8.6 does not
+        ld_library_deps = library_deps + _ld_library_deps
+    elif hs.toolchain.is_windows:
+        # GHC's builtin linker requires .dll files on Windows.
+        library_deps = windows_convert_to_dlls(hs, _library_deps)
+
+        # copied over from Darwin 5 lines above
         ld_library_deps = library_deps + _ld_library_deps
     else:
         library_deps = _library_deps


### PR DESCRIPTION
Fixes #811 

This fixes the name of Haskell shared objects on Windows. By default
Bazel's cc_library generates '.so' files, whereas GHC expects a .dll (or
a few other extensions, non of which are .so):
https://github.com/ghc/ghc/blob/51fd357119b357c52e990ccce9059c423cc49406/rts/linker/PEi386.c#L684