### PR TITLE
Load haskell_toolchain_library dependencies in haskell_repl

### DIFF
--- a/haskell/private/haskell_impl.bzl
+++ b/haskell/private/haskell_impl.bzl
@@ -6,6 +6,7 @@ load(
     "HaddockInfo",
     "HaskellInfo",
     "HaskellLibraryInfo",
+    "HaskellToolchainLibraryInfo",
 )
 load(":cc.bzl", "cc_interop_info")
 load(
@@ -631,6 +632,7 @@ Check that it ships with your version of GHC.
         target.hs_lib_info,
         target.cc_info,
         target.haddock_info,
+        HaskellToolchainLibraryInfo(),
     ]
 
 def haskell_toolchain_libraries_impl(ctx):

--- a/haskell/providers.bzl
+++ b/haskell/providers.bzl
@@ -40,6 +40,10 @@ HaskellLibraryInfo = provider(
     },
 )
 
+HaskellToolchainLibraryInfo = provider(
+    doc = "Library that was imported via haskell_toolchain_library.",
+)
+
 HaskellCoverageInfo = provider(
     doc = "Information about coverage instrumentation for Haskell files.",
     fields = {

--- a/tests/RunTests.hs
+++ b/tests/RunTests.hs
@@ -54,6 +54,9 @@ main = hspec $ do
     it "loads transitive source dependencies" $ do
       let p' (stdout, _stderr) = sort (lines stdout) == ["tests/multi_repl/a/src/A/A.hs","tests/multi_repl/bc/src/BC/B.hs","tests/multi_repl/bc/src/BC/C.hs"]
       outputSatisfy p' (bazel ["run", "//tests/multi_repl:c_multi_repl", "--", "-ignore-dot-ghci", "-e", ":show targets"])
+    it "loads core library dependencies" $ do
+      let p' (stdout, _stderr) = sort (lines stdout) == ["tests/multi_repl/core_package_dep/Lib.hs"]
+      outputSatisfy p' (bazel ["run", "//tests/multi_repl:core_package_dep", "--", "-ignore-dot-ghci", "-e", ":show targets"])
 
   it "startup script" $ do
     assertSuccess (safeShell ["./tests/run-start-script.sh"])

--- a/tests/multi_repl/BUILD.bazel
+++ b/tests/multi_repl/BUILD.bazel
@@ -14,3 +14,8 @@ haskell_repl(
     name = "c_multi_repl",
     deps = ["//tests/multi_repl/bc:c"],
 )
+
+haskell_repl(
+    name = "core_package_dep",
+    deps = ["//tests/multi_repl/core_package_dep"],
+)

--- a/tests/multi_repl/core_package_dep/BUILD.bazel
+++ b/tests/multi_repl/core_package_dep/BUILD.bazel
@@ -1,0 +1,20 @@
+package(default_visibility = ["//visibility:public"])
+
+load(
+    "@io_tweag_rules_haskell//haskell:haskell.bzl",
+    "haskell_library",
+    "haskell_toolchain_library",
+)
+
+haskell_toolchain_library(name = "ghc")
+
+haskell_library(
+    name = "core_package_dep",
+    srcs = [
+        "Lib.hs",
+    ],
+    deps = [
+        ":ghc",
+        "//tests/hackage:base",
+    ],
+)

--- a/tests/multi_repl/core_package_dep/Lib.hs
+++ b/tests/multi_repl/core_package_dep/Lib.hs
@@ -1,0 +1,3 @@
+module Lib (runGhc) where
+
+import GHC (runGhc)


### PR DESCRIPTION
- Fixes `haskell_repl`, which failed to load `haskell_toolchain_library` dependencies.
    See https://github.com/digital-asset/daml/issues/1656.
    Introduces a marker `provider` for `haskell_toolchain_library` targets to make them distinguishable. Otherwise, a `haskell_toolchain_library` would be indistinguishable from a regular `haskell_library` and users would have to add entries to `experimental_from_binary` for all toolchain library dependencies to properly load them as binary libraries. Note, `haskell_toolchain_library` dependencies cannot be loaded by source, as typically no source is available.
- Adds a regression test.