### PR TITLE
mergify: rebase instead of merging if possible

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -7,8 +7,10 @@ pull_request_rules:
       - "base=master"
     actions:
       merge:
-        method: merge
+        method: rebase
+        rebase_fallback: merge
         strict: smart
+        strict_method: merge
   - name: delete head branch after merge
     conditions:
       - merged


### PR DESCRIPTION
https://doc.mergify.io/actions.html#merge

If there are multiple pending PRs, mergify would merge master into
each PR and then merge the PR back into master, leading to an amount
of noise far exceeding the actual content.

Let’s try to rebase if possible and fall back to merge only if that
fails.

Here’s how the history looks currently, when there are four pending pull requests each with trivial (non-colliding) changes: 

![screenshot](https://user-images.githubusercontent.com/3153638/64192120-4aeeb280-ce7a-11e9-9281-a49d5df95949.png)

This makes it very hard to create a changelog.