### PR TITLE
Add support for Bazel persistent workers

### DIFF
--- a/haskell/BUILD.bazel
+++ b/haskell/BUILD.bazel
@@ -33,6 +33,12 @@ py_binary(
     visibility = ["//visibility:public"],
 )
 
+sh_binary(
+    name = "worker",
+    srcs = ["private/worker.sh"],
+    visibility = ["//visibility:public"],
+)
+
 py_binary(
     name = "version_macros",
     srcs = ["private/version_macros.py"],

--- a/haskell/defs.bzl
+++ b/haskell/defs.bzl
@@ -87,6 +87,11 @@ _haskell_common_attrs = {
     "_cc_toolchain": attr.label(
         default = Label("@bazel_tools//tools/cpp:current_cc_toolchain"),
     ),
+    "_worker": attr.label(
+        executable = True,
+        cfg = "host",
+        default = Label("@rules_haskell//haskell:worker"),
+    ),
 }
 
 def _mk_binary_rule(**kwargs):

--- a/haskell/nixpkgs.bzl
+++ b/haskell/nixpkgs.bzl
@@ -83,6 +83,7 @@ haskell_toolchain(
     # hack in Nixpkgs.
     {locale_archive_arg}
     locale = {locale},
+    use_worker = {use_worker},
 )
         """.format(
             toolchain_libraries = toolchain_libraries,
@@ -95,6 +96,7 @@ haskell_toolchain(
             repl_ghci_args = repository_ctx.attr.repl_ghci_args,
             locale_archive_arg = "locale_archive = {},".format(repr(locale_archive)) if locale_archive else "",
             locale = repr(repository_ctx.attr.locale),
+            use_worker = repository_ctx.attr.use_worker,
         ),
     )
 
@@ -120,6 +122,7 @@ _ghc_nixpkgs_haskell_toolchain = repository_rule(
         "locale": attr.string(
             default = "en_US.UTF-8",
         ),
+        "use_worker": attr.bool(),
     },
 )
 
@@ -173,10 +176,15 @@ def haskell_register_ghc_nixpkgs(
         locale = None,
         repositories = {},
         repository = None,
-        nix_file_content = None):
+        nix_file_content = None,
+        use_worker = False):
     """Register a package from Nixpkgs as a toolchain.
 
-    Toolchains can be used to compile Haskell code. To have this
+    Args:
+      use_worker: This is a part of experimental support for the persistent worker mode.
+        It is not intended for production usage, yet.
+
+      Toolchains can be used to compile Haskell code. To have this
     toolchain selected during [toolchain
     resolution][toolchain-resolution], set a host platform that
     includes the `@rules_haskell//haskell/platforms:nixpkgs`
@@ -231,6 +239,7 @@ def haskell_register_ghc_nixpkgs(
         repl_ghci_args = repl_ghci_args,
         locale_archive = locale_archive,
         locale = locale,
+        use_worker = use_worker,
     )
 
     # toolchain definition.

--- a/haskell/private/actions/link.bzl
+++ b/haskell/private/actions/link.bzl
@@ -4,7 +4,7 @@ load(":private/packages.bzl", "expose_packages", "pkg_info_to_compile_flags")
 load(":private/pkg_id.bzl", "pkg_id")
 load(":providers.bzl", "create_link_config")
 
-def _merge_parameter_files(hs, file1, file2):
+def merge_parameter_files(hs, file1, file2):
     """Merge two GHC parameter files into one.
 
     Args:
@@ -225,7 +225,7 @@ def link_binary(
         )
 
     if extra_linker_flags_file != None:
-        params_file = _merge_parameter_files(hs, objects_dir_manifest, extra_linker_flags_file)
+        params_file = merge_parameter_files(hs, objects_dir_manifest, extra_linker_flags_file)
     else:
         params_file = objects_dir_manifest
 

--- a/haskell/private/context.bzl
+++ b/haskell/private/context.bzl
@@ -42,12 +42,17 @@ def haskell_context(ctx, attr = None):
     if hasattr(ctx, "configuration"):
         coverage_enabled = ctx.configuration.coverage_enabled
 
+    worker = None
+    if hasattr(ctx.executable, "_worker"):
+        worker = ctx.executable._worker
+
     return HaskellContext(
         # Fields
         name = attr.name,
         label = ctx.label,
         toolchain = toolchain,
         tools = toolchain.tools,
+        worker = worker,
         package_ids = package_ids,
         src_root = src_root,
         package_root = ctx.label.workspace_root + ctx.label.package,

--- a/haskell/private/worker.sh
+++ b/haskell/private/worker.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+export PATH=${PATH:-} # otherwise GCC fails on Windows
+
+# this is equivalent to 'readarray'. We do not use 'readarray' in order to
+# support older bash versions.
+while IFS= read -r line; do compile_flags+=("$line"); done < $1
+
+# Detect if we are in the persistent worker mode
+if [ "$2" == "--persistent_worker" ]; then
+    compile_flags=("${compile_flags[@]:1}")  # remove ghc executable
+    # This is a proof-of-concept implementation, not ready for production usage:
+    # it assumes https://github.com/tweag/bazel-worker/ installed globally as ~/bin/worker
+    exec ~/bin/worker ${compile_flags[@]} --persistent_worker
+else
+    while IFS= read -r line; do extra_args+=("$line"); done < "$2"
+    "${compile_flags[@]}" "${extra_args[@]}" 2>&1 \
+      | while IFS= read -r line; do [[ $line =~ ^Loaded ]] || echo "$line"; done >&2
+fi

--- a/haskell/protobuf.bzl
+++ b/haskell/protobuf.bzl
@@ -172,6 +172,7 @@ def _haskell_proto_aspect_impl(target, ctx):
         disabled_features = ctx.rule.attr.features,
         executable = struct(
             _ls_modules = ctx.executable._ls_modules,
+            _worker = ctx.executable._worker,
         ),
         # Necessary for CC interop (see cc.bzl).
         features = ctx.rule.attr.features,
@@ -237,6 +238,11 @@ _haskell_proto_aspect = aspect(
         ),
         "_cc_toolchain": attr.label(
             default = Label("@bazel_tools//tools/cpp:current_cc_toolchain"),
+        ),
+        "_worker": attr.label(
+            executable = True,
+            cfg = "host",
+            default = Label("@rules_haskell//haskell:worker"),
         ),
     },
     toolchains = [

--- a/haskell/toolchain.bzl
+++ b/haskell/toolchain.bzl
@@ -12,6 +12,7 @@ load(
     "link_binary",
     "link_library_dynamic",
     "link_library_static",
+    "merge_parameter_files",
 )
 load(":private/actions/package.bzl", "package")
 
@@ -62,46 +63,33 @@ def _run_ghc(hs, cc, inputs, outputs, mnemonic, arguments, params_file = None, e
         extra_args_file,
     ] + cc.files
 
+    flagsfile = extra_args_file
     if params_file:
-        params_file_src = params_file.path
-        extra_inputs.append(params_file)
-    else:
-        params_file_src = "<(:)"  # a temporary file with no contents
-
-    script = """
-export PATH=${PATH:-} # otherwise GCC fails on Windows
-
-# this is equivalent to 'readarray'. We do not use 'readarray' in order to
-# support older bash versions.
-while IFS= read -r line; do compile_flags+=("$line"); done < %s
-while IFS= read -r line; do extra_args+=("$line"); done < %s
-while IFS= read -r line; do param_file_args+=("$line"); done < %s
-
-# XXX Workaround https://gitlab.haskell.org/ghc/ghc/merge_requests/1308.
-set -o pipefail
-"${compile_flags[@]}" "${extra_args[@]}" ${param_file_args+"${param_file_args[@]}"} 2>&1 \
-  | while IFS= read -r line; do [[ $line =~ ^Loaded ]] || echo "$line"; done >&2
-""" % (compile_flags_file.path, extra_args_file.path, params_file_src)
-
-    ghc_wrapper_name = "ghc_wrapper_%s_%s" % (hs.name, mnemonic)
-    ghc_wrapper = hs.actions.declare_file(ghc_wrapper_name)
-    hs.actions.write(ghc_wrapper, script, is_executable = True)
-    extra_inputs.append(ghc_wrapper)
+        flagsfile = merge_parameter_files(hs, extra_args_file, params_file)
+        extra_inputs.append(flagsfile)
 
     if type(inputs) == type(depset()):
         inputs = depset(extra_inputs, transitive = [inputs])
     else:
         inputs += extra_inputs
 
-    hs.actions.run_shell(
+    # Detect persistent worker support
+    flagsfile_prefix = ""
+    execution_requirements = {}
+    if hs.toolchain.use_worker:
+        flagsfile_prefix = "@"
+        execution_requirements = {"supports-workers": "1"}
+
+    hs.actions.run(
         inputs = inputs,
         input_manifests = input_manifests,
         outputs = outputs,
-        command = ghc_wrapper.path,
+        executable = hs.worker,
         mnemonic = mnemonic,
         progress_message = progress_message,
         env = env,
-        arguments = [],
+        arguments = [compile_flags_file.path, flagsfile_prefix + flagsfile.path],
+        execution_requirements = execution_requirements,
     )
 
     return args
@@ -176,6 +164,7 @@ def _haskell_toolchain_impl(ctx):
             is_static = ctx.attr.is_static,
             version = ctx.attr.version,
             global_pkg_db = pkgdb_file,
+            use_worker = ctx.attr.use_worker,
         ),
     ]
 
@@ -228,6 +217,9 @@ Label pointing to the locale archive file to use. Mostly useful on NixOS.
             allow_single_file = True,
             default = Label("@rules_haskell//haskell:private/osx_cc_wrapper.sh.tpl"),
         ),
+        "use_worker": attr.bool(
+            doc = "Whether to use persistent worker strategy during the builds.",
+        ),
     },
 )
 
@@ -241,6 +233,7 @@ def haskell_toolchain(
         repl_ghci_args = [],
         haddock_flags = [],
         locale_archive = None,
+        use_worker = False,
         **kwargs):
     """Declare a compiler toolchain.
 
@@ -300,6 +293,7 @@ def haskell_toolchain(
             "@rules_haskell//haskell/platforms:linux": locale_archive,
             "//conditions:default": None,
         }),
+        use_worker = use_worker,
         **kwargs
     )
 


### PR DESCRIPTION
This is the first (working) step with several shortcomings:

1. The `worker` binary is assumed to be in `~/bin`.
2. No incremental builds yet.
3. No tests or documentation.

First should be fixed ASAP, I imagine. I'd appreciate a bit of advice on this particular matter.

Third should be fixed in the due course.

On the positive side: it should support both standard (non-worker) mode as well as the worker one.