### PR TITLE
Add package name export aliases to nixpkgs toolchain

### DIFF
--- a/haskell/nixpkgs.bzl
+++ b/haskell/nixpkgs.bzl
@@ -278,7 +278,7 @@ filegroup(
 
 haskell_toolchain(
     name = "toolchain-impl",
-    tools = {tools},
+    tools = {other_tools} + {tools},
     libraries = toolchain_libraries,
     version = "{version}",
     compiler_flags = {compiler_flags} + {compiler_flags_select},
@@ -287,6 +287,7 @@ haskell_toolchain(
     # On Darwin we don't need a locale archive. It's a Linux-specific
     # hack in Nixpkgs.
     locale_archive = {locale_archive},
+    locale = {locale},
 )
         """.format(
             toolchain_libraries = toolchain_libraries,
@@ -297,6 +298,8 @@ haskell_toolchain(
             haddock_flags = repository_ctx.attr.haddock_flags,
             repl_ghci_args = repository_ctx.attr.repl_ghci_args,
             locale_archive = locale_archive,
+            locale = repr(repository_ctx.attr.locale) or [],
+            other_tools = repr([str(repository_ctx.path(i)) for i in repository_ctx.attr.tools]),
         ),
     )
 
@@ -312,6 +315,10 @@ _ghc_nixpkgs_haskell_toolchain = repository_rule(
         "repl_ghci_args": attr.string_list(),
         "locale_archive": attr.string(),
         "_nixpkgs_ghc": attr.label(default = "@io_tweag_rules_haskell_ghc_nixpkgs//:BUILD"),
+        "locale": attr.string(
+            default = "en_US.UTF-8",
+        ),
+        "tools": attr.label_list(),
     },
 )
 
@@ -360,7 +367,10 @@ def haskell_register_ghc_nixpkgs(
         attribute_path = "haskellPackages.ghc",
         nix_file = None,
         nix_file_deps = [],
-        repositories = {}):
+        locale = None,
+        repositories = {},
+        tools = [],
+        nix_file_content = ""):
     """Register a package from Nixpkgs as a toolchain.
 
     Toolchains can be used to compile Haskell code. To have this
@@ -401,6 +411,7 @@ def haskell_register_ghc_nixpkgs(
         build_file_content = build_file_content,
         nix_file = nix_file,
         nix_file_deps = nix_file_deps,
+        nix_file_content = nix_file_content,
         repositories = repositories,
     )
 
@@ -413,6 +424,8 @@ def haskell_register_ghc_nixpkgs(
         haddock_flags = haddock_flags,
         repl_ghci_args = repl_ghci_args,
         locale_archive = locale_archive,
+        locale = locale,
+        tools = tools,
     )
 
     # toolchain definition.


### PR DESCRIPTION
Haskell packages exported by nixpkgs toolchain can lead to conflict in
bazel names if the environment contains many packages with the same
package name.

This commit introduces a new aliases attribute to the toolchain
registration rule which allows the override of package exported names.

Packages id are matched using a prefix, this way the author does not
need to provide a fully qualified package id, hence this is more
robust to underlying toolchain changes (such as nixpkgs upgrades). For
example, users can only match on package name + version if the
conflict appears between two packages of different version, such as
`ACME-0.0.0.0` and `ACME-0.0.0.1`.

This closes #885 and depends on #886 (first commit of this PR)