### PR TITLE
The start script is to require a range of Bazel versions (fix #923)

### DIFF
--- a/start
+++ b/start
@@ -3,6 +3,9 @@
 MIN_BAZEL_MAJOR=0
 MIN_BAZEL_MINOR=24
 
+MAX_BAZEL_MAJOR=0
+MAX_BAZEL_MINOR=27
+
 set -e
 
 check_files_dont_exist () {
@@ -20,14 +23,20 @@ check_bazel_version () {
 $actual_raw
 EOF
 
-    local expected=$MIN_BAZEL_MAJOR.$MIN_BAZEL_MINOR.0
-    local cmp=$expected'\n'$actual
+    local expected_min=$MIN_BAZEL_MAJOR.$MIN_BAZEL_MINOR.0
+    local expected_max=$MAX_BAZEL_MAJOR.$MAX_BAZEL_MINOR.x
 
-    if ! ( [ "$actual_major" -gt "$MIN_BAZEL_MAJOR" ] || (
-            [ "$actual_major" -eq "$MIN_BAZEL_MAJOR" ] &&
-                [ "$actual_minor" -ge "$MIN_BAZEL_MINOR" ] ) )
+    if [ "$actual_major" -gt "$MAX_BAZEL_MAJOR" ] || (
+        [ "$actual_major" -eq "$MAX_BAZEL_MAJOR" ] &&
+            [ "$actual_minor" -ge "$MAX_BAZEL_MINOR" ] )
     then
-        echo "Need at least Bazel v${expected}. v${actual_raw} detected." >/dev/stderr
+	echo "Warning: a too new version of Bazel detected: v${actual_raw}."  >/dev/stderr
+	echo "         Recommended versions are from v${expected_min} to v${expected_max}."  >/dev/stderr
+    elif [ "$actual_major" -lt "$MIN_BAZEL_MAJOR" ] || (
+          [ "$actual_major" -eq "$MIN_BAZEL_MAJOR" ] &&
+            [ "$actual_minor" -lt "$MIN_BAZEL_MINOR" ] )
+    then
+        echo "Error: Need at least Bazel v${expected_min} but v${actual_raw} detected." >/dev/stderr
         exit 1
     fi
 }


### PR DESCRIPTION
For too new versions produce a warning; for too old ones produce an error.

[As discussed here](https://github.com/tweag/rules_haskell/pull/974#pullrequestreview-256032938).