### PR TITLE
Remove package_ids from HaskellInfo provider

### DIFF
--- a/haskell/cabal.bzl
+++ b/haskell/cabal.bzl
@@ -221,7 +221,6 @@ def _haskell_cabal_library_impl(ctx):
         ),
     )
     hs_info = HaskellInfo(
-        package_ids = [],
         package_databases = depset([package_database], transitive = [dep_info.package_databases]),
         version_macros = set.empty(),
         source_files = set.empty(),
@@ -369,7 +368,6 @@ def _haskell_cabal_binary_impl(ctx):
     )
 
     hs_info = HaskellInfo(
-        package_ids = dep_info.package_ids,
         package_databases = dep_info.package_databases,
         version_macros = set.empty(),
         source_files = set.empty(),

--- a/haskell/lint.bzl
+++ b/haskell/lint.bzl
@@ -55,7 +55,6 @@ def _haskell_lint_aspect_impl(target, ctx):
     args.add_all(pkg_info_to_compile_flags(expose_packages(
         hs_info,
         lib_info,
-        use_direct = False,
         use_my_pkg_id = None,
         custom_package_databases = None,
         version = getattr(ctx.rule.attr, "version", None),

--- a/haskell/lint.bzl
+++ b/haskell/lint.bzl
@@ -54,8 +54,7 @@ def _haskell_lint_aspect_impl(target, ctx):
 
     args.add_all(pkg_info_to_compile_flags(expose_packages(
         hs_info,
-        lib_info,
-        use_my_pkg_id = None,
+        my_pkg_id = lib_info.package_id if lib_info else None,
         custom_package_databases = None,
         version = getattr(ctx.rule.attr, "version", None),
     )))

--- a/haskell/lint.bzl
+++ b/haskell/lint.bzl
@@ -53,9 +53,8 @@ def _haskell_lint_aspect_impl(target, ctx):
     ])
 
     args.add_all(pkg_info_to_compile_flags(expose_packages(
-        hs_info,
-        my_pkg_id = lib_info.package_id if lib_info else None,
-        custom_package_databases = None,
+        package_ids = hs.package_ids,
+        package_databases = hs_info.package_databases,
         version = getattr(ctx.rule.attr, "version", None),
     )))
 

--- a/haskell/private/actions/compile.bzl
+++ b/haskell/private/actions/compile.bzl
@@ -154,8 +154,7 @@ def _compilation_defaults(hs, cc, java, dep_info, plugin_dep_info, srcs, import_
         pkg_info_to_compile_flags(
             expose_packages(
                 dep_info,
-                lib_info = None,
-                use_my_pkg_id = my_pkg_id,
+                my_pkg_id = my_pkg_id,
                 custom_package_databases = None,
                 version = version,
             ),
@@ -165,8 +164,7 @@ def _compilation_defaults(hs, cc, java, dep_info, plugin_dep_info, srcs, import_
         pkg_info_to_compile_flags(
             expose_packages(
                 plugin_dep_info,
-                lib_info = None,
-                use_my_pkg_id = my_pkg_id,
+                my_pkg_id = my_pkg_id,
                 custom_package_databases = None,
                 version = version,
             ),

--- a/haskell/private/actions/compile.bzl
+++ b/haskell/private/actions/compile.bzl
@@ -14,6 +14,7 @@ load(":private/version_macros.bzl", "version_macro_includes")
 load(
     ":providers.bzl",
     "GhcPluginInfo",
+    "HaskellLibraryInfo",
     "get_libs_for_ghc_linker",
     "merge_HaskellCcInfo",
 )
@@ -153,9 +154,8 @@ def _compilation_defaults(hs, cc, java, dep_info, plugin_dep_info, srcs, import_
     compile_flags.extend(
         pkg_info_to_compile_flags(
             expose_packages(
-                dep_info,
-                my_pkg_id = my_pkg_id,
-                custom_package_databases = None,
+                package_ids = hs.package_ids,
+                package_databases = dep_info.package_databases,
                 version = version,
             ),
         ),
@@ -163,9 +163,13 @@ def _compilation_defaults(hs, cc, java, dep_info, plugin_dep_info, srcs, import_
     compile_flags.extend(
         pkg_info_to_compile_flags(
             expose_packages(
-                plugin_dep_info,
-                my_pkg_id = my_pkg_id,
-                custom_package_databases = None,
+                package_ids = [
+                    dep[HaskellLibraryInfo].package_id
+                    for plugin in plugins
+                    for dep in plugin[GhcPluginInfo].deps
+                    if HaskellLibraryInfo in dep
+                ],
+                package_databases = plugin_dep_info.package_databases,
                 version = version,
             ),
             for_plugin = True,

--- a/haskell/private/actions/compile.bzl
+++ b/haskell/private/actions/compile.bzl
@@ -155,7 +155,6 @@ def _compilation_defaults(hs, cc, java, dep_info, plugin_dep_info, srcs, import_
             expose_packages(
                 dep_info,
                 lib_info = None,
-                use_direct = True,
                 use_my_pkg_id = my_pkg_id,
                 custom_package_databases = None,
                 version = version,
@@ -167,7 +166,6 @@ def _compilation_defaults(hs, cc, java, dep_info, plugin_dep_info, srcs, import_
             expose_packages(
                 plugin_dep_info,
                 lib_info = None,
-                use_direct = True,
                 use_my_pkg_id = my_pkg_id,
                 custom_package_databases = None,
                 version = version,

--- a/haskell/private/actions/link.bzl
+++ b/haskell/private/actions/link.bzl
@@ -392,9 +392,8 @@ def link_binary(
     # lists.
 
     args.add_all(pkg_info_to_compile_flags(expose_packages(
-        dep_info,
-        my_pkg_id = None,
-        custom_package_databases = None,
+        package_ids = hs.package_ids,
+        package_databases = dep_info.package_databases,
         version = version,
     )))
 
@@ -629,9 +628,8 @@ def link_library_dynamic(hs, cc, dep_info, extra_srcs, objects_dir, my_pkg_id):
         args.add("-optl-Wl,-dead_strip_dylibs")
 
     args.add_all(pkg_info_to_compile_flags(expose_packages(
-        dep_info,
-        my_pkg_id = my_pkg_id,
-        custom_package_databases = None,
+        package_ids = hs.package_ids,
+        package_databases = dep_info.package_databases,
         version = my_pkg_id.version if my_pkg_id else None,
     )))
 

--- a/haskell/private/actions/link.bzl
+++ b/haskell/private/actions/link.bzl
@@ -394,7 +394,6 @@ def link_binary(
     args.add_all(pkg_info_to_compile_flags(expose_packages(
         dep_info,
         lib_info = None,
-        use_direct = True,
         use_my_pkg_id = None,
         custom_package_databases = None,
         version = version,
@@ -633,7 +632,6 @@ def link_library_dynamic(hs, cc, dep_info, extra_srcs, objects_dir, my_pkg_id):
     args.add_all(pkg_info_to_compile_flags(expose_packages(
         dep_info,
         lib_info = None,
-        use_direct = True,
         use_my_pkg_id = None,
         custom_package_databases = None,
         version = my_pkg_id.version if my_pkg_id else None,

--- a/haskell/private/actions/link.bzl
+++ b/haskell/private/actions/link.bzl
@@ -393,8 +393,7 @@ def link_binary(
 
     args.add_all(pkg_info_to_compile_flags(expose_packages(
         dep_info,
-        lib_info = None,
-        use_my_pkg_id = None,
+        my_pkg_id = None,
         custom_package_databases = None,
         version = version,
     )))
@@ -631,8 +630,7 @@ def link_library_dynamic(hs, cc, dep_info, extra_srcs, objects_dir, my_pkg_id):
 
     args.add_all(pkg_info_to_compile_flags(expose_packages(
         dep_info,
-        lib_info = None,
-        use_my_pkg_id = None,
+        my_pkg_id = my_pkg_id,
         custom_package_databases = None,
         version = my_pkg_id.version if my_pkg_id else None,
     )))

--- a/haskell/private/actions/package.bzl
+++ b/haskell/private/actions/package.bzl
@@ -88,7 +88,7 @@ def package(
         "dynamic-library-dirs": " ".join(["${pkgroot}"] + extra_lib_dirs),
         "hs-libraries": pkg_id.library_name(hs, my_pkg_id),
         "extra-libraries": " ".join(extra_libs),
-        "depends": ", ".join(dep_info.package_ids),
+        "depends": ", ".join(hs.package_ids),
     }
 
     # Create a file from which ghc-pkg will create the actual package

--- a/haskell/private/actions/repl.bzl
+++ b/haskell/private/actions/repl.bzl
@@ -50,8 +50,7 @@ def build_haskell_repl(
 
     pkg_ghc_info = expose_packages(
         hs_info,
-        lib_info,
-        use_my_pkg_id = None,
+        my_pkg_id = lib_info.package_id if lib_info else None,
         custom_package_databases = package_databases,
         version = version,
     )

--- a/haskell/private/actions/repl.bzl
+++ b/haskell/private/actions/repl.bzl
@@ -49,9 +49,8 @@ def build_haskell_repl(
     args = ["-package", "base", "-package", "directory"]
 
     pkg_ghc_info = expose_packages(
-        hs_info,
-        my_pkg_id = lib_info.package_id if lib_info else None,
-        custom_package_databases = package_databases,
+        package_ids = hs.package_ids,
+        package_databases = package_databases,
         version = version,
     )
     args += pkg_info_to_compile_flags(pkg_ghc_info)
@@ -130,7 +129,7 @@ def build_haskell_repl(
         library_path = library_path,
         ld_library_path = ld_library_path,
         package_ids = pkg_ghc_info.package_ids,
-        package_dbs = pkg_ghc_info.package_dbs,
+        package_dbs = pkg_ghc_info.package_databases,
         lib_imports = lib_imports,
         libraries = libraries,
         execs = struct(

--- a/haskell/private/actions/repl.bzl
+++ b/haskell/private/actions/repl.bzl
@@ -51,7 +51,6 @@ def build_haskell_repl(
     pkg_ghc_info = expose_packages(
         hs_info,
         lib_info,
-        use_direct = False,
         use_my_pkg_id = None,
         custom_package_databases = package_databases,
         version = version,

--- a/haskell/private/actions/runghc.bzl
+++ b/haskell/private/actions/runghc.bzl
@@ -43,9 +43,8 @@ def build_haskell_runghc(
     """
 
     args = pkg_info_to_compile_flags(expose_packages(
-        hs_info,
-        my_pkg_id = lib_info.package_id if lib_info else None,
-        custom_package_databases = package_databases,
+        package_ids = hs.package_ids,
+        package_databases = package_databases,
         version = version,
     ))
 

--- a/haskell/private/actions/runghc.bzl
+++ b/haskell/private/actions/runghc.bzl
@@ -44,8 +44,7 @@ def build_haskell_runghc(
 
     args = pkg_info_to_compile_flags(expose_packages(
         hs_info,
-        lib_info,
-        use_my_pkg_id = None,
+        my_pkg_id = lib_info.package_id if lib_info else None,
         custom_package_databases = package_databases,
         version = version,
     ))

--- a/haskell/private/actions/runghc.bzl
+++ b/haskell/private/actions/runghc.bzl
@@ -45,7 +45,6 @@ def build_haskell_runghc(
     args = pkg_info_to_compile_flags(expose_packages(
         hs_info,
         lib_info,
-        use_direct = False,
         use_my_pkg_id = None,
         custom_package_databases = package_databases,
         version = version,

--- a/haskell/private/context.bzl
+++ b/haskell/private/context.bzl
@@ -1,6 +1,7 @@
 """Derived context with Haskell-specific fields and methods"""
 
 load("@bazel_skylib//lib:paths.bzl", "paths")
+load("@io_tweag_rules_haskell//haskell:providers.bzl", "HaskellLibraryInfo")
 
 HaskellContext = provider()
 
@@ -9,6 +10,15 @@ def haskell_context(ctx, attr = None):
 
     if not attr:
         attr = ctx.attr
+
+    if hasattr(attr, "deps"):
+        package_ids = [
+            dep[HaskellLibraryInfo].package_id
+            for dep in attr.deps
+            if HaskellLibraryInfo in dep
+        ]
+    else:
+        package_ids = []
 
     if hasattr(attr, "src_strip_prefix"):
         src_strip_prefix = attr.src_strip_prefix
@@ -38,6 +48,7 @@ def haskell_context(ctx, attr = None):
         label = ctx.label,
         toolchain = toolchain,
         tools = toolchain.tools,
+        package_ids = package_ids,
         src_root = src_root,
         package_root = ctx.label.workspace_root + ctx.label.package,
         env = env,

--- a/haskell/private/dependencies.bzl
+++ b/haskell/private/dependencies.bzl
@@ -140,11 +140,6 @@ def gather_dep_info(ctx, deps):
       HaskellInfo: Unified information about all dependencies.
     """
 
-    package_ids = [
-        dep[HaskellLibraryInfo].package_id
-        for dep in deps
-        if HaskellLibraryInfo in dep
-    ]
     package_databases = depset(transitive = [
         dep[HaskellInfo].package_databases
         for dep in deps
@@ -167,7 +162,6 @@ def gather_dep_info(ctx, deps):
     ])
 
     acc = HaskellInfo(
-        package_ids = package_ids,
         package_databases = package_databases,
         version_macros = set.empty(),
         static_libraries = static_libraries,
@@ -183,7 +177,6 @@ def gather_dep_info(ctx, deps):
             if HaskellLibraryInfo not in dep:
                 fail("Target {0} cannot depend on binary".format(ctx.attr.name))
             acc = HaskellInfo(
-                package_ids = acc.package_ids,
                 package_databases = acc.package_databases,
                 version_macros = set.mutable_union(acc.version_macros, binfo.version_macros),
                 static_libraries = acc.static_libraries + binfo.static_libraries,
@@ -198,7 +191,6 @@ def gather_dep_info(ctx, deps):
             # in the `CcInfo` provider.
             hs_cc_info = _HaskellCcInfo_from_CcInfo(ctx, dep[CcInfo])
             acc = HaskellInfo(
-                package_ids = acc.package_ids,
                 package_databases = acc.package_databases,
                 version_macros = acc.version_macros,
                 static_libraries = acc.static_libraries,

--- a/haskell/private/haskell_impl.bzl
+++ b/haskell/private/haskell_impl.bzl
@@ -119,6 +119,11 @@ def _haskell_binary_common_impl(ctx, is_test):
         ctx,
         [dep for plugin in ctx.attr.plugins for dep in plugin[GhcPluginInfo].deps],
     )
+    package_ids = [
+        dep[HaskellLibraryInfo].package_id
+        for dep in ctx.attr.deps
+        if HaskellLibraryInfo in dep
+    ]
 
     # Add any interop info for other languages.
     cc = cc_interop_info(ctx)
@@ -174,7 +179,6 @@ def _haskell_binary_common_impl(ctx, is_test):
     )
 
     hs_info = HaskellInfo(
-        package_ids = dep_info.package_ids,
         package_databases = dep_info.package_databases,
         version_macros = set.empty(),
         source_files = c.source_files,
@@ -296,6 +300,11 @@ def haskell_library_impl(ctx):
         ctx,
         [dep for plugin in ctx.attr.plugins for dep in plugin[GhcPluginInfo].deps],
     )
+    package_ids = [
+        dep[HaskellLibraryInfo].package_id
+        for dep in ctx.attr.deps
+        if HaskellLibraryInfo in dep
+    ]
 
     # Add any interop info for other languages.
     cc = cc_interop_info(ctx)
@@ -392,7 +401,6 @@ def haskell_library_impl(ctx):
         )
 
     hs_info = HaskellInfo(
-        package_ids = [pkg_id.to_string(my_pkg_id)] + dep_info.package_ids,
         package_databases = depset([cache_file], transitive = [dep_info.package_databases]),
         version_macros = version_macros,
         source_files = c.source_files,
@@ -624,7 +632,6 @@ def haskell_import_impl(ctx):
             generate_version_macros(ctx, ctx.label.name, ctx.attr.version),
         )
     hs_info = HaskellInfo(
-        package_ids = [id],
         # XXX Empty set of conf and cache files only works for global db.
         package_databases = depset(),
         version_macros = version_macros,

--- a/haskell/private/packages.bzl
+++ b/haskell/private/packages.bzl
@@ -38,7 +38,7 @@ def pkg_info_to_compile_flags(pkg_info, for_plugin = False):
 
     return args
 
-def expose_packages(hs_info, lib_info, use_direct, use_my_pkg_id, custom_package_databases, version):
+def expose_packages(hs_info, lib_info, use_my_pkg_id, custom_package_databases, version):
     """
     Returns the information that is needed by GHC in order to enable haskell
     packages.
@@ -49,7 +49,6 @@ def expose_packages(hs_info, lib_info, use_direct, use_my_pkg_id, custom_package
     All the other arguments are not understood well:
 
     lib_info: only used for repl and linter
-    use_direct: only used for repl and linter
     use_my_pkg_id: only used for one specific task in compile.bzl
     custom_package_databases: override the package_databases of hs_info, used only by the repl
     """

--- a/haskell/private/packages.bzl
+++ b/haskell/private/packages.bzl
@@ -38,7 +38,7 @@ def pkg_info_to_compile_flags(pkg_info, for_plugin = False):
 
     return args
 
-def expose_packages(hs_info, lib_info, use_my_pkg_id, custom_package_databases, version):
+def expose_packages(hs_info, my_pkg_id, custom_package_databases, version):
     """
     Returns the information that is needed by GHC in order to enable haskell
     packages.
@@ -48,22 +48,13 @@ def expose_packages(hs_info, lib_info, use_my_pkg_id, custom_package_databases, 
 
     All the other arguments are not understood well:
 
-    lib_info: only used for repl and linter
-    use_my_pkg_id: only used for one specific task in compile.bzl
+    my_pkg_id: the pkg_id if we're compiling a library
     custom_package_databases: override the package_databases of hs_info, used only by the repl
     """
     has_version = version != None and version != ""
 
     # Expose all bazel dependencies
-    package_ids = []
-    for package in hs_info.package_ids:
-        # XXX: repl and lint uses this lib_info flags
-        # It is set to None in all other usage of this function
-        # TODO: find the meaning of this flag
-        if lib_info == None or package != lib_info.package_id:
-            # XXX: use_my_pkg_id is not None only in compile.bzl
-            if (use_my_pkg_id == None) or package != use_my_pkg_id:
-                package_ids.append(package)
+    package_ids = [package_id for package_id in hs_info.package_ids if package_id != my_pkg_id]
 
     # Only include package DBs for deps.
     package_dbs = []

--- a/haskell/private/packages.bzl
+++ b/haskell/private/packages.bzl
@@ -33,12 +33,12 @@ def pkg_info_to_compile_flags(pkg_info, for_plugin = False):
     for package_id in pkg_info.package_ids:
         args.extend(["-{}package-id".format(namespace), package_id])
 
-    for package_db in pkg_info.package_dbs:
+    for package_db in pkg_info.package_databases:
         args.extend(["-package-db", package_db])
 
     return args
 
-def expose_packages(hs_info, my_pkg_id, custom_package_databases, version):
+def expose_packages(package_ids, package_databases, version):
     """
     Returns the information that is needed by GHC in order to enable haskell
     packages.
@@ -52,18 +52,9 @@ def expose_packages(hs_info, my_pkg_id, custom_package_databases, version):
     custom_package_databases: override the package_databases of hs_info, used only by the repl
     """
     has_version = version != None and version != ""
-
-    # Expose all bazel dependencies
-    package_ids = [package_id for package_id in hs_info.package_ids if package_id != my_pkg_id]
-
-    # Only include package DBs for deps.
-    package_dbs = []
-    for cache in hs_info.package_databases.to_list() if custom_package_databases == None else custom_package_databases.to_list():
-        package_dbs.append(cache.dirname)
-
     ghc_info = struct(
         has_version = has_version,
         package_ids = package_ids,
-        package_dbs = package_dbs,
+        package_databases = [cache.dirname for cache in package_databases.to_list()],
     )
     return ghc_info

--- a/haskell/providers.bzl
+++ b/haskell/providers.bzl
@@ -76,7 +76,6 @@ def merge_HaskellCcInfo(*args):
 HaskellInfo = provider(
     doc = "Common information about build process: dependencies, etc.",
     fields = {
-        "package_ids": "List of all package ids of direct dependencies.",
         "package_databases": "Depset of package cache files.",
         "version_macros": "Depset of version macro files.",
         "import_dirs": "Import hierarchy roots.",


### PR DESCRIPTION
Providers are for *transitive* information. If you only need to summarize
information from your direct dependencies, then you don't need a provider
for that. We were passing `package_ids` to downstream dependencies, but
these would promptly overwrite that field when calling `gather_dep_info()`.
So let's just do away with it.

We simplified `expose_packages()` while we were at it.