### PR TITLE
Fix ghc-paths module in Hazel

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -109,4 +109,7 @@ jobs:
       /c/bazel/bazel.exe test --config windows "//tests/encoding/..."
       /c/bazel/bazel.exe test --config windows "//tests/c-compiles/..."
 
+      # Hazel tests that succeed
+      /c/bazel/bazel.exe test --config windows "@ai_formation_hazel//test:ghc-paths-test"
+
     displayName: 'Run Bazel'

--- a/hazel/ghc_paths.bzl
+++ b/hazel/ghc_paths.bzl
@@ -12,7 +12,7 @@ module GHC.Paths (
 
 libdir, docdir, ghc, ghc_pkg :: FilePath
 
-libdir  = "$({ghc} --print-libdir | sed s:\\:/:g)"
+libdir  = "$({ghc} --print-libdir | sed 's:\\\\:/:g')"
 docdir  = "DOCDIR_IS_NOT_SET"
 
 ghc     = "{ghc}"

--- a/hazel/test/BUILD.bazel
+++ b/hazel/test/BUILD.bazel
@@ -24,6 +24,15 @@ haskell_test(
     ],
 )
 
+haskell_test(
+    name = "ghc-paths-test",
+    srcs = ["ghc-paths-test.hs"],
+    deps = [
+        hazel_library("base"),
+        hazel_library("ghc-paths"),
+    ],
+)
+
 haskell_library(
     name = "DoctestExample",
     srcs = ["DoctestExample.hs"],

--- a/hazel/test/ghc-paths-test.hs
+++ b/hazel/test/ghc-paths-test.hs
@@ -1,0 +1,17 @@
+module Main where
+
+import Control.Monad (when)
+import GHC.Paths (ghc, ghc_pkg, libdir, docdir)
+import System.Exit (exitFailure)
+import System.IO (hPutStrLn, stderr)
+
+main :: IO ()
+main = do
+  let require name value =
+        when (null value) $ do
+          hPutStrLn stderr (name ++ " should not be empty")
+          exitFailure
+  require "ghc" ghc
+  require "ghc_pkg" ghc_pkg
+  require "libdir" libdir
+  require "docdir" docdir


### PR DESCRIPTION
The `sed` expression was not properly quoted, leading to an empty string for `libdir`.

- Quotes the `sed` expression properly.
- Adds a test-case for `ghc-paths`.