### PR TITLE
Install GHC bindist in relocatable mode on Unix

### DIFF
--- a/haskell/ghc_bindist.bzl
+++ b/haskell/ghc_bindist.bzl
@@ -213,7 +213,7 @@ def _ghc_bindist_impl(ctx):
     # On Windows the bindist already contains the built executables
     if os != "windows":
         _execute_fail_loudly(ctx, ["sed", "-i", "s/RelocatableBuild = NO/RelocatableBuild = YES/", "mk/config.mk.in"])
-        _execute_fail_loudly(ctx, ["./configure", "--prefix", bindist_dir.realpath, "--libdir", "${exec_prefix}/lib"])
+        _execute_fail_loudly(ctx, ["./configure", "--prefix", bindist_dir.realpath])
         _execute_fail_loudly(ctx, ["make", "install"])
         ctx.file("patch_bins", executable = True, content = """#!/usr/bin/env bash
 grep -lZ {bindist_dir} bin/* | xargs -0 --verbose \\

--- a/haskell/ghc_bindist.bzl
+++ b/haskell/ghc_bindist.bzl
@@ -218,7 +218,7 @@ def _ghc_bindist_impl(ctx):
         ctx.file("patch_bins", executable = True, content = """#!/usr/bin/env bash
 grep -lZ {bindist_dir} bin/* | xargs -0 --verbose \\
     sed -i \\
-        -e '2iDISTDIR="$( dirname "$(readlink -f "$0")" )/.."' \\
+        -e '2iDISTDIR="$( dirname "$(resolved="$0"; while tmp="$(readlink "$resolved")"; do resolved="$tmp"; done; echo "$resolved")" )/.."' \\
         -e 's:{bindist_dir}:$DISTDIR:'
 """.format(
             bindist_dir = bindist_dir.realpath,

--- a/haskell/ghc_bindist.bzl
+++ b/haskell/ghc_bindist.bzl
@@ -212,7 +212,7 @@ def _ghc_bindist_impl(ctx):
 
     # On Windows the bindist already contains the built executables
     if os != "windows":
-        _execute_fail_loudly(ctx, ["./configure", "--prefix", bindist_dir.realpath])
+        _execute_fail_loudly(ctx, ["./configure", "--prefix", bindist_dir.realpath, "--libdir", "${exec_prefix}/lib"])
         _execute_fail_loudly(ctx, ["make", "install"])
 
     ctx.template(


### PR DESCRIPTION
On Unix the GHC bindist requires to execute `./configure && make && make install`. In its default configuration, it hard-codes the absolute path to the bindist installation dir into various places in the final bindist. This affects the hashes and thereby cache keys, as the absolute install path will likely differ on different machines. This patch builds the bindist in relocatable mode on Unix and patches the generated wrapper scripts to no longer hard-code the absolute installation path.

- Pin the `--libdir` to `EPREFIX/lib`. On some platforms autotools defaults to `EPREFIX/lib64`, instead.
- Patch the configure script to build in relocatable mode.
- Patch the generated executable wrapper scripts to no longer hard-code the absolute path to the installation directory. 