### PR TITLE
Don't sandbox symlink creation

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -390,3 +390,13 @@ buildifier_dependencies()
 load("@ai_formation_hazel//:workspace.bzl", "hazel_setup")
 
 hazel_setup()
+
+# For profiling
+# Required to make use of `bazel build --profile`.
+
+# Dummy target //external:python_headers.
+# See https://github.com/protocolbuffers/protobuf/blob/d9ccd0c0e6bbda9bf4476088eeb46b02d7dcd327/util/python/BUILD
+bind(
+    name = "python_headers",
+    actual = "@com_google_protobuf//util/python:python_headers",
+)

--- a/haskell/private/path_utils.bzl
+++ b/haskell/private/path_utils.bzl
@@ -532,6 +532,13 @@ def ln(hs, target, link, extra_inputs = depset()):
             link = link.path,
         ),
         use_default_shell_env = True,
+        # Don't sandbox symlinking to reduce overhead.
+        # See https://github.com/tweag/rules_haskell/issues/958.
+        execution_requirements = {
+            "no-sandbox": "",
+            "no-cache": "",
+            "no-remote": "",
+        },
     )
 
 def parse_pattern(ctx, pattern_str):


### PR DESCRIPTION
As noted in https://github.com/tweag/rules_haskell/issues/958 symlink creation takes a large amount of time in rules_haskell. This PR aims to reduce the time spent on creating symlinks by reducing the overhead due to sandboxing and caching symlinks.

A fully disk cached build of rules_haskell (`bazel clean && bazel fetch //... && bazel build //...`) takes
- Before this PR:
  - Elapsed time: 37.621s - 46.778s
  - Critical Path: 1.80s - 12.29s (varies strongly)
- After this PR:
  - Elapsed time: 22.375s - 26.950s
  - Critical Path: 1.37s - 1.76s

---

@regnat Could you test this on your use-case to verify that this PR helps?