### PR TITLE
Bazel 0.28 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,18 +32,15 @@ jobs:
             apt-get install -y wget gnupg golang make libgmp3-dev libtinfo-dev libtinfo5 pkg-config zip g++ zlib1g-dev unzip python python3 bash-completion locales
             echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen
             locale-gen
-            wget "https://github.com/bazelbuild/bazel/releases/download/0.27.0/bazel_0.27.0-linux-x86_64.deb"
-            dpkg -i bazel_0.27.0-linux-x86_64.deb
+            wget "https://github.com/bazelbuild/bazel/releases/download/0.28.0/bazel_0.28.0-linux-x86_64.deb"
+            dpkg -i bazel_0.28.0-linux-x86_64.deb
             echo "common:ci --build_tag_filters -requires_hackage,-requires_lz4,-requires_zlib,-requires_doctest,-requires_c2hs,-requires_threaded_rts,-dont_test_with_bindist" > .bazelrc.local
             # XXX: See .bazelrc [backward compatible options] for the the rational behind this flag
             echo "build --incompatible_use_python_toolchains=false" >> .bazelrc.local
       - run:
           name: Build tests
           command: |
-            # XXX bazel 0.27 regression: https://github.com/bazelbuild/bazel/issues/8723
-            # tag filtering (used here to disable rules with dependency to nixpkgs) is broken for
-            # rule_test. Workaround here is to just ignore theses rules using -//...
-            bazel build --config ci //tests/... -- -//tests:test-haskell_doctest_impl -//tests:test-binary-with-prebuilt_impl -//tests:test-haddock_impl
+            bazel build --config ci //tests/...
       - run:
           name: Run tests
           command: |

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -359,9 +359,9 @@ node_repositories(
 
 http_archive(
     name = "io_bazel_skydoc",
-    sha256 = "19eb6c162075707df5703c274d3348127625873dbfa5ff83b1ef4b8f5dbaa449",
-    strip_prefix = "skydoc-0.2.0",
-    urls = ["https://github.com/bazelbuild/skydoc/archive/0.2.0.tar.gz"],
+    sha256 = "c2d66a0cc7e25d857e480409a8004fdf09072a1bd564d6824441ab2f96448eea",
+    strip_prefix = "skydoc-0.3.0",
+    urls = ["https://github.com/bazelbuild/skydoc/archive/0.3.0.tar.gz"],
 )
 
 load("@io_bazel_skydoc//:setup.bzl", "skydoc_repositories")
@@ -372,16 +372,16 @@ skydoc_repositories()
 
 http_archive(
     name = "io_bazel_rules_go",
-    sha256 = "9084496dde809363c491137e077ace81780463ead0060a0a6c3c4c0f613e9fcb",
-    strip_prefix = "rules_go-0.18.6",
-    urls = ["https://github.com/bazelbuild/rules_go/archive/0.18.6.tar.gz"],
+    sha256 = "1ad10f384053ae50c050fdec7d595d12427c82c0a27c58f8554deb4437216892",
+    strip_prefix = "rules_go-0.18.7",
+    urls = ["https://github.com/bazelbuild/rules_go/archive/0.18.7.tar.gz"],
 )
 
 http_archive(
     name = "com_github_bazelbuild_buildtools",
-    sha256 = "86592d703ecbe0c5cbb5139333a63268cf58d7efd2c459c8be8e69e77d135e29",
-    strip_prefix = "buildtools-0.26.0",
-    urls = ["https://github.com/bazelbuild/buildtools/archive/0.26.0.tar.gz"],
+    sha256 = "5ec71602e9b458b01717fab1d37492154c1c12ea83f881c745dbd88e9b2098d8",
+    strip_prefix = "buildtools-0.28.0",
+    urls = ["https://github.com/bazelbuild/buildtools/archive/0.28.0.tar.gz"],
 )
 
 # A repository that generates the Go SDK imports, see ./tools/go_sdk/README

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,7 +9,7 @@ jobs:
       architecture: 'x64'
   - bash: |
       set -e
-      curl -LO https://github.com/bazelbuild/bazel/releases/download/0.27.0/bazel-0.27.0-windows-x86_64.exe
+      curl -LO https://github.com/bazelbuild/bazel/releases/download/0.28.0/bazel-0.28.0-windows-x86_64.exe
       mv bazel-*.exe bazel.exe
       mkdir /c/bazel
       mv bazel.exe /c/bazel

--- a/nixpkgs/default.nix
+++ b/nixpkgs/default.nix
@@ -1,4 +1,8 @@
+let
+  sha256 = "093n9ci000vlhz700mrkdv7jnx6szgmggl0x0wbr1d0yrg2y7q43";
+  rev = "f612ab79002c546d668c4f4ee3d5321fc814b838";
+in
 import (fetchTarball {
-   url = https://github.com/NixOS/nixpkgs/archive/a2075a2c314ccb3df6522dd957bb4e237446dc49.tar.gz;
-   sha256 = "1jbnjw06mca7867q81v3i3jljj0wpm38y9zjwij3nd6pp2bqhvbr";
+  inherit sha256;
+  url = "https://github.com/NixOS/nixpkgs/archive/${rev}.tar.gz";
 })


### PR DESCRIPTION
Straight forward upgrade. Just a few dependencies path where updated
to their latest versions.

Closes #989 