### PR TITLE
Hide haskell_toolchain_libraries

### DIFF
--- a/haskell/BUILD.bazel
+++ b/haskell/BUILD.bazel
@@ -1,5 +1,5 @@
 load(
-    "@rules_haskell//haskell:defs.bzl",
+    "@rules_haskell//haskell:private/haskell_impl.bzl",
     "haskell_toolchain_libraries",
 )
 
@@ -58,7 +58,7 @@ toolchain_type(
     visibility = ["//visibility:public"],
 )
 
-# XXX: This target is a work aroud for the lack toolchain transitions not being
+# XXX: This target is a work-around for toolchain transitions not being
 # implemented, yet. See
 # https://github.com/bazelbuild/proposals/blob/master/designs/2019-02-12-toolchain-transitions.md
 # This will need to be revisited once that proposal is implemented.

--- a/haskell/defs.bzl
+++ b/haskell/defs.bzl
@@ -11,7 +11,6 @@ load(
     _haskell_import_impl = "haskell_import_impl",
     _haskell_library_impl = "haskell_library_impl",
     _haskell_test_impl = "haskell_test_impl",
-    _haskell_toolchain_libraries_impl = "haskell_toolchain_libraries_impl",
     _haskell_toolchain_library_impl = "haskell_toolchain_library_impl",
 )
 load(
@@ -294,19 +293,6 @@ haskell_import = rule(
             default = Label("@bazel_tools//tools/cpp:current_cc_toolchain"),
         ),
     },
-)
-
-haskell_toolchain_libraries = rule(
-    _haskell_toolchain_libraries_impl,
-    attrs = {
-        "_cc_toolchain": attr.label(
-            default = Label("@bazel_tools//tools/cpp:current_cc_toolchain"),
-        ),
-    },
-    toolchains = [
-        "@rules_haskell//haskell:toolchain",
-    ],
-    fragments = ["cpp"],
 )
 
 haskell_toolchain_library = rule(

--- a/haskell/private/haskell_impl.bzl
+++ b/haskell/private/haskell_impl.bzl
@@ -755,6 +755,28 @@ def haskell_toolchain_libraries_impl(ctx):
 
     return [HaskellToolchainLibraries(libraries = library_dict)]
 
+haskell_toolchain_libraries = rule(
+    haskell_toolchain_libraries_impl,
+    attrs = {
+        "_cc_toolchain": attr.label(
+            default = Label("@bazel_tools//tools/cpp:current_cc_toolchain"),
+        ),
+    },
+    toolchains = [
+        "@rules_haskell//haskell:toolchain",
+    ],
+    fragments = ["cpp"],
+)
+"""Generate Haskell toolchain libraries.
+
+This is an internal rule and should not be user facing.
+
+This rule is a work-around for toolchain transitions not being implemented,
+yet. See
+https://github.com/bazelbuild/proposals/blob/master/designs/2019-02-12-toolchain-transitions.md
+This will need to be revisited once that proposal is implemented.
+"""
+
 def haskell_import_impl(ctx):
     id = ctx.attr.id or ctx.attr.name
     target_files = [


### PR DESCRIPTION
It's an internal rule that should not be user facing.