### PR TITLE
Bazel 027

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -14,6 +14,19 @@ build:ci --symlink_prefix=bazel-ci-
 common:ci --color=no
 test:ci --test_output=errors
 
+# Note [backward compatible options]
+
+# XXX: --incompatible_use_python_toolchains needs a specific setup for
+# each environment if python is provided by the system
+# That's complicated to setup. Bazel is supposed to provide automatic
+# detection utilities, see
+# https://github.com/bazelbuild/bazel/issues/7899
+# But it does not work on windows
+# see: https://github.com/bazelbuild/bazel/issues/7844
+# This is only used in rules_haskell tests, so user won't face this
+# issue.
+build  --incompatible_use_python_toolchains=false
+
 # Needed on Windows for //tests/binary-with-data
 # see: https://github.com/tweag/rules_haskell/issues/647#issuecomment-459001362
 test:windows --experimental_enable_runfiles
@@ -25,16 +38,14 @@ build\
       --incompatible_no_support_tools_in_action_inputs=false\
       --incompatible_require_ctx_in_configure_features=false\
       --incompatible_depset_is_not_iterable=false\
-      --incompatible_depset_union=false\
-      --incompatible_use_python_toolchains=false
+      --incompatible_depset_union=false
 test\
       --incompatible_disable_deprecated_attr_params=false\
       --incompatible_new_actions_api=false\
       --incompatible_no_support_tools_in_action_inputs=false\
       --incompatible_require_ctx_in_configure_features=false\
       --incompatible_depset_is_not_iterable=false\
-      --incompatible_depset_union=false\
-      --incompatible_use_python_toolchains=false
+      --incompatible_depset_union=false
 
 # test environment does not propagate locales by default
 # some tests reads files written in UTF8, we need to propagate the correct

--- a/.bazelrc
+++ b/.bazelrc
@@ -18,6 +18,28 @@ test:ci --test_output=errors
 # see: https://github.com/tweag/rules_haskell/issues/647#issuecomment-459001362
 test:windows --experimental_enable_runfiles
 
+# WIP: bazel 0.27 fixs
+build\
+      --incompatible_disable_genrule_cc_toolchain_dependency=false\
+      --incompatible_no_transitive_loads=false\
+      --incompatible_disable_deprecated_attr_params=false\
+      --incompatible_new_actions_api=false\
+      --incompatible_no_support_tools_in_action_inputs=false\
+      --incompatible_require_ctx_in_configure_features=false\
+      --incompatible_depset_is_not_iterable=false\
+      --incompatible_depset_union=false\
+      --incompatible_use_python_toolchains=false
+test\
+      --incompatible_disable_genrule_cc_toolchain_dependency=false\
+      --incompatible_no_transitive_loads=false\
+      --incompatible_disable_deprecated_attr_params=false\
+      --incompatible_new_actions_api=false\
+      --incompatible_no_support_tools_in_action_inputs=false\
+      --incompatible_require_ctx_in_configure_features=false\
+      --incompatible_depset_is_not_iterable=false\
+      --incompatible_depset_union=false\
+      --incompatible_use_python_toolchains=false
+
 # test environment does not propagate locales by default
 # some tests reads files written in UTF8, we need to propagate the correct
 # environment variables, such as LOCALE_ARCHIVE

--- a/.bazelrc
+++ b/.bazelrc
@@ -20,7 +20,6 @@ test:windows --experimental_enable_runfiles
 
 # WIP: bazel 0.27 fixs
 build\
-      --incompatible_disable_genrule_cc_toolchain_dependency=false\
       --incompatible_no_transitive_loads=false\
       --incompatible_disable_deprecated_attr_params=false\
       --incompatible_new_actions_api=false\
@@ -30,7 +29,6 @@ build\
       --incompatible_depset_union=false\
       --incompatible_use_python_toolchains=false
 test\
-      --incompatible_disable_genrule_cc_toolchain_dependency=false\
       --incompatible_no_transitive_loads=false\
       --incompatible_disable_deprecated_attr_params=false\
       --incompatible_new_actions_api=false\

--- a/.bazelrc
+++ b/.bazelrc
@@ -20,7 +20,6 @@ test:windows --experimental_enable_runfiles
 
 # WIP: bazel 0.27 fixs
 build\
-      --incompatible_no_transitive_loads=false\
       --incompatible_disable_deprecated_attr_params=false\
       --incompatible_new_actions_api=false\
       --incompatible_no_support_tools_in_action_inputs=false\
@@ -29,7 +28,6 @@ build\
       --incompatible_depset_union=false\
       --incompatible_use_python_toolchains=false
 test\
-      --incompatible_no_transitive_loads=false\
       --incompatible_disable_deprecated_attr_params=false\
       --incompatible_new_actions_api=false\
       --incompatible_no_support_tools_in_action_inputs=false\

--- a/.bazelrc
+++ b/.bazelrc
@@ -31,12 +31,6 @@ build  --incompatible_use_python_toolchains=false
 # see: https://github.com/tweag/rules_haskell/issues/647#issuecomment-459001362
 test:windows --experimental_enable_runfiles
 
-# WIP: bazel 0.27 fixs
-build\
-      --incompatible_require_ctx_in_configure_features=false
-test\
-      --incompatible_require_ctx_in_configure_features=false
-
 # test environment does not propagate locales by default
 # some tests reads files written in UTF8, we need to propagate the correct
 # environment variables, such as LOCALE_ARCHIVE

