### PR TITLE
Add haskell_repl docs

### DIFF
--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -34,6 +34,7 @@ skylark_doc(
         # sections are presented in the docs.
         "//haskell:haskell.bzl",
         "//haskell:haddock.bzl",
+        "//haskell:repl.bzl",
         "//haskell:lint.bzl",
         "//haskell:toolchain.bzl",
         "//haskell:protobuf.bzl",

--- a/serve-docs.sh
+++ b/serve-docs.sh
@@ -11,7 +11,7 @@ PORT=${1:-8000}
 
 function finish {
     echo Deleting $SCRATCH ...
-    rm -rf "$scratch"
+    rm -rf "$SCRATCH"
 }
 
 trap finish EXIT
@@ -25,4 +25,4 @@ mkdir $SCRATCH/guide
 unzip -d $SCRATCH/guide bazel-genfiles/docs/guide_html.zip
 
 cd $SCRATCH
-python -m SimpleHTTPServer $PORT
+python3 -m http.server $PORT


### PR DESCRIPTION
- Add `haskell_repl` to the API docs
- Fix issues in `serve-docs.sh`
    - `rm -rf` typo
    - Update to python3
    The site served by `serve-docs.sh` is not fully functional. I'm not sure if it's meant to be.