### PR TITLE
Run more tests when using bindists

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -13,7 +13,7 @@ steps:
     label: "Run tests (Nixpkgs)"
     timeout: 30
   - command: |
-      echo "common:ci --build_tag_filters -requires_hackage,-requires_lz4,-requires_proto,-requires_zlib,-requires_doctest,-requires_c2hs,-requires_threaded_rts,-dont_test_with_bindist" > .bazelrc.local
+      echo "common:ci --build_tag_filters -requires_lz4,-requires_proto,-requires_zlib,-requires_doctest,-requires_c2hs,-requires_threaded_rts,-dont_test_with_bindist" > .bazelrc.local
       # XXX: See .bazelrc [backward compatible options] for the the rational behind this flag
       echo "build --incompatible_use_python_toolchains=false" >> .bazelrc.local
       bazel build --config ci //tests/...

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -13,7 +13,7 @@ steps:
     label: "Run tests (Nixpkgs)"
     timeout: 30
   - command: |
-      echo "common:ci --build_tag_filters -requires_hackage,-requires_lz4,-requires_zlib,-requires_doctest,-requires_c2hs,-requires_threaded_rts,-dont_test_with_bindist" > .bazelrc.local
+      echo "common:ci --build_tag_filters -requires_hackage,-requires_lz4,-requires_proto,-requires_zlib,-requires_doctest,-requires_c2hs,-requires_threaded_rts,-dont_test_with_bindist" > .bazelrc.local
       # XXX: See .bazelrc [backward compatible options] for the the rational behind this flag
       echo "build --incompatible_use_python_toolchains=false" >> .bazelrc.local
       bazel build --config ci //tests/...

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -164,7 +164,8 @@ nixpkgs_cc_configure(
 )
 
 nixpkgs_package(
-    name = "zlib",
+    name = "nixpkgs_zlib",
+    attribute_path = "zlib",
     build_file_content = """
 package(default_visibility = ["//visibility:public"])
 
@@ -183,12 +184,13 @@ cc_library(
 )
 
 nixpkgs_package(
-    name = "lz4",
+    name = "nixpkgs_lz4",
+    attribute_path = "lz4",
     build_file_content = """
 package(default_visibility = ["//visibility:public"])
 
 cc_library(
-  name = "lz4",
+  name = "nixpkgs_lz4",
   srcs = glob(["lib/liblz4.dylib", "lib/liblz4.so*"]),
   includes = ["include"],
 )
@@ -250,7 +252,7 @@ filegroup (
 
 cc_library(
     name = "zlib",
-    deps = ["@zlib//:zlib"],
+    srcs = ["@nixpkgs_zlib//:lib"],
     hdrs = [":include"],
     strip_include_prefix = "include",
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -69,6 +69,13 @@ stack_snapshot(
     ],
     snapshot = "lts-13.15",
     tools = ["@happy"],
+)
+
+# In a separate repo because not all platforms support zlib.
+stack_snapshot(
+    name = "stackage-zlib",
+    packages = ["zlib"],
+    snapshot = "lts-13.15",
     deps = ["@zlib.dev//:zlib"],
 )
 
@@ -172,12 +179,6 @@ package(default_visibility = ["//visibility:public"])
 filegroup(
     name = "lib",
     srcs = glob(["lib/**/*.so*", "lib/**/*.dylib", "lib/**/*.a"]),
-)
-
-cc_library(
-    name = "zlib",
-    linkstatic = 1,
-    srcs = [":lib"],
 )
 """,
     repository = "@nixpkgs",

--- a/haskell/haddock.bzl
+++ b/haskell/haddock.bzl
@@ -124,7 +124,6 @@ def _haskell_doc_aspect_impl(target, ctx):
             target[HaskellInfo].dynamic_libraries,
             ghci_extra_libs,
             depset(transitive = [depset(i) for i in transitive_haddocks.values()]),
-            depset(transitive_html.values()),
             target[CcInfo].compilation_context.headers,
             depset([
                 hs.tools.ghc_pkg,

--- a/haskell/nixpkgs.bzl
+++ b/haskell/nixpkgs.bzl
@@ -37,7 +37,7 @@ def _ghc_nixpkgs_haskell_toolchain_impl(repository_ctx):
     # and asks the parent process to generate the associated bazel symlink
     for line in result.stdout.split("\n"):
         if line.startswith("#SYMLINK:"):
-            _, name, path = line.split(" ")
+            _, path, name = line.split(" ")
             repository_ctx.symlink(path, name)
 
     repository_ctx.file(

--- a/haskell/private/pkgdb_to_bzl.py
+++ b/haskell/private/pkgdb_to_bzl.py
@@ -133,39 +133,30 @@ for conf in glob.glob(os.path.join(topdir, "package.conf.d", "*.conf")):
     # this does not work, we generate a path in the workspace and
     # output a SYMLINK information for the parent process
 
-    symlinks = []
-
     # first, try to get a path within the package
     # We check if the file exists because cabal will unconditionally
     # generate the database entry even if no haddock was generated.
-    if pkg.haddock_html and os.path.exists(pkg.haddock_html):
+    haddock_html = None
+    if pkg.haddock_html:
         haddock_html = path_to_label(pkg.haddock_html, pkg.pkgroot)
-
         if not haddock_html:
             haddock_html = os.path.join("haddock", "html", pkg.name)
-            symlinks.append((pkg.haddock_html, haddock_html))
-    else:
-        haddock_html = None
-
-    haddock_interfaces = []
+            output.append("#SYMLINK: {} {}".format(pkg.haddock_html, haddock_html))
 
     # If there is many interfaces, we give them a number
     interface_id = 0
-
+    haddock_interfaces = []
     for interface_path in pkg.haddock_interfaces:
-        if os.path.exists(interface_path):
-            interface = path_to_label(interface_path, pkg.pkgroot)
-
-            if not interface:
-                interface = os.path.join("haddock", "interfaces", pkg.name + "_" + str(interface_id) + ".haddock")
-                symlinks.append((interface_path, interface))
-                interface_id += 1
-
-            haddock_interfaces.append(interface)
-
-    # Write the symlink macro for each paths
-    for (source, destination) in symlinks:
-        output.append("#SYMLINK: {} {}".format(destination, source))
+        interface = path_to_label(interface_path, pkg.pkgroot)
+        if not interface:
+            interface = os.path.join(
+                "haddock",
+                "interfaces",
+                pkg.name + "_" + str(interface_id) + ".haddock",
+            )
+            output.append("#SYMLINK: {} {}".format(interface_path, interface))
+            interface_id += 1
+        haddock_interfaces.append(interface)
 
     output += [
         # We substitute globs instead of actual paths because the

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -381,7 +381,7 @@ haskell_library(
     deps = [
         "//tests/hackage:base",
         "//tests/hackage:bytestring",
-        "@lz4",
+        "@nixpkgs_lz4",
     ],
 )
 

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -42,7 +42,10 @@ haskell_proto_toolchain(
     testonly = 0,
     plugin = "@proto-lens-protoc//:bin/proto-lens-protoc",
     protoc = "@com_google_protobuf//:protoc",
-    tags = ["requires_hackage"],
+    tags = [
+        "requires_hackage",
+        "requires_proto",
+    ],
     deps = [
         "//tests/hackage:base",
         "//tests/hackage:bytestring",

--- a/tests/haskell_proto_library/BUILD.bazel
+++ b/tests/haskell_proto_library/BUILD.bazel
@@ -38,26 +38,38 @@ proto_library(
 
 haskell_proto_library(
     name = "address_haskell_proto",
-    tags = ["requires_hackage"],
+    tags = [
+        "requires_hackage",
+        "requires_proto",
+    ],
     deps = [":address_proto"],
 )
 
 haskell_proto_library(
     name = "stripped_address_haskell_proto",
-    tags = ["requires_hackage"],
+    tags = [
+        "requires_hackage",
+        "requires_proto",
+    ],
     deps = [":stripped_address_proto"],
 )
 
 haskell_proto_library(
     name = "person_haskell_proto",
-    tags = ["requires_hackage"],
+    tags = [
+        "requires_hackage",
+        "requires_proto",
+    ],
     deps = [":person_proto"],
 )
 
 haskell_library(
     name = "hs-lib",
     srcs = ["Bar.hs"],
-    tags = ["requires_hackage"],
+    tags = [
+        "requires_hackage",
+        "requires_proto",
+    ],
     visibility = ["//visibility:public"],
     deps = [
         ":address_haskell_proto",
@@ -69,6 +81,9 @@ haskell_library(
 
 haskell_doc(
     name = "docs",
-    tags = ["requires_hackage"],
+    tags = [
+        "requires_hackage",
+        "requires_proto",
+    ],
     deps = [":hs-lib"],
 )

--- a/tests/stack-snapshot-deps/BUILD.bazel
+++ b/tests/stack-snapshot-deps/BUILD.bazel
@@ -1,0 +1,20 @@
+load(
+    "@rules_haskell//haskell:defs.bzl",
+    "haskell_test",
+)
+
+package(default_testonly = 1)
+
+haskell_test(
+    name = "stack-snapshot-deps",
+    srcs = ["Main.hs"],
+    tags = [
+        "requires_hackage",
+        "requires_zlib",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@stackage-zlib//:zlib",
+        "@stackage//:base",
+    ],
+)

--- a/tests/stack-snapshot-deps/Main.hs
+++ b/tests/stack-snapshot-deps/Main.hs
@@ -1,0 +1,3 @@
+module Main where
+
+main = putStrLn "hello world"


### PR DESCRIPTION
Our test suite is only run in full for the Nixpkgs job. This PR makes
the bindist job run more tests. This uncovered three bugs:

* one bug in stack_install, where certain combinations of packages
  would cause the unpack phase to fail,
* two Haddock related bugs (one in `pkgdb_to_bzl.py` and the other in
  the HaskellHaddock action).

These bugs are fixed as part of this PR.

Fixes #1005 