### PR TITLE
Hazel: Shorten haskell_library target names

### DIFF
--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -243,6 +243,11 @@ haskell_library = rule(
             default = False,
             doc = "Create a static library, not both a static and a shared library.",
         ),
+        package_name = attr.string(
+            doc = """Library name used in version macro generation. Only used
+            if the version attribute is defined, see version attribute
+            documentation. Optional, defaults to target name.""",
+        ),
         version = attr.string(
             doc = """Library version. Not normally necessary unless to build a library
             originally defined as a Cabal package. If this is specified, CPP version macro will be generated.""",

--- a/haskell/private/actions/package.bzl
+++ b/haskell/private/actions/package.bzl
@@ -81,7 +81,7 @@ def package(
     (extra_lib_dirs, extra_libs) = _get_extra_libraries(dep_info)
 
     metadata_entries = {
-        "name": my_pkg_id.name,
+        "name": my_pkg_id.package_name,
         "version": my_pkg_id.version,
         "id": pkg_id.to_string(my_pkg_id),
         "key": pkg_id.to_string(my_pkg_id),

--- a/haskell/private/haskell_impl.bzl
+++ b/haskell/private/haskell_impl.bzl
@@ -313,8 +313,9 @@ def haskell_library_impl(ctx):
         ctx,
         [dep for plugin in ctx.attr.plugins for dep in plugin[GhcPluginInfo].deps],
     )
-    version = ctx.attr.version if ctx.attr.version else None
-    my_pkg_id = pkg_id.new(ctx.label, version)
+    package_name = getattr(ctx.attr, "package_name", None)
+    version = getattr(ctx.attr, "version", None)
+    my_pkg_id = pkg_id.new(ctx.label, package_name, version)
     with_profiling = is_profiling_enabled(hs)
     with_shared = False if hs.toolchain.is_windows else not ctx.attr.linkstatic
 
@@ -443,9 +444,12 @@ def haskell_library_impl(ctx):
         )
 
     version_macros = set.empty()
-    if version != None:
+    if version:
+        package_name = hs.name
+        if hasattr(ctx.attr, "package_name") and ctx.attr.package_name:
+            package_name = ctx.attr.package_name
         version_macros = set.singleton(
-            generate_version_macros(ctx, hs.name, version),
+            generate_version_macros(ctx, package_name, version),
         )
 
     hs_info = HaskellInfo(

--- a/haskell/private/pkg_id.bzl
+++ b/haskell/private/pkg_id.bzl
@@ -27,7 +27,7 @@ def _to_string(my_pkg_id):
         ),
     )
 
-def _new(label, version = None):
+def _new(label, package_name = None, version = None):
     """Create a new package identifier.
 
     Package identifiers should be globally unique. This is why we use
@@ -35,15 +35,18 @@ def _new(label, version = None):
 
     Args:
       label: The label of the rule declaring the package.
+      package_name: an optional override of the package name.
       version: an optional version annotation.
 
     Returns:
       string: GHC package ID to use.
 
     """
+    name = label.name.replace("_", "-")
     return struct(
         label = label,
-        name = label.name.replace("_", "-"),
+        name = name,
+        package_name = package_name if package_name else name,
         version = version,
     )
 

--- a/haskell/private/version_macros.bzl
+++ b/haskell/private/version_macros.bzl
@@ -1,17 +1,17 @@
 load(":private/set.bzl", "set")
 
-def generate_version_macros(ctx, name, version):
+def generate_version_macros(ctx, pkg_name, version):
     """Generate a version macros header file.
 
     Args:
         ctx: Rule context. Needs to define a _version_macros executable attribute.
-        name: The package name.
+        pkg_name: The package name.
         version: The package version.
 
     Returns:
         Version macros header File.
     """
