### PR TITLE
Fix early issues with HTML coverage reports and coverage scoping

### DIFF
--- a/haskell/private/coverage_wrapper.sh.tpl
+++ b/haskell/private/coverage_wrapper.sh.tpl
@@ -114,12 +114,15 @@ then
   $hpc_path markup "$tix_file_path" $hpc_dir_args $hpc_exclude_args \
     --srcdir "." --srcdir "$package_path" --destdir=hpc_out > /dev/null 2>&1
   cd hpc_out
+  echo "COVERAGE REPORT BELOW"
+  echo "%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%"
   for file in *.html **/*.hs.html; do
     [ -e "$file" ] || continue
     echo "<coverage-report-part name=\"$file\">"
-    echo "<![CDATA["
+    echo '<![CDATA['
     cat $file
-    echo "]]>"
+    echo ']]>'
     echo "</coverage-report-part>"
   done
+  echo "%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%"
 fi

--- a/haskell/private/coverage_wrapper.sh.tpl
+++ b/haskell/private/coverage_wrapper.sh.tpl
@@ -30,6 +30,7 @@ hpc_path=$(rlocation {hpc_path})
 tix_file_path={tix_file_path}
 coverage_report_format={coverage_report_format}
 strict_coverage_analysis={strict_coverage_analysis}
+package_path={package_path}
 
 # either of the two expected coverage metrics should be set to -1 if they're meant to be unused
 expected_covered_expressions_percentage={expected_covered_expressions_percentage}
@@ -56,7 +57,8 @@ done
 
 # run the test binary, and then generate the report
 $binary_path "$@" > /dev/null 2>&1
-$hpc_path report "$tix_file_path" $hpc_dir_args $hpc_exclude_args > __hpc_coverage_report
+$hpc_path report "$tix_file_path" $hpc_dir_args $hpc_exclude_args \
+  --srcdir "." --srcdir "$package_path" > __hpc_coverage_report
 
 # if we want a text report, just output the file generated in the previous step
 if [ "$coverage_report_format" == "text" ]
@@ -109,7 +111,8 @@ fi
 # and feed its generated files into stdout, wrapped in XML tags
 if [ "$coverage_report_format" == "html" ]
 then
-  $hpc_path markup "$tix_file_path" $hpc_dir_args $hpc_exclude_args --destdir=hpc_out > /dev/null 2>&1
+  $hpc_path markup "$tix_file_path" $hpc_dir_args $hpc_exclude_args \
+    --srcdir "." --srcdir "$package_path" --destdir=hpc_out > /dev/null 2>&1
   cd hpc_out
   for file in *.html **/*.hs.html; do
     [ -e "$file" ] || continue

--- a/haskell/private/haskell_impl.bzl
+++ b/haskell/private/haskell_impl.bzl
@@ -33,6 +33,7 @@ load(":private/pkg_id.bzl", "pkg_id")
 load(":private/set.bzl", "set")
 load(":private/providers.bzl", "GhcPluginInfo", "HaskellCoverageInfo")
 load("@bazel_skylib//lib:paths.bzl", "paths")
+load("@bazel_skylib//lib:collections.bzl", "collections")
 load("@bazel_skylib//lib:shell.bzl", "shell")
 
 def _prepare_srcs(srcs):
@@ -240,11 +241,13 @@ def _haskell_binary_common_impl(ctx, is_test):
             paths.join(ctx.workspace_name, datum.mix_file.short_path)
             for datum in coverage_data
         ]
+        mix_file_paths = collections.uniq(mix_file_paths)  # remove duplicates
 
         # find which modules to exclude from coverage analysis, by using the specified source patterns
         raw_coverage_source_patterns = ctx.attr.experimental_coverage_source_patterns
         coverage_source_patterns = [parse_pattern(pat) for pat in raw_coverage_source_patterns]
         modules_to_exclude = [paths.split_extension(datum.mix_file.basename)[0] for datum in coverage_data if not _coverage_enabled_for_target(coverage_source_patterns, datum.target_label)]
+        modules_to_exclude = collections.uniq(modules_to_exclude)  # remove duplicates
 
         expected_covered_expressions_percentage = ctx.attr.expected_covered_expressions_percentage
         expected_uncovered_expression_count = ctx.attr.expected_uncovered_expression_count

--- a/haskell/private/haskell_impl.bzl
+++ b/haskell/private/haskell_impl.bzl
@@ -72,6 +72,38 @@ def _coverage_enabled_for_target(coverage_source_patterns, label):
 
     return False
 
+# Mix files refer to genfile srcs including their root. Therefore, we
+# must condition the src filepaths passed in for coverage to match.
+def _condition_coverage_src(hs, src):
+    if not src.path.startswith(hs.genfiles_dir.path):
+        return src
+
+    """ Genfiles have the genfile directory as part of their path,
+    so declaring a file with the sample path actually makes the new
+    file double-qualified by the genfile directory.
+
+    This is necessary because mix files capture the genfile
+    path before compilation, and then expect those files to be
+    qualified by the genfile directory when `hpc report` or
+    `hpc markup` are used. But, genfiles included as runfiles
+    are no longer qualified. So, double-qualifying them results in
+    only one level of qualification as runfiles.
+    """
+    conditioned_src = hs.actions.declare_file(src.path)
+    hs.actions.run_shell(
+        inputs = [src],
+        outputs = [conditioned_src],
+        arguments = [
+            src.path,
+            conditioned_src.path,
+        ],
+        command = """
+        mkdir -p $(dirname "$2") && cp "$1" "$2"
+        """,
+    )
+
+    return conditioned_src
+
 def _haskell_binary_common_impl(ctx, is_test):
     hs = haskell_context(ctx)
     dep_info = gather_dep_info(ctx, ctx.attr.deps)
@@ -236,12 +268,13 @@ def _haskell_binary_common_impl(ctx, is_test):
                 "{modules_to_exclude}": shell.array_literal(modules_to_exclude),
                 "{strict_coverage_analysis}": str(strict_coverage_analysis),
                 "{coverage_report_format}": shell.quote(ctx.attr.coverage_report_format),
+                "{package_path}": shell.quote(ctx.label.package),
             },
             is_executable = True,
         )
         executable = wrapper
         mix_runfiles = [datum.mix_file for datum in coverage_data]
-        srcs_runfiles = [datum.src_file for datum in coverage_data]
+        srcs_runfiles = [_condition_coverage_src(hs, datum.src_file) for datum in coverage_data]
         extra_runfiles = [
             ctx.file._bash_runfiles,
             hs.toolchain.tools.hpc,


### PR DESCRIPTION
This is a little silly: genfiles lose their path qualification (by `bazel-out/k8-fastbuild/genfiles/`) when being passed as runfiles, but .mix files remember their paths as being qualified. So, to avoid losing that information, we have to copy all genfiles to double-qualified names, pass them as runfiles, and then tell `hpc` where to find them. We can't tell `hpc` how to find them when they're not double-qualified, because then their paths don't match the .mix file expectation regardless.