### PR TITLE
Improve handling of C library dependencies of haskell_cabal_library|binary

### DIFF
--- a/haskell/cabal.bzl
+++ b/haskell/cabal.bzl
@@ -116,7 +116,11 @@ def _prepare_cabal_inputs(hs, cc, dep_info, cc_info, package_id, tool_inputs, to
     args = hs.actions.args()
     package_databases = dep_info.package_databases
     extra_headers = cc_info.compilation_context.headers
-    extra_include_dirs = cc_info.compilation_context.includes
+    extra_include_dirs = depset(transitive = [
+        cc_info.compilation_context.includes,
+        cc_info.compilation_context.quote_includes,
+        cc_info.compilation_context.system_includes,
+    ])
     extra_lib_dirs = [
         file.dirname
         for file in ghci_extra_libs.to_list()

--- a/haskell/cabal.bzl
+++ b/haskell/cabal.bzl
@@ -117,7 +117,14 @@ def _prepare_cabal_inputs(hs, cc, dep_info, cc_info, package_id, tool_inputs, to
     package_databases = dep_info.package_databases
     extra_headers = cc_info.compilation_context.headers
     extra_include_dirs = cc_info.compilation_context.includes
-    extra_lib_dirs = [file.dirname for file in ghci_extra_libs.to_list()]
+    extra_lib_dirs = [
+        file.dirname
+        for file in ghci_extra_libs.to_list()
+        # Exclude Haskell libraries, as these are already covered by
+        # package-dbs. This is to avoid command-line length overflow on
+        # collect2.
+        if not file.basename.startswith("libHS")
+    ]
     args.add_all([package_id, setup, cabal.dirname, package_database.dirname])
     args.add("--flags=" + " ".join(flags))
     args.add("--")


### PR DESCRIPTION
- Skip Haskell libraries in `--extra-lib-dirs` flags.
    These are redundant, as they are already defined in the corresponding package databases.
    This is to avoid command-line length overflow on collect2. E.g.
    ```
    gcc: error trying to exec '/nix/store/3ajmsz0ab2dybi1qm7nk0izabyqwfl4r-gcc-7.4.0/libexec/gcc/x86_64-unknown-linux-gnu/7.4.0/collect2': execv: Argument list too long
    `cc' failed in phase `Linker'. (Exit code: 1)
    ```
- Forward all C library include directories.
    I.e. not just `CompilationContext.includes`, but also `quote_includes`, and `system_includes`.
    `cc_library` targets typically expose their include directories in the `system_includes` attribute instead of `includes`.