### PR TITLE
Set empty CcInfo for haskell_import

### DIFF
--- a/haskell/private/haskell_impl.bzl
+++ b/haskell/private/haskell_impl.bzl
@@ -789,6 +789,9 @@ def haskell_import_impl(ctx):
         transitive_haddocks = transitive_haddocks,
     )
 
+    # TODO: fill this CcInfo structure
+    cc_info = cc_common.merge_cc_infos(cc_infos = [])
+
     return [
         hs_info,
         import_info,
@@ -796,6 +799,7 @@ def haskell_import_impl(ctx):
         default_info,
         lib_info,
         haddock_info,
+        cc_info,
     ]
 
 def _exposed_modules_reexports(exports):


### PR DESCRIPTION
~~The guarded code block uses `target[CcInfo]` which may not be
available in this context. This commit just add the relevant test.

I don't know if that's correct, but it fixs the build on my codebase
and the repl is correctly loading.~~

`CcInfo` provider was not provided by `haskell_import`. This PR set it to an empty provider. This fix a few build failures in places which assumes that all haskell libraries have a `CcInfo` provider. 