### PR TITLE
Html report extraction tool

### DIFF
--- a/haskell/private/coverage_wrapper.sh.tpl
+++ b/haskell/private/coverage_wrapper.sh.tpl
@@ -55,7 +55,7 @@ do
 done
 
 # run the test binary, and then generate the report
-$binary_path "$@" > /dev/null
+$binary_path "$@" > /dev/null 2>&1
 $hpc_path report "$tix_file_path" $hpc_dir_args $hpc_exclude_args > __hpc_coverage_report
 
 # if we want a text report, just output the file generated in the previous step
@@ -109,12 +109,14 @@ fi
 # and feed its generated files into stdout, wrapped in XML tags
 if [ "$coverage_report_format" == "html" ]
 then
-  $hpc_path markup "$tix_file_path" $hpc_dir_args $hpc_exclude_args --destdir=hpc_out > /dev/null
+  $hpc_path markup "$tix_file_path" $hpc_dir_args $hpc_exclude_args --destdir=hpc_out > /dev/null 2>&1
   cd hpc_out
   for file in *.html **/*.hs.html; do
     [ -e "$file" ] || continue
-    echo "<coverage-result-file name=\"$file\">"
+    echo "<coverage-report-part name=\"$file\">"
+    echo "<![CDATA["
     cat $file
-    echo "</coverage-result-file>"
+    echo "]]>"
+    echo "</coverage-report-part>"
   done
 fi

--- a/haskell/private/haskell_impl.bzl
+++ b/haskell/private/haskell_impl.bzl
@@ -208,6 +208,10 @@ def _haskell_binary_common_impl(ctx, is_test):
             paths.join(ctx.workspace_name, datum.mix_file.short_path)
             for datum in coverage_data
         ]
+        source_file_paths = [
+            paths.join(ctx.workspace_name, datum.src_file.short_path)
+            for datum in coverage_data
+        ]
 
         # find which modules to exclude from coverage analysis, by using the specified source patterns
         raw_coverage_source_patterns = ctx.attr.experimental_coverage_source_patterns
@@ -233,6 +237,7 @@ def _haskell_binary_common_impl(ctx, is_test):
                 "{expected_covered_expressions_percentage}": str(expected_covered_expressions_percentage),
                 "{expected_uncovered_expression_count}": str(expected_uncovered_expression_count),
                 "{mix_file_paths}": shell.array_literal(mix_file_paths),
+                "{source_file_paths}": shell.array_literal(source_file_paths),
                 "{modules_to_exclude}": shell.array_literal(modules_to_exclude),
                 "{strict_coverage_analysis}": str(strict_coverage_analysis),
                 "{coverage_report_format}": shell.quote(ctx.attr.coverage_report_format),

--- a/haskell/private/haskell_impl.bzl
+++ b/haskell/private/haskell_impl.bzl
@@ -208,10 +208,6 @@ def _haskell_binary_common_impl(ctx, is_test):
             paths.join(ctx.workspace_name, datum.mix_file.short_path)
             for datum in coverage_data
         ]
-        source_file_paths = [
-            paths.join(ctx.workspace_name, datum.src_file.short_path)
-            for datum in coverage_data
-        ]
 
         # find which modules to exclude from coverage analysis, by using the specified source patterns
         raw_coverage_source_patterns = ctx.attr.experimental_coverage_source_patterns
@@ -237,7 +233,6 @@ def _haskell_binary_common_impl(ctx, is_test):
                 "{expected_covered_expressions_percentage}": str(expected_covered_expressions_percentage),
                 "{expected_uncovered_expression_count}": str(expected_uncovered_expression_count),
                 "{mix_file_paths}": shell.array_literal(mix_file_paths),
-                "{source_file_paths}": shell.array_literal(source_file_paths),
                 "{modules_to_exclude}": shell.array_literal(modules_to_exclude),
                 "{strict_coverage_analysis}": str(strict_coverage_analysis),
                 "{coverage_report_format}": shell.quote(ctx.attr.coverage_report_format),

--- a/tools/coverage-reports/BUILD
+++ b/tools/coverage-reports/BUILD
@@ -1,0 +1,20 @@
+load(
+    "@io_tweag_rules_haskell//haskell:haskell.bzl",
+    "haskell_binary",
+)
+
+haskell_binary(
+    name = "coverage-report-renderer",
+    srcs = ["Main.hs"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@hackage//:MissingH",
+        "@hackage//:base",
+        "@hackage//:cmdargs",
+        "@hackage//:directory",
+        "@hackage//:filepath",
+        "@hackage//:hxt",
+        "@hackage//:hxt-xpath",
+        "@hackage//:listsafe",
+    ],
+)

--- a/tools/coverage-reports/Main.hs
+++ b/tools/coverage-reports/Main.hs
@@ -1,0 +1,119 @@
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+import Control.Monad (forM_)
+
+import Control.Arrow.ListArrow (runLA)
+import Data.List (find)
+import Data.List.Safe ((!!), head, tail)
+import Data.List.Utils (replace, split)
+import qualified Data.Maybe as Maybe
+import Data.Tree.NTree.TypeDefs (NTree(..))
+import Prelude hiding ((!!), head, tail)
+import System.Console.CmdArgs.Implicit (Data, Typeable, cmdArgs)
+import System.Directory (createDirectoryIfMissing)
+import System.Exit (exitFailure)
+import System.FilePath (FilePath, (</>), takeDirectory)
+import qualified Text.XML.HXT.Arrow.ReadDocument as XML
+import Text.XML.HXT.Arrow.WriteDocument (writeDocumentToString)
+import Text.XML.HXT.DOM.QualifiedName (localPart, mkName)
+import Text.XML.HXT.DOM.TypeDefs (XNode(..), XmlTree)
+import Text.XML.HXT.XPath.XPathEval (getXPath, getXPathSubTrees)
+
+data Args = Args
+  { testlog :: FilePath
+  , destdir :: FilePath
+  } deriving (Data, Typeable)
+
+data ReportFile = ReportFile
+  { content :: String
+  , filename :: FilePath
+  } deriving (Show)
+
+main :: IO ()
+main = do
+  Args {testlog, destdir} <- cmdArgs $ Args {testlog = "", destdir = ""}
+  if testlog == ""
+    then putStrLn noTestlogError >> exitFailure
+    else do
+      fileContents <- readFile testlog
+      let xmlTrees = runLA XML.xreadDoc fileContents
+      let rootTree = find isRoot xmlTrees
+      case rootTree of
+        Nothing -> do
+          putStrLn "Invalid XML format for testlog."
+          exitFailure
+        Just tree -> do
+          let reportFiles = generateReportFiles tree
+          forM_ reportFiles $ \ReportFile {content, filename} -> do
+            putStrLn filename
+            createDirectoryIfMissing True (destdir </> takeDirectory filename)
+            writeFile (destdir </> filename) content
+
+generateReportFiles :: XmlTree -> [ReportFile]
+generateReportFiles doc =
+  let testSuites = getXPath "/testsuites/testsuite" doc
+   in concat $ Maybe.catMaybes $ reportsForTestCase <$> testSuites
+
+reportsForTestCase :: XmlTree -> Maybe [ReportFile]
+reportsForTestCase testSuite = do
+  caseName <-
+    extractAttr =<<
+    head (getXPathSubTrees "/testsuite/testcase/@name" testSuite)
+  let coverageOutputDirectory = takeDirectory caseName
+  testOutput <-
+    extractText =<< head (getXPathSubTrees "/testsuite/system-out" testSuite)
+  htmlPortion <- head =<< tail (split testOutputSeparator testOutput)
+  let coverageReportPartXmlTrees = runLA XML.hreadDoc htmlPortion
+  traverse
+    (coveragePartToReportFile coverageOutputDirectory)
+    coverageReportPartXmlTrees
+
+coveragePartToReportFile :: FilePath -> XmlTree -> Maybe ReportFile
+coveragePartToReportFile parentDirectory reportPart = do
+  filename <-
+    extractAttr =<<
+    head (getXPathSubTrees "/coverage-report-part/@name" reportPart)
+  content <- extractText reportPart
+  return $
+    ReportFile
+      { content = content
+      , filename = "coverage-reports" </> parentDirectory </> filename
+      }
+
+noTestlogError :: String
+noTestlogError =
+  unlines
+    [ "ERROR: You must specify the testlog XML file location with --testlog."
+    , "It is found inside the bazel-testlog, in the respective"
+    , "folder for the test you're interested in."
+    , "This must be after having run 'bazel coverage'."
+    ]
+
+isRoot :: XmlTree -> Bool
+isRoot tree =
+  case tree of
+    NTree (XTag name _) _ -> localPart name == "testsuites"
+    _ -> False
+
+extractAttr :: XmlTree -> Maybe String
+extractAttr tree =
+  case tree of
+    NTree (XAttr _) [NTree (XText value) []] -> pure value
+    _ -> Nothing
+
+extractText :: XmlTree -> Maybe String
+extractText tree =
+  let treeToText :: XmlTree -> String -> String
+      treeToText textTree acc =
+        case textTree of
+          (NTree (XText value) _) -> value
+          _ -> ""
+   in case tree of
+        NTree (XTag _ _) textTree -> pure $ foldr treeToText "" textTree
+        _ -> Nothing
+
+testOutputSeparator :: String
+testOutputSeparator =
+  "\n-----------------------------------------------------------------------------\n"


### PR DESCRIPTION
Since `bazel coverage` can't output any files, this is the second step for generating an HTML coverage report. For a `haskell_test` rule with attr `coverage_report_format = "html"`, first run it with `bazel coverage`, then, with this new functionality, run:

```
kazel run //tools/coverage-reports:coverage-report-renderer -- \
  --testlog=<absolute path to testlog test.xml file>           \
  --destdir=<absolute path to destination folder>
```

This will generate all of the relevant `hpc markup` report files in the destination folder, under `coverage-reports`.

Generally, the testlog test.xml is found at `{WORKSPACE_ROOT}/bazel-testlogs/tests/{PACKAGE_NAME}/{HASKELL_TEST_TARGET_NAME}/test.xml`.

One thing I haven't figured out is how to pass relative paths in as arguments, since the coverage-report-renderer isn't run in the directory the user is in. If there's a way of getting that information from an environment variable or something like that, that would be great.

Merging this will complete: https://github.com/tweag/rules_haskell/issues/809. Documentation to come later, after seeing how users use this in the wild.