### PR TITLE
bazel_runfiles: Normalize manifest

### DIFF
--- a/tools/runfiles/src/Bazel/Runfiles.hs
+++ b/tools/runfiles/src/Bazel/Runfiles.hs
@@ -189,4 +189,4 @@ parseManifest = map parseLine . lines
   where
     parseLine l =
         let (key, value) = span (/= ' ') l in
-        (key, dropWhile (== ' ') value)
+        (normalize key, normalize $ dropWhile (== ' ') value)


### PR DESCRIPTION
Normalize the entries of the parsed manifest file. This is important on Windows where filepaths are case insensitive, but the manifest file can contain upper case entries nonetheless.