### PR TITLE
Handle hs-libraries: Cffi in pkgdb_to_bzl.py

### DIFF
--- a/haskell/private/haskell_impl.bzl
+++ b/haskell/private/haskell_impl.bzl
@@ -26,6 +26,7 @@ load(
     ":private/path_utils.bzl",
     "get_dynamic_hs_lib_name",
     "get_lib_name",
+    "get_static_hs_lib_name",
     "ln",
     "match_label",
     "parse_pattern",
@@ -646,7 +647,7 @@ Check that it ships with your version of GHC.
         for lib in target[HaskellImportHack].dynamic_libraries
     }
     for lib in target[HaskellImportHack].static_libraries:
-        name = get_lib_name(lib)
+        name = get_static_hs_lib_name(lib)
         entry = libs.get(name, {})
         entry["static"] = lib
         libs[name] = entry

--- a/haskell/private/path_utils.bzl
+++ b/haskell/private/path_utils.bzl
@@ -225,6 +225,22 @@ def get_dynamic_hs_lib_name(ghc_version, lib):
         name = name[:-len(suffix)]
     return name
 
+def get_static_hs_lib_name(lib):
+    """Return name of library by dropping extension, "lib" prefix.
+
+    Takes the unusual case of libCffi.a into account.
+
+    Args:
+      lib: The library File.
+
+    Returns:
+      String: name of library.
+    """
+    name = get_lib_name(lib)
+    if name == "Cffi":
+        return "ffi"
+    return name
+
 def link_libraries(libs_to_link, args):
     """Add linker flags to link against the given libraries.
 


### PR DESCRIPTION
The GHC bindist's rts package contains an entry in hs-libraries called `Cffi`. However, the corresponding library files are `libCffi.a`, `libCffi_p.a`, `libffi.so`, etc.