### PR TITLE
Bump bazel to 0.26.1

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -8,38 +8,31 @@ for building Haskell code.
 * [**rts:**](./rts/) demonstrates foreign exports and shows how to
   link against GHC's RTS library, i.e. `libHSrts.so`.
   
-## **Important**
-
-Run all commands from the root of `rules_haskell`.
-If you `cd examples/`, bazel *will* [break on
-you](https://github.com/tweag/rules_haskell/issues/740).
-This is a current problem with bazel workspaces.
-
 ## Root Workspace
 
 Build everything in the root workspace with;
 
 ```
-$ bazel build @io_tweag_rules_haskell_examples//...
+$ bazel build //...
 ```
 
 Show every target of the vector example;
 
 ```
-$ bazel query @io_tweag_rules_haskell_examples//vector/...
-@io_tweag_rules_haskell_examples//vector:vector
-@io_tweag_rules_haskell_examples//vector:semigroups
-@io_tweag_rules_haskell_examples//vector:primitive
-@io_tweag_rules_haskell_examples//vector:ghc-prim
-@io_tweag_rules_haskell_examples//vector:deepseq
-@io_tweag_rules_haskell_examples//vector:base
+$ bazel query //vector/...
+//vector:vector
+//vector:semigroups
+//vector:primitive
+//vector:ghc-prim
+//vector:deepseq
+//vector:base
 ```
 
 Build the two main Haskell targets;
 
 ```
-$ bazel build @io_tweag_rules_haskell_examples//vector
-$ bazel build @io_tweag_rules_haskell_examples//rts:add-one-hs
+$ bazel build //vector
+$ bazel build //rts:add-one-hs
 ```
 
 [rules_haskell]: https://github.com/tweag/rules_haskell

--- a/haskell/providers.bzl
+++ b/haskell/providers.bzl
@@ -334,15 +334,15 @@ def create_link_config(hs, cc_info, binary, args, dynamic = None, pic = None):
         "name": package_name,
         "extra-libraries": [
             get_lib_name(lib)
-            for lib in cc_static_libs + cc_dynamic_libs
+            for lib in depset(transitive = [cc_static_libs, cc_dynamic_libs])
         ],
         "library-dirs": depset(direct = [
             rel_to_pkgroot(lib.dirname, conf_file.dirname)
-            for lib in cc_static_libs + cc_dynamic_libs
+            for lib in depset(transitive = [cc_static_libs, cc_dynamic_libs])
         ]),
         "dynamic-library-dirs": depset(direct = [
             rel_to_pkgroot(lib.dirname, conf_file.dirname)
-            for lib in cc_static_libs + cc_dynamic_libs
+            for lib in depset(transitive = [cc_static_libs, cc_dynamic_libs])
         ]),
         # XXX: Set user_link_flags.
         "ld-options": depset(direct = [

--- a/nixpkgs/default.nix
+++ b/nixpkgs/default.nix
@@ -1,5 +1,5 @@
 import (fetchTarball {
-   # Checkout from 2019-05-06.
-   url = https://github.com/mboes/nixpkgs/archive/361e9185c83166b44419e05e75fc8473875df6ea.tar.gz;
-   sha256 = "0c6izp9i1ln4yy2h9jlm48k94f018h8pw60jfbhq49p076aaafrb";
+   # Checkout from 2019-06-12.
+   url = https://github.com/NixOS/nixpkgs/archive/f41667a774a2a6ac5a619c4590ea09d9bce91e70.tar.gz;
+   sha256 = "1j05hzl7bnsys5cr2ki96bgqzzhmri2siqzlf5a3fgk2rm6aid3n";
 })

--- a/tests/RunTests.hs
+++ b/tests/RunTests.hs
@@ -71,10 +71,12 @@ main = hspec $ do
     outputSatisfy p (bazel ["run", "//tests/repl-name-conflicts:lib@repl", "--", "-ignore-dot-ghci", "-e", "stdin"])
 
   it "bazel test examples" $ do
-    assertSuccess (bazel ["test", "@io_tweag_rules_haskell_examples//..."])
+    assertSuccess $ (bazel ["build", "//..."]) { Process.cwd = Just "./examples" }
+    assertSuccess $ (bazel ["test", "//..."]) { Process.cwd = Just "./examples" }
 
   it "bazel test tutorial" $ do
-    assertSuccess (bazel ["test", "@io_tweag_rules_haskell_tutorial//..."])
+    assertSuccess $ (bazel ["build", "//..."]) { Process.cwd = Just "./tutorial" }
+    assertSuccess (bazel ["test", "//..."]) { Process.cwd = Just "./tutorial" }
 
   describe "Hazel" $ do
     it "bazel test" $ do

--- a/tutorial/README.md
+++ b/tutorial/README.md
@@ -4,34 +4,27 @@ Code for the [Bazel Haskell tutorial][bazel-haskell-tutorial].
 
 [bazel-haskell-tutorial]: https://rules-haskell.readthedocs.io/en/latest/haskell.html
 
-## **Important**
-
-Run all commands from the root of `rules_haskell`.
-If you `cd examples/`, bazel *will* [break on
-you](https://github.com/tweag/rules_haskell/issues/740).
-This is a current problem with bazel workspaces.
-
 ## Tutorial Workspace
 
 Build everything in the tutorial workspace with;
 
 ```
-$ bazel build @io_tweag_rules_haskell_tutorial//...
+$ bazel build //...
 ```
 
 Show everything in the tutorial;
 
 ```
-$ bazel query @io_tweag_rules_haskell_tutorial//...
-@io_tweag_rules_haskell_tutorial//main:demorgan
-@io_tweag_rules_haskell_tutorial//main:base
-@io_tweag_rules_haskell_tutorial//lib:booleans
+$ bazel query //...
+//main:demorgan
+//main:base
+//lib:booleans
 ```
 
 Build and run the tutorial example;
 
 ```
-$ bazel build @io_tweag_rules_haskell_tutorial//lib:booleans
-$ bazel build @io_tweag_rules_haskell_tutorial//main:demorgan
-$ bazel run @io_tweag_rules_haskell_tutorial//main:demorgan
+$ bazel build //lib:booleans
+$ bazel build //main:demorgan
+$ bazel run //main:demorgan
 ```


### PR DESCRIPTION
Bumping to the new bazel in nixpkgs.

We seem to have a problem with Java dependencies, they try to fetch some binary from god knows where and—oh wonder—that fails to execute on NixOS.

Builds on the fixes in https://github.com/tweag/rules_haskell/pull/947