### PR TITLE
Deduplicate toolchain libraries

### DIFF
--- a/haskell/BUILD.bazel
+++ b/haskell/BUILD.bazel
@@ -58,6 +58,10 @@ toolchain_type(
     visibility = ["//visibility:public"],
 )
 
+# XXX: This target is a work aroud for the lack toolchain transitions not being
+# implemented, yet. See
+# https://github.com/bazelbuild/proposals/blob/master/designs/2019-02-12-toolchain-transitions.md
+# This will need to be revisited once that proposal is implemented.
 haskell_toolchain_libraries(
     name = "toolchain-libraries",
     visibility = ["//visibility:public"],

--- a/haskell/BUILD.bazel
+++ b/haskell/BUILD.bazel
@@ -1,3 +1,8 @@
+load(
+    "@io_tweag_rules_haskell//haskell:haskell.bzl",
+    "haskell_toolchain_libraries",
+)
+
 exports_files(
     glob(["*.bzl"]) + [
         "assets/ghci_script",
@@ -50,5 +55,10 @@ toolchain_type(
 
 toolchain_type(
     name = "doctest-toolchain",
+    visibility = ["//visibility:public"],
+)
+
+haskell_toolchain_libraries(
+    name = "toolchain-libraries",
     visibility = ["//visibility:public"],
 )

--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -31,6 +31,7 @@ load(
     _haskell_import_impl = "haskell_import_impl",
     _haskell_library_impl = "haskell_library_impl",
     _haskell_test_impl = "haskell_test_impl",
+    _haskell_toolchain_libraries_impl = "haskell_toolchain_libraries_impl",
     _haskell_toolchain_library_impl = "haskell_toolchain_library_impl",
 )
 load(
@@ -314,25 +315,28 @@ haskell_import = rule(
     },
 )
 
+haskell_toolchain_libraries = rule(
+    _haskell_toolchain_libraries_impl,
+    attrs = {
+        "_cc_toolchain": attr.label(
+            default = Label("@bazel_tools//tools/cpp:current_cc_toolchain"),
+        ),
+    },
+    toolchains = [
+        "@io_tweag_rules_haskell//haskell:toolchain",
+    ],
+)
+
 haskell_toolchain_library = rule(
     _haskell_toolchain_library_impl,
     attrs = dict(
         package = attr.string(
             doc = "The name of a GHC package not built by Bazel. Defaults to the name of the rule.",
         ),
-        _version_macros = attr.label(
-            executable = True,
-            cfg = "host",
-            default = Label("@io_tweag_rules_haskell//haskell:version_macros"),
-        ),
-        # XXX We'll no longer need this once HaskellImportHack is removed.
-        _cc_toolchain = attr.label(
-            default = Label("@bazel_tools//tools/cpp:current_cc_toolchain"),
+        _toolchain_libraries = attr.label(
+            default = Label("@io_tweag_rules_haskell//haskell:toolchain-libraries"),
         ),
     ),
-    toolchains = [
-        "@io_tweag_rules_haskell//haskell:toolchain",
-    ],
 )
 """Import packages that are prebuilt outside of Bazel.
 

--- a/haskell/private/haskell_impl.bzl
+++ b/haskell/private/haskell_impl.bzl
@@ -618,20 +618,6 @@ def haskell_toolchain_library_impl(ctx):
     else:
         package = ctx.label.name
 
-    id_file = hs.actions.declare_file(target_unique_name(hs, "id"))
-    hs.actions.run_shell(
-        inputs = [hs.tools.ghc_pkg],
-        outputs = [id_file],
-        command = """
-        "$1" --simple-output -v1 field "$2" id > "$3"
-        """,
-        arguments = [
-            hs.tools.ghc_pkg.path,
-            package,
-            id_file.path,
-        ],
-    )
-
     target = hs.toolchain.libraries.get(package)
     if not target:
         fail(


### PR DESCRIPTION
Closes #917 
Workaround for https://github.com/bazelbuild/bazel/issues/8129 and https://github.com/bazelbuild/bazel/pull/5650

- Deduplicate the `CcInfo` providers for toolchain libraries.
- Remove unused `id_file` in `haskell_toolchain_library_impl`.

**What rules_haskell did before**
- `haskell_import` loaded libraries included in the GHC distribution into Bazel.
    This collected the files and flags of all transitive dependencies into a single target. The consequence was duplication. First, the way transitive dependencies were collected would duplicate contents yielding exponential growth. Second, if a regular target depended on two toolchain libraries, e.g. `base` and `transformers`, this would yield additional duplication.
- `haskell_toolchain` depended on all `haskell_import` targets and collected them into a `dict`.
    This is the source of the *host* configuration issue, because `haskell_import` targets are a dependency of the toolchain, they are always built in the *host* configuration. Therefore, we cannot use `CcInfo` providers generated in `haskell_import` to build `haskell_...` targets in the *target* configuration.
- `haskell_toolchain_library` depended on the toolchain, plucked out the requested library from the `dict` and returned its providers.

**What this PR does**
- `haskell_import` still loads libraries included in the GHC distribution into Bazel.
    However, this does no longer collect files or flags of transitive dependencies, it only collects the files and flags of that particular library. Dependencies are handled later on.
- `haskell_toolchain` *unchanged*
- `haskell_toolchain_libraries` (*plural*) Depends on the toolchain and generates `CcInfo` for all toolchain libraries.
    This introduces an additional layer of indirection, which allows to work around the host vs. target configuration issue. We define a single global instance of this rule within rules_haskell. The user is not meant to interact with it directly. Since this is a regular target, it will be built in the *target* configuration. This rule reads the libraries `dict` from the toolchain and generates a `CcInfo` provider (in the *target* configuration) for each library. This is where we handle toolchain library dependencies. We use the standard `cc_common.merge_cc_infos` at this point to merge the `CcInfo`s of all transitive dependencies of a library. These `CcInfo` providers are unique per library and Bazel can properly take care to not duplicate any libraries or flags. This rule exposes a `dict` from library name to a `struct` of providers. This is easily extensible to handle transitive dependencies on other providers, e.g. combining `HaskellInfo` providers.
- `haskell_toolchain_library` (*singular*) now implicitly depends on `haskell_toolchain_libraries`. All it does is pluck out the providers of the requested library and return them.

Note, the API is unchanged. The user does not need to care about `haskell_import` or `haskell_toolchain_libraries`. They call `haskell_toolchain_library` as before to get a handle on a toolchain library. However, now these do not cause any duplication. Even in the following silly example
```
haskell_toolchain_library(name = "base")
haskell_toolchain_library(name = "base_dup", package = "base")
haskell_toolchain_library(name = "transformers")
haskell_library(
    name = "mylib",
    deps = [":base", ":base_dup", ":transformers"],
    ...
)
```