### PR TITLE
Remove HaskellCcInfo in favor of CcInfo

### DIFF
--- a/haskell/doctest.bzl
+++ b/haskell/doctest.bzl
@@ -3,12 +3,7 @@
 load("@bazel_skylib//lib:dicts.bzl", "dicts")
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load(":private/context.bzl", "haskell_context", "render_env")
-load(
-    ":private/path_utils.bzl",
-    "get_dirname",
-    "get_lib_name",
-    "link_libraries",
-)
+load(":private/path_utils.bzl", "link_libraries")
 load(":private/set.bzl", "set")
 load(
     "@io_tweag_rules_haskell//haskell:providers.bzl",

--- a/haskell/haddock.bzl
+++ b/haskell/haddock.bzl
@@ -6,6 +6,7 @@ load(
     "HaddockInfo",
     "HaskellInfo",
     "HaskellLibraryInfo",
+    "get_ghci_extra_libs",
 )
 load(":private/context.bzl", "haskell_context", "render_env")
 load(":private/set.bzl", "set")
@@ -102,9 +103,8 @@ def _haskell_doc_aspect_impl(target, ctx):
         is_executable = True,
     )
 
-    # Transitive library dependencies for runtime.
-    trans_link_ctx = target[HaskellInfo].transitive_cc_dependencies.dynamic_linking
-    trans_libs = trans_link_ctx.libraries_to_link.to_list()
+    # C library dependencies for runtime.
+    (ghci_extra_libs, _ghc_env) = get_ghci_extra_libs(hs, target[CcInfo])
 
     ctx.actions.run(
         inputs = depset(transitive = [
@@ -113,7 +113,7 @@ def _haskell_doc_aspect_impl(target, ctx):
             set.to_depset(target[HaskellInfo].source_files),
             target[HaskellInfo].extra_source_files,
             target[HaskellInfo].dynamic_libraries,
-            depset(trans_libs),
+            ghci_extra_libs,
             depset(transitive_haddocks.values()),
             depset(transitive_html.values()),
             target[CcInfo].compilation_context.headers,

--- a/haskell/private/actions/compile.bzl
+++ b/haskell/private/actions/compile.bzl
@@ -13,7 +13,6 @@ load(":private/pkg_id.bzl", "pkg_id")
 load(":private/version_macros.bzl", "version_macro_includes")
 load(
     ":providers.bzl",
-    "GhcPluginInfo",
     "HaskellLibraryInfo",
     "get_ghci_extra_libs",
 )

--- a/haskell/private/actions/package.bzl
+++ b/haskell/private/actions/package.bzl
@@ -1,54 +1,68 @@
 """Action for creating packages and registering them with ghc-pkg"""
 
 load("@bazel_skylib//lib:paths.bzl", "paths")
-load(":private/path_utils.bzl", "target_unique_name")
+load(":private/path_utils.bzl", "get_lib_name", "target_unique_name")
 load(":private/pkg_id.bzl", "pkg_id")
 load(":private/set.bzl", "set")
-load(":private/path_utils.bzl", "get_lib_name")
+load(":providers.bzl", "get_extra_libs")
 
-def _get_extra_libraries(dep_info):
+def _get_extra_libraries(hs, with_shared, cc_info):
     """Get directories and library names for extra library dependencies.
 
     Args:
-      dep_info: HaskellInfo provider of the package.
+      cc_info: Combined CcInfo provider of the package's dependencies.
 
     Returns:
       (dirs, libs):
       dirs: list: Library search directories for extra library dependencies.
       libs: list: Extra library dependencies.
     """
-    cc_libs = dep_info.cc_dependencies.dynamic_linking.libraries_to_link.to_list()
 
-    # The order in which library dependencies are listed is relevant when
-    # linking static archives. To maintain the order defined by the input
-    # depset we collect the library dependencies in a list, and use a separate
-    # set to deduplicate entries.
-    seen_libs = set.empty()
-    extra_libs = []
-    extra_lib_dirs = set.empty()
-    for lib in cc_libs:
-        lib_name = get_lib_name(lib)
+    # NOTE This is duplicated from path_utils.bzl link_libraries. This whole
+    # function can go away once we track libraries outside of package
+    # configuration files.
+    dynamic = with_shared
+    (static_libs, dynamic_libs) = get_extra_libs(hs, dynamic, cc_info)
 
-        # This test is a hack. When a CC library has a Haskell library
-        # as a dependency, we need to be careful to filter it out,
-        # otherwise it will end up polluting extra-libraries, when GHC
-        # already uses hs-libraries to locate all Haskell libraries.
-        #
-        # TODO Get rid of this hack. See
-        # https://github.com/tweag/rules_haskell/issues/873.
-        if not lib_name.startswith("HS"):
-            if not set.is_member(seen_libs, lib_name):
-                set.mutable_insert(seen_libs, lib_name)
-                extra_libs.append(lib_name)
-            set.mutable_insert(extra_lib_dirs, lib.dirname)
-    return (set.to_list(extra_lib_dirs), extra_libs)
+    # This test is a hack. When a CC library has a Haskell library
+    # as a dependency, we need to be careful to filter it out,
+    # otherwise it will end up polluting the linker flags. GHC
+    # already uses hs-libraries to link all Haskell libraries.
+    #
+    # TODO Get rid of this hack. See
+    # https://github.com/tweag/rules_haskell/issues/873.
+    cc_static_libs = depset(direct = [
+        lib
+        for lib in static_libs.to_list()
+        if not get_lib_name(lib).startswith("HS")
+    ])
+    cc_dynamic_libs = depset(direct = [
+        lib
+        for lib in dynamic_libs.to_list()
+        if not get_lib_name(lib).startswith("HS")
+    ])
+    cc_libs = cc_static_libs.to_list() + cc_dynamic_libs.to_list()
+
+    lib_dirs = depset(direct = [
+        lib.dirname
+        for lib in cc_libs
+    ])
+
+    lib_names = [
+        get_lib_name(lib)
+        for lib in cc_libs
+    ]
+
+    return (lib_dirs.to_list(), lib_names)
 
 def package(
         hs,
         dep_info,
+        cc_info,
         interfaces_dir,
         static_library,
         dynamic_library,
+        with_shared,
         exposed_modules_file,
         other_modules,
         my_pkg_id):
@@ -74,7 +88,7 @@ def package(
         paths.join(pkg_db_dir, "_iface"),
     )
 
-    (extra_lib_dirs, extra_libs) = _get_extra_libraries(dep_info)
+    (extra_lib_dirs, extra_libs) = _get_extra_libraries(hs, with_shared, cc_info)
 
     metadata_entries = {
         "name": my_pkg_id.package_name,

--- a/haskell/private/actions/repl.bzl
+++ b/haskell/private/actions/repl.bzl
@@ -5,7 +5,6 @@ load(":private/packages.bzl", "expose_packages", "pkg_info_to_compile_flags")
 load(
     ":private/path_utils.bzl",
     "get_lib_name",
-    "is_shared_library",
     "link_libraries",
     "ln",
     "target_unique_name",

--- a/haskell/private/actions/runghc.bzl
+++ b/haskell/private/actions/runghc.bzl
@@ -4,7 +4,6 @@ load(":private/context.bzl", "render_env")
 load(":private/packages.bzl", "expose_packages", "pkg_info_to_compile_flags")
 load(
     ":private/path_utils.bzl",
-    "is_shared_library",
     "link_libraries",
     "ln",
     "target_unique_name",

--- a/haskell/private/path_utils.bzl
+++ b/haskell/private/path_utils.bzl
@@ -309,28 +309,6 @@ def link_libraries(libs, args, prefix_optl = False):
         args.extend([libfmt % get_lib_name(lib) for lib in cc_libs])
         args.extend(depset(direct = [dirfmt % lib.dirname for lib in cc_libs]).to_list())
 
-def is_shared_library(f):
-    """Check if the given File is a shared library.
-
-    Args:
-      f: The File to check.
-
-    Returns:
-      Bool: True if the given file `f` is a shared library, False otherwise.
-    """
-    return f.extension in ["so", "dylib"] or f.basename.find(".so.") != -1
-
-def is_static_library(f):
-    """Check if the given File is a static library.
-
-    Args:
-      f: The File to check.
-
-    Returns:
-      Bool: True if the given file `f` is a static library, False otherwise.
-    """
-    return f.extension in ["a"]
-
 def _rel_path_to_module(hs, f):
     """Make given file name relative to the directory where the module hierarchy
     starts.
@@ -404,37 +382,6 @@ def ln(hs, target, link, extra_inputs = depset()):
         ),
         use_default_shell_env = True,
     )
-
-def link_forest(ctx, srcs, basePath = ".", **kwargs):
-    """Write a symlink to each file in `srcs` into a destination directory
-    defined using the same arguments as `ctx.actions.declare_directory`"""
-    local_files = []
-    for src in srcs.to_list():
-        dest = ctx.actions.declare_file(
-            paths.join(basePath, src.basename),
-            **kwargs
-        )
-        local_files.append(dest)
-        ln(ctx, src, dest)
-    return local_files
-
-def copy_all(ctx, srcs, dest):
-    """Copy all the files in `srcs` into `dest`"""
-    if list(srcs.to_list()) == []:
-        ctx.actions.run_shell(
-            command = "mkdir -p {dest}".format(dest = dest.path),
-            outputs = [dest],
-        )
-    else:
-        args = ctx.actions.args()
-        args.add_all(srcs)
-        ctx.actions.run_shell(
-            inputs = depset(srcs),
-            outputs = [dest],
-            mnemonic = "Copy",
-            command = "mkdir -p {dest} && cp -L -R \"$@\" {dest}".format(dest = dest.path),
-            arguments = [args],
-        )
 
 def parse_pattern(ctx, pattern_str):
     """Parses a string label pattern.

--- a/haskell/private/path_utils.bzl
+++ b/haskell/private/path_utils.bzl
@@ -127,71 +127,84 @@ def make_path(libs, prefix = None, sep = None):
 
     return sep.join(set.to_list(r))
 
-def darwin_convert_to_dylibs(hs, libs):
-    """Convert .so dynamic libraries to .dylib.
+def symlink_dynamic_library(hs, lib, outdir):
+    """Create a symbolic link for a dynamic library and fix the extension.
 
-    Bazel's cc_library rule will create .so files for dynamic libraries even
-    on MacOS. GHC's builtin linker, which is used during compilation, GHCi,
-    or doctests, hard-codes the assumption that all dynamic libraries on MacOS
-    end on .dylib. This function serves as an adaptor and produces symlinks
-    from a .dylib version to the .so version for every dynamic library
-    dependencies that does not end on .dylib.
+    This function is used for two reasons:
 
-    Args:
-      hs: Haskell context.
-      libs: List of library files dynamic or static.
+    1) GHCi expects specific file endings for dynamic libraries depending on
+       the platform: (Linux: .so, MacOS: .dylib, Windows: .dll). Bazel does not
+       follow this convention.
 
-    Returns:
-      List of library files where all dynamic libraries end on .dylib.
-    """
-    lib_prefix = "_dylibs"
-    new_libs = []
-    for lib in libs:
-        if is_shared_library(lib) and lib.extension != "dylib":
-            dylib_name = paths.join(
-                target_unique_name(hs, lib_prefix),
-                lib.dirname,
-                "lib" + get_lib_name(lib) + ".dylib",
-            )
-            dylib = hs.actions.declare_file(dylib_name)
-            ln(hs, lib, dylib)
-            new_libs.append(dylib)
-        else:
-            new_libs.append(lib)
-    return new_libs
-
-def windows_convert_to_dlls(hs, libs):
-    """Convert .so dynamic libraries to .dll.
-
-    Bazel's cc_library rule will create .so files for dynamic libraries even
-    on Windows. GHC's builtin linker, which is used during compilation, GHCi,
-    or doctests, hard-codes the assumption that all dynamic libraries on Windows
-    end on .dll. This function serves as an adaptor and produces symlinks
-    from a .dll version to the .so version for every dynamic library
-    dependencies that does not end on .dll.
+    2) MacOS applies a strict limit to the MACH-O header size. Many large
+       dynamic loading commands can quickly exceed this limit. To avoid this we
+       place all dynamic libraries into one directory, so that a single RPATH
+       entry is sufficient.
 
     Args:
       hs: Haskell context.
-      libs: List of library files dynamic or static.
+      lib: The dynamic library file.
+      outdir: Output directory for the symbolic link.
 
     Returns:
-      List of library files where all dynamic libraries end on .dll.
+      File, symbolic link to dynamic library.
     """
-    lib_prefix = "_dlls"
-    new_libs = []
-    for lib in libs:
-        if is_shared_library(lib) and lib.extension != "dll":
-            dll_name = paths.join(
-                target_unique_name(hs, lib_prefix),
-                paths.dirname(lib.short_path),
-                "lib" + get_lib_name(lib) + ".dll",
-            )
-            dll = hs.actions.declare_file(dll_name)
-            ln(hs, lib, dll)
-            new_libs.append(dll)
-        else:
-            new_libs.append(lib)
-    return new_libs
+    if hs.toolchain.is_darwin:
+        extension = "dylib"
+    elif hs.toolchain.is_windows:
+        extension = "dll"
+    else:
+        # On Linux we must preserve endings like .so.1.2.3. If those exist then
+        # there will be a matching .so symlink that points to the final
+        # library.
+        extension = get_lib_extension(lib)
+
+    link = hs.actions.declare_file(
+        paths.join(outdir, "lib" + get_lib_name(lib) + "." + extension),
+    )
+    ln(hs, lib, link)
+    return link
+
+def mangle_static_library(hs, dynamic_lib, static_lib, outdir):
+    """Mangle a static library to match a dynamic library name.
+
+    GHC expects static and dynamic C libraries to have matching library names.
+    Bazel produces static and dynamic C libraries with different names. The
+    dynamic library names are mangled, the static library names are not.
+
+    If the library is not a Haskell library (doesn't start with HS) and if the
+    dynamic library exists and if the static library exists and has a different
+    name. Then this function will create a symbolic link for the static library
+    to match the dynamic library's name.
+
+    Args:
+      hs: Haskell context.
+      dynamic_lib: File or None, the dynamic library.
+      static_lib: File or None, the static library.
+      outdir: Output director for the symbolic link, if necessary.
+
+    Returns:
+      The new static library symlink, if created, otherwise static_lib.
+    """
+    if dynamic_lib == None:
+        return static_lib
+    if static_lib == None:
+        return static_lib
+    libname = get_lib_name(dynamic_lib)
+    if libname.startswith("HS"):
+        return static_lib
+    if get_lib_name(static_lib) == libname:
+        return static_lib
+    else:
+        link = hs.actions.declare_file(
+            paths.join(outdir, "lib" + libname + "." + static_lib.extension),
+        )
+        ln(hs, static_lib, link)
+        return link
+
+def get_dirname(file):
+    """Return the path to the directory containing the file."""
+    return file.dirname
 
 def get_lib_name(lib):
     """Return name of library by dropping extension and "lib" prefix.
@@ -206,6 +219,21 @@ def get_lib_name(lib):
     base = lib.basename[3:] if lib.basename[:3] == "lib" else lib.basename
     n = base.find(".so.")
     end = paths.replace_extension(base, "") if n == -1 else base[:n]
+    return end
+
+def get_lib_extension(lib):
+    """Return extension of the library
+
+    Takes extensions such as so.1.2.3 into account.
+
+    Args:
+      lib: The library File.
+
+    Returns:
+      String: extension of the library.
+    """
+    n = lib.basename.find(".so.")
+    end = lib.extension if n == -1 else lib.basename[n + 1:]
     return end
 
 def get_dynamic_hs_lib_name(ghc_version, lib):
@@ -244,25 +272,42 @@ def get_static_hs_lib_name(with_profiling, lib):
         name = "ffi"
     return name
 
-def link_libraries(libs_to_link, args):
+def link_libraries(libs, args, prefix_optl = False):
     """Add linker flags to link against the given libraries.
 
     Args:
-      libs_to_link: List of library Files.
-      args: Append arguments to this list.
-
-    Returns:
-      List of library names that were linked.
+      libs: Sequence of File, libraries to link.
+      args: Args or List, append arguments to this object.
+      prefix_optl: Bool, whether to prefix linker flags by -optl
 
     """
-    seen_libs = set.empty()
-    libraries = []
-    for lib in libs_to_link:
-        lib_name = get_lib_name(lib)
-        if not set.is_member(seen_libs, lib_name):
-            set.mutable_insert(seen_libs, lib_name)
-            args += ["-l{0}".format(lib_name)]
-            libraries.append(lib_name)
+
+    # This test is a hack. When a CC library has a Haskell library
+    # as a dependency, we need to be careful to filter it out,
+    # otherwise it will end up polluting the linker flags. GHC
+    # already uses hs-libraries to link all Haskell libraries.
+    #
+    # TODO Get rid of this hack. See
+    # https://github.com/tweag/rules_haskell/issues/873.
+    cc_libs = depset(direct = [
+        lib
+        for lib in libs
+        if not get_lib_name(lib).startswith("HS")
+    ])
+
+    if prefix_optl:
+        libfmt = "-optl-l%s"
+        dirfmt = "-optl-L%s"
+    else:
+        libfmt = "-l%s"
+        dirfmt = "-L%s"
+
+    if hasattr(args, "add_all"):
+        args.add_all(cc_libs, map_each = get_lib_name, format_each = libfmt)
+        args.add_all(cc_libs, map_each = get_dirname, format_each = dirfmt, uniquify = True)
+    else:
+        args.extend([libfmt % get_lib_name(lib) for lib in cc_libs])
+        args.extend(depset(direct = [dirfmt % lib.dirname for lib in cc_libs]).to_list())
 
 def is_shared_library(f):
     """Check if the given File is a shared library.

--- a/tests/c-compiles/c-compiles.c
+++ b/tests/c-compiles/c-compiles.c
@@ -1,1 +1,0 @@
-int add_five(int x) { return x + 5; }


### PR DESCRIPTION
Removes the `HaskellCcInfo` provider and instead makes full use of the `CcInfo` provider. This change allowed to factor out and simplify a couple of places related to handling library dependencies. And remove a couple now unused functions.

The main functions to use `CcInfo` are `get_extra_libs` (for linking) and `get_ghci_extra_libs` (for loading in GHCi). Both these functions internally take care of matching static and dynamic library names, adjust dynamic library file extensions, and collecting dynamic libraries into one directory to avoid issues with the MACH-O header size limit.

Constructing linker flags has also been factored out to reduce duplication.

This PR is a step towards #913.