### PR TITLE
Allow reexporting a package from a `haskell_library`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 * The `haskell_register_toolchains()` macro is deprecated. Use
   `rules_haskell_toolchains()` from `haskell/repositories.bzl`
   instead.
-- The `exports` attribute has been renamed to `module_exports`
+- The `exports` attribute has been renamed to `reexported_modules`
 - A new `exports` attribtue allows to re-export other libraries
 
 [bazel-rule-guidelines]: https://docs.bazel.build/versions/master/skylark/deploying.html

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 * The `haskell_register_toolchains()` macro is deprecated. Use
   `rules_haskell_toolchains()` from `haskell/repositories.bzl`
   instead.
+- The `exports` attribute has been renamed to `module_exports`
+- A new `exports` attribtue allows to re-export other libraries
 
 [bazel-rule-guidelines]: https://docs.bazel.build/versions/master/skylark/deploying.html
 

--- a/haskell/cabal.bzl
+++ b/haskell/cabal.bzl
@@ -239,7 +239,7 @@ def _haskell_cabal_library_impl(ctx):
         interface_dirs = depset([interfaces_dir], transitive = [dep_info.interface_dirs]),
         compile_flags = [],
     )
-    lib_info = HaskellLibraryInfo(package_id = name, version = None)
+    lib_info = HaskellLibraryInfo(package_id = name, version = None, package_reexports = [])
     cc_toolchain = find_cpp_toolchain(ctx)
     feature_configuration = cc_common.configure_features(
         ctx = ctx,

--- a/haskell/cabal.bzl
+++ b/haskell/cabal.bzl
@@ -239,7 +239,7 @@ def _haskell_cabal_library_impl(ctx):
         interface_dirs = depset([interfaces_dir], transitive = [dep_info.interface_dirs]),
         compile_flags = [],
     )
