### PR TITLE
Allow @ in Haskell binary names

### DIFF
--- a/haskell/providers.bzl
+++ b/haskell/providers.bzl
@@ -331,7 +331,7 @@ def create_link_config(hs, cc_info, binary, args, dynamic = None, pic = None):
         if not get_lib_name(lib).startswith("HS")
     ])
 
-    package_name = target_unique_name(hs, "link-config").replace("_", "-")
+    package_name = target_unique_name(hs, "link-config").replace("_", "-").replace("@", "-")
     conf_path = paths.join(package_name, package_name + ".conf")
     conf_file = hs.actions.declare_file(conf_path)
     write_package_conf(hs, conf_file, {

--- a/tests/target-name/BUILD.bazel
+++ b/tests/target-name/BUILD.bazel
@@ -1,0 +1,30 @@
+load(
+    "@io_tweag_rules_haskell//haskell:haskell.bzl",
+    "haskell_library",
+    "haskell_test",
+)
+
+package(default_testonly = 1)
+
+# Test that rules_haskell handles allowed characters in target names.
+#
+# The documentation specifies:
+# Target names must be composed entirely of characters drawn from
+# the set a–z, A–Z, 0–9, and the punctuation symbols _/.+-=,@~
+#
+# Currently, rules_haskell does not support the full set.
+
+haskell_library(
+    name = "lib0-a_Aa",
+    srcs = ["Lib.hs"],
+    deps = ["//tests/hackage:base"],
+)
+
+haskell_test(
+    name = "bin0-a_A@a",
+    srcs = ["Main.hs"],
+    deps = [
+        ":lib0-a_Aa",
+        "//tests/hackage:base",
+    ],
+)

--- a/tests/target-name/Lib.hs
+++ b/tests/target-name/Lib.hs
@@ -1,0 +1,4 @@
+module Lib where
+
+value :: Int
+value = 42

--- a/tests/target-name/Main.hs
+++ b/tests/target-name/Main.hs
@@ -1,0 +1,6 @@
+module Main where
+
+import Lib (value)
+
+main :: IO ()
+main = print value


### PR DESCRIPTION
Closes #962.
Fixes a regression introduced in #930.

Note, the Bazel documentation [specifies](https://docs.bazel.build/versions/master/build-ref.html#name)

> Target names must be composed entirely of characters drawn from the set `a–z`, `A–Z`, `0–9`, and the punctuation symbols `_/.+-=,@~`.

Currently, most of these are not supported by rules_haskell.

A possible solution would be to implement full [z-encoding](https://hackage.haskell.org/package/ghc-8.4.3/docs/src/Encoding.html#zEncodeString) in rules_haskell and add a case for `@`. Also, `ghc-pkg` does not allow more than one `-` in a row, so simply replacing characters by `-` can generate invalid package names.