### PR TITLE
Remove special handling of prebuilt libraries

### DIFF
--- a/haskell/cabal.bzl
+++ b/haskell/cabal.bzl
@@ -166,8 +166,6 @@ main = defaultMain
         dynamic_libraries = set.insert(dep_info.dynamic_libraries, dynamic_library),
         interface_dirs = set.insert(dep_info.interface_dirs, interfaces_dir),
         compile_flags = [],
-        prebuilt_dependencies = set.empty(),
-        direct_prebuilt_deps = set.empty(),
         cc_dependencies = dep_info.cc_dependencies,
         transitive_cc_dependencies = dep_info.transitive_cc_dependencies,
     )

--- a/haskell/doctest.bzl
+++ b/haskell/doctest.bzl
@@ -13,7 +13,6 @@ load(
     "@io_tweag_rules_haskell//haskell:providers.bzl",
     "HaskellInfo",
     "HaskellLibraryInfo",
-    "HaskellPrebuiltPackageInfo",
 )
 
 def _doctest_toolchain_impl(ctx):
@@ -81,7 +80,7 @@ def _haskell_doctest_single(target, ctx):
       File: the doctest log.
     """
 
-    if HaskellInfo not in target or HaskellPrebuiltPackageInfo in target:
+    if HaskellInfo not in target:
         return []
 
     hs = haskell_context(ctx, ctx.attr)

--- a/haskell/lint.bzl
+++ b/haskell/lint.bzl
@@ -5,7 +5,6 @@ load(
     "HaskellInfo",
     "HaskellLibraryInfo",
     "HaskellLintInfo",
-    "HaskellPrebuiltPackageInfo",
 )
 load(":private/context.bzl", "haskell_context", "render_env")
 load(":private/packages.bzl", "expose_packages", "pkg_info_to_compile_flags")
@@ -31,7 +30,7 @@ def _haskell_lint_rule_impl(ctx):
 def _haskell_lint_aspect_impl(target, ctx):
     hs = haskell_context(ctx, ctx.rule.attr)
 
-    if HaskellInfo not in target or HaskellPrebuiltPackageInfo in target:
+    if HaskellInfo not in target:
         return []
 
     hs_info = target[HaskellInfo]

--- a/haskell/private/actions/repl.bzl
+++ b/haskell/private/actions/repl.bzl
@@ -131,7 +131,6 @@ def build_haskell_repl(
         has_version = pkg_ghc_info.has_version,
         library_path = library_path,
         ld_library_path = ld_library_path,
-        packages = pkg_ghc_info.packages,
         package_ids = pkg_ghc_info.package_ids,
         package_dbs = pkg_ghc_info.package_dbs,
         lib_imports = lib_imports,

--- a/haskell/private/dependencies.bzl
+++ b/haskell/private/dependencies.bzl
@@ -5,7 +5,6 @@ load(
     "HaskellCcInfo",
     "HaskellInfo",
     "HaskellLibraryInfo",
-    "HaskellPrebuiltPackageInfo",
     "empty_HaskellCcInfo",
     "merge_HaskellCcInfo",
 )
@@ -133,9 +132,6 @@ def _HaskellCcInfo_from_CcInfo(ctx, cc_info):
 def gather_dep_info(ctx, deps):
     """Collapse dependencies into a single `HaskellInfo`.
 
-    Note that the field `prebuilt_dependencies` also includes
-    prebuilt_dependencies of current target.
-
     Args:
       ctx: Rule context.
       deps: deps attribute.
@@ -152,8 +148,6 @@ def gather_dep_info(ctx, deps):
         static_libraries_prof = [],
         dynamic_libraries = set.empty(),
         interface_dirs = set.empty(),
-        prebuilt_dependencies = set.empty(),
-        direct_prebuilt_deps = set.empty(),
         cc_dependencies = empty_HaskellCcInfo(),
         transitive_cc_dependencies = empty_HaskellCcInfo(),
     )
