### PR TITLE
stack_snapshot: Include leaf core-packages 

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -55,6 +55,7 @@ stack_snapshot(
         "base",
         "directory",
         "filepath",
+        "ghc-heap",
         "process",
         # For tests
         "streaming",

--- a/tests/stack-snapshot-deps/BUILD.bazel
+++ b/tests/stack-snapshot-deps/BUILD.bazel
@@ -16,5 +16,7 @@ haskell_test(
     deps = [
         "@stackage-zlib//:zlib",
         "@stackage//:base",
+        # Core package that is no dependency of another item in the snapshot.
+        "@stackage//:ghc-heap",
     ],
 )


### PR DESCRIPTION
Include core-packages that are listed in the packages attribute, but not included in the dependency graph due to unpackaged Stackage packages.
