### PR TITLE
Exclude kernel32 library on Windows

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,6 +32,7 @@ jobs:
       /c/bazel/bazel.exe build --config windows "@haskell_text__metrics//..."
       /c/bazel/bazel.exe build --config windows "@haskell_cryptonite//..."
       /c/bazel/bazel.exe build --config windows "@haskell_unix__compat//..."
+      /c/bazel/bazel.exe build --config windows "@haskell_hostname//..."
 
       # FIXME:
       # this rule is missing dependency declarations for the following files included by 'external/haskell_zlib/cbits/adler32.c':

--- a/hazel/third_party/cabal2bazel/bzl/cabal_package.bzl
+++ b/hazel/third_party/cabal2bazel/bzl/cabal_package.bzl
@@ -50,6 +50,7 @@ _excluded_cxx_libs = sets.make(elements = [
     "iphlpapi",
     "Crypt32",
     "msvcrt",
+    "kernel32",
 ])
 
 def _get_core_dependency_includes(ghc_workspace):


### PR DESCRIPTION
This is a system library that will be linked automatically on Windows.
- Add `kernel32` to `_excluded_cxx_libs`
- Add regression test. The `hostname` library depends on `kernel32` on Windows.