@@ -174,25 +168,8 @@ def gather_dep_info(ctx, deps):
                 static_libraries_prof = acc.static_libraries_prof + binfo.static_libraries_prof,
                 dynamic_libraries = set.mutable_union(acc.dynamic_libraries, binfo.dynamic_libraries),
                 interface_dirs = set.mutable_union(acc.interface_dirs, binfo.interface_dirs),
-                prebuilt_dependencies = set.mutable_union(acc.prebuilt_dependencies, binfo.prebuilt_dependencies),
-                direct_prebuilt_deps = acc.direct_prebuilt_deps,
                 cc_dependencies = acc.cc_dependencies,
                 transitive_cc_dependencies = merge_HaskellCcInfo(acc.transitive_cc_dependencies, binfo.transitive_cc_dependencies),
-            )
-        elif HaskellPrebuiltPackageInfo in dep:
-            pkg = dep[HaskellPrebuiltPackageInfo]
-            acc = HaskellInfo(
-                package_ids = acc.package_ids,
-                package_databases = acc.package_databases,
-                version_macros = set.mutable_insert(acc.version_macros, pkg.version_macros_file),
-                static_libraries = acc.static_libraries,
-                static_libraries_prof = acc.static_libraries_prof,
-                dynamic_libraries = acc.dynamic_libraries,
-                interface_dirs = acc.interface_dirs,
-                prebuilt_dependencies = set.mutable_insert(acc.prebuilt_dependencies, pkg),
-                direct_prebuilt_deps = set.mutable_insert(acc.direct_prebuilt_deps, pkg),
-                cc_dependencies = acc.cc_dependencies,
-                transitive_cc_dependencies = acc.transitive_cc_dependencies,
             )
         elif CcInfo in dep and HaskellInfo not in dep:
             # The final link of a binary must include all static libraries we
@@ -207,8 +184,6 @@ def gather_dep_info(ctx, deps):
                 static_libraries_prof = acc.static_libraries_prof,
                 dynamic_libraries = acc.dynamic_libraries,
                 interface_dirs = acc.interface_dirs,
-                prebuilt_dependencies = acc.prebuilt_dependencies,
-                direct_prebuilt_deps = acc.direct_prebuilt_deps,
                 cc_dependencies = merge_HaskellCcInfo(
                     acc.cc_dependencies,
                     hs_cc_info,

--- a/haskell/private/haddock_wrapper.sh.tpl
+++ b/haskell/private/haddock_wrapper.sh.tpl
@@ -1,42 +1,10 @@
 #!/usr/bin/env bash
 #
-# Usage: haddock-wrapper.sh <PREBUILD_DEPS_FILE> <HADDOCK_ARGS>
+# Usage: haddock-wrapper.sh <HADDOCK_ARGS>
 
 set -eo pipefail
 
 %{env}
-
-PREBUILT_DEPS_FILE=$1
-shift
-
-extra_args=()
-
-for pkg in $(< $PREBUILT_DEPS_FILE)
-do
-    # Assumption: the `haddock-interfaces` field always only contains
-    # exactly one file name. This seems to hold in practice, though the
-    # ghc documentation defines it as:
-    # > (string list) A list of filenames containing Haddock interface files
-    # > (.haddock files) for this package.
-    # If there were more than one file, going by the output for the `depends`,
-    # the file names would be separated by a space character.
-    # https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/packages.html#installedpackageinfo-a-package-specification
-    haddock_interfaces=$(%{ghc-pkg} --simple-output field $pkg haddock-interfaces)
-    haddock_html=$(%{ghc-pkg} --simple-output field $pkg haddock-html)
-
-    # Sometimes the referenced `.haddock` file does not exist
-    # (e.g. for `nixpkgs.haskellPackages` deps with haddock disabled).
-    # In that case, skip this package with a warning.
-    if [[ -f "$haddock_interfaces" ]]
-    then
-        # TODO: link source code,
-        # `--read-interface=$haddock_html,$pkg_src,$haddock_interfaces
-        # https://haskell-haddock.readthedocs.io/en/latest/invoking.html#cmdoption-read-interface
-        extra_args+=("--read-interface=$haddock_html,$haddock_interfaces")
-    else
-        echo "Warning: haddock missing for package $pkg" 1>&2
-    fi
-done
 
 # BSD and GNU mktemp are very different; attempt GNU first
 TEMP=$(mktemp -d 2>/dev/null || mktemp -d -t 'haddock_wrapper')
@@ -45,5 +13,5 @@ cleanup() { rmdir "$TEMP"; }
 # XXX Override TMPDIR to prevent race conditions on certain platforms.
 # This is a workaround for
 # https://github.com/haskell/haddock/issues/894.
-TMPDIR=$TEMP %{haddock} "${extra_args[@]}" "$@"
+TMPDIR=$TEMP %{haddock} "$@"
 cleanup

--- a/haskell/private/packages.bzl
+++ b/haskell/private/packages.bzl
@@ -30,9 +30,6 @@ def pkg_info_to_compile_flags(pkg_info, for_plugin = False):
             "-fno-version-macros",
         ])
 