-    version_macros_file = ctx.actions.declare_file("{}_version_macros.h".format(name))
+    version_macros_file = ctx.actions.declare_file("{}_version_macros.h".format(ctx.attr.name))
     ctx.actions.run_shell(
         inputs = [ctx.executable._version_macros],
         outputs = [version_macros_file],
@@ -20,7 +20,7 @@ def generate_version_macros(ctx, name, version):
         """,
         arguments = [
             ctx.executable._version_macros.path,
-            name,
+            pkg_name,
             version,
             version_macros_file.path,
         ],

--- a/hazel/hazel.bzl
+++ b/hazel/hazel.bzl
@@ -56,7 +56,7 @@ def _core_library_repository_impl(ctx):
         content = """
 load("@io_tweag_rules_haskell//haskell:haskell.bzl", "haskell_toolchain_library")
 haskell_toolchain_library(
-    name = "{pkg}",
+    name = "lib",
     package = "{pkg}",
     visibility = ["//visibility:public"],
 )
@@ -64,7 +64,7 @@ haskell_toolchain_library(
 # CPP includes. To enable uniform handling we define a `-cbits` target for
 # every Hazel Haskell target. In case of core_libraries this is just a dummy.
 cc_import(
-    name = "{pkg}-cbits",
+    name = "cbits",
     visibility = ["//visibility:public"],
 )
 """.format(pkg = ctx.attr.package),

--- a/hazel/hazel.bzl
+++ b/hazel/hazel.bzl
@@ -64,7 +64,7 @@ haskell_toolchain_library(
 # CPP includes. To enable uniform handling we define a `-cbits` target for
 # every Hazel Haskell target. In case of core_libraries this is just a dummy.
 cc_import(
-    name = "cbits",
+    name = "{pkg}-cbits",
     visibility = ["//visibility:public"],
 )
 """.format(pkg = ctx.attr.package),

--- a/hazel/hazel.bzl
+++ b/hazel/hazel.bzl
@@ -136,7 +136,7 @@ def hazel_repositories(
     external dependencies corresponding to the given packages:
     - @hazel_base_repository: The compiled "hazel" Haskell binary, along with
       support files.
-    - @haskell_{package}_{hash}: A build of the given Cabal package, one per entry
+    - @haskell_{package}: A build of the given Cabal package, one per entry
       of the "packages" argument.  (Note that Bazel only builds these
       on-demand when needed by other rules.)  This repository automatically
       downloads the package's Cabal distribution from Hackage and parses the

--- a/hazel/third_party/cabal2bazel/bzl/cabal_package.bzl
+++ b/hazel/third_party/cabal2bazel/bzl/cabal_package.bzl
@@ -109,6 +109,9 @@ def _configure(desc):
         outs = outputs,
     )
 
+_cbits_name = "cbits"
+_lib_name = "lib"
+
 def _paths_module(desc):
     return "Paths_" + desc.package.pkgName.replace("-", "_")
 
@@ -276,11 +279,16 @@ def _get_build_attrs(
     # build_files will contain a list of all files in the build directory.
     build_files = []
 
-    clib_name = name + "-cbits"
     generated_modules = [_paths_module(desc)]
 
     # Keep track of chs modules, as later chs modules may depend on earlier ones.
     chs_targets = []
+
+    # The library components' cbits are called 'cbits'. Executable components'
+    # cbits are called <exe-name>-cbits.
+    cbits_name = _cbits_name
+    if name != _lib_name:
+        cbits_name = name + "-" + _cbits_name
 
     for module in build_info.otherModules + extra_modules:
         if module in generated_modules:
@@ -304,7 +312,7 @@ def _get_build_attrs(
                 boot_module_map[module] = boot_out
                 build_files.append(boot_out)
         elif info.type in ["chs"]:
-            chs_name = name + "-" + module + "-chs"
+            chs_name = module + "-chs"
             module_map[module] = chs_name
             build_files.append(info.src)
             c2hs_library(
@@ -312,7 +320,7 @@ def _get_build_attrs(
                 srcs = [info.src],
                 deps = (
                     _get_extra_libs(build_info.extraLibs, extra_libs) +
-                    [clib_name] +
+                    [cbits_name] +
                     chs_targets
                 ),
             )
@@ -364,7 +372,7 @@ def _get_build_attrs(
         for m in (extra_modules_dict.get(condition, []) +
                   other_modules_dict.get(condition, [])):
             if m == paths_module:
-                deps[condition] += [":" + paths_module]
+                deps[condition] += [":paths"]
             elif m in module_map:
                 srcs[condition] += [module_map[m]]
 
@@ -443,7 +451,7 @@ def _get_build_attrs(
     )
     ghcopts += ["-I" + native.package_name() + "/" + d for d in build_info.includeDirs]
     for xs in deps.values():
-        xs.append(":" + clib_name)
+        xs.append(cbits_name)
 
     ghc_version_components = ghc_version.split(".")
     if len(ghc_version_components) != 3:
@@ -458,7 +466,7 @@ def _get_build_attrs(
     elibs_targets = _get_extra_libs(build_info.extraLibs, extra_libs)
 
     native.cc_library(
-        name = clib_name,
+        name = cbits_name,
         srcs = build_info.cSources,
         includes = build_info.includeDirs,
         copts = ([o for o in build_info.ccOptions if not o.startswith("-D")] +
@@ -519,7 +527,7 @@ def cabal_haskell_package(
         _configure(description)
 
     cabal_paths(
-        name = _paths_module(description),
+        name = "paths",
         package = name.replace("-", "_"),
         version = [int(v) for v in description.package.pkgVersion.split(".")],
         data_dir = description.dataDir,
@@ -527,51 +535,54 @@ def cabal_haskell_package(
     )
 
     lib = description.library
-    if lib and lib.libBuildInfo.buildable:
-        if not lib.exposedModules:
-            native.cc_library(
-                name = name,
-                visibility = ["//visibility:public"],
-                linkstatic = select({
-                    "@bazel_tools//src/conditions:windows": True,
-                    "//conditions:default": False,
-                }),
-            )
-            native.cc_library(
-                name = name + "-cbits",
-                visibility = ["//visibility:public"],
-                linkstatic = select({
-                    "@bazel_tools//src/conditions:windows": True,
-                    "//conditions:default": False,
-                }),
-            )
-        else:
-            lib_attrs = _get_build_attrs(
-                name,
-                lib.libBuildInfo,
-                description,
-                "dist/build",
-                lib.exposedModules,
-                ghc_version,
-                ghc_workspace,
-                extra_libs,
-            )
-            srcs = lib_attrs.pop("srcs")
-            deps = lib_attrs.pop("deps")
+    if lib and lib.libBuildInfo.buildable and lib.exposedModules:
+        lib_attrs = _get_build_attrs(
+            _lib_name,
+            lib.libBuildInfo,
+            description,
+            "dist/build",
+            lib.exposedModules,
+            ghc_version,
+            ghc_workspace,
+            extra_libs,
+        )
+        srcs = lib_attrs.pop("srcs")
+        deps = lib_attrs.pop("deps")
 
-            elibs_targets = _get_extra_libs(lib.libBuildInfo.extraLibs, extra_libs)
+        elibs_targets = _get_extra_libs(lib.libBuildInfo.extraLibs, extra_libs)
 
-            hidden_modules = [m for m in lib.libBuildInfo.otherModules if not m.startswith("Paths_")]
+        hidden_modules = [m for m in lib.libBuildInfo.otherModules if not m.startswith("Paths_")]
 
-            haskell_library(
-                name = name,
-                srcs = select(srcs),
-                hidden_modules = hidden_modules,
-                version = description.package.pkgVersion,
-                deps = select(deps) + elibs_targets,
-                visibility = ["//visibility:public"],
-                **lib_attrs
-            )
+        haskell_library(
+            name = _lib_name,
+            srcs = select(srcs),
+            hidden_modules = hidden_modules,
+            package_name = description.package.pkgName,
+            version = description.package.pkgVersion,
+            deps = select(deps) + elibs_targets,
+            visibility = ["//visibility:public"],
+            **lib_attrs
+        )
+    else:
+        # No exposed library modules. Generate an empty dummy library target.
+        native.cc_library(
+            name = _lib_name,
+            visibility = ["//visibility:public"],
+            linkstatic = select({
+                "@bazel_tools//src/conditions:windows": True,
+                "//conditions:default": False,
+            }),
+        )
+
+        # No exposed library modules. Generate an empty dummy cbits target.
+        native.cc_library(
+            name = _cbits_name,
+            visibility = ["//visibility:public"],
+            linkstatic = select({
+                "@bazel_tools//src/conditions:windows": True,
+                "//conditions:default": False,
+            }),
+        )
 
     for exe in description.executables:
         if not exe.buildInfo.buildable:
@@ -581,7 +592,7 @@ def cabal_haskell_package(
         # Avoid a name clash with the library.  For stability, make this logic
         # independent of whether the package actually contains a library.
         if exe_name == name:
-            exe_name = name + "_bin"
+            exe_name = "bin"
         paths_mod = _paths_module(description)
         attrs = _get_build_attrs(
             exe_name,

--- a/hazel/third_party/haskell/BUILD.conduit
+++ b/hazel/third_party/haskell/BUILD.conduit
@@ -7,7 +7,7 @@ load("@ai_formation_hazel//tools:mangling.bzl", "hazel_library")
 load("@ai_formation_hazel//:tools/mangling.bzl", "hazel_workspace")
 
 haskell_library(
-  name = "conduit",
+  name = "lib",
   srcs = glob([
     "Data/*.hs",
     "Data/**/*.hs",
@@ -31,10 +31,11 @@ haskell_library(
     hazel_library("transformers-compat"),
     hazel_library("vector"),
   ],
+  package_name = "conduit",
   version = "1.2.13.1",
 )
 
 cc_import(
-    name = "conduit-cbits",
+    name = "cbits",
     visibility = ["//visibility:public"],
 )

--- a/hazel/third_party/haskell/BUILD.conduit
+++ b/hazel/third_party/haskell/BUILD.conduit
@@ -36,6 +36,6 @@ haskell_library(
 )
 
 cc_import(
-    name = "cbits",
+    name = "conduit-cbits",
     visibility = ["//visibility:public"],
 )

--- a/hazel/third_party/haskell/BUILD.ghc-paths
+++ b/hazel/third_party/haskell/BUILD.ghc-paths
@@ -21,6 +21,6 @@ haskell_library(
 )
 
 cc_import(
-    name = "cbits",
+    name = "ghc-paths-cbits",
     visibility = ["//visibility:public"],
 )

--- a/hazel/third_party/haskell/BUILD.ghc-paths
+++ b/hazel/third_party/haskell/BUILD.ghc-paths
@@ -11,14 +11,16 @@ ghc_paths_module(
     name = "paths_module")
 
 haskell_library(
-    name = "ghc-paths",
+    name = "lib",
     srcs = [":paths_module"],
     deps = [
         hazel_library("base"),
     ],
+    package_name = "ghc-paths",
+    version = "0.1.0.9",
 )
 
 cc_import(
-    name = "ghc-paths-cbits",
+    name = "cbits",
     visibility = ["//visibility:public"],
 )

--- a/hazel/third_party/haskell/BUILD.text-metrics
+++ b/hazel/third_party/haskell/BUILD.text-metrics
@@ -19,6 +19,6 @@ haskell_library(
 )
 
 cc_import(
-    name = "cbits",
+    name = "text-metrics-cbits",
     visibility = ["//visibility:public"],
 )

--- a/hazel/third_party/haskell/BUILD.text-metrics
+++ b/hazel/third_party/haskell/BUILD.text-metrics
@@ -6,7 +6,7 @@ load("@io_tweag_rules_haskell//haskell:haskell.bzl",
 load("@ai_formation_hazel//:hazel.bzl", "hazel_library")
 
 haskell_library(
-  name = "text-metrics",
+  name = "lib",
   srcs = ["Data/Text/Metrics.hs"],
   deps = [
     hazel_library("base"),
@@ -14,10 +14,11 @@ haskell_library(
     hazel_library("text"),
     hazel_library("vector"),
   ],
+  package_name = "text-metrics",
   version = "0.3.0",
 )
 
 cc_import(
-    name = "text-metrics-cbits",
+    name = "cbits",
     visibility = ["//visibility:public"],
 )

--- a/hazel/third_party/haskell/BUILD.vault
+++ b/hazel/third_party/haskell/BUILD.vault
@@ -4,7 +4,7 @@ load("@io_tweag_rules_haskell//haskell:haskell.bzl", "haskell_library")
 load("@ai_formation_hazel//:hazel.bzl", "hazel_library")
 
 haskell_library(
-  name = "vault",
+  name = "lib",
   srcs = [
     "src/Data/Unique/Really.hs",
     "src/Data/Vault/IO.h",
@@ -29,9 +29,11 @@ haskell_library(
     hazel_library("semigroups"),
     hazel_library("unordered-containers"),
   ],
+  package_name = "vault",
+  version = "0.3.1.1",
 )
 
 cc_import(
-    name = "vault-cbits",
+    name = "cbits",
     visibility = ["//visibility:public"],
 )

--- a/hazel/third_party/haskell/BUILD.vault
+++ b/hazel/third_party/haskell/BUILD.vault
@@ -34,6 +34,6 @@ haskell_library(
 )
 
 cc_import(
-    name = "cbits",
+    name = "vault-cbits",
     visibility = ["//visibility:public"],
 )

--- a/hazel/third_party/haskell/BUILD.wai-app-static
+++ b/hazel/third_party/haskell/BUILD.wai-app-static
@@ -45,6 +45,6 @@ haskell_library(
 )
 
 cc_import(
-    name = "cbits",
+    name = "wai-app-static-cbits",
     visibility = ["//visibility:public"],
 )

--- a/hazel/third_party/haskell/BUILD.wai-app-static
+++ b/hazel/third_party/haskell/BUILD.wai-app-static
@@ -4,7 +4,7 @@ load("@io_tweag_rules_haskell//haskell:haskell.bzl", "haskell_library")
 load("@ai_formation_hazel//:hazel.bzl", "hazel_library")
 
 haskell_library(
-  name = "wai-app-static",
+  name = "lib",
   srcs = glob([
     "Network/Wai/Application/Static.hs",
     "Util.hs",
@@ -40,10 +40,11 @@ haskell_library(
     hazel_library("warp"),
     hazel_library("zlib"),
   ],
+  package_name = "wai-app-static",
   version = "3.1.6.2",
 )
 
 cc_import(
-    name = "wai-app-static-cbits",
+    name = "cbits",
     visibility = ["//visibility:public"],
 )

--- a/hazel/third_party/haskell/BUILD.zlib
+++ b/hazel/third_party/haskell/BUILD.zlib
@@ -7,7 +7,7 @@ load("@io_tweag_rules_haskell//haskell:haskell.bzl",
 load("@ai_formation_hazel//:hazel.bzl", "hazel_library")
 
 cc_library(
-  name = "zlib-cbits",
+  name = "cbits",
   hdrs = glob(["cbits/*.h"]),
   srcs = glob(["cbits/*.c"]),
   includes = ["cbits"],
@@ -15,16 +15,18 @@ cc_library(
 )
 
 haskell_library(
-  name = "zlib",
+  name = "lib",
   srcs = glob([
     "Codec/Compression/*.hs",
     "Codec/Compression/Zlib/*.hs",
     "Codec/Compression/Zlib/*.hsc",
   ]),
   deps = [
-      ":zlib-cbits",
+      ":cbits",
       hazel_library("base"),
       hazel_library("bytestring"),
       hazel_library("ghc-prim"),
   ],
+  package_name = "zlib",
+  version = "0.6.2",
 )

--- a/hazel/third_party/haskell/BUILD.zlib
+++ b/hazel/third_party/haskell/BUILD.zlib
@@ -7,7 +7,7 @@ load("@io_tweag_rules_haskell//haskell:haskell.bzl",
 load("@ai_formation_hazel//:hazel.bzl", "hazel_library")
 
 cc_library(
-  name = "cbits",
+  name = "zlib-cbits",
   hdrs = glob(["cbits/*.h"]),
   srcs = glob(["cbits/*.c"]),
   includes = ["cbits"],
@@ -22,7 +22,7 @@ haskell_library(
     "Codec/Compression/Zlib/*.hsc",
   ]),
   deps = [
-      ":cbits",
+      ":zlib-cbits",
       hazel_library("base"),
       hazel_library("bytestring"),
       hazel_library("ghc-prim"),

--- a/hazel/third_party/haskell/BUILD.zlib-bindings
+++ b/hazel/third_party/haskell/BUILD.zlib-bindings
@@ -7,7 +7,7 @@ load("@io_tweag_rules_haskell//haskell:haskell.bzl",
 load("@ai_formation_hazel//:hazel.bzl", "hazel_library")
 
 cc_library(
-  name = "cbits",
+  name = "zlib-bindings-cbits",
   hdrs = glob(["cbits/*.h"]),
   srcs = glob(["cbits/*.c"]),
   strip_include_prefix = "cbits",
@@ -20,7 +20,7 @@ haskell_library(
     "Codec/Zlib/Lowlevel.hs",
   ]),
   deps = [
-      ":cbits",
+      ":zlib-bindings-cbits",
       hazel_library("base"),
       hazel_library("bytestring"),
       hazel_library("zlib"),

--- a/hazel/third_party/haskell/BUILD.zlib-bindings
+++ b/hazel/third_party/haskell/BUILD.zlib-bindings
@@ -14,7 +14,7 @@ cc_library(
 )
 
 haskell_library(
-  name = "zlib-bindings",
+  name = "lib",
   srcs = glob([
     "Codec/Zlib.hs",
     "Codec/Zlib/Lowlevel.hs",
@@ -25,4 +25,6 @@ haskell_library(
       hazel_library("bytestring"),
       hazel_library("zlib"),
   ],
+  package_name "zlib-bindings",
+  version = "0.1.1.5",
 )

--- a/hazel/tools/mangling.bzl
+++ b/hazel/tools/mangling.bzl
@@ -1,14 +1,14 @@
 def hazel_library(package_name):
     """Returns the label of the haskell_library rule for the given package."""
-    return "@{}//:{}".format(hazel_workspace(package_name), package_name)
+    return "@{}//:lib".format(hazel_workspace(package_name))
 
 def hazel_binary(package_name):
     """Returns the label of the haskell_binary rule for the given package."""
-    return "@{}//:{}_bin".format(hazel_workspace(package_name), package_name)
+    return "@{}//:bin".format(hazel_workspace(package_name))
 
 def hazel_cbits(package_name):
     """Returns the label of the cc_library rule for the given package."""
-    return "@{}//:{}-cbits".format(hazel_workspace(package_name), package_name)
+    return "@{}//:cbits".format(hazel_workspace(package_name))
 
 def hazel_workspace(package_name):
     """Convert a package name to a valid and unambiguous workspace name.

--- a/hazel/tools/mangling.bzl
+++ b/hazel/tools/mangling.bzl
@@ -8,7 +8,7 @@ def hazel_binary(package_name):
 
 def hazel_cbits(package_name):
     """Returns the label of the cc_library rule for the given package."""
-    return "@{}//:cbits".format(hazel_workspace(package_name))
+    return "@{}//:{}-cbits".format(hazel_workspace(package_name), package_name)
 
 def hazel_workspace(package_name):
     """Convert a package name to a valid and unambiguous workspace name.


### PR DESCRIPTION
Previously, Hazel would generate library targets, that repeated the package name in their target name. This lead to too long paths on Windows, which could induce errors with code that did not use API functions with long path support.

This change modifies Hazel to always name the library target "lib" .

This change affects version macro generation, as it was previously based on the target name. To maintain the correct version macro names for Hackage packages, this PR adds an optional `package_name` field, which can be defined to override the package name used in the version macros.

Ideally, we would also shorten the name of the corresponding cbits target from `<pkgname>-cbits` to just `cbits`. However, this is currently not possible because of #862.