### PR TITLE
Support cabal flags in stack_snapshot

### DIFF
--- a/examples/WORKSPACE
+++ b/examples/WORKSPACE
@@ -56,6 +56,10 @@ load("@rules_haskell//haskell:cabal.bzl", "stack_snapshot")
 
 stack_snapshot(
     name = "stackage",
+    flags = {
+        # Sets the default explicitly to demonstrate the flags attribute.
+        "zlib": ["-non-blocking-ffi"],
+    },
     packages = [
         "base",
         "bytestring",


### PR DESCRIPTION
- Adds a `flags` attribute to define Cabal flags in the `stack_snapshot` repository rule.
    The syntax is
    ```
    flags = {
        "package-name": ["some-enabled-flag", "-some-disabled-flag"],
    }
    ```
- Uses the `flags` attribute in `examples` for demonstration and as a test.