-    for package in pkg_info.packages:
-        args.extend(["-{}package".format(namespace), package])
-
     for package_id in pkg_info.package_ids:
         args.extend(["-{}package-id".format(namespace), package_id])
 
@@ -58,16 +55,6 @@ def expose_packages(hs_info, lib_info, use_direct, use_my_pkg_id, custom_package
     """
     has_version = version != None and version != ""
 
-    # Expose all prebuilt dependencies
-    #
-    # We have to remember to specify all (transitive) wired-in
-    # dependencies or we can't find objects for linking
-    #
-    # Set use_direct if hs_info does not have a direct_prebuilt_deps field.
-    packages = []
-    for prebuilt_dep in set.to_list(hs_info.direct_prebuilt_deps if use_direct else hs_info.prebuilt_dependencies):
-        packages.append(prebuilt_dep.package)
-
     # Expose all bazel dependencies
     package_ids = []
     for package in set.to_list(hs_info.package_ids):
@@ -79,15 +66,13 @@ def expose_packages(hs_info, lib_info, use_direct, use_my_pkg_id, custom_package
             if (use_my_pkg_id == None) or package != use_my_pkg_id:
                 package_ids.append(package)
 
-    # Only include package DBs for deps, prebuilt deps should be found
-    # auto-magically by GHC
+    # Only include package DBs for deps.
     package_dbs = []
     for cache in set.to_list(hs_info.package_databases if not custom_package_databases else custom_package_databases):
         package_dbs.append(cache.dirname)
 
     ghc_info = struct(
         has_version = has_version,
-        packages = packages,
         package_ids = package_ids,
         package_dbs = package_dbs,
     )

--- a/haskell/protobuf.bzl
+++ b/haskell/protobuf.bzl
@@ -157,7 +157,6 @@ def _haskell_proto_aspect_impl(target, ctx):
         "srcs": hs_files,
         "deps": ctx.rule.attr.deps +
                 ctx.toolchains["@io_tweag_rules_haskell//protobuf:toolchain"].deps,
-        "prebuilt_dependencies": ctx.toolchains["@io_tweag_rules_haskell//protobuf:toolchain"].prebuilt_deps,
         "plugins": [],
         "_cc_toolchain": ctx.attr._cc_toolchain,
     }
@@ -270,11 +269,6 @@ registered.
 """
 
 def _protobuf_toolchain_impl(ctx):
-    if ctx.attr.prebuilt_deps:
-        print("""The attribute 'prebuilt_deps' has been deprecated,
-use the 'deps' attribute instead.
-""")
-
     return [
         platform_common.ToolchainInfo(
             name = ctx.label.name,
@@ -283,7 +277,6 @@ use the 'deps' attribute instead.
                 protoc = ctx.executable.protoc,
             ),
             deps = ctx.attr.deps,
-            prebuilt_deps = ctx.attr.prebuilt_deps,
         ),
     ]
 
