### PR TITLE
Allow haskell_library to be empty

### DIFF
--- a/haskell/private/actions/compile.bzl
+++ b/haskell/private/actions/compile.bzl
@@ -480,17 +480,24 @@ def compile_library(
             mix_file = hs.actions.declare_file(".hpc/{pkg}/{module}.mix".format(pkg = pkg_id_string, module = module))
             coverage_data.append(_coverage_datum(mix_file, src_file, hs.label))
 
-    hs.toolchain.actions.run_ghc(
-        hs,
-        cc,
-        inputs = c.inputs,
-        input_manifests = c.input_manifests,
-        outputs = c.outputs + [datum.mix_file for datum in coverage_data],
-        mnemonic = "HaskellBuildLibrary" + ("Prof" if with_profiling else ""),
-        progress_message = "HaskellBuildLibrary {}".format(hs.label),
-        env = c.env,
-        arguments = c.args,
-    )
+    if srcs:
+        hs.toolchain.actions.run_ghc(
+            hs,
+            cc,
+            inputs = c.inputs,
+            input_manifests = c.input_manifests,
+            outputs = c.outputs + [datum.mix_file for datum in coverage_data],
+            mnemonic = "HaskellBuildLibrary" + ("Prof" if with_profiling else ""),
+            progress_message = "HaskellBuildLibrary {}".format(hs.label),
+            env = c.env,
+            arguments = c.args,
+        )
+    else:
+        hs.actions.run_shell(
+            inputs = c.inputs,
+            outputs = c.outputs,
+            command = "exit 0",
+        )
 
     return struct(
         interfaces_dir = c.interfaces_dir,

--- a/haskell/private/actions/package.bzl
+++ b/haskell/private/actions/package.bzl
@@ -65,7 +65,8 @@ def package(
         with_shared,
         exposed_modules_file,
         other_modules,
-        my_pkg_id):
+        my_pkg_id,
+        has_hs_library):
     """Create GHC package using ghc-pkg.
 
     Args:
@@ -76,6 +77,7 @@ def package(
       exposed_modules_file: File holding list of exposed modules.
       other_modules: List of hidden modules.
       my_pkg_id: Package id object for this package.
+      has_hs_library: Whether hs-libraries should be non-null.
 
     Returns:
       (File, File): GHC package conf file, GHC package cache file
@@ -105,7 +107,7 @@ def package(
         "import-dirs": [import_dir],
         "library-dirs": ["${pkgroot}"] + extra_lib_dirs,
         "dynamic-library-dirs": ["${pkgroot}"] + extra_lib_dirs,
-        "hs-libraries": [pkg_id.library_name(hs, my_pkg_id)],
+        "hs-libraries": [pkg_id.library_name(hs, my_pkg_id)] if has_hs_library else [],
         "extra-libraries": extra_libs,
         "depends": hs.package_ids,
     })

--- a/tests/library-empty/BUILD.bazel
+++ b/tests/library-empty/BUILD.bazel
@@ -1,0 +1,21 @@
+load(
+    "@rules_haskell//haskell:defs.bzl",
+    "haskell_library",
+    "haskell_test",
+)
+
+package(default_testonly = 1)
+
+haskell_library(name = "empty_lib")
+
+haskell_test(
+    name = "library-empty",
+    size = "small",
+    srcs = ["Main.hs"],
+    linkstatic = 0,
+    visibility = ["//visibility:public"],
+    deps = [
+        ":empty_lib",
+        "//tests/hackage:base",
+    ],
+)

--- a/tests/library-empty/Main.hs
+++ b/tests/library-empty/Main.hs
@@ -1,0 +1,3 @@
+module Main where
+
+main = return 0


### PR DESCRIPTION
An empty `haskell_library` is one where no source files are given.
This leads to no library being produced, but this is now nevertheless
legal. There are two reasons for doing this:

* Match the semantics of `cc_library`, where empty libraries are
  legal.
* Emulate empty Cabal libraries (also legal) using `haskell_library`.
  This can be useful to e.g. workaround `bytestring-builder` or
  `nats`, which are packages on Hackage that expose empty libraries.