### PR TITLE
Hardcode location of ar and strip on Darwin

### DIFF
--- a/haskell/cabal.bzl
+++ b/haskell/cabal.bzl
@@ -84,6 +84,8 @@ def _prepare_cabal_inputs(hs, cc, dep_info, cc_info, tool_inputs, tool_input_man
 
     (ghci_extra_libs, env) = get_ghci_extra_libs(hs, cc_info)
     env["PATH"] = _make_path(hs, tool_inputs)
+    if hs.toolchain.is_darwin:
+        env["SDKROOT"] = "macosx"  # See haskell/private/actions/link.bzl
 
     # TODO Instantiating this template could be done just once in the
     # toolchain rule.
@@ -123,6 +125,7 @@ def _prepare_cabal_inputs(hs, cc, dep_info, cc_info, tool_inputs, tool_input_man
         [setup, hs.tools.ghc, hs.tools.ghc_pkg, hs.tools.runghc],
         transitive = [
             depset(srcs),
+            depset(cc.files),
             package_databases,
             extra_headers,
             ghci_extra_libs,

--- a/haskell/private/cabal_wrapper.sh.tpl
+++ b/haskell/private/cabal_wrapper.sh.tpl
@@ -44,6 +44,8 @@ srcdir=$execroot/$3
 pkgroot="$(realpath $execroot/$4/..)" # By definition (see ghc-pkg source code).
 shift 4
 
+ar=$(realpath %{ar})
+strip=$(realpath %{strip})
 distdir=$(mktemp -d)
 libdir=$pkgroot/iface
 dynlibdir=$pkgroot/lib
@@ -64,8 +66,8 @@ $execroot/%{runghc} $setup configure \
     --user \
     --with-compiler=$execroot/%{ghc} \
     --with-hc-pkg=$execroot/%{ghc_pkg} \
-    --with-ar=%{ar} \
-    --with-strip=%{strip} \
+    --with-ar=$ar \
+    --with-strip=$strip \
     --enable-deterministic \
     --enable-relocatable \
     --builddir=$distdir \


### PR DESCRIPTION
The reason we do this is because `CcToolchainInfo.ar_executable()`
gives us a relative path, but a relative path we cannot include in the
sandbox, because the value is a string, not a path that we can add to
the inputs of an action. This function is deprecated anyways. The
current fix isn't the proper fix, which requires the use of some
different API that may or may not already be available. So for now we
hardcode the absolute path, which in fact we already did previously in
certain cases when on Darwin.

Fixes #1019