--- a/.bazelrc
+++ b/.bazelrc
@@ -37,14 +37,12 @@ build\
       --incompatible_new_actions_api=false\
       --incompatible_no_support_tools_in_action_inputs=false\
       --incompatible_require_ctx_in_configure_features=false\
-      --incompatible_depset_is_not_iterable=false\
       --incompatible_depset_union=false
 test\
       --incompatible_disable_deprecated_attr_params=false\
       --incompatible_new_actions_api=false\
       --incompatible_no_support_tools_in_action_inputs=false\
       --incompatible_require_ctx_in_configure_features=false\
-      --incompatible_depset_is_not_iterable=false\
       --incompatible_depset_union=false
 
 # test environment does not propagate locales by default

--- a/.bazelrc
+++ b/.bazelrc
@@ -34,13 +34,11 @@ test:windows --experimental_enable_runfiles
 # WIP: bazel 0.27 fixs
 build\
       --incompatible_disable_deprecated_attr_params=false\
-      --incompatible_new_actions_api=false\
       --incompatible_no_support_tools_in_action_inputs=false\
       --incompatible_require_ctx_in_configure_features=false\
       --incompatible_depset_union=false
 test\
       --incompatible_disable_deprecated_attr_params=false\
-      --incompatible_new_actions_api=false\
       --incompatible_no_support_tools_in_action_inputs=false\
       --incompatible_require_ctx_in_configure_features=false\
       --incompatible_depset_union=false

--- a/.bazelrc
+++ b/.bazelrc
@@ -34,12 +34,10 @@ test:windows --experimental_enable_runfiles
 # WIP: bazel 0.27 fixs
 build\
       --incompatible_disable_deprecated_attr_params=false\
-      --incompatible_no_support_tools_in_action_inputs=false\
       --incompatible_require_ctx_in_configure_features=false\
       --incompatible_depset_union=false
 test\
       --incompatible_disable_deprecated_attr_params=false\
-      --incompatible_no_support_tools_in_action_inputs=false\
       --incompatible_require_ctx_in_configure_features=false\
       --incompatible_depset_union=false
 

--- a/.bazelrc
+++ b/.bazelrc
@@ -33,11 +33,9 @@ test:windows --experimental_enable_runfiles
 
 # WIP: bazel 0.27 fixs
 build\
-      --incompatible_require_ctx_in_configure_features=false\
-      --incompatible_depset_union=false
+      --incompatible_require_ctx_in_configure_features=false
 test\
-      --incompatible_require_ctx_in_configure_features=false\
-      --incompatible_depset_union=false
+      --incompatible_require_ctx_in_configure_features=false
 
 # test environment does not propagate locales by default
 # some tests reads files written in UTF8, we need to propagate the correct

--- a/.bazelrc
+++ b/.bazelrc
@@ -33,11 +33,9 @@ test:windows --experimental_enable_runfiles
 
 # WIP: bazel 0.27 fixs
 build\
-      --incompatible_disable_deprecated_attr_params=false\
       --incompatible_require_ctx_in_configure_features=false\
       --incompatible_depset_union=false
 test\
-      --incompatible_disable_deprecated_attr_params=false\
       --incompatible_require_ctx_in_configure_features=false\
       --incompatible_depset_union=false
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,10 @@ jobs:
       - run:
           name: Build tests
           command: |
-            bazel build --config ci //tests/...
+            # XXX bazel 0.27 regression: https://github.com/bazelbuild/bazel/issues/8723
+            # tag filtering (used here to disable rules with dependency to nixpkgs) is broken for
+            # rule_test. Workaround here is to just ignore theses rules using -//...
+            bazel build --config ci //tests/... -- -//tests:test-haskell_doctest_impl -//tests:test-binary-with-prebuilt_impl -//tests:test-haddock_impl
       - run:
           name: Run tests
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,6 +35,8 @@ jobs:
             wget "https://github.com/bazelbuild/bazel/releases/download/0.27.0/bazel_0.27.0-linux-x86_64.deb"
             dpkg -i bazel_0.27.0-linux-x86_64.deb
             echo "common:ci --build_tag_filters -requires_hackage,-requires_lz4,-requires_zlib,-requires_doctest,-requires_c2hs,-requires_threaded_rts,-dont_test_with_bindist" > .bazelrc.local
+            # XXX: See .bazelrc [backward compatible options] for the the rational behind this flag
+            echo "build --incompatible_use_python_toolchains=false" >> .bazelrc.local
       - run:
           name: Build tests
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,8 +32,8 @@ jobs:
             apt-get install -y wget gnupg golang make libgmp3-dev libtinfo-dev pkg-config zip g++ zlib1g-dev unzip python python3 bash-completion locales
             echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen
             locale-gen
-            wget "https://github.com/bazelbuild/bazel/releases/download/0.24.0/bazel_0.24.0-linux-x86_64.deb"
-            dpkg -i bazel_0.24.0-linux-x86_64.deb
+            wget "https://github.com/bazelbuild/bazel/releases/download/0.27.0/bazel_0.27.0-linux-x86_64.deb"
+            dpkg -i bazel_0.27.0-linux-x86_64.deb
             echo "common:ci --build_tag_filters -requires_hackage,-requires_lz4,-requires_zlib,-requires_doctest,-requires_c2hs,-requires_threaded_rts,-dont_test_with_bindist" > .bazelrc.local
       - run:
           name: Build tests

--- a/.netlify/build.sh
+++ b/.netlify/build.sh
@@ -23,6 +23,8 @@ mv WORKSPACE.tmp WORKSPACE
 # generation either.
 sed -i 's/vendored_node = "@nixpkgs_nodejs"/vendored_node = None/' WORKSPACE
 
