### PR TITLE
MAINTAINERS: add section on how to bump bazel version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## Upcoming release
 
+### Highlights
+
+* The minimum supported Bazel version is now 0.27.
+  `rules_haskell` supports Bazel up to 0.28.
+
+  0.27 is a LTS release, which means upstream guarantees all new
+  releases are backwards-compatible to it for 3 months. See the [Bazel
+  Stability](https://blog.bazel.build/2019/06/06/Bazel-Semantic-Versioning.html)
+  blog post for more information.
+
 ### Removed
 
 * The `haskell_lint` rule has been removed. It should have been

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -34,3 +34,22 @@
   test it in a temporary directory, create PR against master, publish
   start script.
 - [ ] Announce the new version (on Twitter)
+
+
+## Bumping bazel version
+
+`rules_haskell` should always support the latest LTS release of bazel.
+
+We strive to always test against the latest non-LTS release
+nonetheless, so bumping bazel regularly is required.
+
+- [ ] Bump bazel download link for bazel in `.circleci/config.yml`
+- [ ] Bump bazel download link for bazel in `azure-pipelines.yml`
+- [ ] Update all bazel rules dependencies in `WORKSPACE` (e.g.
+      `io_bazel_skydoc`)
+- [ ] Update bazel in nixpkgs and bump `nixpkgs/default.nix`
+- [ ] Bump MAX_BAZEL_* in `start`
+- If we are updating to a new LTS:
+  - Bump `MIN_BAZEL_*` in `start`
+  - TODO
+- [ ] Add update notice to `CHANGELOG`

--- a/start
+++ b/start
@@ -4,10 +4,10 @@
 # a new Bazel workspace with dummy Haskell build targets.
 
 MIN_BAZEL_MAJOR=0
-MIN_BAZEL_MINOR=24
+MIN_BAZEL_MINOR=27
 
 MAX_BAZEL_MAJOR=0
-MAX_BAZEL_MINOR=27
+MAX_BAZEL_MINOR=28
 
 set -e
 


### PR DESCRIPTION
Adds a TODO list that describes changes necessary to bump the bazel version.

Bumps the minor supported version to 0.27, which https://github.com/tweag/rules_haskell/pull/995 forgot to do.