### PR TITLE
Pass -hide-all-packages to ghci in wrapper script

### DIFF
--- a/haskell/repl.bzl
+++ b/haskell/repl.bzl
@@ -211,7 +211,7 @@ def _create_repl(hs, ctx, repl_info, output):
 
     # The base and directory packages are necessary for the GHCi script we use
     # (loads source files and brings in scope the corresponding modules).
-    args = ["-package", "base", "-package", "directory"]
+    args = ["-hide-all-packages", "-package", "base", "-package", "directory"]
 
     # Load built dependencies (-package-id, -package-db)
     for package_id in repl_info.dep_info.package_ids:


### PR DESCRIPTION
If ghc comes with a rich package-db (e.g., if provisioned using using nixpkgs's `ghcWithPackages`), then we need to ensure they are not in scope, or we may get package import conflicts, etc.