-    lib_info = HaskellLibraryInfo(package_id = name, version = None, package_reexports = [])
+    lib_info = HaskellLibraryInfo(package_id = name, version = None, exports = [])
     cc_toolchain = find_cpp_toolchain(ctx)
     feature_configuration = cc_common.configure_features(
         ctx = ctx,

--- a/haskell/defs.bzl
+++ b/haskell/defs.bzl
@@ -221,6 +221,10 @@ haskell_library = rule(
         exports = attr.label_keyed_string_dict(
             doc = "A dictionary mapping dependencies to module reexports that should be available for import by dependencies.",
         ),
+        package_reexports = attr.label_list(
+            default = [],
+            doc = "A list of other haskell libraries that will be transparently added as a dependency to every downstream rule",
+        ),
         linkstatic = attr.bool(
             default = False,
             doc = "Create a static library, not both a static and a shared library.",

--- a/haskell/defs.bzl
+++ b/haskell/defs.bzl
@@ -218,7 +218,7 @@ haskell_library = rule(
         hidden_modules = attr.string_list(
             doc = "Modules that should be unavailable for import by dependencies.",
         ),
-        module_exports = attr.label_keyed_string_dict(
+        reexported_modules = attr.label_keyed_string_dict(
             doc = "A dictionary mapping dependencies to module reexports that should be available for import by dependencies.",
         ),
         exports = attr.label_list(
@@ -260,7 +260,7 @@ Example:
       deps = [
           "//hello-sublib:lib",
       ],
-      module_exports = {
+      reexported_modules = {
           "//hello-sublib:lib": "Lib1 as HelloLib1, Lib2",
       },
   )

--- a/haskell/defs.bzl
+++ b/haskell/defs.bzl
@@ -218,10 +218,10 @@ haskell_library = rule(
         hidden_modules = attr.string_list(
             doc = "Modules that should be unavailable for import by dependencies.",
         ),
-        exports = attr.label_keyed_string_dict(
+        module_exports = attr.label_keyed_string_dict(
             doc = "A dictionary mapping dependencies to module reexports that should be available for import by dependencies.",
         ),
-        package_reexports = attr.label_list(
+        exports = attr.label_list(
             default = [],
             doc = "A list of other haskell libraries that will be transparently added as a dependency to every downstream rule",
         ),
@@ -260,7 +260,7 @@ Example:
       deps = [
           "//hello-sublib:lib",
       ],
-      exports = {
+      module_exports = {
           "//hello-sublib:lib": "Lib1 as HelloLib1, Lib2",
       },
   )

--- a/haskell/doctest.bzl
+++ b/haskell/doctest.bzl
@@ -7,7 +7,6 @@ load(":private/set.bzl", "set")
 load(
     "@rules_haskell//haskell:providers.bzl",
     "HaskellInfo",
-    "HaskellLibraryInfo",
     "get_ghci_extra_libs",
 )
 
@@ -83,7 +82,6 @@ def _haskell_doctest_single(target, ctx):
 
     hs_info = target[HaskellInfo]
     cc_info = target[CcInfo]
-    lib_info = target[HaskellLibraryInfo] if HaskellLibraryInfo in target else None
 
     args = ctx.actions.args()
     args.add("--no-magic")

--- a/haskell/private/actions/compile.bzl
+++ b/haskell/private/actions/compile.bzl
@@ -18,6 +18,7 @@ load(":private/version_macros.bzl", "version_macro_includes")
 load(
     ":providers.bzl",
     "HaskellLibraryInfo",
+    "all_dependencies_package_ids",
     "get_ghci_extra_libs",
 )
 load(":private/set.bzl", "set")
@@ -153,6 +154,10 @@ def _compilation_defaults(hs, cc, java, dep_info, plugin_dep_info, cc_info, srcs
     if hs.toolchain.is_darwin:
         compile_flags += ["-optl-Wl,-dead_strip_dylibs"]
 
+    package_ids = []
+    for plugin in plugins:
+        package_ids.extend(all_dependencies_package_ids(plugin.deps))
+
     (pkg_info_inputs, pkg_info_args) = pkg_info_to_compile_flags(
         hs,
         pkg_info = expose_packages(
@@ -161,12 +166,7 @@ def _compilation_defaults(hs, cc, java, dep_info, plugin_dep_info, cc_info, srcs
             version = version,
         ),
         plugin_pkg_info = expose_packages(
-            package_ids = [
-                dep[HaskellLibraryInfo].package_id
-                for plugin in plugins
-                for dep in plugin.deps
-                if HaskellLibraryInfo in dep
-            ],
+            package_ids = package_ids,
             package_databases = plugin_dep_info.package_databases,
             version = version,
         ),

--- a/haskell/private/actions/repl.bzl
+++ b/haskell/private/actions/repl.bzl
@@ -64,6 +64,8 @@ def build_haskell_repl(
     lib_imports = []
     if lib_info != None:
         for idir in set.to_list(hs_info.import_dirs):
+            if type(idir) != type(""):  # idir can also be a `File`
+                idir = idir.path
             args += ["-i{0}".format(idir)]
             lib_imports.append(idir)
 

--- a/haskell/private/context.bzl
+++ b/haskell/private/context.bzl
@@ -11,7 +11,7 @@ def haskell_context(ctx, attr = None):
     if not attr:
         attr = ctx.attr
 
-    deps = attr.deps if hasattr(attr, "deps") else []
+    deps = (attr.deps if hasattr(attr, "deps") else []) + (attr.package_reexports if hasattr(attr, "package_reexports") else [])
     package_ids = all_dependencies_package_ids(deps)
 
     if hasattr(attr, "src_strip_prefix"):

--- a/haskell/private/context.bzl
+++ b/haskell/private/context.bzl
@@ -11,7 +11,7 @@ def haskell_context(ctx, attr = None):
     if not attr:
         attr = ctx.attr
 
-    deps = (attr.deps if hasattr(attr, "deps") else []) + (attr.package_reexports if hasattr(attr, "package_reexports") else [])
+    deps = (attr.deps if hasattr(attr, "deps") else []) + (attr.exports if hasattr(attr, "exports") else [])
     package_ids = all_dependencies_package_ids(deps)
 
     if hasattr(attr, "src_strip_prefix"):

--- a/haskell/private/context.bzl
+++ b/haskell/private/context.bzl
@@ -1,7 +1,7 @@
 """Derived context with Haskell-specific fields and methods"""
 
 load("@bazel_skylib//lib:paths.bzl", "paths")
-load("@rules_haskell//haskell:providers.bzl", "HaskellLibraryInfo")
+load("@rules_haskell//haskell:providers.bzl", "HaskellLibraryInfo", "all_dependencies_package_ids")
 
 HaskellContext = provider()
 
@@ -11,14 +11,8 @@ def haskell_context(ctx, attr = None):
     if not attr:
         attr = ctx.attr
 
-    if hasattr(attr, "deps"):
-        package_ids = [
-            dep[HaskellLibraryInfo].package_id
-            for dep in attr.deps
-            if HaskellLibraryInfo in dep
-        ]
-    else:
-        package_ids = []
+    deps = attr.deps if hasattr(attr, "deps") else []
+    package_ids = all_dependencies_package_ids(deps)
 
     if hasattr(attr, "src_strip_prefix"):
         src_strip_prefix = attr.src_strip_prefix

--- a/haskell/private/haskell_impl.bzl
+++ b/haskell/private/haskell_impl.bzl
@@ -365,7 +365,8 @@ def _haskell_binary_common_impl(ctx, is_test):
 
 def haskell_library_impl(ctx):
     hs = haskell_context(ctx)
-    dep_info = gather_dep_info(ctx, ctx.attr.deps)
+    deps = ctx.attr.deps + ctx.attr.package_reexports
+    dep_info = gather_dep_info(ctx, deps)
     plugin_dep_info = gather_dep_info(
         ctx,
         [dep for plugin in ctx.attr.plugins for dep in plugin[GhcPluginInfo].deps],
@@ -373,7 +374,7 @@ def haskell_library_impl(ctx):
     cc_info = cc_common.merge_cc_infos(
         cc_infos = [
             dep[CcInfo]
-            for dep in ctx.attr.deps
+            for dep in deps
             if CcInfo in dep
         ] + [
             dep[CcInfo]
@@ -382,7 +383,7 @@ def haskell_library_impl(ctx):
             if CcInfo in dep
         ],
     )
-    package_ids = all_dependencies_package_ids(ctx.attr.deps)
+    package_ids = all_dependencies_package_ids(deps)
 
     # Add any interop info for other languages.
     cc = cc_interop_info(ctx)
@@ -519,7 +520,7 @@ def haskell_library_impl(ctx):
     hs_info = gather_dep_info(ctx, [my_dummy_struct] + ctx.attr.package_reexports)
 
     dep_coverage_data = []
-    for dep in ctx.attr.deps:
+    for dep in deps:
         if HaskellCoverageInfo in dep:
             dep_coverage_data += dep[HaskellCoverageInfo].coverage_data
 
@@ -611,7 +612,7 @@ def haskell_library_impl(ctx):
                 compilation_context = compilation_context,
                 linking_context = linking_context,
             ),
-        ] + [dep[CcInfo] for dep in ctx.attr.deps if CcInfo in dep],
+        ] + [dep[CcInfo] for dep in deps if CcInfo in dep],
     )
 
     return [

--- a/haskell/private/haskell_impl.bzl
+++ b/haskell/private/haskell_impl.bzl
@@ -7,6 +7,7 @@ load(
     "HaskellInfo",
     "HaskellLibraryInfo",
     "HaskellToolchainLibraryInfo",
+    "all_dependencies_package_ids",
 )
 load(":cc.bzl", "cc_interop_info")
 load(
@@ -181,11 +182,7 @@ def _haskell_binary_common_impl(ctx, is_test):
             if CcInfo in dep
         ],
     )
-    package_ids = [
-        dep[HaskellLibraryInfo].package_id
-        for dep in ctx.attr.deps
-        if HaskellLibraryInfo in dep
-    ]
+    package_ids = all_dependencies_package_ids(ctx.attr.deps)
 
     # Add any interop info for other languages.
     cc = cc_interop_info(ctx)
@@ -385,11 +382,7 @@ def haskell_library_impl(ctx):
             if CcInfo in dep
         ],
     )
-    package_ids = [
-        dep[HaskellLibraryInfo].package_id
-        for dep in ctx.attr.deps
-        if HaskellLibraryInfo in dep
-    ]
+    package_ids = all_dependencies_package_ids(ctx.attr.deps)
 
     # Add any interop info for other languages.
     cc = cc_interop_info(ctx)
@@ -512,6 +505,7 @@ def haskell_library_impl(ctx):
     lib_info = HaskellLibraryInfo(
         package_id = pkg_id.to_string(my_pkg_id),
         version = version,
+        package_reexports = [],
     )
 
     dep_coverage_data = []
@@ -787,6 +781,7 @@ def haskell_import_impl(ctx):
     lib_info = HaskellLibraryInfo(
         package_id = id,
         version = ctx.attr.version,
+        package_reexports = [],
     )
     default_info = DefaultInfo(
         files = depset(target_files),

--- a/haskell/private/haskell_impl.bzl
+++ b/haskell/private/haskell_impl.bzl
@@ -426,7 +426,7 @@ def haskell_library_impl(ctx):
     )
 
     other_modules = ctx.attr.hidden_modules
-    exposed_modules_reexports = _exposed_modules_reexports(ctx.attr.module_exports)
+    exposed_modules_reexports = _exposed_modules_reexports(ctx.attr.reexported_modules)
     exposed_modules_file = list_exposed_modules(
         hs,
         ls_modules = ctx.executable._ls_modules,
@@ -822,7 +822,7 @@ def haskell_import_impl(ctx):
         haddock_info,
     ]
 
-def _exposed_modules_reexports(module_exports):
+def _exposed_modules_reexports(reexported_modules):
     """Creates a ghc-pkg-compatible list of reexport declarations.
 
     A ghc-pkg registration file declares reexports as part of the
@@ -844,14 +844,14 @@ def _exposed_modules_reexports(module_exports):
     }
 
     Args:
-      module_exports: a dictionary mapping package targets to "Cabal-style"
+      reexported_modules: a dictionary mapping package targets to "Cabal-style"
                reexported-modules declarations.
 
     Returns:
       a ghc-pkg-compatible list of reexport declarations.
     """
     exposed_reexports = []
-    for dep, cabal_decls in module_exports.items():
+    for dep, cabal_decls in reexported_modules.items():
         for cabal_decl in cabal_decls.split(","):
             stripped_cabal_decl = cabal_decl.strip()
             cabal_decl_parts = stripped_cabal_decl.split(" as ")

--- a/haskell/protobuf.bzl
+++ b/haskell/protobuf.bzl
@@ -163,6 +163,7 @@ def _haskell_proto_aspect_impl(target, ctx):
         "data": [],
         "tools": [],
         "_cc_toolchain": ctx.attr._cc_toolchain,
+        "package_reexports": [],
     }
 
     patched_ctx = struct(

--- a/haskell/protobuf.bzl
+++ b/haskell/protobuf.bzl
@@ -153,7 +153,7 @@ def _haskell_proto_aspect_impl(target, ctx):
         "_ghci_script": ctx.attr._ghci_script,
         "_ghci_repl_wrapper": ctx.attr._ghci_repl_wrapper,
         "hidden_modules": [],
-        "exports": {},
+        "module_exports": {},
         "name": "proto-autogen-" + ctx.rule.attr.name,
         "srcs": hs_files,
         "extra_srcs": [],
@@ -163,7 +163,7 @@ def _haskell_proto_aspect_impl(target, ctx):
         "data": [],
         "tools": [],
         "_cc_toolchain": ctx.attr._cc_toolchain,
-        "package_reexports": [],
+        "exports": [],
     }
 
     patched_ctx = struct(

--- a/haskell/protobuf.bzl
+++ b/haskell/protobuf.bzl
@@ -153,7 +153,7 @@ def _haskell_proto_aspect_impl(target, ctx):
         "_ghci_script": ctx.attr._ghci_script,
         "_ghci_repl_wrapper": ctx.attr._ghci_repl_wrapper,
         "hidden_modules": [],
-        "module_exports": {},
+        "reexported_modules": {},
         "name": "proto-autogen-" + ctx.rule.attr.name,
         "srcs": hs_files,
         "extra_srcs": [],

--- a/haskell/providers.bzl
+++ b/haskell/providers.bzl
@@ -37,8 +37,20 @@ HaskellLibraryInfo = provider(
     fields = {
         "package_id": "Workspace unique package identifier.",
         "version": "Package version.",
+        "package_reexports": "List of other `HaskellLibraryInfo` that this package reexports",
     },
 )
+
+def all_package_ids(lib_info):
+    return [lib_info.package_id] + [sublib_info.package_id for sublib_info in lib_info.package_reexports]
+
+# XXX: Does this belong here?
+def all_dependencies_package_ids(deps):
+    package_ids = []
+    for dep in deps:
+        if HaskellLibraryInfo in dep:
+            package_ids.extend(all_package_ids(dep[HaskellLibraryInfo]))
+    return package_ids
 
 HaskellToolchainLibraryInfo = provider(
     doc = "Library that was imported via haskell_toolchain_library.",

--- a/haskell/providers.bzl
+++ b/haskell/providers.bzl
@@ -37,12 +37,12 @@ HaskellLibraryInfo = provider(
     fields = {
         "package_id": "Workspace unique package identifier.",
         "version": "Package version.",
-        "package_reexports": "List of other `HaskellLibraryInfo` that this package reexports",
+        "exports": "List of other `HaskellLibraryInfo` that this package reexports",
     },
 )
 
 def all_package_ids(lib_info):
-    return [lib_info.package_id] + [sublib_info.package_id for sublib_info in lib_info.package_reexports]
+    return [lib_info.package_id] + [sublib_info.package_id for sublib_info in lib_info.exports]
 
 # XXX: Does this belong here?
 def all_dependencies_package_ids(deps):

--- a/haskell/repl.bzl
+++ b/haskell/repl.bzl
@@ -16,6 +16,7 @@ load(
     "HaskellInfo",
     "HaskellLibraryInfo",
     "HaskellToolchainLibraryInfo",
+    "all_package_ids",
     "get_ghci_extra_libs",
 )
 load("@rules_haskell//haskell:private/set.bzl", "set")
@@ -127,7 +128,7 @@ def _create_HaskellReplCollectInfo(target, ctx):
     if HaskellLibraryInfo in target:
         lib_info = target[HaskellLibraryInfo]
         dep_infos[target.label] = HaskellReplDepInfo(
-            package_ids = [lib_info.package_id],
+            package_ids = all_package_ids(lib_info),
             package_databases = hs_info.package_databases,
             cc_info = target[CcInfo],
         )

--- a/tests/library-exports/BUILD.bazel
+++ b/tests/library-exports/BUILD.bazel
@@ -9,7 +9,7 @@ package(default_testonly = 1)
 haskell_library(
     name = "sublib",
     srcs = ["TestSubLib.hs"],
-    exports = {"//tests/hackage:containers": "Data.Map as SubLib.Map"},
+    module_exports = {"//tests/hackage:containers": "Data.Map as SubLib.Map"},
     deps = [
         "//tests/hackage:base",
         "//tests/hackage:containers",
@@ -19,7 +19,7 @@ haskell_library(
 haskell_library(
     name = "lib",
     srcs = ["TestLib.hs"],
-    exports = {
+    module_exports = {
         ":sublib": "TestSubLib",
         "//tests/hackage:containers": "Data.Map as Lib.Map",
     },
@@ -30,7 +30,7 @@ haskell_library(
 )
 
 haskell_test(
-    name = "library-exports",
+    name = "library-module_exports",
     size = "small",
     srcs = ["Bin.hs"],
     visibility = ["//visibility:public"],

--- a/tests/library-exports/BUILD.bazel
+++ b/tests/library-exports/BUILD.bazel
@@ -9,7 +9,7 @@ package(default_testonly = 1)
 haskell_library(
     name = "sublib",
     srcs = ["TestSubLib.hs"],
-    module_exports = {"//tests/hackage:containers": "Data.Map as SubLib.Map"},
+    reexported_modules = {"//tests/hackage:containers": "Data.Map as SubLib.Map"},
     deps = [
         "//tests/hackage:base",
         "//tests/hackage:containers",
@@ -19,7 +19,7 @@ haskell_library(
 haskell_library(
     name = "lib",
     srcs = ["TestLib.hs"],
-    module_exports = {
+    reexported_modules = {
         ":sublib": "TestSubLib",
         "//tests/hackage:containers": "Data.Map as Lib.Map",
     },
@@ -30,7 +30,7 @@ haskell_library(
 )
 
 haskell_test(
-    name = "library-module_exports",
+    name = "library-reexported_modules",
     size = "small",
     srcs = ["Bin.hs"],
     visibility = ["//visibility:public"],

--- a/tests/package-reexport/BUILD.bazel
+++ b/tests/package-reexport/BUILD.bazel
@@ -18,8 +18,8 @@ haskell_library(
 haskell_library(
     name = "dep",
     srcs = ["Dep.hs"],
-    package_reexports = [":transitive-dep"],
     visibility = ["//visibility:public"],
+    exports = [":transitive-dep"],
     deps = [
         "//tests/hackage:base",
     ],

--- a/tests/package-reexport/BUILD.bazel
+++ b/tests/package-reexport/BUILD.bazel
@@ -1,0 +1,36 @@
+load(
+    "@rules_haskell//haskell:defs.bzl",
+    "haskell_library",
+    "haskell_test",
+)
+
+package(default_testonly = 1)
+
+haskell_library(
+    name = "transitive-dep",
+    srcs = ["TransitiveDep.hs"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//tests/hackage:base",
+    ],
+)
+
+haskell_library(
+    name = "dep",
+    srcs = ["Dep.hs"],
+    package_reexports = [":transitive-dep"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//tests/hackage:base",
+    ],
+)
+
+haskell_test(
+    name = "final",
+    srcs = ["Final.hs"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":dep",
+        "//tests/hackage:base",
+    ],
+)

--- a/tests/package-reexport/Dep.hs
+++ b/tests/package-reexport/Dep.hs
@@ -1,0 +1,5 @@
+module Dep where
+
+whoAmI :: String
+whoAmI = "Dep"
+

--- a/tests/package-reexport/Dep.hs
+++ b/tests/package-reexport/Dep.hs
@@ -1,5 +1,9 @@
 module Dep where
 
+import qualified TransitiveDep
+
 whoAmI :: String
 whoAmI = "Dep"
 
+whoIsMyDep :: String
+whoIsMyDep = TransitiveDep.whoAmI

--- a/tests/package-reexport/Final.hs
+++ b/tests/package-reexport/Final.hs
@@ -1,9 +1,8 @@
 module Main where
 
-import qualified TransitiveDep 
-
-whoIsMySubDep :: String
-whoIsMySubDep = TransitiveDep.whoAmI
+import qualified TransitiveDep
+import qualified Dep
+import           Control.Exception (assert)
 
 main :: IO ()
-main = putStrLn whoIsMySubDep
+main = pure $ assert (TransitiveDep.whoAmI == Dep.whoIsMyDep) ()

--- a/tests/package-reexport/Final.hs
+++ b/tests/package-reexport/Final.hs
@@ -1,0 +1,9 @@
+module Main where
+
+import qualified TransitiveDep 
+
+whoIsMySubDep :: String
+whoIsMySubDep = TransitiveDep.whoAmI
+
+main :: IO ()
+main = putStrLn whoIsMySubDep

--- a/tests/package-reexport/TransitiveDep.hs
+++ b/tests/package-reexport/TransitiveDep.hs
@@ -1,0 +1,4 @@
+module TransitiveDep where
+
+whoAmI :: String
+whoAmI = "TransitiveDep"


### PR DESCRIPTION
This is the re-opening of #757 (because github doesn't allow me to directly reopen it)

I eventually found the time to finish this.

I didn't reuse the `exports` field since I find it a bit disturbing to suddenly change the meaning of an existing attribute, so the field is called `package_reexports` instead.

So the semantics now are that if a rule `foo` has `package_reexports = [ "bar ]`, then

- `foo` will depend on `bar` (as if it was in its `deps` field)
- Any rule that (directly)  depends on `foo` will see `bar` as if it was in its dependencies
- Running `foo@repl` will load both the modules of `foo` and `bar`