### PR TITLE
Make providers.bzl public

### DIFF
--- a/haskell/c2hs.bzl
+++ b/haskell/c2hs.bzl
@@ -2,7 +2,7 @@
 
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load(
-    "@io_tweag_rules_haskell//haskell:private/providers.bzl",
+    "@io_tweag_rules_haskell//haskell:providers.bzl",
     "C2hsLibraryInfo",
 )
 load(":cc.bzl", "cc_interop_info")

--- a/haskell/cc.bzl
+++ b/haskell/cc.bzl
@@ -13,7 +13,7 @@ load(":private/path_utils.bzl", "ln")
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load(":private/set.bzl", "set")
 load(
-    "@io_tweag_rules_haskell//haskell:private/providers.bzl",
+    "@io_tweag_rules_haskell//haskell:providers.bzl",
     "HaskellBinaryInfo",
     "HaskellBuildInfo",
 )

--- a/haskell/doctest.bzl
+++ b/haskell/doctest.bzl
@@ -7,10 +7,10 @@ load(
     ":private/path_utils.bzl",
     "get_lib_name",
 )
-load(":private/providers.bzl", "get_libs_for_ghc_linker")
+load(":providers.bzl", "get_libs_for_ghc_linker")
 load(":private/set.bzl", "set")
 load(
-    "@io_tweag_rules_haskell//haskell:private/providers.bzl",
+    "@io_tweag_rules_haskell//haskell:providers.bzl",
     "HaskellBinaryInfo",
     "HaskellBuildInfo",
     "HaskellLibraryInfo",

--- a/haskell/haddock.bzl
+++ b/haskell/haddock.bzl
@@ -2,7 +2,7 @@
 
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load(
-    "@io_tweag_rules_haskell//haskell:private/providers.bzl",
+    "@io_tweag_rules_haskell//haskell:providers.bzl",
     "HaddockInfo",
     "HaskellBuildInfo",
     "HaskellLibraryInfo",

--- a/haskell/import.bzl
+++ b/haskell/import.bzl
@@ -2,7 +2,7 @@
 
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load(
-    "@io_tweag_rules_haskell//haskell:private/providers.bzl",
+    "@io_tweag_rules_haskell//haskell:providers.bzl",
     "HaddockInfo",
     "HaskellBuildInfo",
     "HaskellLibraryInfo",

--- a/haskell/lint.bzl
+++ b/haskell/lint.bzl
@@ -1,7 +1,7 @@
 """Linting"""
 
 load(
-    "@io_tweag_rules_haskell//haskell:private/providers.bzl",
+    "@io_tweag_rules_haskell//haskell:providers.bzl",
     "HaskellBinaryInfo",
     "HaskellBuildInfo",
     "HaskellLibraryInfo",
@@ -13,7 +13,7 @@ load(
     ":private/path_utils.bzl",
     "target_unique_name",
 )
-load(":private/providers.bzl", "get_libs_for_ghc_linker")
+load(":providers.bzl", "get_libs_for_ghc_linker")
 load(":private/set.bzl", "set")
 
 def _collect_lint_logs(deps):

--- a/haskell/plugins.bzl
+++ b/haskell/plugins.bzl
@@ -1,4 +1,4 @@
-load(":private/providers.bzl", "GhcPluginInfo", "HaskellLibraryInfo")
+load(":providers.bzl", "GhcPluginInfo", "HaskellLibraryInfo")
 
 def ghc_plugin_impl(ctx):
     args = ctx.attr.args

--- a/haskell/private/actions/compile.bzl
+++ b/haskell/private/actions/compile.bzl
@@ -11,7 +11,7 @@ load(
 )
 load(":private/pkg_id.bzl", "pkg_id")
 load(
-    ":private/providers.bzl",
+    ":providers.bzl",
     "GhcPluginInfo",
     "get_libs_for_ghc_linker",
     "merge_HaskellCcInfo",

--- a/haskell/private/actions/repl.bzl
+++ b/haskell/private/actions/repl.bzl
@@ -10,7 +10,7 @@ load(
     "ln",
     "target_unique_name",
 )
-load(":private/providers.bzl", "get_libs_for_ghc_linker")
+load(":providers.bzl", "get_libs_for_ghc_linker")
 load(
     ":private/set.bzl",
     "set",

--- a/haskell/private/actions/runghc.bzl
+++ b/haskell/private/actions/runghc.bzl
@@ -14,7 +14,7 @@ load(
     ":private/set.bzl",
     "set",
 )
-load(":private/providers.bzl", "get_libs_for_ghc_linker")
+load(":providers.bzl", "get_libs_for_ghc_linker")
 load("@bazel_skylib//lib:shell.bzl", "shell")
 
 def build_haskell_runghc(

--- a/haskell/private/dependencies.bzl
+++ b/haskell/private/dependencies.bzl
@@ -1,7 +1,7 @@
 load("@bazel_skylib//lib:dicts.bzl", "dicts")
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load(
-    "@io_tweag_rules_haskell//haskell:private/providers.bzl",
+    "@io_tweag_rules_haskell//haskell:providers.bzl",
     "HaskellBinaryInfo",
     "HaskellBuildInfo",
     "HaskellCcInfo",

--- a/haskell/private/haskell_impl.bzl
+++ b/haskell/private/haskell_impl.bzl
@@ -1,7 +1,7 @@
 """Implementation of core Haskell rules"""
 
 load(
-    "@io_tweag_rules_haskell//haskell:private/providers.bzl",
+    "@io_tweag_rules_haskell//haskell:providers.bzl",
     "C2hsLibraryInfo",
     "HaskellBinaryInfo",
     "HaskellBuildInfo",
@@ -31,7 +31,7 @@ load(
 )
 load(":private/pkg_id.bzl", "pkg_id")
 load(":private/set.bzl", "set")
-load(":private/providers.bzl", "GhcPluginInfo", "HaskellCoverageInfo")
+load(":providers.bzl", "GhcPluginInfo", "HaskellCoverageInfo")
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load("@bazel_skylib//lib:shell.bzl", "shell")
 

--- a/haskell/protobuf.bzl
+++ b/haskell/protobuf.bzl
@@ -6,7 +6,7 @@ load(
 )
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load(
-    "@io_tweag_rules_haskell//haskell:private/providers.bzl",
+    "@io_tweag_rules_haskell//haskell:providers.bzl",
     "HaskellBuildInfo",
     "HaskellLibraryInfo",
     "HaskellProtobufInfo",

--- a/haskell/providers.bzl
+++ b/haskell/providers.bzl
@@ -1,3 +1,5 @@
+"""Providers exposed by the Haskell rules."""
+
 load(
     ":private/path_utils.bzl",
     "darwin_convert_to_dylibs",

--- a/haskell/repl.bzl
+++ b/haskell/repl.bzl
@@ -11,7 +11,7 @@ load(
     "target_unique_name",
 )
 load(
-    "@io_tweag_rules_haskell//haskell:private/providers.bzl",
+    "@io_tweag_rules_haskell//haskell:providers.bzl",
     "HaskellBinaryInfo",
     "HaskellBuildInfo",
     "HaskellLibraryInfo",

--- a/tests/library-linkstatic-flag/get_library_files.bzl
+++ b/tests/library-linkstatic-flag/get_library_files.bzl
@@ -1,5 +1,5 @@
 load(
-    "@io_tweag_rules_haskell//haskell:private/providers.bzl",
+    "@io_tweag_rules_haskell//haskell:providers.bzl",
     "HaskellBuildInfo",
     "HaskellLibraryInfo",
 )


### PR DESCRIPTION
Providers are everything but private. They should be considered an
integral part of the interface of a rule. Any downstream dependencies
are free to query the providers passed to them and poke at each of
their fields. We should carefully consider any changes to providers,
because changing providers means changing the interface of a rule.

We can allow ourselves sweeping changes to the providers ahead of the
next release, because they were marked private previously (even if
abusively). But after that, we'll have to be a lot more careful. We
may consider marking some providers as "experimental" for some time
(like Bazel does).