### PR TITLE
TemplateHaskell with cbits dependencies

### DIFF
--- a/haskell/private/actions/compile.bzl
+++ b/haskell/private/actions/compile.bzl
@@ -10,6 +10,7 @@ load("@bazel_skylib//lib:paths.bzl", "paths")
 load(
     ":private/path_utils.bzl",
     "declare_compiled",
+    "link_libraries",
     "module_name",
     "target_unique_name",
 )
@@ -320,6 +321,7 @@ def _compilation_defaults(hs, cc, java, dep_info, plugin_dep_info, cc_info, srcs
 
     # Transitive library dependencies for runtime.
     (ghci_extra_libs, ghc_env) = get_ghci_extra_libs(hs, cc_info)
+    link_libraries(ghci_extra_libs, args)
 
     return struct(
         args = args,

--- a/tests/template-haskell-with-cbits/BUILD.bazel
+++ b/tests/template-haskell-with-cbits/BUILD.bazel
@@ -1,0 +1,19 @@
+load(
+    "@rules_haskell//haskell:defs.bzl",
+    "haskell_test",
+)
+
+package(default_testonly = 1)
+
+haskell_test(
+    name = "template-haskell-with-cbits",
+    srcs = [
+        "Main.hs",
+        "TH.hs",
+    ],
+    deps = [
+        "//tests/data:ourclibrary",
+        "//tests/hackage:base",
+        "//tests/hackage:template-haskell",
+    ],
+)

--- a/tests/template-haskell-with-cbits/Main.hs
+++ b/tests/template-haskell-with-cbits/Main.hs
@@ -1,0 +1,14 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+module Main where
+
+import Control.Monad (unless)
+import System.Exit (exitFailure)
+import System.IO (hPutStrLn, stderr)
+import TH (value)
+
+main :: IO ()
+main =
+  unless ($(value) == 42) $ do
+    hPutStrLn stderr "Expected 42"
+    exitFailure

--- a/tests/template-haskell-with-cbits/TH.hs
+++ b/tests/template-haskell-with-cbits/TH.hs
@@ -1,0 +1,10 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+module TH where
+
+import Language.Haskell.TH
+
+foreign import ccall "c_add_one" c_add_one' :: Int -> Int
+
+value :: Q Exp
+value = [| c_add_one' 41 |]


### PR DESCRIPTION
Before we never linked (`-l`) C library dependencies of the current package during compilation (already before #921). This made TemplateHaskell depending on such C libraries fail with
```
ghc: panic! (the 'impossible' happened)
  (GHC version 8.6.5 for x86_64-unknown-linux):
        Loading temp shared object failed: /run/user/1000/ghc4_0/libghc_6.so: undefined symbol: c_add_one
```
This fixes this issue. This also highlights that we need to use dynamic libraries during compilation so long as we're using the dynamic rts.