### PR TITLE
Fix ghc bindist scripts on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed
 
-- Bindists were broken on MacOS.
+- Bindists were broken on macOS.
   See [884](https://github.com/tweag/rules_haskell/issues/884).
 
 ## [0.9] - 2019-05-07
@@ -336,14 +336,14 @@ of `rules_haskell`.
 * Template Haskell linking against `cc_library`. See
   [#218](https://github.com/tweag/rules_haskell/pull/218).
 
-* Linking issues on MacOS. See
+* Linking issues on macOS. See
   [#221](https://github.com/tweag/rules_haskell/pull/221).
 
 * GHC packages that correspond to targets with the same name but in
   different Bazel packages no longer clash. See
   [#219](https://github.com/tweag/rules_haskell/issues/219).
 
-* Build breakage on MacOS when XCode is not installed. See
+* Build breakage on macOS when XCode is not installed. See
   [#223](https://github.com/tweag/rules_haskell/pull/223).
 
 * Bug preventing Haddock generation because of missing dynamic shared
@@ -404,7 +404,7 @@ of `rules_haskell`.
 
 ### Added
 
-* Support for MacOS, courtesy of Judah Jacobson. See
+* Support for macOS, courtesy of Judah Jacobson. See
   [#165](https://github.com/tweag/rules_haskell/issues/165).
 
 * Support for `data` attributes in `haskell_binary` and `haskell_library`

--- a/haskell/ghc_bindist.bzl
+++ b/haskell/ghc_bindist.bzl
@@ -189,6 +189,7 @@ def _ghc_bindist_impl(ctx):
     version = ctx.attr.version
     target = ctx.attr.target
     os, _, arch = target.partition("_")
+    python_bin = _find_python(ctx)
 
     if GHC_BINDIST[version].get(target) == None:
         fail("Operating system {0} does not have a bindist for GHC version {1}".format(ctx.os.name, ctx.attr.version))
@@ -235,9 +236,8 @@ grep --files-with-matches --null {bindist_dir} bin/* | xargs -0 \
     # Cannot use //haskell:pkgdb_to_bzl because that's a generated
     # target. ctx.path() only works on source files.
     pkgdb_to_bzl = ctx.path(Label("@io_tweag_rules_haskell//haskell:private/pkgdb_to_bzl.py"))
-    python = _find_python(ctx)
     result = ctx.execute([
-        python,
+        python_bin,
         pkgdb_to_bzl,
         ctx.attr.name,
         "lib",

--- a/haskell/ghc_bindist.bzl
+++ b/haskell/ghc_bindist.bzl
@@ -171,7 +171,7 @@ def _execute_fail_loudly(ctx, args):
     """Execute a command and fail loudly if it fails.
 
     ATTN: All commands have to be cross-compatible between BSD tools and GNU tools,
-    because we want to support MacOS. Please cross-reference the MacOS man-pages.
+    because we want to support macOS. Please cross-reference the macOS man-pages.
 
     Args:
       ctx: Repository rule context.

--- a/haskell/private/actions/link.bzl
+++ b/haskell/private/actions/link.bzl
@@ -175,7 +175,7 @@ def _merge_parameter_files(hs, file1, file2):
     return params_file
 
 def _darwin_create_extra_linker_flags_file(hs, cc, objects_dir, executable, dynamic, solibs):
-    """Write additional linker flags required on MacOS to a parameter file.
+    """Write additional linker flags required on macOS to a parameter file.
 
     Args:
       hs: Haskell context.
@@ -197,7 +197,7 @@ def _darwin_create_extra_linker_flags_file(hs, cc, objects_dir, executable, dyna
     # Bazel's builtin cc rules, which assume that the final binary will load
     # all transitive shared library dependencies. In particlar shared libraries
     # produced by Bazel's cc rules never load shared libraries themselves. This
-    # causes missing symbols at runtime on MacOS, see #170.
+    # causes missing symbols at runtime on macOS, see #170.
     #
     # The following work-around applies the `-u` flag to the linker for any
     # symbol that is undefined in any transitive shared library dependency.
@@ -208,7 +208,7 @@ def _darwin_create_extra_linker_flags_file(hs, cc, objects_dir, executable, dyna
     # Unfortunately, this prohibits elimination of any truly redundant shared
     # library dependencies. Furthermore, the transitive closure of shared
     # library dependencies can be large, so this makes it more likely to exceed
-    # the MACH-O header size limit on MacOS.
+    # the MACH-O header size limit on macOS.
     #
     # This is a horrendous hack, but it seems to be forced on us by how Bazel
     # builds dynamic cc libraries.

--- a/haskell/private/path_utils.bzl
+++ b/haskell/private/path_utils.bzl
@@ -133,10 +133,10 @@ def symlink_dynamic_library(hs, lib, outdir):
     This function is used for two reasons:
 
     1) GHCi expects specific file endings for dynamic libraries depending on
-       the platform: (Linux: .so, MacOS: .dylib, Windows: .dll). Bazel does not
+       the platform: (Linux: .so, macOS: .dylib, Windows: .dll). Bazel does not
        follow this convention.
 
-    2) MacOS applies a strict limit to the MACH-O header size. Many large
+    2) macOS applies a strict limit to the MACH-O header size. Many large
        dynamic loading commands can quickly exceed this limit. To avoid this we
        place all dynamic libraries into one directory, so that a single RPATH
        entry is sufficient.

--- a/haskell/providers.bzl
+++ b/haskell/providers.bzl
@@ -175,7 +175,7 @@ def get_ghci_extra_libs(hs, cc_info, dynamic = True, path_prefix = None):
 
     GHCi can load PIC static libraries (-fPIC -fexternal-dynamic-refs) and
     dynamic libraries. Preferring static libraries can be useful to reduce the
-    risk of exceeding the MACH-O header size limit on MacOS, and to reduce
+    risk of exceeding the MACH-O header size limit on macOS, and to reduce
     build times by avoiding to generate dynamic libraries. However, this
     requires GHCi to run with the statically linked rts library.
 

--- a/hazel/hazel.bzl
+++ b/hazel/hazel.bzl
@@ -172,7 +172,7 @@ def hazel_repositories(
         targets that provide the shared library and headers as a cc_library, or
         empty string if the library is a system library not defined by Bazel.
       ghc_workspaces: Dictionary mapping OS names to GHC workspaces.
-        Default: Linux/MacOS: "@ghc", Windows: "@ghc_windows".
+        Default: Linux/macOS: "@ghc", Windows: "@ghc_windows".
         Dictionary keys correspond to CPU values as returned by
         `get_cpu_value` from `@bazel_tools//tools/cpp:lib_cc_configure.bzl`.
     """

--- a/hazel/tools/bazel.rc
+++ b/hazel/tools/bazel.rc
@@ -1,2 +1,2 @@
-# Use the overrides from @local_config_cc on MacOS as well:
+# Use the overrides from @local_config_cc on macOS as well:
 build --action_env=BAZEL_USE_CPP_ONLY_TOOLCHAIN=1

--- a/shell.nix
+++ b/shell.nix
@@ -23,7 +23,7 @@ mkShell {
     git
     # Needed to get correct locale for tests with encoding
     glibcLocales
-    # to avoid CA certificate failures on MacOS CI
+    # to avoid CA certificate failures on macOS CI
     cacert
     # Needed for debug/linking_utils
     binutils

--- a/tests/binary-linkstatic-flag/BUILD.bazel
+++ b/tests/binary-linkstatic-flag/BUILD.bazel
@@ -63,7 +63,7 @@ sh_inline_test(
     script = """
     set -eo pipefail
     binary="$1"
-    # Symbols are prefixed with underscore on MacOS but not on Linux.
+    # Symbols are prefixed with underscore on macOS but not on Linux.
     if nm -u "$binary" | grep -q "\<_\?value"; then
         echo "C library dependency not linked statically: ${binary}"
         exit 1
@@ -96,7 +96,7 @@ sh_inline_test(
         # Skip test in debug builds. Debug mode forces static linking.
         exit 0
     fi
-    # Symbols are prefixed with underscore on MacOS but not on Linux.
+    # Symbols are prefixed with underscore on macOS but not on Linux.
     if ! nm -u "$binary" | grep -q "\<_\?value"; then
         echo "C library dependency not linked dynamically"
         exit 1


### PR DESCRIPTION
We have to be compatible with BSD utils in repository_rules if we want to be compatible with MacOS for bindists.