### PR TITLE
Add haskell_cabal_library

### DIFF
--- a/haskell/BUILD.bazel
+++ b/haskell/BUILD.bazel
@@ -1,9 +1,10 @@
 exports_files(
     glob(["*.bzl"]) + [
         "assets/ghci_script",
+        "private/cabal_wrapper.sh.tpl",
+        "private/coverage_wrapper.sh.tpl",
         "private/ghci_repl_wrapper.sh",
         "private/haddock_wrapper.sh.tpl",
-        "private/coverage_wrapper.sh.tpl",
         "private/osx_cc_wrapper.sh.tpl",
         "private/pkgdb_to_bzl.py",
     ],

--- a/haskell/cabal.bzl
+++ b/haskell/cabal.bzl
@@ -1,0 +1,245 @@
+"""Cabal packages"""
+
+load("@bazel_skylib//lib:dicts.bzl", "dicts")
+load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
+load(":cc.bzl", "cc_interop_info")
+load(":private/context.bzl", "haskell_context")
+load(":private/dependencies.bzl", "gather_dep_info")
+load(":private/mode.bzl", "is_profiling_enabled")
+load(":private/set.bzl", "set")
+load(
+    ":providers.bzl",
+    "HaskellInfo",
+    "HaskellLibraryInfo",
+    "empty_HaskellCcInfo",
+    "get_libs_for_ghc_linker",
+    "merge_HaskellCcInfo",
+)
+
+def _execute_or_fail_loudly(repository_ctx, arguments):
+    exec_result = repository_ctx.execute(arguments)
+    if exec_result.return_code != 0:
+        fail("\n".join(["Command failed: " + " ".join(arguments), exec_result.stderr]))
+    return exec_result
+
+def _so_extension(hs):
+    return "dylib" if hs.toolchain.is_darwin else "so"
+
+def _dirname(file):
+    return file.dirname
+
+def _haskell_cabal_library_impl(ctx):
+    hs = haskell_context(ctx)
+    dep_info = gather_dep_info(ctx, ctx.attr.deps)
+    cc = cc_interop_info(ctx)
+    cc_info = cc_common.merge_cc_infos(
+        cc_infos = [dep[CcInfo] for dep in ctx.attr.deps if CcInfo in dep],
+    )
+    name = hs.label.name
+    with_profiling = is_profiling_enabled(hs)
+
+    # Check that a .cabal file exists. Choose the root one.
+    cabal = None
+    for f in ctx.files.srcs:
+        if f.extension == "cabal":
+            if not cabal or f.dirname < cabal.dirname:
+                cabal = f
+    if not cabal:
+        fail("A .cabal file was not found in the srcs attribute.")
+
+    # Check that a Setup script exists. If not, create a default one.
+    setup = None
+    for f in ctx.files.srcs:
+        if f.basename in ["Setup.hs", "Setup.lhs"]:
+            if not setup or f.dirname < setup.dirname:
+                setup = f
+    if not setup:
+        setup = hs.actions.declare_file("Setup.hs", sibling = cabal)
+        hs.actions.write(
+            output = setup,
+            content = """
+module Main where
+import Distribution.Simple
+
+main :: IO ()
+main = defaultMain
+""",
+        )
+
+    package_database = hs.actions.declare_file(
+        "_install/package.conf.d/package.cache",
+        sibling = cabal,
+    )
+    interfaces_dir = hs.actions.declare_directory(
+        "_install/iface",
+        sibling = cabal,
+    )
+    static_library = hs.actions.declare_file(
+        "_install/lib/libHS{}.a".format(name),
+        sibling = cabal,
+    )
+    static_library_prof = None
+    if with_profiling:
+        static_library_prof = hs.actions.declare_file(
+            "_install/lib/libHS{}_p.a".format(name),
+            sibling = cabal,
+        )
+    dynamic_library = hs.actions.declare_file(
+        "_install/lib/libHS{}-ghc{}.{}".format(name, hs.toolchain.version, _so_extension(hs)),
+        sibling = cabal,
+    )
+
+    args = hs.actions.args()
+    package_databases = set.to_depset(dep_info.package_databases)
+    extra_headers = cc_info.compilation_context.headers
+    extra_include_dirs = cc_info.compilation_context.includes
+    (library_deps, ld_library_deps, ghc_env) = get_libs_for_ghc_linker(
+        hs,
+        dep_info.transitive_cc_dependencies,
+    )
+    extra_lib_dirs = [file.dirname for file in library_deps]
+    args.add_all([name, setup, cabal.dirname, package_database.dirname])
+    args.add_all(package_databases, map_each = _dirname, format_each = "--package-db=%s")
+    args.add_all(extra_include_dirs, format_each = "--extra-include-dirs=%s")
+    args.add_all(extra_lib_dirs, format_each = "--extra-lib-dirs=%s", uniquify = True)
+    if with_profiling:
+        args.add("--enable-profiling")
+
+    # TODO Instantiating this template could be done just once in the
+    # toolchain rule.
+    cabal_wrapper = ctx.actions.declare_file("cabal_wrapper-{}.sh".format(hs.label.name))
+    ctx.actions.expand_template(
+        template = ctx.file._cabal_wrapper_tpl,
+        output = cabal_wrapper,
+        is_executable = True,
+        substitutions = {
+            "%{ghc}": hs.tools.ghc.path,
+            "%{ghc_pkg}": hs.tools.ghc_pkg.path,
+            "%{runghc}": hs.tools.runghc.path,
+            "%{ar}": cc.tools.ar,
+            "%{strip}": cc.tools.strip,
+        },
+    )
+
+    # Make the Cabal configure/build/install steps one big action so
+    # that we don't have to track all inputs explicitly between steps.
+    ctx.actions.run(
+        executable = cabal_wrapper,
+        arguments = [args],
+        inputs = depset(
+            [setup, hs.tools.ghc, hs.tools.ghc_pkg, hs.tools.runghc],
+            transitive = [
+                depset(ctx.files.srcs),
+                package_databases,
+                extra_headers,
+                depset(library_deps),
+                depset(ld_library_deps),
+                set.to_depset(dep_info.interface_dirs),
+                depset(dep_info.static_libraries),
+                set.to_depset(dep_info.dynamic_libraries),
+            ],
+        ),
+        outputs = [
+            package_database,
+            interfaces_dir,
+            static_library,
+            dynamic_library,
+        ] + ([static_library_prof] if with_profiling else []),
+        env = dicts.add(ghc_env, hs.env),
+        mnemonic = "HaskellCabalLibrary",
+        progress_message = "HaskellCabalLibrary {}".format(hs.label),
+        use_default_shell_env = True,
+    )
+
+    default_info = DefaultInfo(files = depset([static_library, dynamic_library]))
+    hs_info = HaskellInfo(
+        package_ids = set.empty(),
+        package_databases = set.insert(dep_info.package_databases, package_database),
+        version_macros = set.empty(),
+        source_files = set.empty(),
+        extra_source_files = depset(),
+        import_dirs = set.empty(),
+        static_libraries = [static_library] + dep_info.static_libraries,
+        static_libraries_prof = (
+            [static_library_prof] if with_profiling else []
+        ) + dep_info.static_libraries_prof,
+        dynamic_libraries = set.insert(dep_info.dynamic_libraries, dynamic_library),
+        interface_dirs = set.insert(dep_info.interface_dirs, interfaces_dir),
+        compile_flags = [],
+        prebuilt_dependencies = set.empty(),
+        direct_prebuilt_deps = set.empty(),
+        cc_dependencies = dep_info.cc_dependencies,
+        transitive_cc_dependencies = dep_info.transitive_cc_dependencies,
+    )
+    lib_info = HaskellLibraryInfo(package_id = name, version = None)
+    cc_toolchain = find_cpp_toolchain(ctx)
+    feature_configuration = cc_common.configure_features(
+        cc_toolchain = cc_toolchain,
+        requested_features = ctx.features,
+        unsupported_features = ctx.disabled_features,
+    )
+    library_to_link = cc_common.create_library_to_link(
+        actions = ctx.actions,
+        feature_configuration = feature_configuration,
+        dynamic_library = dynamic_library,
+        static_library = static_library,
+        cc_toolchain = cc_toolchain,
+    )
+    compilation_context = cc_common.create_compilation_context()
+    linking_context = cc_common.create_linking_context(
+        libraries_to_link = [library_to_link],
+    )
+    cc_info = cc_common.merge_cc_infos(
+        cc_infos = [
+            CcInfo(
+                compilation_context = compilation_context,
+                linking_context = linking_context,
+            ),
+            cc_info,
+        ],
+    )
+    return [default_info, hs_info, cc_info, lib_info]
+
+haskell_cabal_library = rule(
+    _haskell_cabal_library_impl,
+    attrs = {
+        "srcs": attr.label_list(allow_files = True),
+        "deps": attr.label_list(),
+        "_cabal_wrapper_tpl": attr.label(
+            allow_single_file = True,
+            default = Label("@io_tweag_rules_haskell//haskell:private/cabal_wrapper.sh.tpl"),
+        ),
+        "_cc_toolchain": attr.label(
+            default = Label("@bazel_tools//tools/cpp:current_cc_toolchain"),
+        ),
+    },
+    toolchains = ["@io_tweag_rules_haskell//haskell:toolchain"],
+)
+"""Use Cabal to build a library.
+
+Example:
+  ```bzl
+  haskell_cabal_library(
+      name = "lib-0.1.0.0",
+      srcs = ["lib.cabal", "Lib.hs", "Setup.hs"],
+  )
+
+  haskell_toolchain_library(name = "base")
+
+  haskell_binary(
+      name = "bin",
+      deps = [":base", ":lib-0.1.0.0"],
+      srcs = ["Main.hs"],
+  )
+  ```
+
+This rule does not use `cabal-install`. It calls the package's
+`Setup.hs` script directly if one exists, or the default one if not.
+All sources files that would have been part of a Cabal sdist need to
+be listed in `srcs` (crucially, including the `.cabal` file).
+A `haskell_cabal_library` can be substituted for any
+`haskell_library`. The two are interchangeable in most contexts.
+However, using a plain `haskell_library` sometimes leads to better
+build times, and does not require drafting a `.cabal` file.
+
+"""

--- a/haskell/cc.bzl
+++ b/haskell/cc.bzl
@@ -126,6 +126,7 @@ def cc_interop_info(ctx):
         "ld": cc_toolchain.ld_executable(),
         "cpp": cc_toolchain.preprocessor_executable(),
         "nm": cc_toolchain.nm_executable(),
+        "strip": cc_toolchain.strip_executable(),
     }
 
     # If running on darwin but XCode is not installed (i.e., only the Command

