### PR TITLE
Fix $(location) references to data attribute

### DIFF
--- a/haskell/private/haskell_impl.bzl
+++ b/haskell/private/haskell_impl.bzl
@@ -146,8 +146,19 @@ def _expand_make_variables(name, ctx, strings):
         ctx.attr.plugins,
         ctx.attr.tools,
     ]
-    for attr in label_attrs:
-        strings = [ctx.expand_location(str, attr) for str in strings]
+
+    # Deduplicate targets. Targets could be duplicated between attributes, e.g.
+    # srcs and extra_srcs. ctx.expand_location fails if any target occurs
+    # multiple times.
+    targets = {
+        target.label: target
+        for attr in label_attrs
+        for target in attr
+        # expand_location expects a list of targets, but haskell_proto_aspect
+        # can inject lists of files instead.
+        if hasattr(target, "label")
+    }.values()
+    strings = [ctx.expand_location(str, targets = targets) for str in strings]
     strings = [ctx.expand_make_variables(name, str, {}) for str in strings]
     return strings
 

--- a/tests/binary-with-data/BUILD.bazel
+++ b/tests/binary-with-data/BUILD.bazel
@@ -11,10 +11,14 @@ package(default_testonly = 1)
 haskell_test(
     name = "bin1",
     srcs = ["bin1.hs"],
+    compiler_flags = ['-DBIN1_INPUT="$(rootpath bin1-input)"'],
     # Regular file input:
     data = ["bin1-input"],
     visibility = ["//visibility:public"],
-    deps = ["//tests/hackage:base"],
+    deps = [
+        "//tests/hackage:base",
+        "//tools/runfiles",
+    ],
 )
 
 haskell_test(

--- a/tests/binary-with-data/bin1.hs
+++ b/tests/binary-with-data/bin1.hs
@@ -1,9 +1,14 @@
+{-# LANGUAGE CPP #-}
+
 module Main where
 
+import qualified Bazel.Runfiles
 import Control.Monad (unless)
 
 main :: IO ()
 main = do
-    contents <- readFile "tests/binary-with-data/bin1-input"
+    runfiles <- Bazel.Runfiles.create
+    let path = Bazel.Runfiles.rlocation runfiles ("io_tweag_rules_haskell/" ++ BIN1_INPUT)
+    contents <- readFile path
     unless (contents == "contents\n")
       $ error $ "Incorrect input; got " ++ show contents

--- a/tools/runfiles/BUILD.bazel
+++ b/tools/runfiles/BUILD.bazel
@@ -2,7 +2,16 @@ load(
     "@io_tweag_rules_haskell//haskell:haskell.bzl",
     "haskell_library",
     "haskell_test",
+    "haskell_toolchain_library",
 )
+
+haskell_toolchain_library(name = "base")
+
+haskell_toolchain_library(name = "directory")
+
+haskell_toolchain_library(name = "filepath")
+
+haskell_toolchain_library(name = "process")
 
 haskell_library(
     name = "runfiles",
@@ -10,9 +19,9 @@ haskell_library(
     src_strip_prefix = "src",
     visibility = ["//visibility:public"],
     deps = [
-        "@stackage//:base",
-        "@stackage//:directory",
-        "@stackage//:filepath",
+        ":base",
+        ":directory",
+        ":filepath",
     ],
 )
 
@@ -23,9 +32,9 @@ haskell_test(
     data = ["bin-data.txt"],
     src_strip_prefix = "bin",
     deps = [
+        ":base",
+        ":filepath",
         ":runfiles",
-        "@stackage//:base",
-        "@stackage//:filepath",
     ],
 )
 
@@ -38,9 +47,9 @@ haskell_test(
     ],
     src_strip_prefix = "test",
     deps = [
+        ":base",
+        ":filepath",
+        ":process",
         ":runfiles",
-        "@stackage//:base",
-        "@stackage//:filepath",
-        "@stackage//:process",
     ],
 )


### PR DESCRIPTION
The following kind of `$(location)` expansion failed with an "*expression is not a declared prerequisite of this rule*" error.

```
haskell_library(
    ...
    data = ["//some/genrule:target"],
    compiler_flags = ["-DSOME_DEF=$(rootpath //some/genrule:target)"],
)
```

The reason is that since #959 `expand_location` was called multiple times, iterating over all relevant attributes. However, `expand_location` fails immediately if any reference cannot be resolved. This issue didn't come up so far, because certain attributes (e.g. `tools`) are always included implicitly. However, `data` is not.

This PR changes the code to instead deduplicate the list of targets and call `expand_location` only once. This PR also modifies `//tests/binary-with-data` to serve as a regression test for this issue.