### PR TITLE
Write the -optP flags to a response because they can be very long

### DIFF
--- a/haskell/private/actions/compile.bzl
+++ b/haskell/private/actions/compile.bzl
@@ -214,7 +214,7 @@ def _compilation_defaults(hs, cc, java, dep_info, plugin_dep_info, srcs, import_
 
     ghc_args += ["-i{0}".format(d) for d in set.to_list(import_dirs)]
 
-    # Write the -optP flags to a response because they can be very long on Windows
+    # Write the -optP flags to a parameter file because they can be very long on Windows
     # e.g. 27Kb for grpc-haskell
     # Equivalent to: ghc_args += ["-optP" + f for f in cc.cpp_flags]
     optp_args_file = hs.actions.declare_file("optp_args_%s" % hs.name)

--- a/haskell/private/actions/compile.bzl
+++ b/haskell/private/actions/compile.bzl
@@ -213,7 +213,18 @@ def _compilation_defaults(hs, cc, java, dep_info, plugin_dep_info, srcs, import_
             set.mutable_insert(import_dirs, idir)
 
     ghc_args += ["-i{0}".format(d) for d in set.to_list(import_dirs)]
-    ghc_args += ["-optP" + f for f in cc.cpp_flags]
+
+    # Write the -optP flags to a response because they can be very long on Windows
+    # e.g. 27Kb for grpc-haskell
+    # Equivalent to: ghc_args += ["-optP" + f for f in cc.cpp_flags]
+    optp_args_file = hs.actions.declare_file("optp_args_%s" % hs.name)
+    optp_args = hs.actions.args()
+    optp_args.add_all(cc.cpp_flags)
+    optp_args.set_param_file_format("multiline")
+    print(cc.cpp_flags)
+    hs.actions.write(optp_args_file, optp_args)
+    ghc_args += ["-optP@" + optp_args_file.path]
+
     ghc_args += cc.include_args
 
     locale_archive_depset = (
@@ -326,6 +337,7 @@ def _compilation_defaults(hs, cc, java, dep_info, plugin_dep_info, srcs, import_
             java.inputs,
             locale_archive_depset,
             depset(transitive = plugin_tool_inputs),
+            depset([optp_args_file]),
         ]),
         input_manifests = plugin_tool_input_manifests,
         objects_dir = objects_dir,

--- a/haskell/private/actions/compile.bzl
+++ b/haskell/private/actions/compile.bzl
@@ -345,7 +345,7 @@ def _compilation_defaults(hs, cc, java, dep_info, plugin_dep_info, srcs, import_
         header_files = set.from_list(cc.hdrs + header_files),
         boot_files = set.from_list(boot_files),
         source_files = source_files,
-        extra_source_files = extra_srcs,
+        extra_source_files = depset(transitive = [extra_srcs, depset([optp_args_file])]),
         import_dirs = import_dirs,
         env = dicts.add(
             ghc_env,


### PR DESCRIPTION
Before I failed to build grpc-haskell because I had 42Kb of command line. After, I can build it because 27K of that can go in a response file passed to the preprocessor. While the fix is only necessary on Windows, I suspect it's good practice to apply it universally, for consistency.

We are using this patch in the digital-asset/daml repo.