### PR TITLE
Separate list_exposed_modules from compile_library

### DIFF
--- a/haskell/private/actions/compile.bzl
+++ b/haskell/private/actions/compile.bzl
@@ -464,9 +464,6 @@ def compile_library(
         dep_info,
         plugin_dep_info,
         srcs,
-        ls_modules,
-        other_modules,
-        exposed_modules_reexports,
         import_dir_map,
         extra_srcs,
         user_compile_flags,
@@ -512,13 +509,6 @@ def compile_library(
         arguments = c.args,
     )
 
-    if with_profiling:
-        exposed_modules_file = None
-    else:
-        exposed_modules_file = list_exposed_modules(
-            hs, ls_modules, other_modules, exposed_modules_reexports, c.interfaces_dir
-        )
-
     return struct(
         interfaces_dir = c.interfaces_dir,
         objects_dir = c.objects_dir,
@@ -526,7 +516,6 @@ def compile_library(
         source_files = c.source_files,
         extra_source_files = c.extra_source_files,
         import_dirs = c.import_dirs,
-        exposed_modules_file = exposed_modules_file,
         coverage_data = coverage_data,
     )
 

--- a/haskell/private/actions/compile.bzl
+++ b/haskell/private/actions/compile.bzl
@@ -427,33 +427,12 @@ def compile_binary(
         arguments = c.args,
     )
 
-    if with_profiling:
-        exposed_modules_file = None
-    else:
-        exposed_modules_file = hs.actions.declare_file(
-            target_unique_name(hs, "exposed-modules"),
-        )
-        hs.actions.run(
-            inputs = [c.interfaces_dir, hs.toolchain.global_pkg_db],
-            outputs = [exposed_modules_file],
-            executable = ls_modules,
-            arguments = [
-                c.interfaces_dir.path,
-                hs.toolchain.global_pkg_db.path,
-                "/dev/null",  # no hidden modules
-                "/dev/null",  # no reexported modules
-                exposed_modules_file.path,
-            ],
-            use_default_shell_env = True,
-        )
-
     return struct(
         objects_dir = c.objects_dir,
         source_files = c.source_files,
         extra_source_files = c.extra_source_files,
         import_dirs = c.import_dirs,
         compile_flags = c.compile_flags,
-        exposed_modules_file = exposed_modules_file,
         coverage_data = coverage_data,
     )
 

--- a/haskell/private/haskell_impl.bzl
+++ b/haskell/private/haskell_impl.bzl
@@ -10,6 +10,10 @@ load(
 )
 load(":cc.bzl", "cc_interop_info")
 load(
+    ":private/actions/compile.bzl",
+    "list_exposed_modules",
+)
+load(
     ":private/actions/link.bzl",
     "link_binary",
     "link_library_dynamic",
@@ -337,9 +341,6 @@ def haskell_library_impl(ctx):
         dep_info,
         plugin_dep_info,
         srcs = srcs_files,
-        ls_modules = ctx.executable._ls_modules,
-        other_modules = other_modules,
-        exposed_modules_reexports = exposed_modules_reexports,
         import_dir_map = import_dir_map,
         extra_srcs = depset(ctx.files.extra_srcs),
         user_compile_flags = ctx.attr.compiler_flags,
@@ -347,6 +348,14 @@ def haskell_library_impl(ctx):
         with_profiling = False,
         my_pkg_id = my_pkg_id,
         plugins = ctx.attr.plugins,
+    )
+
+    exposed_modules_file = list_exposed_modules(
+        hs,
+        ls_modules = ctx.executable._ls_modules,
+        other_modules = other_modules,
+        exposed_modules_reexports = exposed_modules_reexports,
+        interfaces_dir = c.interfaces_dir,
     )
 
     c_p = None
@@ -359,9 +368,6 @@ def haskell_library_impl(ctx):
             dep_info,
             plugin_dep_info,
             srcs = srcs_files,
-            ls_modules = ctx.executable._ls_modules,
-            other_modules = other_modules,
-            exposed_modules_reexports = exposed_modules_reexports,
             import_dir_map = import_dir_map,
             # NOTE We must make the object files compiled without profiling
             # available to this step for TH to work, presumably because GHC is
@@ -424,7 +430,7 @@ def haskell_library_impl(ctx):
         c_p.interfaces_dir if c_p != None else None,
         static_library,
         dynamic_library,
-        c.exposed_modules_file,
+        exposed_modules_file,
         other_modules,
         my_pkg_id,
         static_library_prof = static_library_prof,


### PR DESCRIPTION
Before `compile_library` contained a conditional step to list all exposed modules, but only if `with_profiling` was `False`. This step is not strictly related to `compile_library` and the step being conditional meant that the function potentially returned a `None` value which was error prone. This PR separates `list_exposed_modules` into its own step.