--- a/haskell/private/cabal_wrapper.sh.tpl
+++ b/haskell/private/cabal_wrapper.sh.tpl
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+#
+# cabal_wrapper.sh <PKG_NAME> <SETUP_PATH> <PKG_DIR> <PACKAGE_DB_PATH> [SETUP_ARGS...]
+
+set -euo pipefail
+execroot="$(pwd)"
+
+# Set these variables if unset.
+: ${LD_LIBRARY_PATH:=}
+: ${LIBRARY_PATH:=}
+export LD_LIBRARY_PATH=$execroot/${LD_LIBRARY_PATH//:/:$execroot/}
+export LIBRARY_PATH=$execroot/${LIBRARY_PATH//:/:$execroot/}
+
+name=$1
+setup=$execroot/$2
+srcdir=$execroot/$3
+pkgroot="$(realpath $execroot/$4/..)" # By definition (see ghc-pkg source code).
+shift 4
+
+distdir=$(mktemp -d)
+libdir=$pkgroot/iface
+dynlibdir=$pkgroot/lib
+package_database=$pkgroot/package.conf.d
+
+%{ghc_pkg} recache --package-db=$package_database
+
+# Cabal really wants the current working directory to be directory
+# where the .cabal file is located. So we have no choice but to chance
+# cd into it, but then we have to rewrite all relative references into
+# absolute ones before doing so (using $execroot).
+cd $srcdir
+export HOME=/var/empty
+$execroot/%{runghc} $setup configure \
+    --verbose=0 \
+    --user \
+    --with-compiler=$execroot/%{ghc} \
+    --with-hc-pkg=$execroot/%{ghc_pkg} \
+    --with-ar=%{ar} \
+    --with-strip=%{strip} \
+    --enable-deterministic \
+    --enable-relocatable \
+    --builddir=$distdir \
+    --prefix=$pkgroot \
+    --libdir=$libdir \
+    --dynlibdir=$dynlibdir \
+    --libsubdir= \
+    --package-db=clear \
+    --package-db=global \
+    "${@/=/=$execroot/}" \
+    --package-db=$package_database # This arg must come last.
+$execroot/%{runghc} $setup build --verbose=0 --builddir=$distdir
+$execroot/%{runghc} $setup install --verbose=0 --builddir=$distdir
+cd - >/dev/null
+
+# XXX Cabal has a bizarre layout that we can't control directly. It
+# confounds the library-dir and the import-dir (but not the
+# dynamic-library-dir). That's pretty annoying, because Bazel won't
+# allow overlap in the path to the interface files directory and the
+# path to the static library. So we move the static library elsewhere
+# and patch the .conf file accordingly.
+#
+# There were plans for controlling this, but they died. See:
+# https://github.com/haskell/cabal/pull/3982#issuecomment-254038734
+mv $libdir/libHS*.a $dynlibdir
+sed 's,library-dirs:.*,library-dirs: ${pkgroot}/lib,' \
+    $package_database/$name.conf > $package_database/$name.conf.tmp
+mv  $package_database/$name.conf.tmp $package_database/$name.conf
+%{ghc_pkg} recache --package-db=$package_database

--- a/tests/haskell_cabal_library/BUILD.bazel
+++ b/tests/haskell_cabal_library/BUILD.bazel
@@ -1,0 +1,25 @@
+load("@io_tweag_rules_haskell//haskell:cabal.bzl", "haskell_cabal_library")
+load(
+    "@io_tweag_rules_haskell//haskell:haskell.bzl",
+    "haskell_test",
+    "haskell_toolchain_library",
+)
+
+haskell_toolchain_library(name = "base")
+
+haskell_cabal_library(
+    name = "lib-0.1.0.0",
+    srcs = [
+        "Lib.hs",
+        "lib.cabal",
+    ],
+)
+
+haskell_test(
+    name = "haskell_cabal_library",
+    srcs = ["Main.hs"],
+    deps = [
+        ":base",
+        ":lib-0.1.0.0",
+    ],
+)

--- a/tests/haskell_cabal_library/Lib.hs
+++ b/tests/haskell_cabal_library/Lib.hs
@@ -1,0 +1,3 @@
+module Lib where
+
+x = 2

--- a/tests/haskell_cabal_library/Main.hs
+++ b/tests/haskell_cabal_library/Main.hs
@@ -1,0 +1,5 @@
+module Main where
+
+import Lib
+
+main = print Lib.x

--- a/tests/haskell_cabal_library/lib.cabal
+++ b/tests/haskell_cabal_library/lib.cabal
@@ -1,0 +1,9 @@
+cabal-version: >=1.10
+name: lib
+version: 0.1.0.0
+build-type: Simple
+
+library
+  build-depends: base >=4.12 && <4.13
+  default-language: Haskell2010
+  exposed-modules: Lib


### PR DESCRIPTION
(This PR does not include Windows support, which should be easy to add later.)

This is an alternative solution for handling Cabal libraries published
on Hackage to both Hazel and Nixpkgs. The idea in this one is to use
Cabal to build Cabal packages, and Stack to download source
distributions from a Stackage snapshot and generate a dependency
graph. See #874 for the rationale. The Stack part will be submitted as
the next PR in the series.

This rule exposes all the same providers as `haskell_library`, so one
can be substituted for the other.

I haven't tried building all of Stackage, but as a data point, this
rule is able to build the close to 200 dependencies of Stack. The vast
majority of Cabal packages in Stackage build out-of-the-box, including
those that have system dependencies like `zlib`. Only packages that do
very funky things like attempt creating their own files in the CWD
fail (like Stack itself), because Bazel sensibly marks the source
directory as read-only.

cc @ndmitchell @judah