### PR TITLE
Document compiler_flags_select and point out that it's temporary.

### DIFF
--- a/haskell/nixpkgs.bzl
+++ b/haskell/nixpkgs.bzl
@@ -192,6 +192,11 @@ def haskell_register_ghc_nixpkgs(
 
     [toolchain-resolution]: https://docs.bazel.build/versions/master/toolchains.html#toolchain-resolution
 
+    Args:
+      compiler_flags_select: temporary workaround to pass conditional arguments.
+        See https://github.com/bazelbuild/bazel/issues/9199 for details.
+
+
     Example:
 
       ```


### PR DESCRIPTION
See bazelbuild/bazel#9199.