### PR TITLE
Catch GHC errors immediately.

### DIFF
--- a/haskell/private/ghc_wrapper.sh
+++ b/haskell/private/ghc_wrapper.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -ueo pipefail
 export PATH=${PATH:-} # otherwise GCC fails on Windows
 
 # this is equivalent to 'readarray'. We do not use 'readarray' in order to


### PR DESCRIPTION
Make sure that GHC errors are not silently ignored in the `ghc_wrapper`. Previously, in non-wrapper mode, errors could be ignored due to the pipe that filters GHC output without `pipefail` being set.

The following example illustrates the issue. A target like this
```
haskell_binary(
    name = "hidden-compiler-error",
    srcs = ["Main.hs", "Deps.hs"],
    ...
)
```
with an erroneous `Deps.hs`
```
{-# OPTIONS_GHC -Werror=unused-imports #-}
module Deps where
import Data.List
```
will fail with a confusing error message
```
ghc: no input files
Usage: For basic information, try the `--help' option.
ERROR: /home/aj/tweag.io/da/bazel-projects/rules_haskell/tests/failures/hidden-compiler-error/BUILD:3:1: output 'tests/failures/hidden-compiler-error/hidden-compiler-error' was not created
ERROR: /home/aj/tweag.io/da/bazel-projects/rules_haskell/tests/failures/hidden-compiler-error/BUILD:3:1: not all outputs were created or valid
Target //tests/failures/hidden-compiler-error:hidden-compiler-error failed to build
```
Instead of the immediately failing at the actual error
```
tests/failures/hidden-compiler-error/Deps.hs:5:1: error: [-Wunused-imports, -Werror=unused-imports]
    The import of ‘Data.List’ is redundant
      except perhaps to import instances from ‘Data.List’
    To import instances alone, use: import Data.List()
  |
5 | import Data.List
  | ^^^^^^^^^^^^^^^^
Target //tests/failures/hidden-compiler-error:hidden-compiler-error failed to build
Use --verbose_failures to see the command lines of failed build steps.
```

cc @cocreature 