### PR TITLE
Expand location and make variables in compiler flags

### DIFF
--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -75,13 +75,13 @@ _haskell_common_attrs = {
         allow_files = True,
     ),
     "compiler_flags": attr.string_list(
-        doc = "Flags to pass to Haskell compiler.",
+        doc = "Flags to pass to Haskell compiler. Subject to Make variable substitution.",
     ),
     "repl_ghci_args": attr.string_list(
-        doc = "Arbitrary extra arguments to pass to GHCi. This extends `compiler_flags` and `repl_ghci_args` from the toolchain",
+        doc = "Arbitrary extra arguments to pass to GHCi. This extends `compiler_flags` and `repl_ghci_args` from the toolchain. Subject to Make variable substitution.",
     ),
     "runcompile_flags": attr.string_list(
-        doc = "Arbitrary extra arguments to pass to runghc. This extends `compiler_flags` and `repl_ghci_args` from the toolchain",
+        doc = "Arbitrary extra arguments to pass to runghc. This extends `compiler_flags` and `repl_ghci_args` from the toolchain. Subject to Make variable substitution.",
     ),
     "plugins": attr.label_list(
         doc = "Compiler plugins to use during compilation.",

--- a/haskell/private/haskell_impl.bzl
+++ b/haskell/private/haskell_impl.bzl
@@ -136,6 +136,21 @@ def _resolve_preprocessors(ctx, preprocessors):
         input_manifests = input_manifests,
     )
 
+def _expand_make_variables(name, ctx, strings):
+    # All labels in all attributes should be location-expandable.
+    label_attrs = [
+        ctx.attr.srcs,
+        ctx.attr.extra_srcs,
+        ctx.attr.data,
+        ctx.attr.deps,
+        ctx.attr.plugins,
+        ctx.attr.tools,
+    ]
+    targets = [target for attr in label_attrs for target in attr]
+    strings = [ctx.expand_location(str, targets) for str in strings]
+    strings = [ctx.expand_make_variables(name, str, {}) for str in strings]
+    return strings
+
 def _haskell_binary_common_impl(ctx, is_test):
     hs = haskell_context(ctx)
     dep_info = gather_dep_info(ctx, ctx.attr.deps)
@@ -167,6 +182,7 @@ def _haskell_binary_common_impl(ctx, is_test):
 
     plugins = [_resolve_plugin_tools(ctx, plugin[GhcPluginInfo]) for plugin in ctx.attr.plugins]
     preprocessors = _resolve_preprocessors(ctx, ctx.attr.tools)
