### PR TITLE
Set LD_LIBRARY_PATH for haddock

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ jobs:
             locale-gen
             wget "https://github.com/bazelbuild/bazel/releases/download/0.24.0/bazel_0.24.0-linux-x86_64.deb"
             dpkg -i bazel_0.24.0-linux-x86_64.deb
-            echo "common:ci --build_tag_filters -requires_hackage,-requires_zlib,-requires_doctest,-requires_c2hs,-requires_threaded_rts,-dont_test_with_bindist" > .bazelrc.local
+            echo "common:ci --build_tag_filters -requires_hackage,-requires_lz4,-requires_zlib,-requires_doctest,-requires_c2hs,-requires_threaded_rts,-dont_test_with_bindist" > .bazelrc.local
       - run:
           name: Build tests
           command: |

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -188,6 +188,20 @@ cc_library(
 )
 
 nixpkgs_package(
+    name = "lz4",
+    build_file_content = """
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+  name = "lz4",
+  srcs = glob(["lib/liblz4.dylib", "lib/liblz4.so*"]),
+  includes = ["include"],
+)
+    """,
+    repository = "@nixpkgs",
+)
+
+nixpkgs_package(
     name = "c2hs",
     attribute_path = "haskellPackages.c2hs",
     repository = "@nixpkgs",

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -8,7 +8,9 @@ load(
 load(
     "@io_tweag_rules_haskell//haskell:haskell.bzl",
     "haskell_binary",
+    "haskell_doc",
     "haskell_doctest_toolchain",
+    "haskell_library",
     "haskell_proto_toolchain",
     "haskell_test",
     "haskell_toolchain",
@@ -341,4 +343,34 @@ haskell_binary(
         "@stackage//:hspec",
         "@stackage//:hspec-core",
     ],
+)
+
+haskell_library(
+    name = "lz4",
+    srcs = [
+        "LZ4.hs",
+    ],
+    src_strip_prefix = "src",
+    tags = ["requires_lz4"],
+    deps = [
+        "//tests/hackage:base",
+        "//tests/hackage:bytestring",
+        "@lz4",
+    ],
+)
+
+haskell_library(
+    name = "utils",
+    srcs = ["Foo.hs"],
+    tags = ["requires_lz4"],
+    deps = [
+        ":lz4",
+        "//tests/hackage:base",
+    ],
+)
+
+haskell_doc(
+    name = "toto",
+    tags = ["requires_lz4"],
+    deps = [":utils"],
 )

--- a/tests/Foo.hs
+++ b/tests/Foo.hs
@@ -1,0 +1,5 @@
+{-# LANGUAGE TemplateHaskell #-}
+module Foo where
+
+-- This is here just to trigger template haskell
+blork = $([| 1 + 1 |])

--- a/tests/LZ4.hs
+++ b/tests/LZ4.hs
@@ -1,0 +1,2 @@
+-- | Foreign bindings to LZ4 library.
+module LZ4 where


### PR DESCRIPTION
Closes: #965 

Haddock failed on the example given by @guibou in https://github.com/tweag/rules_haskell/commit/376123c0a3b376a9b4cb68f35b5b659d995f0f40 due to `liblz4.so.1` not being found. This PR resolves this issue by exporting `LD_LIBRARY_PATH` in the same way as is done for the REPL and doctests.

@guibou I've included your example as a regression test.