### PR TITLE
Make ghc-paths work on Windows

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,6 +39,7 @@ jobs:
       /c/bazel/bazel.exe build --config windows "@haskell_unix__compat//..."
       /c/bazel/bazel.exe build --config windows "@haskell_hostname//..."
       /c/bazel/bazel.exe build --config windows "@haskell_zlib//..."
+      /c/bazel/bazel.exe build --config windows "@haskell_ghc__paths//..."
 
       # FIXME: needs network, warp, cryptonite, etc...
       # /c/bazel/bazel.exe build --config windows "@haskell_wai__app__static//..."

--- a/hazel/ghc_paths.bzl
+++ b/hazel/ghc_paths.bzl
@@ -12,7 +12,7 @@ module GHC.Paths (
 
 libdir, docdir, ghc, ghc_pkg :: FilePath
 
-libdir  = "$({ghc} --print-libdir)"
+libdir  = "$({ghc} --print-libdir | sed s:\\:/:g)"
 docdir  = "DOCDIR_IS_NOT_SET"
 
 ghc     = "{ghc}"


### PR DESCRIPTION
Before building ghc-paths lead to the error:

```
bazel-out\x64_windows-fastbuild\bin\external\haskell_ghc__paths\GHC\Paths.hs:7:15: error:
    lexical error in string/character literal at character 'U'
  |
7 | libdir  = "C:\Users\ndmit_000\_bazel_Neil\cqtxsy6d\external\io_tweag_rules_haskell_ghc_windows_amd64\lib"
  |               ^
```

I fix that by using `sed` to replace `\` with `/`.