### PR TITLE
BuildKite support

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -6,7 +6,6 @@
 build:windows --crosstool_top=@rules_haskell_ghc_windows_amd64//:cc_toolchain -s --verbose_failures --sandbox_debug
 
 build:ci --loading_phase_threads=1
-build:ci --jobs=2
 build:ci --verbose_failures
 # Make sure we don't rely on the names of convenience symlinks because those
 # can be changed by user.

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,0 +1,14 @@
+steps:
+  - command: |
+      . /var/lib/buildkite-agent/.nix-profile/etc/profile.d/nix.sh
+      echo "build:ci --host_platform=@rules_haskell//haskell/platforms:linux_x86_64_nixpkgs" > .bazelrc.local
+      nix-shell --arg docTools false --pure --run \
+          'bazel build --config ci //tests:run-tests'
+      # TODO(Profpatsch) re-add a nixpkgs startup script
+      # and enable this test again
+      nix-shell --arg docTools false --pure --run \
+          './bazel-ci-bin/tests/run-tests --skip "/startup script/"'
+      nix-shell --arg docTools false --pure --run \
+          'bazel coverage //tests/... --config ci --build_tag_filters "coverage-compatible" --test_tag_filters "coverage-compatible" --test_output=all'
+    label: "Run tests"
+    timeout: 30

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -10,5 +10,13 @@ steps:
           './bazel-ci-bin/tests/run-tests --skip "/startup script/"'
       nix-shell --arg docTools false --pure --run \
           'bazel coverage //tests/... --config ci --build_tag_filters "coverage-compatible" --test_tag_filters "coverage-compatible" --test_output=all'
-    label: "Run tests"
+    label: "Run tests (Nixpkgs)"
+    timeout: 30
+  - command: |
+      echo "common:ci --build_tag_filters -requires_hackage,-requires_lz4,-requires_zlib,-requires_doctest,-requires_c2hs,-requires_threaded_rts,-dont_test_with_bindist" > .bazelrc.local
+      # XXX: See .bazelrc [backward compatible options] for the the rational behind this flag
+      echo "build --incompatible_use_python_toolchains=false" >> .bazelrc.local
+      bazel build --config ci //tests/...
+      ./tests/run-start-script.sh
+    label: "Run tests (bindists)"
     timeout: 30

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,38 +18,6 @@ version: 2
 #       doing it.
 
 jobs:
-  build-linux-ghc-bindist:
-    docker:
-      - image: debian
-    working_directory: ~/rules_haskell
-    resource_class: large
-    steps:
-      - checkout
-      - run:
-          name: Setup test environment
-          command: |
-            apt-get update
-            apt-get install -y wget gnupg golang make libgmp3-dev libtinfo-dev libtinfo5 pkg-config zip g++ zlib1g-dev unzip python python3 bash-completion locales
-            echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen
-            locale-gen
-            wget "https://github.com/bazelbuild/bazel/releases/download/0.28.0/bazel_0.28.0-linux-x86_64.deb"
-            dpkg -i bazel_0.28.0-linux-x86_64.deb
-            echo "common:ci --build_tag_filters -requires_hackage,-requires_lz4,-requires_zlib,-requires_doctest,-requires_c2hs,-requires_threaded_rts,-dont_test_with_bindist" > .bazelrc.local
-            # XXX: See .bazelrc [backward compatible options] for the the rational behind this flag
-            echo "build --incompatible_use_python_toolchains=false" >> .bazelrc.local
-      - run:
-          name: Build tests
-          command: |
-            bazel build --config ci //tests/...
-      - run:
-          name: Run tests
-          command: |
-            # Run the start script test.
-            # Doesn't use the test suite binary, because that depends on nixpkgs dependencies.
-            ./tests/run-start-script.sh
-            # TODO: enable all tests for bindists
-            # (this will require tests to both work with nixpkgs and hazel backends)
-
   build-darwin:
     macos:
       xcode: "9.0"
@@ -142,6 +110,5 @@ workflows:
   version: 2
   build:
     jobs:
-      - build-linux-ghc-bindist
       - build-darwin:
           context: org-global # for the cachix token

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,61 +50,6 @@ jobs:
             # TODO: enable all tests for bindists
             # (this will require tests to both work with nixpkgs and hazel backends)
 
