### PR TITLE
Bring back cat_hs example

### DIFF
--- a/docs/haskell.rst
+++ b/docs/haskell.rst
@@ -331,8 +331,9 @@ Further reading
 ---------------
 
 Congratulations! You now know the basics of building a Haskell project
-with Bazel. Next, read up on the most common :ref:`Common Haskell
-build use cases <use-cases>`. Then, check out the following:
+with Bazel. Next, read up on :ref:`Common Haskell build use cases
+<use-cases>` and have a look `cat_hs`_ for an example build
+description of a full application. Then, check out the following:
 
 * `External Dependencies`_ to learn more about working with local and
    remote repositories.
@@ -355,6 +356,7 @@ Happy building!
 
 .. note:: This tutorial is adapted from the Bazel `C++ build tutorial`_.
 
+.. _cat_hs: https://github.com/tweag/rules_haskell/tree/master/examples/cat_hs
 .. _install Bazel: https://docs.bazel.build/versions/master/install.html
 .. _haskell_binary: http://api.haskell.build/haskell/haskell.html#haskell_binary
 .. _haskell_toolchain_library: http://api.haskell.build/haskell/haskell.html#haskell_toolchain_library

--- a/examples/README.md
+++ b/examples/README.md
@@ -6,6 +6,12 @@ for building Haskell code.
 * [**vector:**](./vector/) shows how to build the `vector` package
   that is found on Hackage (as well as transitive dependencies
   `primitive` and `transformers`) without using Cabal.
+* [**cat_hs:**](./cat_hs/) is an example of a non-trivial application
+  with multiple third-party dependencies downloaded from Hackage,
+  C library dependencies and split up into multiple libraries and
+  a binary. We use a rule wrapping Cabal to build the Hackage
+  dependencies. This example requires Nix installed. It is used to
+  build (or download from a binary cache) the C library dependencies.
 * [**rts:**](./rts/) demonstrates foreign exports and shows how to
   link against GHC's RTS library, i.e. `libHSrts.so`.
   

--- a/examples/WORKSPACE
+++ b/examples/WORKSPACE
@@ -54,3 +54,43 @@ load(
 )
 
 rules_haskell_toolchains(version = "8.6.5")
+
+# Everything below for the cat_hs example.
+
+nixpkgs_package(
+    name = "nixpkgs_zlib",
+    attribute_path = "zlib",
+    repository = "@rules_haskell//nixpkgs:default.nix",
+)
+
+nixpkgs_package(
+    name = "zlib.dev",
+    build_file_content = """
+cc_library(
+    name = "zlib",
+    srcs = ["@nixpkgs_zlib//:lib"],
+    hdrs = glob(["include/*.h"]),
+    strip_include_prefix = "include",
+    visibility = ["//visibility:public"],
+)
+""",
+    repository = "@rules_haskell//nixpkgs:default.nix",
+)
+
+load("@rules_haskell//haskell:cabal.bzl", "stack_snapshot")
+
+stack_snapshot(
+    name = "stackage",
+    packages = [
+        "base",
+        "bytestring",
+        "conduit",
+        "conduit-extra",
+        "hspec",
+        "optparse-applicative",
+        "text",
+        "text-show",
+    ],
+    snapshot = "lts-14.0",
+    deps = ["@zlib.dev//:zlib"],
+)

--- a/examples/cat_hs/BUILD.bazel
+++ b/examples/cat_hs/BUILD.bazel
@@ -1,0 +1,12 @@
+load(
+    "@rules_haskell//haskell:defs.bzl",
+    "haskell_doc",
+)
+
+haskell_doc(
+    name = "api-doc",
+    deps = [
+        "//cat_hs/lib/args",
+        "//cat_hs/lib/cat",
+    ],
+)

--- a/examples/cat_hs/README.md
+++ b/examples/cat_hs/README.md
@@ -1,0 +1,41 @@
+# cat_hs - A rules_haskell Example Project
+
+This project re-implements a subset of the `cat` command-line tool in
+Haskell. It serves as an example of a project built using
+the [Bazel][bazel] build system, using [rules_haskell][rules_haskell]
+to define the Haskell build, including rules that wrap Cabal to build
+third-party dependencies downloadable from Hackage, and
+using [rules_nixpkgs][rules_nixpkgs] and [Nix][nix] to manage system
+dependencies.
+
+[bazel]: https://bazel.build/
+[rules_haskell]: https://haskell.build/
+[rules_nixpkgs]: https://github.com/tweag/rules_nixpkgs
+[nix]: https://nixos.org/nix/
+
+## Prerequisites
+
+You need to install the [Nix package manager][nix]. All further dependencies
+will be managed using Nix.
+
+## Instructions
+
+To build the package execute the following command in the checked out source
+repository.
+
+```
+$ nix-shell --pure --run "bazel build //..."
+```
+
+To run the tests execute the following command.
+
+```
+$ nix-shell --pure --run "bazel test //..."
+```
+
+To run the executable enter the following commands.
+
+```
+$ nix-shell --pure --run "bazel run //exec/cat_hs -- -h"
+$ nix-shell --pure --run "bazel run //exec/cat_hs -- $PWD/README.md"
+```

