### PR TITLE
Hazel: Make excluded C libraries configurable

### DIFF
--- a/hazel/workspace.bzl
+++ b/hazel/workspace.bzl
@@ -1,10 +1,12 @@
 """Workspace rules (setup)"""
 
+load("@bazel_skylib//lib:dicts.bzl", "dicts")
 load("@io_tweag_rules_nixpkgs//nixpkgs:nixpkgs.bzl", "nixpkgs_package")
 load(
     "@ai_formation_hazel//:hazel.bzl",
     "hazel_custom_package_github",
     "hazel_custom_package_hackage",
+    "hazel_default_extra_libs",
     "hazel_extra_packages",
     "hazel_repositories",
 )
@@ -110,8 +112,8 @@ cc_library(
             "wai-app-static",
             "zlib",
         ],
-        extra_libs = {
+        extra_libs = dicts.add(hazel_default_extra_libs, {
             "pq": "@postgresql",
             "tag_c": "@taglib",
-        },
+        }),
     )


### PR DESCRIPTION
Some packages list libraries in the extra-libraries section of their cabal file, which are always provided by the system and do not need to be provided as Bazel targets. E.g. libstdc++, or libpthread.

Previously, Hazel held a hard-coded list of such libraries for which it would not expect a user-provided Bazel target.

This change allows users to configure this list of system libraries themselves by passing empty string entries in the extra_libs argument to hazel_repositories. A default selection is provided.

Addresses the user configurability aspect of #834.