### PR TITLE
haskell_toolchain tools as a list

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ genrule(
 # Make it visible to rules_haskell rules:
 haskell_toolchain(
     name = "ghc",
-    tools = "@ghc//:bin",
+    tools = ["@ghc//:bin"],
     version = "8.4.1",
     extra_binaries = [":toolchain_as"], # <----
 )
@@ -187,7 +187,7 @@ C99 or later, as the error message says, so try this:
 ```bzl
 haskell_toolchain(
     name = "ghc",
-    tools = "@ghc//:bin",
+    tools = ["@ghc//:bin"],
     version = "8.4.1",
     compiler_flags = ["-optc-std=c99"], # <----
 )

--- a/docs/haskell-use-cases.rst
+++ b/docs/haskell-use-cases.rst
@@ -60,7 +60,7 @@ the repository that includes the following::
     # Versions here and in WORKSPACE must match.
     version = "8.4.3",
     # Use binaries from @ghc//:bin to define //:ghc toolchain.
-    tools = "@ghc//:bin",
+    tools = ["@ghc//:bin"],
   )
 
 .. _Bazel+Nix blog post: https://www.tweag.io/posts/2018-03-15-bazel-nix.html

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -5,6 +5,6 @@ load(
 
 haskell_toolchain(
     name = "ghc",
-    tools = "@ghc//:bin",
+    tools = ["@ghc//:bin"],
     version = "8.6.4",
 )

--- a/haskell/ghc_bindist.bzl
+++ b/haskell/ghc_bindist.bzl
@@ -269,7 +269,7 @@ load("@io_tweag_rules_haskell//haskell:toolchain.bzl", "haskell_toolchain")
 
 haskell_toolchain(
     name = "toolchain",
-    tools = "{tools}",
+    tools = ["{tools}"],
     version = "{version}",
     compiler_flags = {compiler_flags},
     haddock_flags = {haddock_flags},

--- a/haskell/nixpkgs.bzl
+++ b/haskell/nixpkgs.bzl
@@ -255,7 +255,7 @@ load("@io_tweag_rules_haskell//haskell:toolchain.bzl", "haskell_toolchain")
 
 haskell_toolchain(
     name = "toolchain",
-    tools = "{tools}",
+    tools = ["{tools}"],
     version = "{version}",
     compiler_flags = {compiler_flags} + {compiler_flags_select},
     haddock_flags = {haddock_flags},

--- a/haskell/toolchain.bzl
+++ b/haskell/toolchain.bzl
@@ -202,8 +202,8 @@ fi
 _haskell_toolchain = rule(
     _haskell_toolchain_impl,
     attrs = {
-        "tools": attr.label(
-            doc = "GHC and executables that come with it",
+        "tools": attr.label_list(
+            doc = "GHC and executables that come with it. First item take precedance.",
             mandatory = True,
         ),
         "compiler_flags": attr.string_list(
@@ -270,7 +270,7 @@ def haskell_toolchain(
       haskell_toolchain(
           name = "ghc",
           version = "1.2.3",
-          tools = "@sys_ghc//:bin",
+          tools = ["@sys_ghc//:bin"],
           compiler_flags = ["-Wall"],
       )
       ```


### PR DESCRIPTION
`haskell_toolchain` `tools` attribute is now a list of
labels. Binaries (such as `ghc`, `haddock`, ...) are now located in
this list, first entries take precedence.

This is a backward incompatible change, but the conversion of
repository is trivial (i.e. add list bracket on your `tools` attribute).

Closes #848