### PR TITLE
Set src_strip_prefix in Hazel-generated c2hs_library

### DIFF
--- a/hazel/third_party/cabal2bazel/bzl/cabal_package.bzl
+++ b/hazel/third_party/cabal2bazel/bzl/cabal_package.bzl
@@ -176,9 +176,11 @@ def _find_module_by_ending(modulePath, ending, sourceDirs):
       module source file. See `_find_module` for details.
     """
 
+    fileName = modulePath + "." + ending
+
     # Find module source file in source directories.
     files = native.glob([
-        paths.join(d if d != "." else "", modulePath + "." + ending)
+        paths.join(d if d != "." else "", fileName)
         for d in sourceDirs
     ])
     if len(files) == 0:
@@ -194,6 +196,7 @@ def _find_module_by_ending(modulePath, ending, sourceDirs):
     return struct(
         type = ending,
         src = file,
+        prefix = file[:-len(fileName)],
         out = _module_output(file, ending),
         boot = bootFile,
     )
@@ -212,6 +215,7 @@ def _find_module(module, sourceDirs):
       `type`: The ending.
       `src`: The source file that was found.
         E.g. `Some/Module/Name.y`
+      `prefix`: The directory prefix before the file name of the module, E.g. `src`.
       `out`: The expected generated output module file.
         E.g. `Some/Module/Name.hs`.
       `bootFile`: Haskell boot file path or `None` if no boot file was found.
@@ -318,6 +322,7 @@ def _get_build_attrs(
             c2hs_library(
                 name = chs_name,
                 srcs = [info.src],
+                src_strip_prefix = info.prefix,
                 deps = (
                     _get_extra_libs(build_info.extraLibs, extra_libs) +
                     [cbits_name] +


### PR DESCRIPTION
c2hs_library relies on src_strip_prefix being set correctly. Otherwise
we can end up with situations where we pass `-i foobar` to c2hs which
searches for `A.chi` in `foobar` but the file is in `foobar/src`.

cc @aherrmann 