### PR TITLE
stack_snapshot: Precise extra dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## Upcoming release
 
-nothing yet
+### Changed
+
+* The `deps` attribute to `stack_snapshot` has been replaced by the
+  `extra_deps` attribute. It no longer takes a list of dependencies to be added
+  to all packages, but instead a dictionary specifying additional dependencies
+  to select packages. See `stack_snapshot` API docs for an example. See
+  [#1068](https://github.com/tweag/rules_haskell/pull/1068).
 
 ## [0.10.0] - 2019-09-03
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -77,7 +77,7 @@ stack_snapshot(
     name = "stackage-zlib",
     packages = ["zlib"],
     snapshot = "lts-13.15",
-    deps = ["@zlib.win//:zlib" if is_windows else "@zlib.dev//:zlib"],
+    deps = {"zlib": ["@zlib.win//:zlib" if is_windows else "@zlib.dev//:zlib"]},
 )
 
 load(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -75,9 +75,9 @@ stack_snapshot(
 # In a separate repo because not all platforms support zlib.
 stack_snapshot(
     name = "stackage-zlib",
+    extra_deps = {"zlib": ["@zlib.win//:zlib" if is_windows else "@zlib.dev//:zlib"]},
     packages = ["zlib"],
     snapshot = "lts-13.15",
-    deps = {"zlib": ["@zlib.win//:zlib" if is_windows else "@zlib.dev//:zlib"]},
 )
 
 load(

--- a/examples/WORKSPACE
+++ b/examples/WORKSPACE
@@ -96,7 +96,7 @@ stack_snapshot(
     ],
     snapshot = "lts-14.0",
     vendored_packages = {"split": "@split//:split"},
-    deps = ["@zlib.dev//:zlib"],
+    deps = {"zlib": ["@zlib.dev//:zlib"]},
 )
 
 # For the rts example.

--- a/examples/WORKSPACE
+++ b/examples/WORKSPACE
@@ -77,6 +77,7 @@ load("@rules_haskell//haskell:cabal.bzl", "stack_snapshot")
 
 stack_snapshot(
     name = "stackage",
+    extra_deps = {"zlib": ["@zlib.dev//:zlib"]},
     flags = {
         # Sets the default explicitly to demonstrate the flags attribute.
         "zlib": [
@@ -96,7 +97,6 @@ stack_snapshot(
     ],
     snapshot = "lts-14.0",
     vendored_packages = {"split": "@split//:split"},
-    deps = {"zlib": ["@zlib.dev//:zlib"]},
 )
 
 # For the rts example.

--- a/haskell/cabal.bzl
+++ b/haskell/cabal.bzl
@@ -721,6 +721,9 @@ def _invert(d):
 
 def _from_string_keyed_label_list_dict(d):
     """Convert string_keyed_label_list_dict to label_keyed_string_dict."""
+
+    # TODO Remove _from_string_keyed_label_list_dict once following issue
+    # is resolved: https://github.com/bazelbuild/bazel/issues/7989.
     out = {}
     for (string_key, label_list) in d.items():
         for label in label_list:
@@ -732,6 +735,9 @@ def _from_string_keyed_label_list_dict(d):
 
 def _to_string_keyed_label_list_dict(d):
     """Convert label_keyed_string_dict to string_keyed_label_list_dict."""
+
+    # TODO Remove _to_string_keyed_label_list_dict once following issue
+    # is resolved: https://github.com/bazelbuild/bazel/issues/7989.
     out = {}
     for (label, string_key_list) in d.items():
         for string_key in string_key_list.split(" "):

--- a/haskell/cabal.bzl
+++ b/haskell/cabal.bzl
@@ -782,7 +782,7 @@ def _stack_snapshot_impl(repository_ctx):
         vendored_packages,
     )
 
-    extra_deps = _to_string_keyed_label_list_dict(repository_ctx.attr.deps)
+    extra_deps = _to_string_keyed_label_list_dict(repository_ctx.attr.extra_deps)
     tools = [_label_to_string(label) for label in repository_ctx.attr.tools]
 
     # Write out dependency graph as importable Starlark value.
@@ -881,7 +881,7 @@ _stack_snapshot = repository_rule(
         "packages": attr.string_list(),
         "vendored_packages": attr.label_keyed_string_dict(),
         "flags": attr.string_list_dict(),
-        "deps": attr.label_keyed_string_dict(),
+        "extra_deps": attr.label_keyed_string_dict(),
         "tools": attr.label_list(),
         "stack": attr.label(),
     },
@@ -960,7 +960,7 @@ _fetch_stack = repository_rule(
 )
 """Find a suitably recent local Stack or download it."""
 
-def stack_snapshot(stack = None, deps = {}, vendored_packages = {}, **kwargs):
+def stack_snapshot(stack = None, extra_deps = {}, vendored_packages = {}, **kwargs):
     """Use Stack to download and extract Cabal source distributions.
 
     Args:
@@ -973,7 +973,7 @@ def stack_snapshot(stack = None, deps = {}, vendored_packages = {}, **kwargs):
         unpacked source distribution. Each package must contain a Cabal file
         named `<package-name>.cabal` in the package root.
       flags: A dict from package name to list of flags.
-      deps: Extra dependencies of packages, e.g. system libraries or C/C++ libraries.
+      extra_deps: Extra dependencies of packages, e.g. system libraries or C/C++ libraries.
       tools: Tool dependencies. They are built using the host configuration, since
         the tools are executed as part of the build.
       stack: The stack binary to use to enumerate package dependencies.
@@ -987,7 +987,7 @@ def stack_snapshot(stack = None, deps = {}, vendored_packages = {}, **kwargs):
           vendored_packages = {"split": "//split:split"},
           tools = ["@happy//:happy", "@c2hs//:c2hs"],
           snapshot = "lts-13.15",
-          deps = {"zlib": ["@zlib.dev//:zlib"]},
+          extra_deps = {"zlib": ["@zlib.dev//:zlib"]},
       )
       ```
       defines `@stackage//:conduit`, `@stackage//:lens`,
@@ -1001,7 +1001,7 @@ def stack_snapshot(stack = None, deps = {}, vendored_packages = {}, **kwargs):
           flags = {"zlib": ["-non-blocking-ffi"]},
           tools = ["@happy//:happy", "@c2hs//:c2hs"],
           local_Snapshot = "//:snapshot.yaml",
-          deps = {"zlib": ["@zlib.dev//:zlib"]},
+          extra_deps = {"zlib": ["@zlib.dev//:zlib"]},
       ```
       Does the same as the previous example, provided there is a
       `snapshot.yaml`, at the root of the repository with content
@@ -1015,8 +1015,8 @@ def stack_snapshot(stack = None, deps = {}, vendored_packages = {}, **kwargs):
     This rule will use Stack to compute the transitive closure of the
     subset of the given snapshot listed in the `packages` attribute, and
     generate a dependency graph. If a package in the closure depends on
-    system libraries or other external libraries, use the `deps` attribute
-    to list them. This attribute works like the
+    system libraries or other external libraries, use the `extra_deps`
+    attribute to list them. This attribute works like the
     `--extra-{include,lib}-dirs` flags for Stack and cabal-install do.
 
     Packages that are in the snapshot need not have their versions
@@ -1040,7 +1040,7 @@ def stack_snapshot(stack = None, deps = {}, vendored_packages = {}, **kwargs):
         stack = stack,
         # TODO Remove _from_string_keyed_label_list_dict once following issue
         # is resolved: https://github.com/bazelbuild/bazel/issues/7989.
-        deps = _from_string_keyed_label_list_dict(deps),
+        extra_deps = _from_string_keyed_label_list_dict(extra_deps),
         # TODO Remove _invert once following issue is resolved:
         # https://github.com/bazelbuild/bazel/issues/7989.
         vendored_packages = _invert(vendored_packages),


### PR DESCRIPTION
Precisely control which packages to add additional dependencies to.

This PR changes `stack_snapshot` so that the `deps` attribute no longer takes a list of targets to add as dependencies to all packages in the snapshot. Instead, it takes a dictionary mapping Stack package names to lists of targets to precisely control which dependencies to add to which package in the snapshot.

### Motivation

This change is motivated by #1062. Simply adding all `deps` to all packages in the snapshot has the effect that the library-dirs and include-dirs of these `deps` will be added to the package-db entry of each package in the snapshot. GHC doesn't deduplicate the include-dirs and this leads to overflowing the maximum command-line length, even on Linux.

Unfortunately, we cannot avoid adding to the library-dirs and include-dirs of snapshot packages that actually depend on extra libraries. Their cabal files will list `extra-libraries` and `includes`, and `Setup.hs` enforces that these can be found in the library-dirs and include-dirs of the resulting package configuration.

An advantage is that this thins the dependency graph and gives the user more control. The downside is that `stack_snapshot` becomes more cumbersome to use.

### Alternatives

An alternative approach would be to automatically detect which snapshot packages depend on which extra libraries and only add the extra dependencies where necessary. This would require either parsing the Cabal files, or for `stack dot` (or `stack ls dependencies json`) to list `extra-libraries` dependencies. However, that would also require some user input or heuristics to map from `extra-libraries` to Bazel targets, and would assume that all `includes` are provided by targets providing `extra-libraries`.

Closes #1062 