### PR TITLE
bazel-runfiles: Support runfiles_manifest

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -27,10 +27,6 @@ test:ci --test_output=errors
 # issue.
 build  --incompatible_use_python_toolchains=false
 
-# Needed on Windows for //tests/binary-with-data
-# see: https://github.com/tweag/rules_haskell/issues/647#issuecomment-459001362
-test:windows --experimental_enable_runfiles
-
 # test environment does not propagate locales by default
 # some tests reads files written in UTF8, we need to propagate the correct
 # environment variables, such as LOCALE_ARCHIVE

--- a/hazel/paths-template.hs
+++ b/hazel/paths-template.hs
@@ -5,6 +5,7 @@ module %{module} (
     getDataFileName,
     ) where
 
+import qualified Bazel.Runfiles as Runfiles
 import Data.Version (Version, makeVersion)
 import Prelude
 import System.FilePath ((</>), takeDirectory)
@@ -13,8 +14,8 @@ import System.Environment (getExecutablePath)
 -- TODO: automatically locate root directory
 getDataDir :: IO FilePath
 getDataDir = do
-    exePath <- getExecutablePath
-    return $ takeDirectory exePath </> "%{base_dir}"
+    r <- Runfiles.create
+    pure $! Runfiles.rlocation r "%{data_dir}"
 
 getDataFileName :: FilePath -> IO FilePath
 getDataFileName name = do

