### PR TITLE
Exclusive profiling mode

### DIFF
--- a/haskell/cabal.bzl
+++ b/haskell/cabal.bzl
@@ -155,16 +155,13 @@ def _haskell_cabal_library_impl(ctx):
         "_install/iface",
         sibling = cabal,
     )
+    static_library_filename = "_install/lib/libHS{}.a".format(name)
+    if with_profiling:
+        static_library_filename = "_install/lib/libHS{}_p.a".format(name)
     static_library = hs.actions.declare_file(
-        "_install/lib/libHS{}.a".format(name),
+        static_library_filename,
         sibling = cabal,
     )
-    static_library_prof = None
-    if with_profiling:
-        static_library_prof = hs.actions.declare_file(
-            "_install/lib/libHS{}_p.a".format(name),
-            sibling = cabal,
-        )
     dynamic_library = hs.actions.declare_file(
         "_install/lib/libHS{}-ghc{}.{}".format(name, hs.toolchain.version, _so_extension(hs)),
         sibling = cabal,
@@ -189,7 +186,7 @@ def _haskell_cabal_library_impl(ctx):
             interfaces_dir,
             static_library,
             dynamic_library,
-        ] + ([static_library_prof] if with_profiling else []),
+        ],
         env = c.env,
         mnemonic = "HaskellCabalLibrary",
         progress_message = "HaskellCabalLibrary {}".format(hs.label),
@@ -205,9 +202,6 @@ def _haskell_cabal_library_impl(ctx):
         extra_source_files = depset(),
         import_dirs = set.empty(),
         static_libraries = [static_library] + dep_info.static_libraries,
-        static_libraries_prof = (
-            [static_library_prof] if with_profiling else []
-        ) + dep_info.static_libraries_prof,
         dynamic_libraries = set.insert(dep_info.dynamic_libraries, dynamic_library),
         interface_dirs = set.insert(dep_info.interface_dirs, interfaces_dir),
         compile_flags = [],

--- a/haskell/private/actions/compile.bzl
+++ b/haskell/private/actions/compile.bzl
@@ -113,8 +113,8 @@ def _compilation_defaults(hs, cc, java, dep_info, plugin_dep_info, srcs, import_
     ]
     compile_flags += cc_args
 
-    interface_dir_raw = "_iface_prof" if with_profiling else "_iface"
-    object_dir_raw = "_obj_prof" if with_profiling else "_obj"
+    interface_dir_raw = "_iface"
+    object_dir_raw = "_obj"
 
     # Declare file directories.
     #
