### PR TITLE
Compatibility with bazel 0.26

### DIFF
--- a/haskell/private/dependencies.bzl
+++ b/haskell/private/dependencies.bzl
@@ -204,7 +204,7 @@ def gather_dep_info(ctx, deps):
             acc = HaskellInfo(
                 package_databases = acc.package_databases,
                 version_macros = set.mutable_union(acc.version_macros, binfo.version_macros),
-                static_libraries = acc.static_libraries + binfo.static_libraries,
+                static_libraries = depset(transitive = [acc.static_libraries, binfo.static_libraries]),
                 dynamic_libraries = acc.dynamic_libraries,
                 interface_dirs = acc.interface_dirs,
                 import_dirs = import_dirs,


### PR DESCRIPTION
With theses changes, a subset of rules_haskell is now compatible with
bazel 0.26.0.

- depset union with + is deprecated in favor of depset constructor

NOTE: I tested theses changes with bazel 0.26 hacked from nixpkgs on a client codebase and it worked for a subset of rules which are not using java.