--- a/hazel/third_party/cabal2bazel/bzl/cabal_paths.bzl
+++ b/hazel/third_party/cabal2bazel/bzl/cabal_paths.bzl
@@ -40,12 +40,8 @@ def _impl_path_module_gen(ctx):
         output = paths_file,
         substitutions = {
             "%{module}": ctx.attr.module,
-            "%{base_dir}": paths.join(
-                # TODO: this probably won't work for packages not in external
-                # repositories.  See:
-                # https://github.com/bazelbuild/bazel/wiki/Updating-the-runfiles-tree-structure
-                "..",
-                paths.relativize(ctx.label.workspace_root, "external"),
+            "%{data_dir}": paths.join(
+                ctx.label.workspace_name,
                 base_dir,
             ),
             "%{version}": str(ctx.attr.version),
@@ -123,6 +119,7 @@ def cabal_paths(name = None, package = None, data_dir = "", data = [], version =
         deps = [
             hazel_library("base"),
             hazel_library("filepath"),
+            "@io_tweag_rules_haskell//tools/runfiles",
         ],
         # TODO: run directory resolution.
         **kwargs

--- a/tests/binary-with-data/BUILD.bazel
+++ b/tests/binary-with-data/BUILD.bazel
@@ -5,9 +5,6 @@ load(
 
 package(default_testonly = 1)
 
-# XXX: on Windows those tests need `--experimental_enable_runfiles` to succeed
-# XXX: see: https://github.com/tweag/rules_haskell/issues/647#issuecomment-459001362
-
 haskell_test(
     name = "bin1",
     srcs = ["bin1.hs"],

--- a/tests/binary-with-data/BUILD.bazel
+++ b/tests/binary-with-data/BUILD.bazel
@@ -31,5 +31,6 @@ haskell_test(
     deps = [
         "//tests/hackage:base",
         "//tests/hackage:process",
+        "//tools/runfiles",
     ],
 )

--- a/tests/binary-with-data/bin2.hs
+++ b/tests/binary-with-data/bin2.hs
@@ -1,8 +1,11 @@
 module Main where
 
+import qualified Bazel.Runfiles
 import System.Process (callProcess)
 import System.Environment (getArgs)
 
 main = do
   [arg] <- getArgs
-  callProcess arg []
+  runfiles <- Bazel.Runfiles.create
+  let path = Bazel.Runfiles.rlocation runfiles ("io_tweag_rules_haskell/" ++ arg)
+  callProcess path []

--- a/tools/runfiles/BUILD.bazel
+++ b/tools/runfiles/BUILD.bazel
@@ -13,6 +13,8 @@ haskell_toolchain_library(name = "filepath")
 
 haskell_toolchain_library(name = "process")
 
+haskell_toolchain_library(name = "transformers")
+
 haskell_library(
     name = "runfiles",
     srcs = ["src/Bazel/Runfiles.hs"],
@@ -22,6 +24,7 @@ haskell_library(
         ":base",
         ":directory",
         ":filepath",
+        ":transformers",
     ],
 )
 

--- a/tools/runfiles/bazel-runfiles.cabal
+++ b/tools/runfiles/bazel-runfiles.cabal
@@ -37,6 +37,7 @@ library
       base >=4.7 && <5
     , directory
     , filepath
+    , transformers
   default-language: Haskell2010
 
 executable bazel-runfiles-exe

--- a/tools/runfiles/src/Bazel/Runfiles.hs
+++ b/tools/runfiles/src/Bazel/Runfiles.hs
@@ -1,13 +1,9 @@
+{-# LANGUAGE TupleSections #-}
+
 -- | This module enables finding data dependencies ("runfiles") of Haskell
 -- binaries at runtime.
 --
 -- For more information, see: https://github.com/bazelbuild/bazel/issues/4460
---
--- Note: this does not currently support the RUNFILES_MANIFEST environmental
--- variable.  However, that's only necessary on Windows, which rules_haskell
--- doesn't support yet.
---
--- Additionally, this is not yet supported by the REPL.
 module Bazel.Runfiles
     ( Runfiles
     , create
@@ -15,19 +11,69 @@ module Bazel.Runfiles
     , env
     ) where
 
-import System.Directory (doesDirectoryExist)
+import Control.Monad (guard)
+import Control.Monad.Trans.Maybe (MaybeT (..))
+import Control.Monad.IO.Class (liftIO)
+import Data.Char (toLower)
+import Data.Foldable (asum)
+import Data.List (find, isPrefixOf, isSuffixOf)
+import Data.Maybe (fromMaybe)
+import System.Directory (doesDirectoryExist, doesFileExist, listDirectory)
 import System.Environment (getExecutablePath, lookupEnv)
-import System.FilePath (FilePath, (</>), (<.>))
+import qualified System.FilePath
+import System.FilePath (FilePath, (</>), (<.>), addTrailingPathSeparator)
+import System.Info (os)
 
--- | A path to a directory tree containing runfiles for the given
-newtype Runfiles = Runfiles FilePath
-    deriving Show
+-- | Reference to Bazel runfiles, runfiles root or manifest file.
+data Runfiles
+  = RunfilesRoot !FilePath
+    -- ^ The runfiles root directory.
+  | RunfilesManifest !FilePath ![(FilePath, FilePath)]
+    -- ^ The runfiles manifest file and its content.
+  deriving Show
+
 
 -- | Construct a path to a data dependency within the given runfiles.
 --
--- For example: @rlocation \"myworkspace/mypackage/myfile.txt\"@
+-- For example: @rlocation \"myworkspace\/mypackage\/myfile.txt\"@
 rlocation :: Runfiles -> FilePath -> FilePath
-rlocation (Runfiles f) g = f </> g
+rlocation (RunfilesRoot f) g = f </> normalize g
+rlocation (RunfilesManifest _ m) g = fromMaybe g' $ asum [lookup g' m, lookupDir g' m]
+  where
+    g' = normalize g
+
+-- | Lookup a directory in the manifest file.
+--
+-- Bazel's manifest file only lists files. However, the @RunfilesRoot@ method
+-- supports looking up directories, and this is an important feature for Cabal
+-- path modules in Hazel. This function allows to lookup a directory in a
+-- manifest file, by looking for the first entry with a matching prefix and
+-- then stripping the superfluous suffix.
+lookupDir :: FilePath -> [(FilePath, FilePath)] -> Maybe FilePath
+lookupDir p = fmap stripSuffix . find match
+  where
+    p' = normalize $ addTrailingPathSeparator p
+    match (key, value) = p' `isPrefixOf` key && drop (length p') key `isSuffixOf` value
+    stripSuffix (key, value) = take (length value - (length key - length p')) value
+
+-- | Normalize a path according to the Bazel specification.
+--
+-- See https://docs.google.com/document/d/e/2PACX-1vSDIrFnFvEYhKsCMdGdD40wZRBX3m3aZ5HhVj4CtHPmiXKDCxioTUbYsDydjKtFDAzER5eg7OjJWs3V/pub
+--
+-- "[...] returns the absolute path of the file, which is normalized (and
+-- lowercase on Windows) and uses "/" as directory separator on every platform
+-- (including Windows)"
+normalize :: FilePath -> FilePath
+normalize | os == "mingw32" = normalizeWindows
+          | otherwise       = System.FilePath.normalise
+
+-- | Normalize a path on Windows according to the Bazel specification.
+normalizeWindows :: FilePath -> FilePath
+normalizeWindows = map (toLower . normalizeSlash) . System.FilePath.normalise
+  where
+    normalizeSlash '\\' = '/'
+    normalizeSlash c    = c
+
 
 -- | Set environmental variables for locating the given runfiles directory.
 --
@@ -36,27 +82,111 @@ rlocation (Runfiles f) g = f </> g
 -- during "bazel run"; thus, non-test binaries should set the
 -- environment manually for processes that they call.
 env :: Runfiles -> [(String, String)]
-env (Runfiles f) = [(runfilesDirEnv, f)]
+env (RunfilesRoot f) = [(runfilesDirEnv, f)]
+env (RunfilesManifest f _) = [(manifestFileEnv, f), (manifestOnlyEnv, "1")]
 
 runfilesDirEnv :: String
 runfilesDirEnv = "RUNFILES_DIR"
 
--- | Locate the runfiles directory for the current binary.
+manifestFileEnv :: String
+manifestFileEnv = "RUNFILES_MANIFEST_FILE"
+
+manifestOnlyEnv :: String
+manifestOnlyEnv = "RUNFILES_MANIFEST_ONLY"
+
+
+-- | Locate the runfiles directory or manifest for the current binary.
 --
 -- This behaves according to the specification in:
 -- https://docs.google.com/document/d/e/2PACX-1vSDIrFnFvEYhKsCMdGdD40wZRBX3m3aZ5HhVj4CtHPmiXKDCxioTUbYsDydjKtFDAzER5eg7OjJWs3V/pub
---
--- Note: it does not currently support the @RUNFILES_MANIFEST@ environmental
--- variable.  However, that's only necessary on Windows, which rules_haskell
--- doesn't support yet anyway.
 create :: IO Runfiles
 create = do
-    exeRunfilesPath <- fmap (<.> "runfiles") getExecutablePath
-    exeRunfilesExists <- doesDirectoryExist exeRunfilesPath
-    if exeRunfilesExists
-      then return $ Runfiles exeRunfilesPath
-      else do
-        envDir <- lookupEnv runfilesDirEnv
-        case envDir of
-            Just f -> return $ Runfiles f
-            Nothing -> error "Unable to locate runfiles directory"
+    exePath <- getExecutablePath
+
+    mbRunfiles <- runMaybeT $ asum
+      [ do
+        -- Bazel sets RUNFILES_MANIFEST_ONLY=1 if the manifest file should be
+        -- used instead of the runfiles root.
+        manifestOnly <- liftIO $ lookupEnv manifestOnlyEnv
+        guard (manifestOnly /= Just "1")
+        -- Locate runfiles directory relative to executable or by environment.
+        runfilesRoot <- asum
+          [ do
+            let dir = exePath <.> "runfiles"
+            exists <- liftIO $ doesDirectoryExist dir
+            guard exists
+            pure dir
+          , do
+            dir <- MaybeT $ lookupEnv runfilesDirEnv
+            exists <- liftIO $ doesDirectoryExist dir
+            guard exists
+            pure dir
+          ]
+        -- Existence alone is not sufficient, on Windows Bazel creates a
+        -- runfiles directory containing only MANIFEST. We need to check that
+        -- more entries exist, before we commit to using the runfiles
+        -- directory.
+        containsData <- liftIO $ containsOneDataFile runfilesRoot
+        guard containsData
+        pure $! RunfilesRoot runfilesRoot
+      , do
+        -- Locate manifest file relative to executable or by environment.
+        manifestPath <- asum
+          [ do
+            let file = exePath <.> "runfiles_manifest"
+            exists <- liftIO $ doesFileExist file
+            guard exists
+            pure file
+          , do
+            file <- MaybeT $ lookupEnv manifestFileEnv
+            exists <- liftIO $ doesFileExist file
+            guard exists
+            pure file
+          ]
+        content <- liftIO $ readFile manifestPath
+        let mapping = parseManifest content
+        pure $! RunfilesManifest manifestPath mapping
+      ]
+
+    case mbRunfiles of
+        Just runfiles -> pure runfiles
+        Nothing -> error "Unable to locate runfiles directory or manifest"
+
+-- | Check if the given directory contains at least one data file.
+--
+-- Traverses the given directory tree until a data file is found. A file named
+-- @MANIFEST@ does not count, as it corresponds to @runfiles_manifest@.
+--
+-- Assumes that the given filepath exists and is a directory.
+containsOneDataFile :: FilePath -> IO Bool
+containsOneDataFile = loop
+  where
+    loop fp = do
+        isDir <- doesDirectoryExist fp
+        if isDir
+            then anyM loop =<< listDirectory fp
+            else pure $! fp /= "MANIFEST"
+
+-- | Check if the given predicate holds on any of the given values.
+--
+-- Short-circuting:
+-- Stops iteration on the first element for which the predicate holds.
+anyM :: Monad m => (a -> m Bool) -> [a] -> m Bool
+anyM predicate = loop
+  where
+    loop [] = pure False
+    loop (x:xs) = do
+        b <- predicate x
+        if b
+            then pure True
+            else loop xs
+
+-- | Parse Bazel's manifest file content.
+--
+-- The manifest file holds lines of keys and values separted by a space.
+parseManifest :: String -> [(FilePath, FilePath)]
+parseManifest = map parseLine . lines
+  where
+    parseLine l =
+        let (key, value) = span (/= ' ') l in
+        (key, dropWhile (== ' ') value)

--- a/tools/runfiles/test/Test.hs
+++ b/tools/runfiles/test/Test.hs
@@ -2,6 +2,7 @@ module Main (main) where
 
 import qualified Bazel.Runfiles as Runfiles
 import Control.Monad (when)
+import System.Info (os)
 import System.Process (callProcess)
 
 main :: IO ()
@@ -10,4 +11,6 @@ main = do
     foo <- readFile (Runfiles.rlocation r "io_tweag_rules_haskell/tools/runfiles/test-data.txt")
     when (lines foo /= ["foo"]) -- ignore trailing newline
         $ error $ "Incorrect contents: got: " ++ show foo
-    callProcess (Runfiles.rlocation r "io_tweag_rules_haskell/tools/runfiles/bin") []
+    let bin | os == "mingw32" =  "io_tweag_rules_haskell/tools/runfiles/bin.exe"
+            | otherwise       =  "io_tweag_rules_haskell/tools/runfiles/bin"
+    callProcess (Runfiles.rlocation r bin) []


### PR DESCRIPTION
Bazel has [two different mechanisms](https://docs.google.com/document/d/e/2PACX-1vSDIrFnFvEYhKsCMdGdD40wZRBX3m3aZ5HhVj4CtHPmiXKDCxioTUbYsDydjKtFDAzER5eg7OjJWs3V/pub) for supplying runfiles to binaries and tests:
- `<exe>.runfiles/` - A directory tree of symbolic links to runfile dependencies
- `<exe>.runfiles_manifest` - A text file mapping runfile dependencies to their paths

On Unix Bazel uses `.runfiles`, on Windows Bazel defaults to `.runfiles_manifest`, since many configurations don't allow creating symbolic links on Windows. Bazel can be forced to use `.runfiles` on Windows by setting `--experimental_enable_runfiles`, however, this [requires admin permissions or special system configuration](https://blogs.windows.com/windowsdeveloper/2016/12/02/symlinks-windows-10/).

This PR
- Adds support for `.runfiles_manifest` to the `bazel-runfiles` library.
    - The current API is unchanged: `create` performs the necessary `IO` and decides which mechanism to use, `rlocation` is pure and constructs a runfiles path for the given dependency.
    - Supports locating directories also when using `.runfiles_manifest`, as is already supported when using `.runfiles` (needed for Cabal paths module in Hazel)
- Removes `--experimental_enable_runfiles` such that the `.runfiles_manifest` mechanism is tested on Windows CI and Windows users can build and test rules_haskell without admin permissions or special configuration.
- Changes Hazel's Cabal paths module implementation to use `bazel-runfiles`.
    This enables a Hazel built `hlint` to work on Unix and Windows as follows. (Before it failed to find its builtin hint files and aborted)
    ```
    bazel build @haskell_hlint//:bin
    bazel-bin/external/haskell_hlint/bin ./some/path
    ```

Closes #638