### PR TITLE
Various refactors and fixes to Cabal support

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -33,9 +33,9 @@ load("@os_info//:os_info.bzl", "is_linux", "is_windows")
 # bazel dependencies
 haskell_repositories()
 
-load("@io_tweag_rules_haskell//haskell:cabal.bzl", "stack_install")
+load("@io_tweag_rules_haskell//haskell:cabal.bzl", "stack_snapshot")
 
-stack_install(
+stack_snapshot(
     name = "stackage",
     packages = [
         # Core libraries

--- a/haskell/cabal.bzl
+++ b/haskell/cabal.bzl
@@ -496,11 +496,13 @@ Example:
   ```bzl
   stack_snapshot(
       name = "stackage",
-      packages = ["conduit", "lens", "zlib"],
+      packages = ["conduit", "lens", "zlib-0.6.2"],
       snapshot = "lts-13.15",
       deps = ["@zlib.dev//:zlib"],
   )
   ```
+  defines `@stackage//:conduit`, `@stackage//:lens`,
+  `@stackage//:zlib` library targets.
 
 This rule will use Stack to compute the transitive closure of the
 subset of the given snapshot listed in the `packages` attribute, and
@@ -508,6 +510,11 @@ generate a dependency graph. If a package in the closure depends on
 system libraries or other external libraries, use the `deps` attribute
 to list them. This attribute works like the
 `--extra-{include,lib}-dirs` flags for Stack and cabal-install do.
+
+Packages that are in the snapshot need not have their versions
+specified. But any additional packages or version overrides will have
+to be specified with a package identifier of the form
+`<package>-<version>` in the `packages` attribute.
 
 In the external repository defined by the rule, all given packages are
 available as top-level targets named after each package.

--- a/haskell/cabal.bzl
+++ b/haskell/cabal.bzl
@@ -366,6 +366,13 @@ def _compute_dependency_graph(repository_ctx, versioned_packages, unversioned_pa
         for unpacked_sdist in exec_result.stdout.splitlines()
         if _chop_version(unpacked_sdist) not in _CORE_PACKAGES
     ]
+    for unpacked_sdist in transitive_unpacked_sdists:
+        package = _chop_version(unpacked_sdist)
+        if _version(unpacked_sdist) == "<unknown>":
+            fail("""\
+Could not resolve version of {}. It is not in the snapshot.
+Specify a fully qualified package name of the form <package>-<version>.
+            """.format(package))
     _execute_or_fail_loudly(
         repository_ctx,
         stack + ["unpack"] + [

--- a/haskell/cabal.bzl
+++ b/haskell/cabal.bzl
@@ -354,7 +354,7 @@ def _compute_dependency_graph(repository_ctx, versioned_packages, unversioned_pa
                 dependencies[src].append(dest)
     return (dependencies, transitive_unpacked_sdists)
 
-def _stack_install_impl(repository_ctx):
+def _stack_snapshot_impl(repository_ctx):
     packages = repository_ctx.attr.packages
     non_core_packages = [
         package
@@ -428,8 +428,8 @@ haskell_cabal_library(
     build_file_content = "\n".join(build_file_builder)
     repository_ctx.file("BUILD.bazel", build_file_content, executable = False)
 
-stack_install = repository_rule(
-    _stack_install_impl,
+stack_snapshot = repository_rule(
+    _stack_snapshot_impl,
     attrs = {
         "snapshot": attr.string(
             doc = "The name of a Stackage snapshot.",
@@ -446,7 +446,7 @@ stack_install = repository_rule(
 
 Example:
   ```bzl
-  stack_install(
+  stack_snapshot(
       name = "stackage",
       packages = ["conduit", "lens", "zlib"],
       snapshot = "lts-13.15",

--- a/haskell/private/cabal_wrapper.sh.tpl
+++ b/haskell/private/cabal_wrapper.sh.tpl
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 #
 # cabal_wrapper.sh <PKG_NAME> <SETUP_PATH> <PKG_DIR> <PACKAGE_DB_PATH> [SETUP_ARGS...]
+#
+# This wrapper calls Cabal's configure/build/install steps one big
+# action so that we don't have to track all inputs explicitly between
+# steps.
 
 set -euo pipefail
 execroot="$(pwd)"

--- a/haskell/private/cabal_wrapper.sh.tpl
+++ b/haskell/private/cabal_wrapper.sh.tpl
@@ -6,6 +6,10 @@
 # action so that we don't have to track all inputs explicitly between
 # steps.
 
+# TODO Remove once https://github.com/bazelbuild/bazel/issues/5980 is
+# fixed.
+%{env}
+
 set -euo pipefail
 execroot="$(pwd)"
 


### PR DESCRIPTION
In anticipation of `haskell_cabal_binary`, we split more code into
functions that can be reused. Also, the `env` attribute was being
silently ignored due to
https://github.com/bazelbuild/bazel/issues/5980. We have a workaround
in place now. Documentation fixes also included.

`stack_install` has been renamed to `stack_snapshot`, for reasons
explained in the commit.