-bazel build //docs:api_html
+# XXX: see .bazelrc note [backward compatible options] for rational behind
+# the --incompatible_use_python_toolchains flag
+bazel build --incompatible_use_python_toolchains=false //docs:api_html
 unzip -d public bazel-bin/docs/api_html-skydoc.zip
 cp start public

--- a/.netlify/install.sh
+++ b/.netlify/install.sh
@@ -2,7 +2,13 @@
 
 set -eux
 
-V=0.20.0
+# XXX: This should be bazel 0.27
+# However, starting from bazel 0.27, they link with a more recent
+# glibc, they are based on ubuntu 16.04 instead of 14.04.
+# Apparently, netlify does not have the right glibc for now
+# So, using bazel 0.26 is a temporary solution until netlify fix its
+# environment.
+V=0.26.0
 
 curl -LO https://github.com/bazelbuild/bazel/releases/download/$V/bazel-$V-installer-linux-x86_64.sh
 chmod +x bazel-$V-installer-linux-x86_64.sh

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -161,6 +161,9 @@ register_toolchains(
     "//tests:c2hs-toolchain",
     "//tests:doctest-toolchain",
     "//tests:protobuf-toolchain",
+    # XXX: see .bazelrc for discussion, the python toolchain
+    # work in postponed to future bazel version
+    # "//tests:python_toolchain",
 )
 
 nixpkgs_cc_configure(
@@ -218,6 +221,12 @@ nixpkgs_package(
     attribute_path = "haskellPackages.proto-lens-protoc",
     repository = "@nixpkgs",
 )
+
+#nixpkgs_package(
+#    name = "python3",
+#    attribute_path = "python3",
+#    repository = "@nixpkgs",
+#)
 
 nixpkgs_package(
     name = "sphinx",
@@ -285,6 +294,13 @@ jvm_maven_import_external(
 local_repository(
     name = "c2hs_repo",
     path = "tests/c2hs/repo",
+)
+
+# python toolchain
+nixpkgs_package(
+    name = "python3",
+    attribute_path = "python3",
+    repository = "@nixpkgs",
 )
 
 load(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -98,10 +98,14 @@ nixpkgs_package(
 
 http_archive(
     name = "com_google_protobuf",
-    sha256 = "73fdad358857e120fd0fa19e071a96e15c0f23bb25f85d3f7009abfd4f264a2a",
-    strip_prefix = "protobuf-3.6.1.3",
-    urls = ["https://github.com/google/protobuf/archive/v3.6.1.3.tar.gz"],
+    sha256 = "03d2e5ef101aee4c2f6ddcf145d2a04926b9c19e7086944df3842b1b8502b783",
+    strip_prefix = "protobuf-3.8.0",
+    urls = ["https://github.com/google/protobuf/archive/v3.8.0.tar.gz"],
 )
+
+load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
+
+protobuf_deps()  # configure and install zlib for protobuf
 
 nixpkgs_local_repository(
     name = "nixpkgs",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -385,16 +385,16 @@ skydoc_repositories()
 
 http_archive(
     name = "io_bazel_rules_go",
-    sha256 = "8be57ff66da79d9e4bd434c860dce589195b9101b2c187d144014bbca23b5166",
-    strip_prefix = "rules_go-0.16.3",
-    urls = ["https://github.com/bazelbuild/rules_go/archive/0.16.3.tar.gz"],
+    sha256 = "9084496dde809363c491137e077ace81780463ead0060a0a6c3c4c0f613e9fcb",
+    strip_prefix = "rules_go-0.18.6",
+    urls = ["https://github.com/bazelbuild/rules_go/archive/0.18.6.tar.gz"],
 )
 
 http_archive(
     name = "com_github_bazelbuild_buildtools",
-    sha256 = "0a0920151acf18c51866331944d12db9023707a6861e78225366f5711efc845b",
-    strip_prefix = "buildtools-0.25.1",
-    urls = ["https://github.com/bazelbuild/buildtools/archive/0.25.1.tar.gz"],
+    sha256 = "86592d703ecbe0c5cbb5139333a63268cf58d7efd2c459c8be8e69e77d135e29",
+    strip_prefix = "buildtools-0.26.0",
+    urls = ["https://github.com/bazelbuild/buildtools/archive/0.26.0.tar.gz"],
 )
 
 # A repository that generates the Go SDK imports, see ./tools/go_sdk/README
@@ -404,7 +404,7 @@ local_repository(
 )
 
 load(
-    "@io_bazel_rules_go//go:def.bzl",
+    "@io_bazel_rules_go//go:deps.bzl",
     "go_register_toolchains",
     "go_rules_dependencies",
 )

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,7 +9,7 @@ jobs:
       architecture: 'x64'
   - bash: |
       set -e
-      curl -LO https://github.com/bazelbuild/bazel/releases/download/0.24.0/bazel-0.24.0-windows-x86_64.exe
+      curl -LO https://github.com/bazelbuild/bazel/releases/download/0.27.0/bazel-0.27.0-windows-x86_64.exe
       mv bazel-*.exe bazel.exe
       mkdir /c/bazel
       mv bazel.exe /c/bazel

--- a/debug/linking_utils/BUILD.bazel
+++ b/debug/linking_utils/BUILD.bazel
@@ -30,9 +30,7 @@ def contains_error(error):
     return f
 
 # output should have some runpaths
-assert \
-    ldd(identity, sys.argv[1])['runpath_dirs']\
-    > 0
+assert len(ldd(identity, sys.argv[1])['runpath_dirs']) > 0
 
 # some of the dependencies are implicit and not in NEEDED flags
 assert ldd(contains_error(LDD_UNKNOWN), sys.argv[1])

--- a/haskell/c2hs.bzl
+++ b/haskell/c2hs.bzl
@@ -116,6 +116,7 @@ c2hs_library = rule(
         "@io_tweag_rules_haskell//haskell:toolchain",
         "@io_tweag_rules_haskell//haskell/c2hs:toolchain",
     ],
+    fragments = ["cpp"],
 )
 
 def _c2hs_toolchain_impl(ctx):

--- a/haskell/cabal.bzl
+++ b/haskell/cabal.bzl
@@ -107,7 +107,7 @@ def _prepare_cabal_inputs(hs, cc, dep_info, cc_info, tool_inputs, tool_input_man
     package_databases = dep_info.package_databases
     extra_headers = cc_info.compilation_context.headers
     extra_include_dirs = cc_info.compilation_context.includes
-    extra_lib_dirs = [file.dirname for file in ghci_extra_libs]
+    extra_lib_dirs = [file.dirname for file in ghci_extra_libs.to_list()]
     args.add_all([name, setup, cabal.dirname, package_database.dirname])
     args.add_all(package_databases, map_each = _dirname, format_each = "--package-db=%s")
     args.add_all(extra_include_dirs, format_each = "--extra-include-dirs=%s")

--- a/haskell/cabal.bzl
+++ b/haskell/cabal.bzl
@@ -231,6 +231,7 @@ def _haskell_cabal_library_impl(ctx):
     lib_info = HaskellLibraryInfo(package_id = name, version = None)
     cc_toolchain = find_cpp_toolchain(ctx)
     feature_configuration = cc_common.configure_features(
+        ctx = ctx,
         cc_toolchain = cc_toolchain,
         requested_features = ctx.features,
         unsupported_features = ctx.disabled_features,
@@ -277,6 +278,7 @@ haskell_cabal_library = rule(
         ),
     },
     toolchains = ["@io_tweag_rules_haskell//haskell:toolchain"],
+    fragments = ["cpp"],
 )
 """Use Cabal to build a library.
 
@@ -401,6 +403,7 @@ haskell_cabal_binary = rule(
         ),
     },
     toolchains = ["@io_tweag_rules_haskell//haskell:toolchain"],
+    fragments = ["cpp"],
 )
 """Use Cabal to build a binary.
 

--- a/haskell/cc.bzl
+++ b/haskell/cc.bzl
@@ -51,18 +51,18 @@ def cc_interop_info(ctx):
     for cc in ccs:
         cc_ctx = cc.compilation_context
         hdrs.append(cc_ctx.headers)
-        include_args.extend(["-I" + include for include in cc_ctx.includes])
+        include_args.extend(["-I" + include for include in cc_ctx.includes.to_list()])
         cpp_flags.extend(
             [
                 "-D" + define
-                for define in cc_ctx.defines
+                for define in cc_ctx.defines.to_list()
             ] + [
                 f
-                for include in cc_ctx.quote_includes
+                for include in cc_ctx.quote_includes.to_list()
                 for f in ["-iquote", include]
             ] + [
                 f
-                for include in cc_ctx.system_includes
+                for include in cc_ctx.system_includes.to_list()
                 for f in ["-isystem", include]
             ],
         )

--- a/haskell/cc.bzl
+++ b/haskell/cc.bzl
@@ -73,6 +73,9 @@ def cc_interop_info(ctx):
     # Should be find_cpp_toolchain() instead.
     cc_toolchain = ctx.attr._cc_toolchain[cc_common.CcToolchainInfo]
     feature_configuration = cc_common.configure_features(
+        # XXX: protobuf is passing a "patched ctx"
+        # which includes the real ctx as "real_ctx"
+        ctx = getattr(ctx, "real_ctx", ctx),
         cc_toolchain = cc_toolchain,
         requested_features = ctx.features,
         unsupported_features = ctx.disabled_features,

--- a/haskell/ghc.BUILD.tpl
+++ b/haskell/ghc.BUILD.tpl
@@ -39,7 +39,6 @@ cc_toolchain(
     ar_files = ":mingw",
     as_files = ":mingw",
     compiler_files = ":mingw",
-    cpu = "x64_windows",
     dwp_files = ":mingw",
     linker_files = ":mingw",
     objcopy_files = ":mingw",

--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -293,7 +293,7 @@ haskell_import = rule(
         "hdrs": attr.label_list(allow_files = True),
         "includes": attr.string_list(),
         "haddock_interfaces": attr.label_list(allow_files = True),
-        "haddock_html": attr.label(allow_files = True, single_file = True),
+        "haddock_html": attr.label(allow_single_file = True),
         "_version_macros": attr.label(
             executable = True,
             cfg = "host",

--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -187,6 +187,7 @@ def _mk_binary_rule(**kwargs):
         toolchains = [
             "@io_tweag_rules_haskell//haskell:toolchain",
         ],
+        fragments = ["cpp"],
         **kwargs
     )
 
@@ -257,6 +258,7 @@ haskell_library = rule(
     toolchains = [
         "@io_tweag_rules_haskell//haskell:toolchain",
     ],
+    fragments = ["cpp"],
 )
 """Build a library from Haskell source.
 
@@ -315,6 +317,7 @@ haskell_toolchain_libraries = rule(
     toolchains = [
         "@io_tweag_rules_haskell//haskell:toolchain",
     ],
+    fragments = ["cpp"],
 )
 
 haskell_toolchain_library = rule(
@@ -327,6 +330,7 @@ haskell_toolchain_library = rule(
             default = Label("@io_tweag_rules_haskell//haskell:toolchain-libraries"),
         ),
     ),
+    fragments = ["cpp"],
 )
 """Import packages that are prebuilt outside of Bazel.
 

--- a/haskell/private/actions/link.bzl
+++ b/haskell/private/actions/link.bzl
@@ -92,7 +92,7 @@ def _darwin_create_extra_linker_flags_file(hs, cc, objects_dir, executable, dyna
         done
         """.format(
             nm = cc.tools.nm,
-            solibs = " ".join(["\"" + l.path + "\"" for l in solibs]),
+            solibs = " ".join(["\"" + l.path + "\"" for l in solibs.to_list()]),
             out = linker_flags_file.path,
         ),
     )

--- a/haskell/private/actions/repl.bzl
+++ b/haskell/private/actions/repl.bzl
@@ -77,8 +77,9 @@ def build_haskell_repl(
 
     # NOTE: We can avoid constructing this in the future by instead generating
     #   a dedicated package configuration file defining the required libraries.
-    library_path = [lib.dirname for lib in ghci_extra_libs]
-    libraries = [get_lib_name(lib) for lib in ghci_extra_libs]
+    ghci_extra_libs_list = ghci_extra_libs.to_list()
+    library_path = [lib.dirname for lib in ghci_extra_libs_list]
+    libraries = [get_lib_name(lib) for lib in ghci_extra_libs_list]
 
     repl_file = hs.actions.declare_file(target_unique_name(hs, "repl"))
 

--- a/haskell/private/haskell_impl.bzl
+++ b/haskell/private/haskell_impl.bzl
@@ -658,7 +658,7 @@ def haskell_toolchain_libraries_impl(ctx):
     ])
 
     library_dict = {}
-    for package in ordered:
+    for package in ordered.to_list():
         target = libraries[package]
 
         # Construct CcInfo
@@ -669,7 +669,7 @@ def haskell_toolchain_libraries_impl(ctx):
             # don't import dynamic libraries in profiling mode.
             libs = {
                 get_static_hs_lib_name(hs.toolchain.version, lib): {"static": lib}
-                for lib in target[HaskellImportHack].static_profiling_libraries
+                for lib in target[HaskellImportHack].static_profiling_libraries.to_list()
             }
         else:
             # Workaround for https://github.com/tweag/rules_haskell/issues/881
@@ -678,7 +678,7 @@ def haskell_toolchain_libraries_impl(ctx):
             # dynamic libHSrts and the static libCffi and libHSrts.
             libs = {
                 get_dynamic_hs_lib_name(hs.toolchain.version, lib): {"dynamic": lib}
-                for lib in target[HaskellImportHack].dynamic_libraries
+                for lib in target[HaskellImportHack].dynamic_libraries.to_list()
             }
             for lib in target[HaskellImportHack].static_libraries.to_list():
                 name = get_static_hs_lib_name(with_profiling, lib)

--- a/haskell/private/haskell_impl.bzl
+++ b/haskell/private/haskell_impl.bzl
@@ -569,6 +569,9 @@ def haskell_library_impl(ctx):
     # Should be find_cpp_toolchain() instead.
     cc_toolchain = ctx.attr._cc_toolchain[cc_common.CcToolchainInfo]
     feature_configuration = cc_common.configure_features(
+        # XXX: protobuf is passing a "patched ctx"
+        # which includes the real ctx as "real_ctx"
+        ctx = getattr(ctx, "real_ctx", ctx),
         cc_toolchain = cc_toolchain,
         requested_features = ctx.features,
         unsupported_features = ctx.disabled_features,
@@ -643,6 +646,7 @@ def haskell_toolchain_libraries_impl(ctx):
     # Should be find_cpp_toolchain() instead.
     cc_toolchain = ctx.attr._cc_toolchain[cc_common.CcToolchainInfo]
     feature_configuration = cc_common.configure_features(
+        ctx = ctx,
         cc_toolchain = cc_toolchain,
         requested_features = ctx.features,
         unsupported_features = ctx.disabled_features,

--- a/haskell/private/java.bzl
+++ b/haskell/private/java.bzl
@@ -36,7 +36,7 @@ def java_interop_info(ctx):
     env_dict = dict()
     uniq_classpath = collections.uniq([
         f.path
-        for f in inputs
+        for f in inputs.to_list()
     ])
 
     if len(uniq_classpath) > 0:

--- a/haskell/private/path_utils.bzl
+++ b/haskell/private/path_utils.bzl
@@ -118,7 +118,7 @@ def make_path(libs, prefix = None, sep = None):
 
     sep = sep if sep else ":"
 
-    for lib in libs:
+    for lib in libs.to_list():
         lib_dir = paths.dirname(lib.path)
         if prefix:
             lib_dir = paths.join(prefix, lib_dir)
@@ -291,7 +291,7 @@ def link_libraries(libs, args, prefix_optl = False):
     # https://github.com/tweag/rules_haskell/issues/873.
     cc_libs = depset(direct = [
         lib
-        for lib in libs
+        for lib in libs.to_list()
         if not get_lib_name(lib).startswith("HS")
     ])
 
@@ -306,8 +306,9 @@ def link_libraries(libs, args, prefix_optl = False):
         args.add_all(cc_libs, map_each = get_lib_name, format_each = libfmt)
         args.add_all(cc_libs, map_each = get_dirname, format_each = dirfmt, uniquify = True)
     else:
-        args.extend([libfmt % get_lib_name(lib) for lib in cc_libs])
-        args.extend(depset(direct = [dirfmt % lib.dirname for lib in cc_libs]).to_list())
+        cc_libs_list = cc_libs.to_list()
+        args.extend([libfmt % get_lib_name(lib) for lib in cc_libs_list])
+        args.extend([dirfmt % lib.dirname for lib in cc_libs_list])
 
 # tests in /tests/unit_tests/BUILD
 def parent_dir_path(path):

--- a/haskell/private/version_macros.bzl
+++ b/haskell/private/version_macros.bzl
@@ -13,7 +13,7 @@ def generate_version_macros(ctx, pkg_name, version):
     """
     version_macros_file = ctx.actions.declare_file("{}_version_macros.h".format(ctx.attr.name))
     ctx.actions.run_shell(
-        inputs = [ctx.executable._version_macros],
+        tools = [ctx.executable._version_macros],
         outputs = [version_macros_file],
         command = """
         "$1" "$2" "$3" > "$4"

--- a/haskell/protobuf.bzl
+++ b/haskell/protobuf.bzl
@@ -185,6 +185,7 @@ def _haskell_proto_aspect_impl(target, ctx):
         label = ctx.label,
         toolchains = ctx.toolchains,
         var = ctx.var,
+        real_ctx = ctx,
     )
 
     # TODO this pattern match is very brittle. Let's not do this. The
@@ -242,6 +243,7 @@ _haskell_proto_aspect = aspect(
         "@io_tweag_rules_haskell//haskell:toolchain",
         "@io_tweag_rules_haskell//protobuf:toolchain",
     ],
+    fragments = ["cpp"],
 )
 
 def _haskell_proto_library_impl(ctx):

--- a/haskell/protobuf.bzl
+++ b/haskell/protobuf.bzl
@@ -90,7 +90,7 @@ def _haskell_proto_aspect_impl(target, ctx):
     transitive_proto_paths = target.proto.transitive_proto_path
 
     args.add_all([
-        "-I{0}={1}".format(_proto_path(s, transitive_proto_paths), s.path)
+        "-I{0}={1}".format(_proto_path(s, transitive_proto_paths.to_list()), s.path)
         for s in target.proto.transitive_sources.to_list()
     ])
 

--- a/haskell/providers.bzl
+++ b/haskell/providers.bzl
@@ -334,7 +334,7 @@ def create_link_config(hs, cc_info, binary, args, dynamic = None, pic = None):
     package_name = target_unique_name(hs, "link-config").replace("_", "-").replace("@", "-")
     conf_path = paths.join(package_name, package_name + ".conf")
     conf_file = hs.actions.declare_file(conf_path)
-    libs = (cc_static_libs + cc_dynamic_libs).to_list()
+    libs = cc_static_libs.to_list() + cc_dynamic_libs.to_list()
     write_package_conf(hs, conf_file, {
         "name": package_name,
         "extra-libraries": [

--- a/haskell/providers.bzl
+++ b/haskell/providers.bzl
@@ -141,7 +141,7 @@ def _get_unique_lib_files(cc_info):
     # https://github.com/tweag/rules_haskell/issues/917
     libs_by_filename = {}
     filenames = []
-    for lib_to_link in libs_to_link:
+    for lib_to_link in libs_to_link.to_list():
         if lib_to_link.dynamic_library:
             lib = lib_to_link.dynamic_library
         elif lib_to_link.interface_library:
@@ -322,31 +322,32 @@ def create_link_config(hs, cc_info, binary, args, dynamic = None, pic = None):
     # https://github.com/tweag/rules_haskell/issues/873.
     cc_static_libs = depset(direct = [
         lib
-        for lib in static_libs
+        for lib in static_libs.to_list()
         if not get_lib_name(lib).startswith("HS")
     ])
     cc_dynamic_libs = depset(direct = [
         lib
-        for lib in dynamic_libs
+        for lib in dynamic_libs.to_list()
         if not get_lib_name(lib).startswith("HS")
     ])
 
     package_name = target_unique_name(hs, "link-config").replace("_", "-").replace("@", "-")
     conf_path = paths.join(package_name, package_name + ".conf")
     conf_file = hs.actions.declare_file(conf_path)
+    libs = (cc_static_libs + cc_dynamic_libs).to_list()
     write_package_conf(hs, conf_file, {
         "name": package_name,
         "extra-libraries": [
             get_lib_name(lib)
-            for lib in cc_static_libs + cc_dynamic_libs
+            for lib in libs
         ],
         "library-dirs": depset(direct = [
             rel_to_pkgroot(lib.dirname, conf_file.dirname)
-            for lib in cc_static_libs + cc_dynamic_libs
+            for lib in libs
         ]),
         "dynamic-library-dirs": depset(direct = [
             rel_to_pkgroot(lib.dirname, conf_file.dirname)
-            for lib in cc_static_libs + cc_dynamic_libs
+            for lib in libs
         ]),
         # XXX: Set user_link_flags.
         "ld-options": depset(direct = [
@@ -356,7 +357,7 @@ def create_link_config(hs, cc_info, binary, args, dynamic = None, pic = None):
                 keep_filename = False,
                 prefix = "@loader_path" if hs.toolchain.is_darwin else "$ORIGIN",
             )
-            for lib in dynamic_libs
+            for lib in dynamic_libs.to_list()
         ]),
     })
     cache_file = ghc_pkg_recache(hs, conf_file)

--- a/hazel/ghc_paths.bzl
+++ b/hazel/ghc_paths.bzl
@@ -10,14 +10,18 @@ module GHC.Paths (
         ghc, ghc_pkg, libdir, docdir
   ) where
 
-libdir, docdir, ghc, ghc_pkg :: FilePath
-
-libdir  = "$({ghc} --print-libdir | sed 's:\\\\:/:g')"
-docdir  = "DOCDIR_IS_NOT_SET"
+ghc, ghc_pkg, docdir, libdir :: FilePath
 
 ghc     = "{ghc}"
 ghc_pkg = "{ghc_pkg}"
-EOM""".format(
+
+docdir  = "DOCDIR_IS_NOT_SET"
+EOM
+
+      echo -n 'libdir  = "' >> {out}
+      {ghc} --print-libdir | tr '\\' '/' | tr -d '[:space:]' >> {out}
+      echo '"' >> {out}
+""".format(
             ghc = ghc.path,
             ghc_pkg = tools.ghc_pkg.path,
             out = ctx.outputs.out.path,

--- a/hazel/hazel.bzl
+++ b/hazel/hazel.bzl
@@ -17,7 +17,10 @@ load(
 )
 load("@os_info//:os_info.bzl", "is_windows")
 load("//tools:ghc.bzl", "default_ghc_workspaces", "get_ghc_workspace")
-load("//tools:mangling.bzl", "hazel_binary", "hazel_library", "hazel_workspace")
+load("//tools:mangling.bzl", "hazel_binary", "hazel_workspace", _hazel_library = "hazel_library")
+
+# reexport hazel symbols
+hazel_library = _hazel_library
 
 def _cabal_haskell_repository_impl(ctx):
     ghc_workspace = get_ghc_workspace(ctx.attr.ghc_workspaces, ctx)

--- a/hazel/third_party/cabal2bazel/bzl/cabal_package.bzl
+++ b/hazel/third_party/cabal2bazel/bzl/cabal_package.bzl
@@ -125,7 +125,7 @@ def _hazel_symlink_impl(ctx):
 hazel_symlink = rule(
     implementation = _hazel_symlink_impl,
     attrs = {
-        "src": attr.label(mandatory = True, allow_files = True, single_file = True),
+        "src": attr.label(mandatory = True, allow_single_file = True),
         "out": attr.string(mandatory = True),
     },
     outputs = {"out": "%{out}"},

--- a/hazel/third_party/cabal2bazel/bzl/cabal_package.bzl
+++ b/hazel/third_party/cabal2bazel/bzl/cabal_package.bzl
@@ -365,7 +365,7 @@ def _get_build_attrs(
     paths_module = _paths_module(desc)
     extra_modules_dict = _conditions_dict(extra_modules)
     other_modules_dict = _conditions_dict(build_info.otherModules)
-    for condition in depset(extra_modules_dict.keys() + other_modules_dict.keys()):
+    for condition in extra_modules_dict.keys() + other_modules_dict.keys():
         srcs[condition] = []
         deps[condition] = []
         cdeps[condition] = []
@@ -479,7 +479,7 @@ def _get_build_attrs(
                      "-w",
                  ]),
         defines = [o[2:] for o in build_info.ccOptions if o.startswith("-D")],
-        textual_hdrs = list(headers),
+        textual_hdrs = headers.to_list(),
         deps = ["@haskell_rts//:lib"] + select(cdeps) + cc_deps + elibs_targets,
         visibility = ["//visibility:public"],
         linkstatic = select({

--- a/hazel/third_party/cabal2bazel/bzl/cabal_package.bzl
+++ b/hazel/third_party/cabal2bazel/bzl/cabal_package.bzl
@@ -36,6 +36,7 @@ load(":bzl/cabal_paths.bzl", "cabal_paths")
 load(":bzl/happy.bzl", "genhappy")
 load("//templates:templates.bzl", "templates")
 load("//tools:mangling.bzl", "hazel_cbits", "hazel_library")
+load("@bazel_tools//tools/cpp:cc_flags_supplier.bzl", "cc_flags_supplier")
 
 _conditions_default = "//conditions:default"
 
@@ -78,6 +79,7 @@ def _configure(desc):
         for f in desc.extraTmpFiles
         if f.split("/")[-1] not in _header_blacklist
     ]
+    cc_flags_supplier(name = "cc_flags")
     native.genrule(
         name = "run-configure",
         cmd = "\n".join([
@@ -94,7 +96,10 @@ def _configure(desc):
             for out in outputs
         ]),
         tools = ["configure"],
-        toolchains = ["@bazel_tools//tools/cpp:current_cc_toolchain"],
+        toolchains = [
+            ":cc_flags",
+            "@bazel_tools//tools/cpp:current_cc_toolchain",
+        ],
         srcs = native.glob(["**"], exclude = outputs),
         outs = outputs,
     )

--- a/hazel/third_party/cabal2bazel/bzl/cabal_paths.bzl
+++ b/hazel/third_party/cabal2bazel/bzl/cabal_paths.bzl
@@ -28,14 +28,14 @@ load("@io_tweag_rules_haskell//haskell:haskell.bzl", "haskell_library")
 load("//tools:mangling.bzl", "hazel_library")
 
 def _impl_path_module_gen(ctx):
-    paths_file = ctx.new_file(ctx.label.name)
+    paths_file = ctx.actions.declare_file(ctx.label.name)
 
     base_dir = paths.join(
         ctx.label.package,
         ctx.attr.data_dir if ctx.attr.data_dir else "",
     )
 
-    ctx.template_action(
+    ctx.actions.expand_template(
         template = ctx.file._template,
         output = paths_file,
         substitutions = {

--- a/hazel/third_party/cabal2bazel/bzl/cabal_paths.bzl
+++ b/hazel/third_party/cabal2bazel/bzl/cabal_paths.bzl
@@ -58,10 +58,9 @@ _path_module_gen = rule(
     attrs = {
         "data_dir": attr.string(),
         "module": attr.string(),
-        "version": attr.int_list(mandatory = True, non_empty = True),
+        "version": attr.int_list(mandatory = True, allow_empty = False),
         "_template": attr.label(
-            allow_files = True,
-            single_file = True,
+            allow_single_file = True,
             default = Label(
                 "@ai_formation_hazel//:paths-template.hs",
             ),

--- a/nixpkgs/default.nix
+++ b/nixpkgs/default.nix
@@ -1,5 +1,4 @@
 import (fetchTarball {
-   # Checkout from 2019-05-06.
-   url = https://github.com/mboes/nixpkgs/archive/361e9185c83166b44419e05e75fc8473875df6ea.tar.gz;
-   sha256 = "0c6izp9i1ln4yy2h9jlm48k94f018h8pw60jfbhq49p076aaafrb";
+   url = https://github.com/NixOS/nixpkgs/archive/a2075a2c314ccb3df6522dd957bb4e237446dc49.tar.gz;
+   sha256 = "1jbnjw06mca7867q81v3i3jljj0wpm38y9zjwij3nd6pp2bqhvbr";
 })

--- a/shell.nix
+++ b/shell.nix
@@ -1,7 +1,6 @@
 { pkgs ? import ./nixpkgs {}, docTools ? true }:
 
 with pkgs;
-
 mkShell {
   # XXX: hack for macosX, this flags disable bazel usage of xcode
   # Note: this is set even for linux so any regression introduced by this flag

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -19,6 +19,7 @@ load(
     "//:constants.bzl",
     "test_ghc_version",
 )
+load("@bazel_tools//tools/python:toolchain.bzl", "py_runtime_pair")
 
 package(default_testonly = 1)
 
@@ -59,6 +60,25 @@ c2hs_toolchain(
     c2hs = "@c2hs//:bin",
     tags = ["requires_c2hs"],
 )
+
+#py_runtime(
+#    name = "py3_runtime",
+#    testonly = False,
+#    interpreter = "@python3//:bin/python",
+#    python_version = "PY3",
+#    visibility = ["//visibility:public"],
+#)
+#
+#py_runtime_pair(
+#    name = "py_runtime_pair",
+#    py3_runtime = ":py3_runtime",
+#)
+#
+#toolchain(
+#    name = "python_toolchain",
+#    toolchain = ":py_runtime_pair",
+#    toolchain_type = "@bazel_tools//tools/python:toolchain_type",
+#)
 
 rule_test_exe(
     name = "test-binary-simple",

--- a/tests/cc_haskell_import/python_add_one.py
+++ b/tests/cc_haskell_import/python_add_one.py
@@ -9,10 +9,5 @@ path = r.Rlocation('io_tweag_rules_haskell/tests/cc_haskell_import/hs-lib-b-wrap
 
 foreignlib = ctypes.cdll.LoadLibrary(path)
 
-# ATTN: If you remove this print *statement* hs_init will segfault!
-# If you use the python3 print *function*, it will segfault as well!
-# TODO: wtf?
-print foreignlib
-
 foreignlib.hs_init()
 assert(str(foreignlib.add_one_hs(1)) == "2")


### PR DESCRIPTION
Summary of the tasks done for this PR.

- [x] bazel 0.27 upstream in nixpkgs
  - [X] Fix the /bin/bash
  - [x] Fix the `ijar` ld loader
  - [x] Fix the `checkPhase` issues
  - [x] Python compatibility with python3
  - [x] Merged PR
- [x] bazel 0.27 incompatibles flags (It works without it, but it may be better to remove the compatibility flags)
  - [x] Deprecated `cpu` attribute
  - [x]  `--incompatible_disable_genrule_cc_toolchain_dependency`
  - [x] `--incompatible_no_transitive_loads`
  - [x] `--incompatible_disable_deprecated_attr_params=false`
  - [x] `--incompatible_new_actions_api=false`
  - [x] `--incompatible_no_support_tools_in_action_inputs=false`
  - [x] `--incompatible_require_ctx_in_configure_features=false`
  - [x] `--incompatible_depset_is_not_iterable=false`
  - [x] `--incompatible_depset_union=false`
  - [x] `--incompatible_use_python_toolchains=false`
- [x] CI failures
   - [x] Netlify. It was using bazel 0.20. Upgrade to 0.27 breaks due to GLIBC symbols.. *NOTE*: I'm using bazel 0.26 for netlify.
   - [x] Windows
   - [x] Linux-nixpkgs
   - [x] Darwin-nixpkgs
   - [x] Linux-bindist: it fails because the `--build_tag_filters` are not taken into account, leading to the build of the `nixpkgs_package` targets.

*Open issue*

`--incompatible_use_python_toolchains` is a pain to manage with the three platform we use. For now it was reactivated. The code for the python toolchain (working on linux / darwin nixpkgs) is still here, but the toolchain is not used and `--incompatible_use_python_toolchains=false` is set in `.bazelrc`.

That's difficult to fix considering that the windows python autodetection bazel script is not functional (bazel issue reported in comments). I think it is a correct tradeoff for now, considering that it won't leak in user code. That's only used for our tests, so I prefer keeping it simple for now and wait for future bazel upgrade which may comes with a functional windows autodetection script.

This closes #956 and #948.