### PR TITLE
Allow passing additional Cabal flags

### DIFF
--- a/examples/WORKSPACE
+++ b/examples/WORKSPACE
@@ -58,7 +58,10 @@ stack_snapshot(
     name = "stackage",
     flags = {
         # Sets the default explicitly to demonstrate the flags attribute.
-        "zlib": ["-non-blocking-ffi"],
+        "zlib": [
+            "-non-blocking-ffi",
+            "-pkg-config",
+        ],
     },
     packages = [
         "base",

--- a/tests/haskell_cabal_library/BUILD.bazel
+++ b/tests/haskell_cabal_library/BUILD.bazel
@@ -13,7 +13,10 @@ haskell_cabal_library(
         "Lib.hs",
         "lib.cabal",
     ],
-    cabal_flags = ["--flags=use-base expose-lib"],
+    flags = [
+        "use-base",
+        "expose-lib",
+    ],
     version = "0.1.0.0",
 )
 

--- a/tests/haskell_cabal_library/BUILD.bazel
+++ b/tests/haskell_cabal_library/BUILD.bazel
@@ -13,6 +13,7 @@ haskell_cabal_library(
         "Lib.hs",
         "lib.cabal",
     ],
+    cabal_flags = ["--flags=use-base expose-lib"],
     version = "0.1.0.0",
 )
 

--- a/tests/haskell_cabal_library/lib.cabal
+++ b/tests/haskell_cabal_library/lib.cabal
@@ -3,7 +3,22 @@ name: lib
 version: 0.1.0.0
 build-type: Simple
 
+-- Example flags to test the Cabal flags attribute.
+flag use-base
+  default: False
+  manual: True
+  description: Depend on the base library.
+
+flag expose-lib
+  default: False
+  manual: True
+  description: Expose the Lib module.
+
 library
-  build-depends: base >=4.12 && <4.13
+  if flag(use-base)
+    build-depends: base >=4.12 && <4.13
   default-language: Haskell2010
-  exposed-modules: Lib
+  if flag(expose-lib)
+    exposed-modules: Lib
+  else
+    other-modules: Lib


### PR DESCRIPTION
- Adds a `cabal_flags` attribute to the `haskell_cabal_library|binary` rules to pass extra flags to `Setup.hs configure`.
- Uses `cabal_flags` to forward `stack_snapshot` flags to Cabal.
    Flags are not only relevant for `stack`'s dependency resolution, but also need to be forwarded to Cabal to take effect during the package build. This was not an issue before, because `stack_snapshot` was only testes with flags that were either the default flags, or flags to core-packages which are not built by `stack_snapshot` anymore.
- Modifies the `stack_snapshot` example to pass more than one flag.
- Modifies the `haskell_cabal_library` test case to add flags that are relevant for the test to succeed.
    I.e. not passing the flags correctly would make the test-case fail.