### PR TITLE
Handle missing library in haskell_toolchain_library

### DIFF
--- a/haskell/private/haskell_impl.bzl
+++ b/haskell/private/haskell_impl.bzl
@@ -637,6 +637,7 @@ Check that it ships with your version of GHC.
         unsupported_features = ctx.disabled_features,
     )
 
+    # Workaround for https://github.com/tweag/rules_haskell/issues/881
     # Static and dynamic libraries don't necessarily pair up 1 to 1.
     # E.g. the rts package in the Unix GHC bindist contains the
     # dynamic libHSrts and the static libCffi and libHSrts.

--- a/haskell/private/path_utils.bzl
+++ b/haskell/private/path_utils.bzl
@@ -208,6 +208,23 @@ def get_lib_name(lib):
     end = paths.replace_extension(base, "") if n == -1 else base[:n]
     return end
 
+def get_dynamic_hs_lib_name(ghc_version, lib):
+    """Return name of library by dropping extension,
+    "lib" prefix, and GHC version suffix.
+
+    Args:
+      version: GHC version.
+      lib: The library File.
+
+    Returns:
+      String: name of library.
+    """
+    name = get_lib_name(lib)
+    suffix = "-ghc{}".format(ghc_version)
+    if name.endswith(suffix):
+        name = name[:-len(suffix)]
+    return name
+
 def link_libraries(libs_to_link, args):
     """Add linker flags to link against the given libraries.
 


### PR DESCRIPTION
`haskell_toolchain_library` expects the incoming lists of static and dynamic libraries to pair up exactly. As detailed in #881 this is currently not the case. This PR does not resolve issue #881. However, it makes the code in question more robust by making sure that in case a library component is missing the right libraries are paired up. E.g. it will prevent `libCffi.a` to be paired up with `libHSrts-ghc*.so`.