--- a/examples/cat_hs/exec/cat_hs/BUILD.bazel
+++ b/examples/cat_hs/exec/cat_hs/BUILD.bazel
@@ -1,0 +1,18 @@
+load(
+    "@rules_haskell//haskell:defs.bzl",
+    "haskell_binary",
+)
+load(
+    "@rules_haskell//haskell:cabal.bzl",
+    "haskell_cabal_library",
+)
+
+haskell_binary(
+    name = "cat_hs",
+    srcs = glob(["src/**/*.hs"]),
+    deps = [
+        "//cat_hs/lib/args",
+        "//cat_hs/lib/cat",
+        "@stackage//:base",
+    ],
+)

--- a/examples/cat_hs/exec/cat_hs/src/Main.hs
+++ b/examples/cat_hs/exec/cat_hs/src/Main.hs
@@ -1,0 +1,10 @@
+module Main
+  ( main
+  ) where
+
+import qualified Args
+import Cat (runCat)
+
+
+main :: IO ()
+main = Args.parse >>= runCat

--- a/examples/cat_hs/lib/args/BUILD.bazel
+++ b/examples/cat_hs/lib/args/BUILD.bazel
@@ -1,0 +1,30 @@
+load(
+    "@rules_haskell//haskell:defs.bzl",
+    "haskell_library",
+    "haskell_test",
+)
+load(
+    "@rules_haskell//haskell:cabal.bzl",
+    "haskell_cabal_library",
+)
+
+haskell_library(
+    name = "args",
+    srcs = glob(["src/**/*.hs"]),
+    visibility = ["//visibility:public"],
+    deps = [
+        "@stackage//:base",
+        "@stackage//:optparse-applicative",
+    ],
+)
+
+haskell_test(
+    name = "unit",
+    srcs = glob(["test/**/*.hs"]),
+    deps = [
+        ":args",
+        "@stackage//:base",
+        "@stackage//:hspec",
+        "@stackage//:optparse-applicative",
+    ],
+)

