### PR TITLE
Allow multiple haskell_cabal_* targets per package

### DIFF
--- a/haskell/cabal.bzl
+++ b/haskell/cabal.bzl
@@ -185,15 +185,15 @@ def _haskell_cabal_library_impl(ctx):
     cabal = _find_cabal(hs, ctx.files.srcs)
     setup = _find_setup(hs, cabal, ctx.files.srcs)
     package_database = hs.actions.declare_file(
-        "_install/package.conf.d/package.cache",
+        "_install/{}.conf.d/package.cache".format(package_id),
         sibling = cabal,
     )
     interfaces_dir = hs.actions.declare_directory(
-        "_install/iface",
+        "_install/{}_iface".format(package_id),
         sibling = cabal,
     )
     data_dir = hs.actions.declare_directory(
-        "_install/data",
+        "_install/{}_data".format(package_id),
         sibling = cabal,
     )
     static_library_filename = "_install/lib/libHS{}.a".format(package_id)
@@ -374,7 +374,7 @@ def _haskell_cabal_binary_impl(ctx):
     cabal = _find_cabal(hs, ctx.files.srcs)
     setup = _find_setup(hs, cabal, ctx.files.srcs)
     package_database = hs.actions.declare_file(
-        "_install/package.conf.d/package.cache",
+        "_install/{}.conf.d/package.cache".format(hs.label.name),
         sibling = cabal,
     )
     binary = hs.actions.declare_file(
@@ -385,7 +385,7 @@ def _haskell_cabal_binary_impl(ctx):
         sibling = cabal,
     )
     data_dir = hs.actions.declare_directory(
-        "_install/data",
+        "_install/{}_data".format(hs.label.name),
         sibling = cabal,
     )
     (tool_inputs, tool_input_manifests) = ctx.resolve_tools(tools = ctx.attr.tools)

--- a/haskell/private/cabal_wrapper.sh.tpl
+++ b/haskell/private/cabal_wrapper.sh.tpl
@@ -84,11 +84,11 @@ shift 1
 ar=$(realpath %{ar})
 strip=$(realpath %{strip})
 distdir=$(mktemp -d)
-libdir=$pkgroot/iface
+libdir="$pkgroot/${name}_iface"
 dynlibdir=$pkgroot/lib
 bindir=$pkgroot/bin
-datadir=$pkgroot/data
-package_database=$pkgroot/package.conf.d
+datadir="$pkgroot/${name}_data"
+package_database="$pkgroot/${name}.conf.d"
 
 cleanup () {
   rm -rf "$distdir"

--- a/tests/haskell_cabal_library/BUILD.bazel
+++ b/tests/haskell_cabal_library/BUILD.bazel
@@ -27,11 +27,21 @@ haskell_cabal_library(
     deps = [":c-lib"],
 )
 
+haskell_cabal_library(
+    name = "second-lib",
+    srcs = [
+        "SecondLib.hs",
+        "second-lib.cabal",
+    ],
+    version = "0.1.0.0",
+)
+
 haskell_test(
     name = "haskell_cabal_library",
     srcs = ["Main.hs"],
     deps = [
         ":base",
         ":lib",
+        ":second-lib",
     ],
 )

--- a/tests/haskell_cabal_library/Lib.hs
+++ b/tests/haskell_cabal_library/Lib.hs
@@ -4,4 +4,5 @@ module Lib where
 
 foreign import ccall "add" add :: Int -> Int -> Int
 
+x :: Int
 x = add 1 1

--- a/tests/haskell_cabal_library/Main.hs
+++ b/tests/haskell_cabal_library/Main.hs
@@ -1,5 +1,6 @@
 module Main where
 
 import Lib
+import SecondLib
 
-main = print Lib.x
+main = print (Lib.x + SecondLib.y)

--- a/tests/haskell_cabal_library/SecondLib.hs
+++ b/tests/haskell_cabal_library/SecondLib.hs
@@ -1,0 +1,4 @@
+module SecondLib where
+
+y :: Int
+y = 3

--- a/tests/haskell_cabal_library/second-lib.cabal
+++ b/tests/haskell_cabal_library/second-lib.cabal
@@ -1,0 +1,9 @@
+cabal-version: >=1.10
+name: second-lib
+version: 0.1.0.0
+build-type: Simple
+
+library
+  build-depends: base >=4.12 && <4.13
+  default-language: Haskell2010
+  exposed-modules: SecondLib

--- a/tests/haskell_cabal_package/BUILD.bazel
+++ b/tests/haskell_cabal_package/BUILD.bazel
@@ -1,0 +1,27 @@
+load(
+    "@rules_haskell//haskell:cabal.bzl",
+    "haskell_cabal_binary",
+    "haskell_cabal_library",
+)
+load(
+    "@rules_haskell//haskell:defs.bzl",
+    "haskell_toolchain_library",
+)
+
+haskell_toolchain_library(name = "base")
+
+haskell_cabal_library(
+    name = "lib",
+    srcs = glob(["**"]),
+    version = "0.1.0.0",
+    deps = [":base"],
+)
+
+haskell_cabal_binary(
+    name = "haskell_cabal_package",
+    srcs = glob(["**"]),
+    deps = [
+        ":base",
+        ":lib",
+    ],
+)

--- a/tests/haskell_cabal_package/exe/Main.hs
+++ b/tests/haskell_cabal_package/exe/Main.hs
@@ -1,0 +1,3 @@
+module Main (main) where
+
+import Lib (main)

--- a/tests/haskell_cabal_package/lib.cabal
+++ b/tests/haskell_cabal_package/lib.cabal
@@ -1,0 +1,16 @@
+cabal-version: >=1.10
+name: lib
+version: 0.1.0.0
+build-type: Simple
+
+library
+  build-depends: base >=4.12 && <4.13
+  default-language: Haskell2010
+  exposed-modules: Lib
+  hs-source-dirs: lib
+
+executable haskell_cabal_package
+  build-depends: base, lib
+  default-language: Haskell2010
+  main-is: Main.hs
+  hs-source-dirs: exe

--- a/tests/haskell_cabal_package/lib/Lib.hs
+++ b/tests/haskell_cabal_package/lib/Lib.hs
@@ -1,0 +1,4 @@
+module Lib (main) where
+
+main :: IO ()
+main = pure ()


### PR DESCRIPTION
Makes the output of `haskell_cabal_library|binary` depend on the target name. This is to avoid collisions with other targets in the same Bazel package and allow multiple Cabal targets per Bazel package.

Adds regression tests for two `haskell_cabal_library` targets within one Bazel package, and for a `haskell_cabal_library` and `haskell_cabal_binary` within the same Bazel package. The latter has a real world use-case in Hackage packages that have a library and an executable component where the user wants to access both from Bazel.