### PR TITLE
Don't expose exposed_modules_file in providers

### DIFF
--- a/haskell/private/haskell_impl.bzl
+++ b/haskell/private/haskell_impl.bzl
@@ -196,7 +196,6 @@ def _haskell_binary_common_impl(ctx, is_test):
         binary = binary,
         ghc_args = c.ghc_args,
         header_files = c.header_files,
-        exposed_modules_file = c.exposed_modules_file,
     )
 
     target_files = depset([binary])
@@ -461,7 +460,6 @@ def haskell_library_impl(ctx):
         header_files = c.header_files,
         boot_files = c.boot_files,
         source_files = c.source_files,
-        exposed_modules_file = c.exposed_modules_file,
         extra_source_files = c.extra_source_files,
     )
 

--- a/haskell/providers.bzl
+++ b/haskell/providers.bzl
@@ -174,7 +174,6 @@ HaskellLibraryInfo = provider(
         "source_files": "Set of files that contain Haskell modules.",
         "extra_source_files": "A depset of non-Haskell source files.",
         "ghc_args": "Arguments that were used to compile the package.",
-        "exposed_modules_file": "File containing a list of exposed module names.",
     },
 )
 
@@ -186,7 +185,6 @@ HaskellBinaryInfo = provider(
         "binary": "File, compiled binary.",
         "header_files": "Set of header files.",
         "ghc_args": "Arguments that were used to compile the binary.",
-        "exposed_modules_file": "File containing a list of exposed module names.",
     },
 )
 


### PR DESCRIPTION
The only rule that was using this was the `haskell_doctest` rule. But
arguably this was an incorrect usage of this file. The reason is as
follows. `haskell_doctest` uses GHCi under the hood. Unlike GHC, GHCi
does *not* use module names to correctly locate source files, unless
the source file paths can be derived from the module name. So if we
have `Foo.hs` defining `Bar`, we should *not* tell `doctest` to load
`Bar`, but instead tell it about `Foo`.

For this reason it would be better for `haskell_doctest` to only talk
about source files and not about modules, i.e. deprecate the `modules`
attribute. But that's a matter for another day.