-  # ATTN: when you change anything here, don’t forget to copy it to the build-darwin section
-  build-linux-nixpkgs:
-    docker:
-      - image: nixos/nix:2.1.3
-    working_directory: ~/rules_haskell
-    resource_class: large
-    steps:
-      - checkout
-      - run:
-          name: System dependencies
-          command: |
-            set -e
-            apk --no-progress update
-            apk --no-progress add bash ca-certificates
-
-            mkdir -p /etc/nix
-            # CircleCI and Nix sandboxing don't play nice. See
-            # https://discourse.nixos.org/t/nixos-on-ovh-kimsufi-cloning-builder-process-operation-not-permitted/1494/5
-            echo "sandbox = false" > /etc/nix/nix.conf
-            # No builders and no local jobs ensures that everything has to come from a binary cache
-            # If we want to add packages that are not cached by the offical NixOS binary cache,
-            # we need to manually build them (e.g. `nix-build -A <dependency> --max-jobs <no-cpu-cores>`).
-            # This is a sanity check.
-            echo "builders =" >> /etc/nix/nix.conf
-            echo "max-jobs = 0" >> /etc/nix/nix.conf
-      - run:
-          name: Configure
-          command: |
-            echo "build:ci --host_platform=@rules_haskell//haskell/platforms:linux_x86_64_nixpkgs" > .bazelrc.local
-      - run:
-          name: Prefetch Stackage snapshot
-          command: |
-            # Retry if needed due to network flakiness.
-            nix-shell --arg docTools false --pure --run \
-              'cmd="bazel fetch @stackage//..."; $cmd || $cmd || $cmd'
-      - run:
-          name: Build tests
-          command: |
-            nix-shell --arg docTools false --pure --run \
-              'bazel build --config ci //tests/...'
-      - run:
-          name: Run tests
-          # bazel does not support recursive bazel call, so we
-          # cannot use bazel run here because the test runner uses
-          # bazel
-          command: |
-            nix-shell --arg docTools false --pure --run \
-              'bazel build --config ci //tests:run-tests'
-            # TODO(Profpatsch) re-add a nixpkgs startup script
-            # and enable this test again
-            nix-shell --arg docTools false --pure --run \
-              './bazel-ci-bin/tests/run-tests --skip "/startup script/"'
-            nix-shell --arg docTools false --pure --run \
-              'bazel coverage //tests/... --config ci --build_tag_filters "coverage-compatible" --test_tag_filters "coverage-compatible" --test_output=all'
-
   build-darwin:
     macos:
       xcode: "9.0"
@@ -198,6 +143,5 @@ workflows:
   build:
     jobs:
       - build-linux-ghc-bindist
-      - build-linux-nixpkgs
       - build-darwin:
           context: org-global # for the cachix token

--- a/tests/RunTests.hs
+++ b/tests/RunTests.hs
@@ -82,15 +82,11 @@ main = hspec $ do
     assertSuccess (bazel ["test", "//..."]) { Process.cwd = Just "./tutorial" }
 
   describe "Hazel" $ do
-    -- TODO Reenable Hazel tests. As of 2019-07, they are disabled due to no
-    -- large enough CircleCI resource class being available (need "large" at
-    -- a minimum).
-    return ()
-    -- it "bazel test" $ do
-    --   assertSuccess (bazel ["test", "@ai_formation_hazel//..."])
-    -- for_ hazelPackages $ \pkg -> do
-    --   it ("builds " ++ pkg) $ do
-    --     assertSuccess (bazel ["build", "@haskell_" ++ pkg ++ "//..."])
+    it "bazel test" $ do
+      assertSuccess (bazel ["test", "@ai_formation_hazel//..."])
+    for_ hazelPackages $ \pkg -> do
+      it ("builds " ++ pkg) $ do
+        assertSuccess (bazel ["build", "@haskell_" ++ pkg ++ "//..."])
 
       where
         hazelPackages =


### PR DESCRIPTION
Migrate Nixpkgs Linux job, which is flaky on CircleCI due to
underpowered resource classes, to BuildKite.