@@ -333,12 +333,10 @@ def _compilation_defaults(hs, cc, java, dep_info, plugin_dep_info, srcs, import_
             set.to_depset(dep_info.package_databases),
             set.to_depset(dep_info.interface_dirs),
             depset(dep_info.static_libraries),
-            depset(dep_info.static_libraries_prof),
             set.to_depset(dep_info.dynamic_libraries),
             set.to_depset(plugin_dep_info.package_databases),
             set.to_depset(plugin_dep_info.interface_dirs),
             depset(plugin_dep_info.static_libraries),
-            depset(plugin_dep_info.static_libraries_prof),
             set.to_depset(plugin_dep_info.dynamic_libraries),
             depset(library_deps),
             depset(ld_library_deps),
@@ -503,7 +501,8 @@ def list_exposed_modules(
         ls_modules,
         other_modules,
         exposed_modules_reexports,
-        interfaces_dir):
+        interfaces_dir,
+        with_profiling):
     """Construct file listing the exposed modules of this package.
 
     Args:
@@ -512,6 +511,7 @@ def list_exposed_modules(
       other_modules: List of hidden modules.
       exposed_modules_reexports: List of re-exported modules.
       interfaces_dir: The directory containing the interface files.
+      with_profiling: Whether we're building in profiling mode.
 
     Returns:
       File: File holding the package ceonfiguration exposed-modules value.
@@ -543,6 +543,7 @@ def list_exposed_modules(
         outputs = [exposed_modules_file],
         executable = ls_modules,
         arguments = [
+            str(with_profiling),
             interfaces_dir.path,
             hs.toolchain.global_pkg_db.path,
             hidden_modules_file.path,

--- a/haskell/private/actions/link.bzl
+++ b/haskell/private/actions/link.bzl
@@ -456,7 +456,6 @@ def link_binary(
             set.to_depset(dep_info.package_databases),
             set.to_depset(dep_info.dynamic_libraries),
             depset(dep_info.static_libraries),
-            depset(dep_info.static_libraries_prof),
             depset([objects_dir]),
             cc_link_libs,
         ]),

--- a/haskell/private/dependencies.bzl
+++ b/haskell/private/dependencies.bzl
@@ -145,7 +145,6 @@ def gather_dep_info(ctx, deps):
         package_databases = set.empty(),
         version_macros = set.empty(),
         static_libraries = [],
-        static_libraries_prof = [],
         dynamic_libraries = set.empty(),
         interface_dirs = set.empty(),
         cc_dependencies = empty_HaskellCcInfo(),
@@ -165,7 +164,6 @@ def gather_dep_info(ctx, deps):
                 package_databases = set.mutable_union(acc.package_databases, binfo.package_databases),
                 version_macros = set.mutable_union(acc.version_macros, binfo.version_macros),
                 static_libraries = acc.static_libraries + binfo.static_libraries,
-                static_libraries_prof = acc.static_libraries_prof + binfo.static_libraries_prof,
                 dynamic_libraries = set.mutable_union(acc.dynamic_libraries, binfo.dynamic_libraries),
                 interface_dirs = set.mutable_union(acc.interface_dirs, binfo.interface_dirs),
                 cc_dependencies = acc.cc_dependencies,
@@ -181,7 +179,6 @@ def gather_dep_info(ctx, deps):
                 package_databases = acc.package_databases,
                 version_macros = acc.version_macros,
                 static_libraries = acc.static_libraries,
-                static_libraries_prof = acc.static_libraries_prof,
                 dynamic_libraries = acc.dynamic_libraries,
                 interface_dirs = acc.interface_dirs,
                 cc_dependencies = merge_HaskellCcInfo(

--- a/haskell/private/haskell_impl.bzl
+++ b/haskell/private/haskell_impl.bzl
@@ -128,6 +128,14 @@ def _haskell_binary_common_impl(ctx, is_test):
     srcs_files, import_dir_map = _prepare_srcs(ctx.attr.srcs)
     inspect_coverage = _should_inspect_coverage(ctx, hs, is_test)
 
+    dynamic = not ctx.attr.linkstatic
+    if with_profiling or hs.toolchain.is_windows:
+        # NOTE We can't have profiling and dynamic code at the
+        # same time, see:
+        # https://ghc.haskell.org/trac/ghc/ticket/15394
+        # Also, GHC on Windows doesn't support dynamic code
+        dynamic = False
+
     c = hs.toolchain.actions.compile_binary(
         hs,
         cc,
@@ -139,8 +147,8 @@ def _haskell_binary_common_impl(ctx, is_test):
         import_dir_map = import_dir_map,
         extra_srcs = depset(ctx.files.extra_srcs),
         user_compile_flags = ctx.attr.compiler_flags,
-        dynamic = False if hs.toolchain.is_windows else not ctx.attr.linkstatic,
-        with_profiling = False,
+        dynamic = dynamic,
+        with_profiling = with_profiling,
         main_function = ctx.attr.main_function,
         version = ctx.attr.version,
         inspect_coverage = inspect_coverage,
@@ -153,38 +161,14 @@ def _haskell_binary_common_impl(ctx, is_test):
         if HaskellCoverageInfo in dep:
             coverage_data += dep[HaskellCoverageInfo].coverage_data
 
-    c_p = None
-
-    if with_profiling:
-        c_p = hs.toolchain.actions.compile_binary(
-            hs,
-            cc,
-            java,
-            dep_info,
-            plugin_dep_info,
-            srcs = srcs_files,
-            ls_modules = ctx.executable._ls_modules,
-            import_dir_map = import_dir_map,
-            extra_srcs = depset(ctx.files.extra_srcs),
-            user_compile_flags = ctx.attr.compiler_flags,
-            # NOTE We can't have profiling and dynamic code at the
-            # same time, see:
-            # https://ghc.haskell.org/trac/ghc/ticket/15394
-            dynamic = False,
-            with_profiling = True,
-            main_function = ctx.attr.main_function,
-            version = ctx.attr.version,
-            plugins = ctx.attr.plugins,
-        )
-
     (binary, solibs) = link_binary(
         hs,
         cc,
         dep_info,
         ctx.files.extra_srcs,
         ctx.attr.compiler_flags,
-        c_p.objects_dir if with_profiling else c.objects_dir,
-        dynamic = False if hs.toolchain.is_windows else not ctx.attr.linkstatic,
+        c.objects_dir,
+        dynamic = dynamic,
         with_profiling = with_profiling,
         version = ctx.attr.version,
     )
@@ -197,7 +181,6 @@ def _haskell_binary_common_impl(ctx, is_test):
         extra_source_files = c.extra_source_files,
         import_dirs = c.import_dirs,
         static_libraries = dep_info.static_libraries,
-        static_libraries_prof = dep_info.static_libraries_prof,
         dynamic_libraries = dep_info.dynamic_libraries,
         interface_dirs = dep_info.interface_dirs,
         compile_flags = c.compile_flags,
@@ -313,19 +296,25 @@ def haskell_library_impl(ctx):
         ctx,
         [dep for plugin in ctx.attr.plugins for dep in plugin[GhcPluginInfo].deps],
     )
-    package_name = getattr(ctx.attr, "package_name", None)
-    version = getattr(ctx.attr, "version", None)
-    my_pkg_id = pkg_id.new(ctx.label, package_name, version)
-    with_profiling = is_profiling_enabled(hs)
-    with_shared = False if hs.toolchain.is_windows else not ctx.attr.linkstatic
 
     # Add any interop info for other languages.
     cc = cc_interop_info(ctx)
     java = java_interop_info(ctx)
 
+    with_profiling = is_profiling_enabled(hs)
     srcs_files, import_dir_map = _prepare_srcs(ctx.attr.srcs)
-    other_modules = ctx.attr.hidden_modules
-    exposed_modules_reexports = _exposed_modules_reexports(ctx.attr.exports)
+
+    with_shared = not ctx.attr.linkstatic
+    if with_profiling or hs.toolchain.is_windows:
+        # NOTE We can't have profiling and dynamic code at the
+        # same time, see:
+        # https://ghc.haskell.org/trac/ghc/ticket/15394
+        # Also, GHC on Windows doesn't support dynamic code
+        with_shared = False
+
+    package_name = getattr(ctx.attr, "package_name", None)
+    version = getattr(ctx.attr, "version", None)
+    my_pkg_id = pkg_id.new(ctx.label, package_name, version)
 
     c = hs.toolchain.actions.compile_library(
         hs,
@@ -338,40 +327,21 @@ def haskell_library_impl(ctx):
         extra_srcs = depset(ctx.files.extra_srcs),
         user_compile_flags = ctx.attr.compiler_flags,
         with_shared = with_shared,
-        with_profiling = False,
+        with_profiling = with_profiling,
         my_pkg_id = my_pkg_id,
         plugins = ctx.attr.plugins,
     )
 
+    other_modules = ctx.attr.hidden_modules
+    exposed_modules_reexports = _exposed_modules_reexports(ctx.attr.exports)
     exposed_modules_file = list_exposed_modules(
         hs,
         ls_modules = ctx.executable._ls_modules,
         other_modules = other_modules,
         exposed_modules_reexports = exposed_modules_reexports,
         interfaces_dir = c.interfaces_dir,
+        with_profiling = with_profiling,
     )
-
-    c_p = None
-
-    if with_profiling:
-        c_p = hs.toolchain.actions.compile_library(
-            hs,
-            cc,
-            java,
-            dep_info,
-            plugin_dep_info,
-            srcs = srcs_files,
-            import_dir_map = import_dir_map,
-            extra_srcs = depset(ctx.files.extra_srcs),
-            user_compile_flags = ctx.attr.compiler_flags,
-            # NOTE We can't have profiling and dynamic code at the
-            # same time, see:
-            # https://ghc.haskell.org/trac/ghc/ticket/15394
-            with_shared = False,
-            with_profiling = True,
-            my_pkg_id = my_pkg_id,
-            plugins = ctx.attr.plugins,
-        )
 
     static_library = link_library_static(
         hs,
@@ -379,7 +349,7 @@ def haskell_library_impl(ctx):
         dep_info,
         c.objects_dir,
         my_pkg_id,
-        with_profiling = False,
+        with_profiling = with_profiling,
     )
 
     if with_shared:
@@ -399,45 +369,21 @@ def haskell_library_impl(ctx):
         dynamic_library = None
         dynamic_libraries = dep_info.dynamic_libraries
 
-    static_library_prof = None
-    if with_profiling:
-        static_library_prof = link_library_static(
-            hs,
-            cc,
-            dep_info,
-            c_p.objects_dir,
-            my_pkg_id,
-            with_profiling = True,
-        )
-
     conf_file, cache_file = package(
         hs,
         dep_info,
         c.interfaces_dir,
-        c_p.interfaces_dir if c_p != None else None,
         static_library,
         dynamic_library,
         exposed_modules_file,
         other_modules,
         my_pkg_id,
-        static_library_prof = static_library_prof,
     )
-
-    static_libraries_prof = dep_info.static_libraries_prof
-
-    if static_library_prof != None:
-        static_libraries_prof = [static_library_prof] + dep_info.static_libraries_prof
 
     interface_dirs = set.union(
         dep_info.interface_dirs,
         set.singleton(c.interfaces_dir),
     )
-
-    if c_p != None:
-        interface_dirs = set.mutable_union(
-            interface_dirs,
-            set.singleton(c_p.interfaces_dir),
-        )
 
     version_macros = set.empty()
     if version:
@@ -460,7 +406,6 @@ def haskell_library_impl(ctx):
         # left, i.e. you first feed a library which has unresolved symbols and
         # then you feed the library which resolves the symbols.
         static_libraries = [static_library] + dep_info.static_libraries,
-        static_libraries_prof = static_libraries_prof,
         dynamic_libraries = dynamic_libraries,
         interface_dirs = interface_dirs,
         compile_flags = c.compile_flags,
@@ -611,16 +556,27 @@ Check that it ships with your version of GHC.
         unsupported_features = ctx.disabled_features,
     )
 
-    # Workaround for https://github.com/tweag/rules_haskell/issues/881
-    # Static and dynamic libraries don't necessarily pair up 1 to 1.
-    # E.g. the rts package in the Unix GHC bindist contains the
-    # dynamic libHSrts and the static libCffi and libHSrts.
-    libs = {
-        get_dynamic_hs_lib_name(hs.toolchain.version, lib): {"dynamic": lib}
-        for lib in target[HaskellImportHack].dynamic_libraries
-    }
-    for lib in target[HaskellImportHack].static_libraries:
-        name = get_static_hs_lib_name(lib)
+    with_profiling = is_profiling_enabled(hs)
+
+    if with_profiling:
+        # GHC does not provide dynamic profiling mode libraries. The dynamic
+        # libraries that are available are missing profiling symbols, that
+        # other profiling mode build results will reference. Therefore, we
+        # don't import dynamic libraries in profiling mode.
+        libs = {}
+        static_libraries = target[HaskellImportHack].static_profiling_libraries
+    else:
+        # Workaround for https://github.com/tweag/rules_haskell/issues/881
+        # Static and dynamic libraries don't necessarily pair up 1 to 1.
+        # E.g. the rts package in the Unix GHC bindist contains the
+        # dynamic libHSrts and the static libCffi and libHSrts.
+        libs = {
+            get_dynamic_hs_lib_name(hs.toolchain.version, lib): {"dynamic": lib}
+            for lib in target[HaskellImportHack].dynamic_libraries
+        }
+        static_libraries = target[HaskellImportHack].static_libraries
+    for lib in static_libraries:
+        name = get_static_hs_lib_name(with_profiling, lib)
         entry = libs.get(name, {})
         entry["static"] = lib
         libs[name] = entry
@@ -673,7 +629,6 @@ def haskell_import_impl(ctx):
         source_files = set.empty(),
         extra_source_files = depset(),
         static_libraries = [],
-        static_libraries_prof = [],
         dynamic_libraries = set.empty(),
         interface_dirs = set.empty(),
         compile_flags = [],
@@ -689,6 +644,15 @@ def haskell_import_impl(ctx):
         ]),
         static_libraries = depset(ctx.files.static_libraries, order = "topological", transitive = [
             dep[HaskellImportHack].static_libraries
+            for dep in ctx.attr.deps
+        ]),
+        # NOTE: haskell_import is evaluated as a toolchain rule. Even if we
+        # bazel build with -c dbg, this rule is still executed with
+        # ctx.var["COMPILATION_MODE"] == "opt". Therefore, we need to carry
+        # both profiling and non-profiling libraries forward so that a later
+        # haskell_toolchain_library can select the appropriate artifacts.
+        static_profiling_libraries = depset(ctx.files.static_profiling_libraries, order = "topological", transitive = [
+            dep[HaskellImportHack].static_profiling_libraries
             for dep in ctx.attr.deps
         ]),
         headers = depset(ctx.files.hdrs, transitive = [

--- a/haskell/private/haskell_impl.bzl
+++ b/haskell/private/haskell_impl.bzl
@@ -563,8 +563,10 @@ Check that it ships with your version of GHC.
         # libraries that are available are missing profiling symbols, that
         # other profiling mode build results will reference. Therefore, we
         # don't import dynamic libraries in profiling mode.
-        libs = {}
-        static_libraries = target[HaskellImportHack].static_profiling_libraries
+        libs = {
+            get_static_hs_lib_name(hs.toolchain.version, lib): {"static": lib}
+            for lib in target[HaskellImportHack].static_profiling_libraries
+        }
     else:
         # Workaround for https://github.com/tweag/rules_haskell/issues/881
         # Static and dynamic libraries don't necessarily pair up 1 to 1.
@@ -574,12 +576,11 @@ Check that it ships with your version of GHC.
             get_dynamic_hs_lib_name(hs.toolchain.version, lib): {"dynamic": lib}
             for lib in target[HaskellImportHack].dynamic_libraries
         }
-        static_libraries = target[HaskellImportHack].static_libraries
-    for lib in static_libraries:
-        name = get_static_hs_lib_name(with_profiling, lib)
-        entry = libs.get(name, {})
-        entry["static"] = lib
-        libs[name] = entry
+        for lib in target[HaskellImportHack].static_libraries:
+            name = get_static_hs_lib_name(with_profiling, lib)
+            entry = libs.get(name, {})
+            entry["static"] = lib
+            libs[name] = entry
     libraries_to_link = [
         cc_common.create_library_to_link(
             actions = ctx.actions,

--- a/haskell/private/ls_modules.py
+++ b/haskell/private/ls_modules.py
@@ -16,14 +16,15 @@ import re
 import sys
 import io
 
-if len(sys.argv) != 6:
-    sys.exit("Usage: %s <DIRECTORY> <GLOBAL_PKG_DB> <HIDDEN_MODS_FILE> <REEXPORTED_MODS_FILE> <RESULT_FILE>" % sys.argv[0])
+if len(sys.argv) != 7:
+    sys.exit("Usage: %s <WITH_PROFILING> <DIRECTORY> <GLOBAL_PKG_DB> <HIDDEN_MODS_FILE> <REEXPORTED_MODS_FILE> <RESULT_FILE>" % sys.argv[0])
 
-root = sys.argv[1]
-global_pkg_db_dump = sys.argv[2]
-hidden_modules_file = sys.argv[3]
-reexported_modules_file = sys.argv[4]
-results_file = sys.argv[5]
+with_profiling = sys.argv[1] == 'True'
+root = sys.argv[2]
+global_pkg_db_dump = sys.argv[3]
+hidden_modules_file = sys.argv[4]
+reexported_modules_file = sys.argv[5]
+results_file = sys.argv[6]
 
 with io.open(global_pkg_db_dump, "r", encoding='utf8') as f:
     names = [line.split()[1] for line in f if line.startswith("name:")]
@@ -87,7 +88,7 @@ On Windows you may need to enable long file path support:
 interface_files = (
     os.path.join(path, f)
     for path, dirs, files in os.walk(root, onerror=handle_walk_error)
-    for f in fnmatch.filter(files, '*.hi')
+    for f in fnmatch.filter(files, '*.p_hi' if with_profiling else '*.hi')
 )
 
 modules = (

--- a/haskell/private/path_utils.bzl
+++ b/haskell/private/path_utils.bzl
@@ -225,20 +225,23 @@ def get_dynamic_hs_lib_name(ghc_version, lib):
         name = name[:-len(suffix)]
     return name
 
-def get_static_hs_lib_name(lib):
-    """Return name of library by dropping extension, "lib" prefix.
-
-    Takes the unusual case of libCffi.a into account.
+def get_static_hs_lib_name(with_profiling, lib):
+    """Return name of library by dropping extension,
+    "lib" prefix, and potential profiling suffix.
 
     Args:
+      with_profiling: Whether profiling mode is enabled.
       lib: The library File.
 
     Returns:
       String: name of library.
     """
     name = get_lib_name(lib)
