### PR TITLE
De-duplicated mix files being passed along libraries & binaries

### DIFF
--- a/haskell/private/list.bzl
+++ b/haskell/private/list.bzl
@@ -9,7 +9,7 @@ def _dedup_on(f, list_):
     def compare_x(el):
       return el.x
 
-    dedup_on([struct(x=3), struct(x=4), struct(x=3)], compare_x)
+    dedup_on(compare_x, [struct(x=3), struct(x=4), struct(x=3)])
     => [struct(x=3), struct(x=4)]
     """
     seen = set.empty()


### PR DESCRIPTION
When multiple direct dependencies have the same transitive dependency, they were passing along the same mix files when using `bazel coverage`. This work prevents that from happening by deduplicating by the short_path of the mix files.