### PR TITLE
Add a tools argument to Stack and Cabal rules

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -33,6 +33,17 @@ load("@os_info//:os_info.bzl", "is_linux", "is_windows")
 # bazel dependencies
 haskell_repositories()
 
+http_archive(
+    name = "happy",
+    build_file_content = """
+load("@io_tweag_rules_haskell//haskell:cabal.bzl", "haskell_cabal_binary")
+haskell_cabal_binary(name = "happy", srcs = glob(["**"]), visibility = ["//visibility:public"])
+    """,
+    sha256 = "22eb606c97105b396e1c7dc27e120ca02025a87f3e44d2ea52be6a653a52caed",
+    strip_prefix = "happy-1.19.10",
+    urls = ["http://hackage.haskell.org/package/happy-1.19.10/happy-1.19.10.tar.gz"],
+)
+
 load("@io_tweag_rules_haskell//haskell:cabal.bzl", "stack_snapshot")
 
 stack_snapshot(
@@ -56,6 +67,7 @@ stack_snapshot(
         "lens-family",
     ],
     snapshot = "lts-13.15",
+    tools = ["@happy"],
     deps = ["@zlib.dev//:zlib"],
 )
 


### PR DESCRIPTION
Tools are built using the host configuration. Currently, they are not
very useful unless they are tools part of a whitelist defined by
Cabal. For example, Cabal lets you customize which happy or c2hs you
want to use. We support that.

Packages that correspond to the whitelisted tools are detected as such
and filtered from the dependency graph in `stackage_snapshot`. That
way only packages that produce libraries remain.