--- a/examples/cat_hs/lib/args/src/Args.hs
+++ b/examples/cat_hs/lib/args/src/Args.hs
@@ -1,0 +1,71 @@
+{-# LANGUAGE LambdaCase #-}
+
+module Args
+  ( -- * Configuration Types
+    Args (..)
+  , FileArg (..)
+    -- * I/O Interface
+  , parse
+    -- * Command-Line Parser
+  , parser
+  ) where
+
+import Options.Applicative
+
+
+-- | A file argument.
+data FileArg
+  = StdIn
+    -- ^ Read from standard input.
+  | File FilePath
+    -- ^ Read from the given file.
+  deriving (Eq, Show)
+
+
+-- | Parsed command-line arguments.
+data Args = Args
+  { number :: Bool
+    -- ^ Number output lines flag.
+  , files :: [FileArg]
+    -- ^ The list of input files.
+  } deriving (Eq, Show)
+
+
+-- | Parse the command-line arguments.
+parse :: IO Args
+parse = execParser parser
+
+
+-- | Command-line parser.
+parser :: ParserInfo Args
+parser =
+  info (argsParser <**> helper)
+    ( fullDesc
+    <> progDesc "Concatenate files to standard output."
+    <> header "cat_hs - A Haskell implementation of cat." )
+
+
+argsParser :: Parser Args
+argsParser = Args
+  <$> switch
+    ( long "number"
+    <> short 'n'
+    <> help "Number all output lines." )
+  <*> many fileArgParser
+
+
+fileArgParser :: Parser FileArg
+fileArgParser =
+  argument readFileArg
+    ( metavar "FILES..."
+    <> help
+      "Read from the given file, or from standard input if '-'.\
+      \ Use './-' to read from a file named '-'." )
+
+
+-- | Read a 'FileArg' from a 'String'.
+readFileArg :: ReadM FileArg
+readFileArg =
+  maybeReader $ \case
+    "-" -> Just StdIn
+    fname -> Just $ File fname

--- a/examples/cat_hs/lib/args/test/Main.hs
+++ b/examples/cat_hs/lib/args/test/Main.hs
@@ -1,0 +1,67 @@
+module Main
+  ( main
+  ) where
+
+import Args (Args (Args))
+import qualified Args
+import Options.Applicative
+import Test.Hspec
+
+
+main :: IO ()
+main = hspec $ do
+  describe "Args.parser" $ do
+    it "parses no arguments" $ do
+      parse []
+        `shouldBe`
+        Just Args { Args.files = [], Args.number = False }
+    it "parses one stdin" $ do
+      parse ["-"]
+        `shouldBe`
+        Just Args { Args.files = [Args.StdIn], Args.number = False }
+    it "parses two stdin" $ do
+      parse ["-", "-"]
+        `shouldBe`
+        Just Args
+          { Args.files = [Args.StdIn, Args.StdIn], Args.number = False }
+    it "parses numbered stdin" $ do
+      parse ["-n", "-"]
+        `shouldBe`
+        Just Args { Args.files = [Args.StdIn], Args.number = True }
+    it "parses numbered stdin reversed" $ do
+      parse ["-", "-n"]
+        `shouldBe`
+        Just Args { Args.files = [Args.StdIn], Args.number = True }
+    it "parses file -n" $ do
+      parse ["--", "-n"]
+        `shouldBe`
+        Just Args { Args.files = [Args.File "-n"], Args.number = False }
+    it "parses file -" $ do
+      parse ["./-"]
+        `shouldBe`
+        Just Args { Args.files = [Args.File "./-"], Args.number = False }
+    it "parses stdin and file" $ do
+      parse ["-", "file"]
+        `shouldBe`
+        Just Args
+          { Args.files = [Args.StdIn, Args.File "file"], Args.number = False }
+    it "recognizes -h" $ do
+      parse ["-h"]
+        `shouldBe`
+        Nothing
+    it "recognizes --help" $ do
+      parse ["-h"]
+        `shouldBe`
+        Nothing
+    it "parses file -h" $ do
+      parse ["--", "-h"]
+        `shouldBe`
+        Just Args { Args.files = [Args.File "-h"], Args.number = False }
+
+
+-- | Execute the command-line parser on the given arguments.
+-- Returns 'Nothing' if the parser failed, or @--help@ was passed.
+parse :: [String] -> Maybe Args
+parse args =
+  getParseResult $
+    execParserPure defaultPrefs Args.parser args

--- a/examples/cat_hs/lib/cat/BUILD.bazel
+++ b/examples/cat_hs/lib/cat/BUILD.bazel
@@ -1,0 +1,37 @@
+load(
+    "@rules_haskell//haskell:defs.bzl",
+    "haskell_library",
+    "haskell_test",
+)
+load(
+    "@rules_haskell//haskell:cabal.bzl",
+    "haskell_cabal_library",
+)
+
+haskell_library(
+    name = "cat",
+    srcs = glob(["src/**/*.hs"]),
+    visibility = ["//visibility:public"],
+    deps = [
+        "//cat_hs/lib/args",
+        "@stackage//:base",
+        "@stackage//:bytestring",
+        "@stackage//:conduit",
+        "@stackage//:conduit-extra",
+        "@stackage//:text",
+        "@stackage//:text-show",
+    ],
+)
+
+haskell_test(
+    name = "unit",
+    srcs = glob(["test/**/*.hs"]),
+    deps = [
+        ":cat",
+        "//cat_hs/lib/args",
+        "@stackage//:base",
+        "@stackage//:conduit",
+        "@stackage//:hspec",
+        "@stackage//:text",
+    ],
+)

--- a/examples/cat_hs/lib/cat/src/Cat.hs
+++ b/examples/cat_hs/lib/cat/src/Cat.hs
@@ -1,0 +1,97 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Cat
+  ( -- * I/O Interface
+    runCat
+    -- * Conduits
+  , catSource
+  , fileSource
+  , numberLinesUtf8
+  , numberLines
+  ) where
+
+import Args (Args)
+import qualified Args
+import Conduit
+import Control.Monad (void)
+import Data.ByteString (ByteString)
+import Data.Conduit.List (mapAccum)
+import Data.Conduit.Text (decodeUtf8Lenient, encodeUtf8, lines)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import Prelude hiding (lines)
+import TextShow (showt)
+
+
+-- | Read the inputs and write them to standard out.
+runCat :: Args -> IO ()
+runCat args = runConduitRes (catSource args .| stdoutC)
+
+
+-- | A source for the files defined by the given arguments,
+-- numbered or unnumbered as defined by the given arguments.
+catSource
+  :: MonadResource m
+  => Args -> ConduitT i ByteString m ()
+catSource args
+  | Args.number args = unnumbered .| numberLinesUtf8
+  | otherwise = unnumbered
+  where
+    unnumbered = yieldMany (Args.files args) .| fileSource
+
+
+-- | Open a source for a 'Args.FileArg' argument.
+fileSource
+  :: MonadResource m
+  => ConduitT Args.FileArg ByteString m ()
+fileSource = awaitForever $ \case
+  -- XXX: Annotate file IO exceptions with file-name.
+  Args.StdIn -> stdinC
+  Args.File f -> sourceFile f
+{-# INLINE fileSource #-}
+
+
+-- | Number lines of the input stream, assuming that they are UTF-8 encoded.
+numberLinesUtf8
+  :: Monad m
+  => ConduitT ByteString ByteString m ()
+numberLinesUtf8 = decodeUtf8Lenient .| numberLines .| encodeUtf8
+
+
+-- | Prepend each line with its number starting from one.
+--
+-- Note, that this diverges from cat's behaviour, in that resulting lines will
+-- always end in a new line, even if the input didn't.
+numberLines
+  :: forall m. Monad m
+  => ConduitT Text Text m ()
+numberLines = void $ lines .| mapAccum go 1
+  where
+    go :: Text -> Int -> (Int, Text)
+    go l n = (succ n, numbered)
+      where
+        numbered =
+          Text.concat
+            [ Text.justifyRight width ' ' (showt n)
+            , Text.replicate gap " "
+            , l
+            , "\n"
+            ]
+    width :: Int
+    width = 6
+    gap :: Int
+    gap = 2
+
+-- An alternative implementation that seems to be a fair bit slower.
+--
+--   numberLines = void $ foldLines go 1
+--     where
+--       go :: Int -> ConduitT Text Text m Int
+--       go n = do
+--         yield $ Text.justifyRight width ' ' (showt n)
+--         yield $ Text.replicate gap " "
+--         awaitForever yield
+--         yield "\n"
+--         pure (succ n)

--- a/examples/cat_hs/lib/cat/test/Main.hs
+++ b/examples/cat_hs/lib/cat/test/Main.hs
@@ -1,0 +1,46 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Main
+  ( main
+  ) where
+
+import Args (Args (Args))
+import qualified Args
+import Cat
+import Conduit
+import Data.Text (Text)
+import qualified Data.Text.Lazy as Text.Lazy
+import Test.Hspec
+
+
+main :: IO ()
+main = hspec $ do
+  describe "numberLines" $ do
+    let runNumberLines :: [Text] -> Text.Lazy.Text
+        runNumberLines ls =
+          runConduitPure $
+            yieldMany ls .| numberLines .| sinkLazy
+    it "handles empty input" $ do
+      runNumberLines []
+        `shouldBe`
+        ""
+    it "handles one line" $
+      runNumberLines ["first line"]
+        `shouldBe`
+        "     1  first line\n"
+    it "handles two lines" $
+      runNumberLines ["first line\nsecond line"]
+        `shouldBe`
+        "     1  first line\n     2  second line\n"
+    it "handles two lines across chunks" $
+      runNumberLines ["first ", "line\nsecond", " line"]
+        `shouldBe`
+        "     1  first line\n     2  second line\n"
+    it "preserves one new line at the end" $
+      runNumberLines ["first line\n"]
+        `shouldBe`
+        "     1  first line\n"
+    it "handles empty line within input" $
+      runNumberLines ["first line\n\n"]
+        `shouldBe`
+        "     1  first line\n     2  \n"

--- a/examples/shell.nix
+++ b/examples/shell.nix
@@ -1,0 +1,1 @@
+../shell.nix


### PR DESCRIPTION
This reverts commit ba7af702d9e942ea0471b99edf33ae4f773046c7.

We migrated the cat_hs example from using Hazel to using
`haskell_cabal_library` and `stack_snapshot`. This is an example of a
non-trivial application, with system dependencies and Hackage-downloaded
depnedencies.

Closes #732