### PR TITLE
hazel: windows: fix unix-compat

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -31,6 +31,7 @@ jobs:
       /c/bazel/bazel.exe build --config windows "@haskell_lens//..."
       /c/bazel/bazel.exe build --config windows "@haskell_text__metrics//..."
       /c/bazel/bazel.exe build --config windows "@haskell_cryptonite//..."
+      /c/bazel/bazel.exe build --config windows "@haskell_unix__compat//..."
 
       # FIXME:
       # this rule is missing dependency declarations for the following files included by 'external/haskell_zlib/cbits/adler32.c':

--- a/hazel/hazel.bzl
+++ b/hazel/hazel.bzl
@@ -140,10 +140,14 @@ def hazel_repositories(
           specified).
         - output, type, stripPrefix: Only when "url" is specified. See the
           download_and_extract documentation.
-        - patches: list of labels, patch files to apply after unpacking.
-        - patch_tool: string, patch executable.
-        - patch_args: list of strings, extra arguments to patch tool.
-        - patch_cmds: list of strings, commands to apply after patches.
+        - patches: list of labels, a list of files that are to be applied as
+	  patches after extracting the archive.
+        - patch_tool: string, the patch(1) utility to use.
+        - patch_args: list of strings, the arguments given to the patch tool.
+        - patch_cmds: list of strings, sequence of commands to be executed after
+	  patches are applied.
+	The patch fields are forwarded to the patch function from bazel_tools:
+	https://github.com/bazelbuild/bazel/blob/b941e0b939c18257107f7f4b5186ae3a4b770eac/tools/build_defs/repo/utils.bzl#L70-L101
       extra_flags: A dict mapping package names to cabal flags.
       exclude_packages: names of packages to exclude.
       extra_libs: A dictionary that maps from name of extra libraries to Bazel

--- a/hazel/third_party/haskell/unix-compat.patch
+++ b/hazel/third_party/haskell/unix-compat.patch
@@ -1,0 +1,14 @@
+--- src/System/PosixCompat/Files.hsc    2018-08-23 02:44:16.000000000 +0200
++++ src/System/PosixCompat/Files.hsc    2019-04-15 13:41:46.371761110 +0200
+@@ -392,11 +392,7 @@
+ -- Renaming
+
+ rename :: FilePath -> FilePath -> IO ()
+-#if MIN_VERSION_Win32(2, 6, 0)
+ rename name1 name2 = moveFileEx name1 (Just name2) mOVEFILE_REPLACE_EXISTING
+-#else
+-rename name1 name2 = moveFileEx name1 name2 mOVEFILE_REPLACE_EXISTING
+-#endif
+
+ -- -----------------------------------------------------------------------------
+ -- chown()

--- a/hazel/workspace.bzl
+++ b/hazel/workspace.bzl
@@ -98,6 +98,7 @@ cc_library(
         packages = hazel_extra_packages(
             pkgs = packages,
             extra_pkgs = {
+                "unix-compat": {"version": "0.5.1", "sha256": "a39d0c79dd906763770b80ba5b6c5cb710e954f894350e9917de0d73f3a19c52", "patches": ["@ai_formation_hazel//third_party/haskell:unix-compat.patch"]},
                 "unix-time": {"version": "0.4.5", "sha256": "fe7805c62ad682589567afeee265e6e230170c3941cdce479a2318d1c5088faf"},
             },
         ),


### PR DESCRIPTION
- Allow to apply patches to Hazel packages fetched from Hackage or custom URLs.
- Apply patch to `unix-compat` fixing issue #796 due to missing version macros in `hsc` files.

Closes #796.