+    suffix = "_p" if with_profiling else ""
+    if name.endswith(suffix):
+        name = name[:-len(suffix)]
     if name == "Cffi":
-        return "ffi"
+        name = "ffi"
     return name
 
 def link_libraries(libs_to_link, args):

--- a/haskell/private/path_utils.bzl
+++ b/haskell/private/path_utils.bzl
@@ -238,7 +238,7 @@ def get_static_hs_lib_name(with_profiling, lib):
     """
     name = get_lib_name(lib)
     suffix = "_p" if with_profiling else ""
-    if name.endswith(suffix):
+    if suffix and name.endswith(suffix):
         name = name[:-len(suffix)]
     if name == "Cffi":
         name = "ffi"

--- a/haskell/providers.bzl
+++ b/haskell/providers.bzl
@@ -83,7 +83,6 @@ HaskellInfo = provider(
         "source_files": "Set of files that contain Haskell modules.",
         "extra_source_files": "A depset of non-Haskell source files.",
         "static_libraries": "Ordered collection of compiled library archives.",
-        "static_libraries_prof": "Ordered collection of static libraries with profiling.",
         "dynamic_libraries": "Set of dynamic libraries.",
         "interface_dirs": "Set of interface dirs belonging to the packages.",
         "compile_flags": "Arguments that were used to compile the code.",

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -118,19 +118,37 @@ config_setting(
     },
 )
 
+config_setting(
+    name = "fastbuild_darwin",
+    values = {
+        "compilation_mode": "fastbuild",
+        "cpu": "darwin",
+    },
+)
+
+config_setting(
+    name = "fastbuild_windows",
+    values = {
+        "compilation_mode": "fastbuild",
+        "cpu": "x64_windows",
+    },
+)
+
 rule_test(
     name = "test-library-deps",
     size = "small",
+    # Bazel does not allow nested select statements. Therefore we flatten
+    # compilation_mode and cpu conditions into one select statement.
     generates = select({
         ":debug_build": [
             # In profiling build we only generate profiling static archives.
             "libHStestsZSlibrary-depsZSlibrary-deps_p.a",
         ],
-        "@bazel_tools//src/conditions:darwin": [
+        ":fastbuild_darwin": [
             "libHStestsZSlibrary-depsZSlibrary-deps-ghc{}.dylib".format(test_ghc_version),
             "libHStestsZSlibrary-depsZSlibrary-deps.a",
         ],
-        "@bazel_tools//src/conditions:windows": [
+        ":fastbuild_windows": [
             "libHStestsZSlibrary-depsZSlibrary-deps-ghc{}.dll".format(test_ghc_version),
             "libHStestsZSlibrary-depsZSlibrary-deps.a",
         ],

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -111,10 +111,21 @@ sh_test(
     tags = ["requires_hackage"],
 )
 
+config_setting(
+    name = "debug_build",
+    values = {
+        "compilation_mode": "dbg",
+    },
+)
+
 rule_test(
     name = "test-library-deps",
     size = "small",
     generates = select({
+        ":debug_build": [
+            # In profiling build we only generate profiling static archives.
+            "libHStestsZSlibrary-depsZSlibrary-deps_p.a",
+        ],
         "@bazel_tools//src/conditions:darwin": [
             "libHStestsZSlibrary-depsZSlibrary-deps-ghc{}.dylib".format(test_ghc_version),
             "libHStestsZSlibrary-depsZSlibrary-deps.a",
@@ -210,7 +221,10 @@ sh_test(
         "//tests/cc_haskell_import:python_add_one",
         "@bazel_tools//tools/bash/runfiles",
     ],
-    tags = ["requires_threaded_rts"],
+    tags = [
+        "requires_dynamic",
+        "requires_threaded_rts",
+    ],
 )
 
 sh_inline_test(

--- a/tests/RunTests.hs
+++ b/tests/RunTests.hs
@@ -6,6 +6,7 @@
 import Data.Foldable (for_)
 import Data.List (isInfixOf, sort)
 import System.Exit (ExitCode(..))
+import System.Info (os)
 
 import qualified System.Process as Process
 import Test.Hspec.Core.Spec (SpecM)
@@ -37,7 +38,13 @@ main = hspec $ do
       ])
 
   it "bazel test prof" $ do
-    assertSuccess (bazel ["test", "-c", "dbg", "//...", "--build_tests_only", "--test_tag_filters", "-requires_dynamic"])
+    -- In .circleci/config.yml we specify --test_tag_filters
+    -- -dont_test_on_darwin. However, specifiying --test_tag_filters
+    -- -requires_dynamic here alone would override that filter. So,
+    -- we have to duplicate that filter here.
+    let tagFilter | os == "darwin" = "-dont_test_on_darwin,-requires_dynamic"
+                  | otherwise      = "-requires_dynamic"
+    assertSuccess (bazel ["test", "-c", "dbg", "//...", "--build_tests_only", "--test_tag_filters", tagFilter])
 
   describe "repl" $ do
     it "for libraries" $ do

--- a/tests/RunTests.hs
+++ b/tests/RunTests.hs
@@ -37,7 +37,7 @@ main = hspec $ do
       ])
 
   it "bazel test prof" $ do
-    assertSuccess (bazel ["test", "-c", "dbg", "//...", "--build_tests_only"])
+    assertSuccess (bazel ["test", "-c", "dbg", "//...", "--build_tests_only", "--test_tag_filters", "-requires_dynamic"])
 
   describe "repl" $ do
     it "for libraries" $ do

--- a/tests/cc_haskell_import/BUILD.bazel
+++ b/tests/cc_haskell_import/BUILD.bazel
@@ -44,7 +44,10 @@ cc_binary(
     name = "hs-lib-b-wrapped.so",
     linkshared = 1,
     linkstatic = 0,
-    tags = ["requires_threaded_rts"],
+    tags = [
+        "requires_dynamic",
+        "requires_threaded_rts",
+    ],
     visibility = ["//tests:__subpackages__"],
     deps = [
         ":hs-lib-b",
@@ -60,7 +63,12 @@ py_binary(
     ],
     default_python_version = "PY3",
     srcs_version = "PY3ONLY",
-    tags = ["requires_threaded_rts"],
+    # This requires a shared object, which is not provided in profiling mode.
+    # Hence we disable this test in profiling mode using requires_dynamic.
+    tags = [
+        "requires_dynamic",
+        "requires_threaded_rts",
+    ],
     visibility = ["//tests:__subpackages__"],
     deps = ["@bazel_tools//tools/python/runfiles"],
 )


### PR DESCRIPTION
Closes #895 

- When profiling mode is active (`compilation_mode == "dbg"`) then we compile only profiling libraries and binaries instead of compiling both profiling and non-profiling. In profiling mode the toolchain libraries only carry their static archives, as profiling mode doesn't provide any shared libraries.
- Some test cases strictly require shared objects. Those are disabled in profiling mode.

Wrt. https://github.com/tweag/rules_haskell/issues/438 this PR goes further down the road of `-fexternal-interpreter`. Given the large performance penalty that that implies we may yet want to compile non-profiling objects for GHCi/Template Haskell. However, as mentioned in #895 it seems better to not expose these in the `CcInfo` provider, but instead handle them separately in `HaskellInfo`.