### PR TITLE
Fix incompatible_string_join_requires_strings

### DIFF
--- a/haskell/cabal.bzl
+++ b/haskell/cabal.bzl
@@ -17,7 +17,7 @@ load(
 def _execute_or_fail_loudly(repository_ctx, arguments):
     exec_result = repository_ctx.execute(arguments)
     if exec_result.return_code != 0:
-        fail("\n".join(["Command failed: " + " ".join(arguments), exec_result.stderr]))
+        fail("\n".join(["Command failed: " + " ".join([repr(arg) for arg in arguments]), exec_result.stderr]))
     return exec_result
 
 def _so_extension(hs):


### PR DESCRIPTION
Addresses [issue on CI](https://circleci.com/gh/tweag/rules_haskell/6979?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-checks-link).

It seems that stack failed at the fetch step and the Bazel error is from the code-path that constructs the error message. Since [Bazel 0.27](https://github.com/bazelbuild/bazel/issues/7802) it is no longer legal to apply string join to a list that contains non-string elements.