### PR TITLE
Release 0.9 master

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The full reference documentation for rules is at https://haskell.build.
 
 ## Setup
 
-You'll need [Bazel >= 0.22.0][bazel-getting-started] installed.
+You'll need [Bazel >= 0.24][bazel-getting-started] installed.
 
 ### The easy way
 


### PR DESCRIPTION
The [`release-0.9`](https://github.com/tweag/rules_haskell/commits/release-0.9) branch, cherry picked with the parts that are relevant for master.