### PR TITLE
Use package environment file

### DIFF
--- a/haskell/doctest.bzl
+++ b/haskell/doctest.bzl
@@ -117,6 +117,7 @@ def _haskell_doctest_single(target, ctx):
             depset(sources),
             hs_info.package_databases,
             hs_info.interface_dirs,
+            hs_info.extra_source_files,
             hs_info.dynamic_libraries,
             cc_info.compilation_context.headers,
             ghci_extra_libs,

--- a/haskell/private/actions/link.bzl
+++ b/haskell/private/actions/link.bzl
@@ -174,11 +174,16 @@ def link_binary(
 
     args.add_all(["-o", executable.path])
 
-    args.add_all(pkg_info_to_compile_flags(expose_packages(
-        package_ids = hs.package_ids,
-        package_databases = dep_info.package_databases,
-        version = version,
-    )))
+    (pkg_info_inputs, pkg_info_args) = pkg_info_to_compile_flags(
+        hs,
+        pkg_info = expose_packages(
+            package_ids = hs.package_ids,
+            package_databases = dep_info.package_databases,
+            version = version,
+        ),
+        prefix = "link-",
+    )
+    args.add_all(pkg_info_args)
 
     (cache_file, static_libs, dynamic_libs) = create_link_config(
         hs = hs,
@@ -237,6 +242,7 @@ def link_binary(
             dep_info.dynamic_libraries,
             dep_info.static_libraries,
             depset([cache_file, objects_dir]),
+            pkg_info_inputs,
             static_libs,
             dynamic_libs,
         ]),
@@ -339,11 +345,16 @@ def link_library_dynamic(hs, cc, dep_info, cc_info, extra_srcs, objects_dir, my_
     if hs.toolchain.is_darwin:
         args.add("-optl-Wl,-dead_strip_dylibs")
 
-    args.add_all(pkg_info_to_compile_flags(expose_packages(
-        package_ids = hs.package_ids,
-        package_databases = dep_info.package_databases,
-        version = my_pkg_id.version if my_pkg_id else None,
-    )))
+    (pkg_info_inputs, pkg_info_args) = pkg_info_to_compile_flags(
+        hs,
+        pkg_info = expose_packages(
+            package_ids = hs.package_ids,
+            package_databases = dep_info.package_databases,
+            version = my_pkg_id.version if my_pkg_id else None,
+        ),
+        prefix = "link-",
+    )
+    args.add_all(pkg_info_args)
 
     # When linking a dynamic library we still collect static libraries for
     # dependencies where possible. This is so that a final binary that depends
@@ -376,6 +387,7 @@ def link_library_dynamic(hs, cc, dep_info, cc_info, extra_srcs, objects_dir, my_
             depset(extra_srcs),
             dep_info.package_databases,
             dep_info.dynamic_libraries,
+            pkg_info_inputs,
             static_libs,
             dynamic_libs,
         ]),

--- a/haskell/private/actions/repl.bzl
+++ b/haskell/private/actions/repl.bzl
@@ -54,7 +54,12 @@ def build_haskell_repl(
         package_databases = package_databases,
         version = version,
     )
-    args += pkg_info_to_compile_flags(pkg_ghc_info)
+    (pkg_info_inputs, pkg_info_args) = pkg_info_to_compile_flags(
+        hs,
+        pkg_info = pkg_ghc_info,
+        prefix = "repl-",
+    )
+    args += pkg_info_args
 
     lib_imports = []
     if lib_info != None:
@@ -163,6 +168,7 @@ def build_haskell_repl(
             ghc_info_file,
         ]),
         package_databases,
+        pkg_info_inputs,
         ghci_extra_libs,
         set.to_depset(hs_info.source_files),
     ])

--- a/haskell/private/actions/runghc.bzl
+++ b/haskell/private/actions/runghc.bzl
@@ -41,11 +41,15 @@ def build_haskell_runghc(
       None.
     """
 
-    args = pkg_info_to_compile_flags(expose_packages(
-        package_ids = hs.package_ids,
-        package_databases = package_databases,
-        version = version,
-    ))
+    (pkg_info_inputs, args) = pkg_info_to_compile_flags(
+        hs,
+        pkg_info = expose_packages(
+            package_ids = hs.package_ids,
+            package_databases = package_databases,
+            version = version,
+        ),
+        prefix = "runghc-",
+    )
 
     if lib_info != None:
         for idir in set.to_list(hs_info.import_dirs):
@@ -98,6 +102,7 @@ def build_haskell_runghc(
             runghc_file,
         ]),
         package_databases,
+        pkg_info_inputs,
         ghci_extra_libs,
         set.to_depset(hs_info.source_files),
     ])

--- a/haskell/private/path_utils.bzl
+++ b/haskell/private/path_utils.bzl
@@ -472,7 +472,7 @@ def _rel_path_to_module(hs, f):
 
 # TODO Consider merging with paths.relativize. See
 # https://github.com/bazelbuild/bazel-skylib/pull/44.
-def _truly_relativize(target, relative_to):
+def truly_relativize(target, relative_to):
     """Return a relative path to `target` from `relative_to`.
 
     Args:
@@ -509,7 +509,7 @@ def rel_to_pkgroot(target, pkgdb):
     """
     return paths.join(
         "${pkgroot}",
-        _truly_relativize(target, paths.dirname(pkgdb)),
+        truly_relativize(target, paths.dirname(pkgdb)),
     )
 
 def ln(hs, target, link, extra_inputs = depset()):
@@ -522,7 +522,7 @@ def ln(hs, target, link, extra_inputs = depset()):
     Returns:
       None
     """
-    relative_target = _truly_relativize(target.path, link.dirname)
+    relative_target = truly_relativize(target.path, link.dirname)
     hs.actions.run_shell(
         inputs = depset([target], transitive = [extra_inputs]),
         outputs = [link],


### PR DESCRIPTION
Closes https://github.com/tweag/rules_haskell/issues/819

Pass `-package-id` and `-package-db` flags through a package environment file to reduce the command line length and avoid exceeding the OS limit for command-line length, on Windows in particular.

cc @cocreature 