### PR TITLE
Deprecate Hazel

### DIFF
--- a/docs/haskell-use-cases.rst
+++ b/docs/haskell-use-cases.rst
@@ -196,13 +196,6 @@ Each package mentioned in ``ghc.nix`` can then be imported using
 
 .. _haskell_toolchain_library: http://api.haskell.build/haskell/haskell.html#haskell_toolchain_library
 
-Building code with Hackage dependencies (using Hazel)
------------------------------------------------------
-
-.. todo::
-
-   Explain how to use Hazel instead of Nix
-
 Generating API documentation
 ----------------------------
 

--- a/hazel/README.md
+++ b/hazel/README.md
@@ -2,6 +2,9 @@
 
 [![CircleCI](https://circleci.com/gh/tweag/rules_haskell/tree/master.svg?style=svg)](https://circleci.com/gh/tweag/rules_haskell/tree/master)
 
+**NOTE: Hazel is deprecated in favour of [Cabal rules][cabal-rules].
+Use those instead for new projects.**
+
 Hazel is a Bazel framework that manages build rules for third-party Haskell
 dependencies.
 
@@ -14,6 +17,8 @@ parsing their .cabal files and creating Haskell build rules.
 Hazel uses the [`rules_haskell`](https://github.com/tweag/rules_haskell)
 package for Haskell build rules. Hazel is now part of the `rules_haskell`
 repository.
+
+[cabal-rules]: https://api.haskell.build/haskell/cabal.html
 
 ## Status
 Hazel is still experimental, and its API is subject to change.  Most Hackage


### PR DESCRIPTION
Hazel was previously marked as experimental, and never shipped as part
of any release. So deprecating it is a matter of moving any references
from the documentation, and adding a note to the README. We'll still
carry the code for now, since there are still users of Hazel and we
need to continue adapting the Hazel code as rules_haskell changes.