### PR TITLE
Hazel: Fix zlib on Windows

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,13 +33,7 @@ jobs:
       /c/bazel/bazel.exe build --config windows "@haskell_cryptonite//..."
       /c/bazel/bazel.exe build --config windows "@haskell_unix__compat//..."
       /c/bazel/bazel.exe build --config windows "@haskell_hostname//..."
-
-      # FIXME:
-      # this rule is missing dependency declarations for the following files included by 'external/haskell_zlib/cbits/adler32.c':
-      #   'external/haskell_zlib/cbits/zutil.h'
-      #   'external/haskell_zlib/cbits/zlib.h'
-      #   'external/haskell_zlib/cbits/zconf.h'
-      #/c/bazel/bazel.exe build --config windows "@haskell_zlib//..."
+      /c/bazel/bazel.exe build --config windows "@haskell_zlib//..."
 
       # FIXME: needs network, warp, cryptonite, etc...
       # /c/bazel/bazel.exe build --config windows "@haskell_wai__app__static//..."

--- a/hazel/third_party/haskell/BUILD.zlib
+++ b/hazel/third_party/haskell/BUILD.zlib
@@ -10,6 +10,7 @@ cc_library(
   name = "zlib-cbits",
   hdrs = glob(["cbits/*.h"]),
   srcs = glob(["cbits/*.c"]),
+  includes = ["cbits"],
   strip_include_prefix = "cbits",
 )
 


### PR DESCRIPTION
- Add `includes = ["cbits"]` attribute to the `zlib` build definition.
    Using `strip_include_prefix` alone caused the Windows build to fail with the following error
    ```
    this rule is missing dependency declarations for the following files included by 
    'external/haskell_zlib/cbits/adler32.c':
      'external/haskell_zlib/cbits/zutil.h'
      'external/haskell_zlib/cbits/zlib.h'
      'external/haskell_zlib/cbits/zconf.h'
    ```
    Adding `includes` resolves that issue. It seems that Bazel on Windows does not take `strip_include_prefix` into account when checking for undeclared dependencies. 
- Add `zlib` to Windows CI.