### PR TITLE
Download Stack if possible

### DIFF
--- a/haskell/private/workspace_utils.bzl
+++ b/haskell/private/workspace_utils.bzl
@@ -12,7 +12,7 @@ def execute_or_fail_loudly(repository_ctx, arguments):
       exec_result: The output of the command.
 
     """
-    exec_result = repository_ctx.execute(arguments)
+    exec_result = repository_ctx.execute(arguments, quiet = True)
     if exec_result.return_code != 0:
         arguments = [_as_string(x) for x in arguments]
         fail("\n".join(["Command failed: " + " ".join(arguments), exec_result.stderr]))


### PR DESCRIPTION
If we don't find a recent enough Stack on the PATH, then just download
one locally and use that. Since this is happening in a workspace rule,
we have no choice but to use prebuilt binaries. This behaviour brings
us closer to what rules_jvm_external does, which likewise downloads
a tool used to compute the dependency graph.

NixOS users will of course need to continue providing Stack in the
shell, because the Stack bindists don't work there.