### PR TITLE
ls_modules: Don't swallow errors in os.walk

### DIFF
--- a/haskell/private/ls_modules.py
+++ b/haskell/private/ls_modules.py
@@ -6,7 +6,7 @@
 # dependencies). The exposed modules are filtered using a provided
 # list of hidden modules, and augmented with reexport declarations.
 
-from __future__ import unicode_literals
+from __future__ import unicode_literals, print_function
 
 import collections
 import fnmatch
@@ -62,9 +62,18 @@ with io.open(reexported_modules_file, "r", encoding='utf8') as f:
         for mod in raw_reexported_modules
     )
 
+def handle_walk_error(e):
+    print("""
+Failed to list interface files:
+    {}
+On Windows you may need to enable long file path support:
+    Set-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem' -Name 'LongPathsEnabled' -Value 1
+    """.strip().format(e), file=sys.stderr)
+    exit(1)
+
 interface_files = (
     os.path.join(path, f)
-    for path, dirs, files in os.walk(root)
+    for path, dirs, files in os.walk(root, onerror=handle_walk_error)
     for f in fnmatch.filter(files, '*.hi')
 )
 


### PR DESCRIPTION
By default `os.walk` will silently ignore file access errors. This can lead to missing module errors if `os.walk` fails. E.g. on Windows long path support has to be enabled for targets with long package or module names.