@@ -307,9 +300,6 @@ _protobuf_toolchain = rule(
         "deps": attr.label_list(
             doc = "List of other Haskell libraries to be linked to protobuf libraries.",
         ),
-        "prebuilt_deps": attr.string_list(
-            doc = "Non-Bazel supplied Cabal dependencies for protobuf libraries.",
-        ),
     },
 )
 
@@ -317,7 +307,6 @@ def haskell_proto_toolchain(
         name,
         plugin,
         deps = [],
-        prebuilt_deps = [],
         protoc = Label("@com_google_protobuf//:protoc"),
         **kwargs):
     """Declare a Haskell protobuf toolchain.
@@ -336,7 +325,7 @@ def haskell_proto_toolchain(
         name = "protobuf-toolchain",
         protoc = "@com_google_protobuf//:protoc",
         plugin = "@hackage-proto-lens-protoc//:bin/proto-lens-protoc",
-        prebuilt_deps = [
+        deps = [
           "base",
           "bytestring",
           "containers",
@@ -349,8 +338,8 @@ def haskell_proto_toolchain(
       )
       ```
 
-      The `prebuilt_deps` and `deps` arguments allow to specify Haskell
-      libraries to use to compile the auto-generated source files.
+      The `deps` attribute is for specifying Haskell libraries to use
+      when compiling the auto-generated source files.
 
       In `WORKSPACE` you could have something like this:
 
@@ -373,13 +362,13 @@ def haskell_proto_toolchain(
         "//tests:protobuf-toolchain",
       )
       ```
+
     """
     impl_name = name + "-impl"
     _protobuf_toolchain(
         name = impl_name,
         plugin = plugin,
         deps = deps,
-        prebuilt_deps = prebuilt_deps,
         protoc = protoc,
         visibility = ["//visibility:public"],
         **kwargs

--- a/haskell/providers.bzl
+++ b/haskell/providers.bzl
@@ -76,7 +76,7 @@ def merge_HaskellCcInfo(*args):
 HaskellInfo = provider(
     doc = "Common information about build process: dependencies, etc.",
     fields = {
-        "package_ids": "Set of all package ids of direct (non-prebuilt) dependencies.",
+        "package_ids": "Set of all package ids of direct dependencies.",
         "package_databases": "Set of package cache files.",
         "version_macros": "Set of version macro files.",
         "import_dirs": "Import hierarchy roots.",
@@ -87,8 +87,6 @@ HaskellInfo = provider(
         "dynamic_libraries": "Set of dynamic libraries.",
         "interface_dirs": "Set of interface dirs belonging to the packages.",
         "compile_flags": "Arguments that were used to compile the code.",
-        "prebuilt_dependencies": "Transitive collection of info of wired-in Haskell dependencies.",
-        "direct_prebuilt_deps": "Set of info of direct prebuilt dependencies.",
         "cc_dependencies": "Direct cc library dependencies. See HaskellCcInfo.",
         "transitive_cc_dependencies": "Transitive cc library dependencies. See HaskellCcInfo.",
     },
@@ -180,10 +178,6 @@ HaskellCoverageInfo = provider(
     fields = {
         "coverage_data": "A list of coverage data containing which parts of Haskell source code are being tracked for code coverage.",
     },
-)
-
-HaskellPrebuiltPackageInfo = provider(
-    doc = "Information about a prebuilt GHC package.",
 )
 
 HaddockInfo = provider(


### PR DESCRIPTION
Now that prebuilt libraries look exactly like any other Haskell
libraries except for the fact that we have no source code for them, we
can get rid of `HaskellPrebuiltPackageInfo`. This in turn simplifies
a lot of internals:

* we no longer need the `prebuilt_deps` and `direct_prebuilt`
  attributes to `HaskellInfo` anymore.
* the Haddock wrapper is vastly simplified.

Closes #440