### PR TITLE
Full CC/Haskell/CC sandwich using CC Skylark API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 * The default outputs of `haskell_library` are now the static and/or
   shared library files, not the package database config and cache
   files.
+* `cc_haskell_import` and `haskell_cc_import` are now no longer
+  necessary and are deprecated. A `haskell_library` can be used nearly
+  anywhere a `cc_library` can.
 
 ## [0.8] - 2019-01-28
 

--- a/haskell/cc.bzl
+++ b/haskell/cc.bzl
@@ -1,6 +1,6 @@
 """Interop with cc_* rules
 
-These rules are temporary and will be deprecated in the future.
+These rules are deprecated.
 """
 
 load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
@@ -335,9 +335,7 @@ separately to your `cc_library`. If you're getting
 `prebuilt_dependencies` from your toolchain, you will likely want to
 extract those and pass them in as well.
 
-*This rule is temporary and only needed until the Bazel C/C++
-"sandwich" (see [bazelbuild/bazel#2163][bazel-cpp-sandwich]) is
-implemented. This rule will be deprecated in the future.*
+*This rule is deprecated.*
 
 Example:
   ```bzl

--- a/haskell/cc.bzl
+++ b/haskell/cc.bzl
@@ -44,7 +44,7 @@ def cc_interop_info(ctx):
     Returns:
       CcInteropInfo: Information needed for CC interop.
     """
-    ccs = [dep[CcInfo] for dep in ctx.attr.deps if CcInfo in dep]
+    ccs = [dep[CcInfo] for dep in ctx.attr.deps if CcInfo in dep and HaskellBuildInfo not in dep]
 
     hdrs = []
     include_args = []

--- a/haskell/private/dependencies.bzl
+++ b/haskell/private/dependencies.bzl
@@ -195,7 +195,7 @@ def gather_dep_info(ctx, deps):
                 cc_dependencies = acc.cc_dependencies,
                 transitive_cc_dependencies = acc.transitive_cc_dependencies,
             )
-        elif CcInfo in dep:
+        elif CcInfo in dep and HaskellBuildInfo not in dep:
             # The final link of a binary must include all static libraries we
             # depend on, including transitives ones. Theses libs are provided
             # in the `CcInfo` provider.

--- a/haskell/protobuf.bzl
+++ b/haskell/protobuf.bzl
@@ -184,7 +184,10 @@ def _haskell_proto_aspect_impl(target, ctx):
         var = ctx.var,
     )
 
-    [build_info, library_info, default_info, coverage_info] = _haskell_library_impl(patched_ctx)
+    # TODO this pattern match is very brittle. Let's not do this. The
+    # order should match the order in the return value expression in
+    # haskell_library_impl().
+    [build_info, cc_info, coverage_info, default_info, library_info] = _haskell_library_impl(patched_ctx)
 
     return [
         build_info,  # HaskellBuildInfo

--- a/tests/cc_haskell_import/BUILD.bazel
+++ b/tests/cc_haskell_import/BUILD.bazel
@@ -24,21 +24,19 @@ haskell_library(
     ],
 )
 
-cc_haskell_import(
-    name = "hs-lib-b.so",
-    dep = ":hs-lib-b",
-    visibility = ["//tests:__subpackages__"],
-)
-
 cc_binary(
     name = "cc-bin",
     srcs = [
         "main.c",
-        ":hs-lib-b.so",
     ],
+    # TODO support linking with static haskell libraries.
+    linkstatic = False,
     tags = ["requires_threaded_rts"],
     visibility = ["//tests:__subpackages__"],
-    deps = ["@ghc//:threaded-rts"],
+    deps = [
+        ":hs-lib-b",
+        "@ghc//:threaded-rts",
+    ],
 )
 
 # We go one step further and use the Haskell library from above
@@ -48,14 +46,14 @@ cc_binary(
 # shared library which python will dlopen
 cc_binary(
     name = "hs-lib-b-wrapped.so",
-    srcs = [
-        ":hs-lib-b.so",
-    ],
     linkshared = 1,
-    linkstatic = 1,
+    linkstatic = 0,
     tags = ["requires_threaded_rts"],
     visibility = ["//tests:__subpackages__"],
-    deps = ["@ghc//:threaded-rts"],
+    deps = [
+        ":hs-lib-b",
+        "@ghc//:threaded-rts",
+    ],
 )
 
 # just dlopens hb-lib-b-wrapped.so and prints it


### PR DESCRIPTION
We had the full sandwich previously, but it relied on two wrapper
rules, `cc_haskell_import` and `haskell_cc_import` along with various
hacks in order to do the job. Both of those rules are now deprecated.
Haskell rules now return a `CcInfo` provider the way any `cc_library`
does.