### PR TITLE
Compatibility with bazel 0.25

### DIFF
--- a/debug/linking_utils/ldd_test.bzl
+++ b/debug/linking_utils/ldd_test.bzl
@@ -1,5 +1,5 @@
 load(
-    "//:tests/inline_tests.bzl",
+    "//tests:inline_tests.bzl",
     "py_inline_test",
 )
 

--- a/haskell/ghc_bindist.bzl
+++ b/haskell/ghc_bindist.bzl
@@ -1,5 +1,7 @@
 """Workspace rules (GHC binary distributions)"""
 
+load("@bazel_tools//tools/build_defs/repo:utils.bzl", "patch")
+
 _GHC_DEFAULT_VERSION = "8.6.5"
 
 # Generated with `bazel run @io_tweag_rules_haskell//haskell:gen-ghc-bindist`
@@ -175,8 +177,6 @@ def _execute_fail_loudly(ctx, args):
     eresult = ctx.execute(args, quiet = False)
     if eresult.return_code != 0:
         fail("{0} failed, aborting creation of GHC bindist".format(" ".join(args)))
-
-load("@bazel_tools//tools/build_defs/repo:utils.bzl", "patch")
 
 def _ghc_bindist_impl(ctx):
     # Avoid rule restart by resolving these labels early. See

--- a/tests/cc_haskell_import/BUILD.bazel
+++ b/tests/cc_haskell_import/BUILD.bazel
@@ -61,7 +61,7 @@ py_binary(
     data = [
         ":hs-lib-b-wrapped.so",
     ],
-    default_python_version = "PY3",
+    python_version = "PY3",
     srcs_version = "PY3ONLY",
     # This requires a shared object, which is not provided in profiling mode.
     # Hence we disable this test in profiling mode using requires_dynamic.


### PR DESCRIPTION
With theses changes, a subset of rules_haskell is now compatible with
bazel 0.25.

- `load` arguments must be placed first in bazel files
- `default_python_version` is now `python_version`
- Some rule path where fixed. Bazel is now more strict about the
  syntax package:rule. Previously accepted //:package/path/rulename
  must be converted to //package/path:rulename

*NOTE*

I tested these changes using a bazel 0.25 hacked from nixpkgs. It does not fully build rules_haskell (i.e. java issues, which are related to nixpkgs packaging), but everything else works. I'm successfully using bazel 0.25 with rules_haskell on a client codebase with these changes.