### PR TITLE
Support GHC with static RTS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
           name: Setup test environment
           command: |
             apt-get update
-            apt-get install -y wget gnupg golang make libgmp3-dev libtinfo-dev pkg-config zip g++ zlib1g-dev unzip python python3 bash-completion locales
+            apt-get install -y wget gnupg golang make libgmp3-dev libtinfo-dev libtinfo5 pkg-config zip g++ zlib1g-dev unzip python python3 bash-completion locales
             echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen
             locale-gen
             wget "https://github.com/bazelbuild/bazel/releases/download/0.27.0/bazel_0.27.0-linux-x86_64.deb"

--- a/haskell/ghc_bindist.bzl
+++ b/haskell/ghc_bindist.bzl
@@ -1,6 +1,10 @@
 """Workspace rules (GHC binary distributions)"""
 
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "patch")
+load(
+    ":private/workspace_utils.bzl",
+    "ghc_is_static",
+)
 
 _GHC_DEFAULT_VERSION = "8.6.5"
 
@@ -253,6 +257,7 @@ haskell_toolchain(
     tools = [":bin"],
     libraries = toolchain_libraries,
     version = "{version}",
+    is_static = {is_static},
     compiler_flags = {compiler_flags},
     haddock_flags = {haddock_flags},
     repl_ghci_args = {repl_ghci_args},
@@ -261,6 +266,7 @@ haskell_toolchain(
     """.format(
         toolchain_libraries = toolchain_libraries,
         version = ctx.attr.version,
+        is_static = ghc_is_static(ctx),
         compiler_flags = ctx.attr.compiler_flags,
         haddock_flags = ctx.attr.haddock_flags,
         repl_ghci_args = ctx.attr.repl_ghci_args,

--- a/haskell/ghc_bindist.bzl
+++ b/haskell/ghc_bindist.bzl
@@ -1,10 +1,7 @@
 """Workspace rules (GHC binary distributions)"""
 
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "patch")
-load(
-    ":private/workspace_utils.bzl",
-    "ghc_is_static",
-)
+load("@bazel_tools//tools/cpp:lib_cc_configure.bzl", "get_cpu_value")
 
 _GHC_DEFAULT_VERSION = "8.6.5"
 
@@ -266,7 +263,7 @@ haskell_toolchain(
     """.format(
         toolchain_libraries = toolchain_libraries,
         version = ctx.attr.version,
-        is_static = ghc_is_static(ctx),
+        is_static = os == "windows",
         compiler_flags = ctx.attr.compiler_flags,
         haddock_flags = ctx.attr.haddock_flags,
         repl_ghci_args = ctx.attr.repl_ghci_args,

--- a/haskell/nixpkgs.bzl
+++ b/haskell/nixpkgs.bzl
@@ -4,6 +4,10 @@ load(
     "@io_tweag_rules_nixpkgs//nixpkgs:nixpkgs.bzl",
     "nixpkgs_package",
 )
+load(
+    ":private/workspace_utils.bzl",
+    "ghc_is_static",
+)
 
 def _ghc_nixpkgs_haskell_toolchain_impl(repository_ctx):
     compiler_flags_select = "select({})".format(
@@ -64,6 +68,7 @@ haskell_toolchain(
     tools = {tools},
     libraries = toolchain_libraries,
     version = "{version}",
+    is_static = {is_static},
     compiler_flags = {compiler_flags} + {compiler_flags_select},
     haddock_flags = {haddock_flags},
     repl_ghci_args = {repl_ghci_args},
@@ -76,6 +81,7 @@ haskell_toolchain(
             toolchain_libraries = toolchain_libraries,
             tools = ["@io_tweag_rules_haskell_ghc_nixpkgs//:bin"],
             version = repository_ctx.attr.version,
+            is_static = ghc_is_static(repository_ctx),
             compiler_flags = repository_ctx.attr.compiler_flags,
             compiler_flags_select = compiler_flags_select,
             haddock_flags = repository_ctx.attr.haddock_flags,

--- a/haskell/nixpkgs.bzl
+++ b/haskell/nixpkgs.bzl
@@ -4,10 +4,6 @@ load(
     "@io_tweag_rules_nixpkgs//nixpkgs:nixpkgs.bzl",
     "nixpkgs_package",
 )
-load(
-    ":private/workspace_utils.bzl",
-    "ghc_is_static",
-)
 
 def _ghc_nixpkgs_haskell_toolchain_impl(repository_ctx):
     compiler_flags_select = "select({})".format(
@@ -81,7 +77,7 @@ haskell_toolchain(
             toolchain_libraries = toolchain_libraries,
             tools = ["@io_tweag_rules_haskell_ghc_nixpkgs//:bin"],
             version = repository_ctx.attr.version,
-            is_static = ghc_is_static(repository_ctx),
+            is_static = repository_ctx.attr.is_static,
             compiler_flags = repository_ctx.attr.compiler_flags,
             compiler_flags_select = compiler_flags_select,
             haddock_flags = repository_ctx.attr.haddock_flags,
@@ -97,6 +93,7 @@ _ghc_nixpkgs_haskell_toolchain = repository_rule(
         # These attributes just forward to haskell_toolchain.
         # They are documented there.
         "version": attr.string(),
+        "is_static": attr.bool(),
         "compiler_flags": attr.string_list(),
         "compiler_flags_select": attr.string_list_dict(),
         "haddock_flags": attr.string_list(),
@@ -150,6 +147,7 @@ _ghc_nixpkgs_toolchain = repository_rule(_ghc_nixpkgs_toolchain_impl)
 
 def haskell_register_ghc_nixpkgs(
         version,
+        is_static = False,
         build_file = None,
         build_file_content = None,
         compiler_flags = None,
@@ -215,6 +213,7 @@ def haskell_register_ghc_nixpkgs(
     _ghc_nixpkgs_haskell_toolchain(
         name = haskell_toolchain_repo_name,
         version = version,
+        is_static = is_static,
         compiler_flags = compiler_flags,
         compiler_flags_select = compiler_flags_select,
         haddock_flags = haddock_flags,

--- a/haskell/private/actions/compile.bzl
+++ b/haskell/private/actions/compile.bzl
@@ -267,6 +267,11 @@ def _compilation_defaults(hs, cc, java, dep_info, plugin_dep_info, cc_info, srcs
         # to debug issues in non-sandboxed builds.
         "-Wmissing-home-modules",
     ])
+    if hs.toolchain.is_static and not hs.toolchain.is_windows:
+        # A static GHC RTS requires -fPIC. However, on Unix we also require
+        # -fexternal-dynamic-refs, otherwise GHC still generates R_X86_64_PC32
+        # relocations which prevents loading these static libraries as PIC.
+        args.add("-fexternal-dynamic-refs")
 
     # Output directories
     args.add_all([

--- a/haskell/private/haskell_impl.bzl
+++ b/haskell/private/haskell_impl.bzl
@@ -185,11 +185,11 @@ def _haskell_binary_common_impl(ctx, is_test):
     inspect_coverage = _should_inspect_coverage(ctx, hs, is_test)
 
     dynamic = not ctx.attr.linkstatic
-    if with_profiling or hs.toolchain.is_windows:
+    if with_profiling or hs.toolchain.is_static:
         # NOTE We can't have profiling and dynamic code at the
         # same time, see:
         # https://ghc.haskell.org/trac/ghc/ticket/15394
-        # Also, GHC on Windows doesn't support dynamic code
+        # Also, static GHC doesn't support dynamic code
         dynamic = False
 
     plugins = [_resolve_plugin_tools(ctx, plugin[GhcPluginInfo]) for plugin in ctx.attr.plugins]
@@ -388,11 +388,11 @@ def haskell_library_impl(ctx):
     srcs_files, import_dir_map = _prepare_srcs(ctx.attr.srcs)
 
     with_shared = not ctx.attr.linkstatic
-    if with_profiling or hs.toolchain.is_windows:
+    if with_profiling or hs.toolchain.is_static:
         # NOTE We can't have profiling and dynamic code at the
         # same time, see:
         # https://ghc.haskell.org/trac/ghc/ticket/15394
-        # Also, GHC on Windows doesn't support dynamic code
+        # Also, static GHC doesn't support dynamic code
         with_shared = False
 
     package_name = getattr(ctx.attr, "package_name", None)

--- a/haskell/private/workspace_utils.bzl
+++ b/haskell/private/workspace_utils.bzl
@@ -1,0 +1,67 @@
+load("@bazel_tools//tools/cpp:lib_cc_configure.bzl", "get_cpu_value")
+
+def execute_or_fail_loudly(repository_ctx, arguments):
+    """Execute the given command
+
+    Fails if the command does not exit with exit-code 0.
+
+    Args:
+      arguments: List, the command line to execute.
+
+    Returns:
+      exec_result: The output of the command.
+
+    """
+    exec_result = repository_ctx.execute(arguments)
+    if exec_result.return_code != 0:
+        arguments = [_as_string(x) for x in arguments]
+        fail("\n".join(["Command failed: " + " ".join(arguments), exec_result.stderr]))
+    return exec_result
+
+def _as_string(v):
+    if type(v) == "string":
+        return v
+    else:
+        return repr(v)
+
+def _find_ghc(repository_ctx):
+    """Find the GHC executable in the current workspace.
+
+    Returns:
+      path, The path to the GHC executable.
+
+    """
+    if get_cpu_value(repository_ctx) == "x64_windows":
+        ghc = repository_ctx.path("bin/ghc.exe")
+    else:
+        ghc = repository_ctx.path("bin/ghc")
+
+    if not ghc.exists:
+        fail("Cannot find GHC executable in {}.".format(ghc))
+
+    return ghc
+
+def ghc_is_static(repository_ctx):
+    """Query GHC for whether the RTS is static or dynamic
+
+    Requires the GHC executable to exist under `bin/` in the current workspace.
+
+    Returns:
+      Bool, True for static RTS, False for dynamic RTS.
+
+    """
+    ghc = _find_ghc(repository_ctx)
+    repository_ctx.file(
+        "_ghc_is_dynamic.ghci",
+        content = 'foreign import ccall unsafe "rts_isDynamic" isDynamic :: IO Int',
+        executable = False,
+    )
+    result = execute_or_fail_loudly(repository_ctx, [
+        ghc,
+        "--interactive",
+        "-ghci-script",
+        "_ghc_is_dynamic.ghci",
+        "-e",
+        "isDynamic",
+    ])
+    return result.stdout.strip() == "0"

--- a/haskell/private/workspace_utils.bzl
+++ b/haskell/private/workspace_utils.bzl
@@ -40,28 +40,3 @@ def _find_ghc(repository_ctx):
         fail("Cannot find GHC executable in {}.".format(ghc))
 
     return ghc
-
-def ghc_is_static(repository_ctx):
-    """Query GHC for whether the RTS is static or dynamic
-
-    Requires the GHC executable to exist under `bin/` in the current workspace.
-
-    Returns:
-      Bool, True for static RTS, False for dynamic RTS.
-
-    """
-    ghc = _find_ghc(repository_ctx)
-    repository_ctx.file(
-        "_ghc_is_dynamic.ghci",
-        content = 'foreign import ccall unsafe "rts_isDynamic" isDynamic :: IO Int',
-        executable = False,
-    )
-    result = execute_or_fail_loudly(repository_ctx, [
-        ghc,
-        "--interactive",
-        "-ghci-script",
-        "_ghc_is_dynamic.ghci",
-        "-e",
-        "isDynamic",
-    ])
-    return result.stdout.strip() == "0"

--- a/haskell/providers.bzl
+++ b/haskell/providers.bzl
@@ -252,8 +252,8 @@ def get_extra_libs(hs, cc_info, dynamic = False, pic = None, fixup_dir = "_libs"
     if pic == None:
         pic = dynamic
 
-    # PIC is irrelevant on Windows.
-    pic_required = pic and not hs.toolchain.is_windows
+    # PIC is irrelevant on static GHC.
+    pic_required = pic and not hs.toolchain.is_static
     for lib_to_link in libs_to_link:
         dynamic_lib = None
         if lib_to_link.dynamic_library:

--- a/haskell/toolchain.bzl
+++ b/haskell/toolchain.bzl
@@ -196,6 +196,7 @@ fi
             libraries = libraries,
             is_darwin = ctx.attr.is_darwin,
             is_windows = ctx.attr.is_windows,
+            is_static = ctx.attr.is_static,
             version = ctx.attr.version,
             # Pass through the version_file, that it can be required as
             # input in _run_ghc, to make every call to GHC depend on a
@@ -236,6 +237,9 @@ _haskell_toolchain = rule(
         "is_windows": attr.bool(
             doc = "Whether compile on and for Windows.",
             mandatory = True,
+        ),
+        "is_static": attr.bool(
+            doc = "Whether GHC was linked statically.",
         ),
         "locale": attr.string(
             default = "en_US.UTF-8",

--- a/haskell/toolchain.bzl
+++ b/haskell/toolchain.bzl
@@ -261,6 +261,7 @@ Label pointing to the locale archive file to use. Mostly useful on NixOS.
 def haskell_toolchain(
         name,
         version,
+        is_static,
         tools,
         libraries,
         compiler_flags = [],
@@ -283,6 +284,7 @@ def haskell_toolchain(
       haskell_toolchain(
           name = "ghc",
           version = "1.2.3",
+          is_static = is_static,
           tools = ["@sys_ghc//:bin"],
           compiler_flags = ["-Wall"],
       )
@@ -304,6 +306,7 @@ def haskell_toolchain(
     _haskell_toolchain(
         name = name,
         version = version,
+        is_static = is_static,
         tools = tools,
         libraries = libraries,
         compiler_flags = compiler_flags,


### PR DESCRIPTION
GHC can be compiled with a static RTS. This allows to use only static Haskell librarires including for GHCi and Template Haskell. This is the default on Windows.

This PR adds support for a static GHC on Unix as well. The mode of GHC (static or dynamic) is detected automatically during toolchain setup.
