### PR TITLE
Nixpkgs config is explicitly set to {}

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -292,7 +292,7 @@ nixpkgs_package(
     # a workaround for
     # https://github.com/bazelbuild/bazel/issues/2927.
     nix_file_content = """
-    with import <nixpkgs> {};
+    with import <nixpkgs> { config = {}; };
     runCommand "nodejs-rules_haskell" { buildInputs = [ nodejs ]; } ''
       mkdir -p $out/nixpkgs_nodejs
       cd $out/nixpkgs_nodejs

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -292,7 +292,7 @@ nixpkgs_package(
     # a workaround for
     # https://github.com/bazelbuild/bazel/issues/2927.
     nix_file_content = """
-    with import <nixpkgs> { config = {}; };
+    with import <nixpkgs> { config = {}; overlays = []; };
     runCommand "nodejs-rules_haskell" { buildInputs = [ nodejs ]; } ''
       mkdir -p $out/nixpkgs_nodejs
       cd $out/nixpkgs_nodejs

--- a/docs/haskell-use-cases.rst
+++ b/docs/haskell-use-cases.rst
@@ -144,7 +144,7 @@ This definition assumes a ``ghc.nix`` file at the root of the
 repository. In this file, you can use the Nix expression language to
 construct a compiler with all the packages you depend on in scope::
 
-  with (import <nixpkgs> { config = {}; });
+  with (import <nixpkgs> { config = {}; overlays = []; });
 
   haskellPackages.ghcWithPackages (p: with p; [
     containers

--- a/docs/haskell-use-cases.rst
+++ b/docs/haskell-use-cases.rst
@@ -144,7 +144,7 @@ This definition assumes a ``ghc.nix`` file at the root of the
 repository. In this file, you can use the Nix expression language to
 construct a compiler with all the packages you depend on in scope::
 
-  with (import <nixpkgs> {});
+  with (import <nixpkgs> { config = {}; });
 
   haskellPackages.ghcWithPackages (p: with p; [
     containers

--- a/nixpkgs/cc-toolchain.nix
+++ b/nixpkgs/cc-toolchain.nix
@@ -1,4 +1,4 @@
-with import ./. { config = {}; };
+with import ./. { config = {}; overlays = []; };
 with darwin.apple_sdk.frameworks;
 
 # XXX On Darwin, workaround

--- a/nixpkgs/cc-toolchain.nix
+++ b/nixpkgs/cc-toolchain.nix
@@ -1,4 +1,4 @@
-with import ./. {};
+with import ./. { config = {}; };
 with darwin.apple_sdk.frameworks;
 
 # XXX On Darwin, workaround


### PR DESCRIPTION
Else, nixpkgs will try to load it from ~/.config/nixpkgs/config.nix
which is not reproducible at all.

Future version of rules_nixpkgs won't accept it anymore.