+    user_compile_flags = _expand_make_variables("compiler_flags", ctx, ctx.attr.compiler_flags)
     c = hs.toolchain.actions.compile_binary(
         hs,
         cc,
@@ -177,7 +193,7 @@ def _haskell_binary_common_impl(ctx, is_test):
         ls_modules = ctx.executable._ls_modules,
         import_dir_map = import_dir_map,
         extra_srcs = depset(ctx.files.extra_srcs),
-        user_compile_flags = ctx.attr.compiler_flags,
+        user_compile_flags = user_compile_flags,
         dynamic = dynamic,
         with_profiling = with_profiling,
         main_function = ctx.attr.main_function,
@@ -193,12 +209,13 @@ def _haskell_binary_common_impl(ctx, is_test):
         if HaskellCoverageInfo in dep:
             coverage_data += dep[HaskellCoverageInfo].coverage_data
 
+    user_compile_flags = _expand_make_variables("compiler_flags", ctx, ctx.attr.compiler_flags)
     (binary, solibs) = link_binary(
         hs,
         cc,
         dep_info,
         ctx.files.extra_srcs,
-        ctx.attr.compiler_flags,
+        user_compile_flags,
         c.objects_dir,
         dynamic = dynamic,
         with_profiling = with_profiling,
@@ -224,12 +241,14 @@ def _haskell_binary_common_impl(ctx, is_test):
 
     target_files = depset([binary])
 
+    user_compile_flags = _expand_make_variables("compiler_flags", ctx, ctx.attr.compiler_flags)
+    repl_ghci_args = _expand_make_variables("repl_ghci_args", ctx, ctx.attr.repl_ghci_args)
     build_haskell_repl(
         hs,
         ghci_script = ctx.file._ghci_script,
         ghci_repl_wrapper = ctx.file._ghci_repl_wrapper,
-        user_compile_flags = ctx.attr.compiler_flags,
-        repl_ghci_args = ctx.attr.repl_ghci_args,
+        user_compile_flags = user_compile_flags,
+        repl_ghci_args = repl_ghci_args,
         output = ctx.outputs.repl,
         package_databases = dep_info.package_databases,
         version = ctx.attr.version,
@@ -240,11 +259,13 @@ def _haskell_binary_common_impl(ctx, is_test):
     # See https://github.com/tweag/rules_haskell/pull/460.
     ln(hs, ctx.outputs.repl, ctx.outputs.repl_deprecated)
 
+    user_compile_flags = _expand_make_variables("compiler_flags", ctx, ctx.attr.compiler_flags)
+    extra_args = _expand_make_variables("runcompile_flags", ctx, ctx.attr.runcompile_flags)
     build_haskell_runghc(
         hs,
         runghc_wrapper = ctx.file._ghci_repl_wrapper,
-        extra_args = ctx.attr.runcompile_flags,
-        user_compile_flags = ctx.attr.compiler_flags,
+        extra_args = extra_args,
+        user_compile_flags = user_compile_flags,
         output = ctx.outputs.runghc,
         package_databases = dep_info.package_databases,
         version = ctx.attr.version,
@@ -354,6 +375,7 @@ def haskell_library_impl(ctx):
 
     plugins = [_resolve_plugin_tools(ctx, plugin[GhcPluginInfo]) for plugin in ctx.attr.plugins]
     preprocessors = _resolve_preprocessors(ctx, ctx.attr.tools)
+    user_compile_flags = _expand_make_variables("compile_flags", ctx, ctx.attr.compiler_flags)
     c = hs.toolchain.actions.compile_library(
         hs,
         cc,
@@ -363,7 +385,7 @@ def haskell_library_impl(ctx):
         srcs = srcs_files,
         import_dir_map = import_dir_map,
         extra_srcs = depset(ctx.files.extra_srcs),
-        user_compile_flags = ctx.attr.compiler_flags,
+        user_compile_flags = user_compile_flags,
         with_shared = with_shared,
         with_profiling = with_profiling,
         my_pkg_id = my_pkg_id,
@@ -468,12 +490,14 @@ def haskell_library_impl(ctx):
     target_files = depset([file for file in [static_library, dynamic_library] if file])
 
     if hasattr(ctx, "outputs"):
+        user_compile_flags = _expand_make_variables("compiler_flags", ctx, ctx.attr.compiler_flags)
+        repl_ghci_args = _expand_make_variables("repl_ghci_args", ctx, ctx.attr.repl_ghci_args)
         build_haskell_repl(
             hs,
             ghci_script = ctx.file._ghci_script,
             ghci_repl_wrapper = ctx.file._ghci_repl_wrapper,
-            repl_ghci_args = ctx.attr.repl_ghci_args,
-            user_compile_flags = ctx.attr.compiler_flags,
+            repl_ghci_args = repl_ghci_args,
+            user_compile_flags = user_compile_flags,
             output = ctx.outputs.repl,
             package_databases = dep_info.package_databases,
             version = ctx.attr.version,
@@ -485,11 +509,13 @@ def haskell_library_impl(ctx):
         # See https://github.com/tweag/rules_haskell/pull/460.
         ln(hs, ctx.outputs.repl, ctx.outputs.repl_deprecated)
 
+        extra_args = _expand_make_variables("runcompile_flags", ctx, ctx.attr.runcompile_flags)
+        user_compile_flags = _expand_make_variables("compiler_flags", ctx, ctx.attr.compiler_flags)
         build_haskell_runghc(
             hs,
             runghc_wrapper = ctx.file._ghci_repl_wrapper,
-            extra_args = ctx.attr.runcompile_flags,
-            user_compile_flags = ctx.attr.compiler_flags,
+            extra_args = extra_args,
+            user_compile_flags = user_compile_flags,
             output = ctx.outputs.runghc,
             package_databases = dep_info.package_databases,
             version = ctx.attr.version,

--- a/haskell/protobuf.bzl
+++ b/haskell/protobuf.bzl
@@ -155,9 +155,11 @@ def _haskell_proto_aspect_impl(target, ctx):
         "exports": {},
         "name": "proto-autogen-" + ctx.rule.attr.name,
         "srcs": hs_files,
+        "extra_srcs": [],
         "deps": ctx.rule.attr.deps +
                 ctx.toolchains["@io_tweag_rules_haskell//protobuf:toolchain"].deps,
         "plugins": [],
+        "data": [],
         "tools": [],
         "_cc_toolchain": ctx.attr._cc_toolchain,
     }

--- a/tests/binary-with-tool/BUILD.bazel
+++ b/tests/binary-with-tool/BUILD.bazel
@@ -15,6 +15,7 @@ haskell_binary(
 haskell_test(
     name = "binary-with-tool",
     srcs = ["Main.hs"],
+    compiler_flags = ["-DCAT=$(location :cat)"],
     tools = [":cat"],
     visibility = ["//visibility:public"],
     deps = ["//tests/hackage:base"],

--- a/tests/binary-with-tool/Main.hs
+++ b/tests/binary-with-tool/Main.hs
@@ -1,4 +1,5 @@
-{-# OPTIONS_GHC -F -pgmF bazel-out/host/bin/tests/binary-with-tool/cat #-}
+{-# LANGUAGE CPP #-}
+{-# OPTIONS_GHC -F -pgmF CAT #-}
 
 module Main where
 


### PR DESCRIPTION
The documentation for both the C/C++ rules and the Java rules
carefully notes in any attribute that is a list of flags to something
that this attribute is subject to "Make variable substitution" (and
bourne shell tokenization). I don't know how to do the latter, and
I don't know that it matters. But for consistency with the Java and
C/C++ rules, we now do the same too.

This can occasionally come in handy. For example to pass in the
location of a tool that belongs to the java toolchain.