### PR TITLE
expand_location: Multiple entries with same key

### DIFF
--- a/haskell/private/haskell_impl.bzl
+++ b/haskell/private/haskell_impl.bzl
@@ -147,8 +147,8 @@ def _expand_make_variables(name, ctx, strings):
         ctx.attr.plugins,
         ctx.attr.tools,
     ]
-    targets = [target for attr in label_attrs for target in attr]
-    strings = [ctx.expand_location(str, targets) for str in strings]
+    for attr in label_attrs:
+        strings = [ctx.expand_location(str, attr) for str in strings]
     strings = [ctx.expand_make_variables(name, str, {}) for str in strings]
     return strings
 

--- a/tests/extra-source-files/BUILD.bazel
+++ b/tests/extra-source-files/BUILD.bazel
@@ -35,6 +35,7 @@ haskell_test(
     compiler_flags = ["-optl-Wl,@tests/extra-source-files/ld-options.txt"],
     extra_srcs = [
         "file.txt",
+        "Foo.hs",  # Test "Multiple entries with same key" in expand_location
         "ld-options.txt",
     ],
     deps = [


### PR DESCRIPTION
If a target, e.g. a source file, appears in more than one attribute, e.g. `srcs` and `extra_srcs`, or `srcs` and `data`, then this caused `expand_location` to fail with the error "Multiple entries with same key". This issue was triggered by the Hazel build of [`ghc-lib-parser`](http://hackage.haskell.org/package/ghc-lib-parser).

This PR fixes the issue by applying `expand_location` one attribute at a time, instead of all attributes at once.