### PR TITLE
Fix c2hs on Windows

### DIFF
--- a/haskell/c2hs.bzl
+++ b/haskell/c2hs.bzl
@@ -80,8 +80,8 @@ def _c2hs_library_impl(ctx):
             # not in PATH so we add it to PATH explicitely.
             (
                 """
-        export PATH=$PATH:{mingw-bin}
-        """.format(cc = paths.dirname(cc.tools.cc)) if hs.toolchain.is_windows else ""
+        export PATH=$PATH:{mingw_bin}
+        """.format(mingw_bin = paths.dirname(cc.tools.cc)) if hs.toolchain.is_windows else ""
             ) +
             """
         # Include libdir in include path just like hsc2hs does.


### PR DESCRIPTION
This fixes a few issues with c2hs_library that we encountered in daml,
see https://github.com/digital-asset/daml/pull/2574 for the upstream
PR.

1. c2hs did not have the runfiles setup properly. This works fine on
this repo since c2hs comes from nixpkgs but we get it from Hazel.

2. cpp invoked via c2hs crashes without any error if the mingw bin dir
is not in PATH. For now, we fix this in a rather hacky way by
calculating it relative to cc.

3. language-c has issues when it comes to parsing some headers shipped
with mingw, see https://github.com/haskell/c2hs/issues/199. You can
avoid this by setting certain flags in cpp so I added an `extra_args`
option to `c2hs_library` that allows passing additional arguments.

cc @aherrmann 