### PR TITLE
stack unpack cpphs and doctest

### DIFF
--- a/haskell/cabal.bzl
+++ b/haskell/cabal.bzl
@@ -68,6 +68,7 @@ main = defaultMain
     return setup
 
 _CABAL_TOOLS = ["alex", "c2hs", "cpphs", "doctest", "happy"]
+_CABAL_TOOL_LIBRARIES = ["cpphs", "doctest"]
 
 # Some old packages are empty compatibility shims. Empty packages
 # cause Cabal to not produce the outputs it normally produces. Instead
@@ -631,7 +632,7 @@ def _compute_dependency_graph(repository_ctx, snapshot, core_packages, versioned
     indirect_unpacked_sdists = []
     for package in exec_result.stdout.splitlines():
         name = _chop_version(package)
-        if name in _CABAL_TOOLS:
+        if name in _CABAL_TOOLS and not name in _CABAL_TOOL_LIBRARIES:
             continue
 
         version = _version(package)


### PR DESCRIPTION
`cpphs` and `doctest` are cabal tools and therefore listed in `_CABAL_TOOLS`. This means they are excluded from the `stack unpack` step and thereby the dependency graph.

However, they are also packages providing libraries. Excluding these from `stack unpack` can cause build failures due to missing dependencies, e.g. on `hlint` the library, which depends on `cpphs` the library. This change whitelists `cpphs` and `docteset`,which both provide libraries, to be included in the dependency graph.