### PR TITLE
Windows support for haskell_cabal_* and stack_snapshot

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -77,7 +77,7 @@ stack_snapshot(
     name = "stackage-zlib",
     packages = ["zlib"],
     snapshot = "lts-13.15",
-    deps = ["@zlib.dev//:zlib"],
+    deps = ["@zlib.win//:zlib" if is_windows else "@zlib.dev//:zlib"],
 )
 
 load(
@@ -266,6 +266,25 @@ filegroup(
 )
 """,
     repository = "@nixpkgs",
+)
+
+http_archive(
+    name = "zlib.win",
+    build_file_content = """
+cc_library(
+    name = "zlib",
+    # Import `:z` as `srcs` to enforce the library name `libz.so`. Otherwise,
+    # Bazel would mangle the library name and e.g. Cabal wouldn't recognize it.
+    srcs = [":z"],
+    hdrs = glob(["*.h"]),
+    includes = ["."],
+    visibility = ["//visibility:public"],
+)
+cc_library(name = "z", srcs = glob(["*.c"]), hdrs = glob(["*.h"]))
+""",
+    sha256 = "c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1",
+    strip_prefix = "zlib-1.2.11",
+    urls = ["http://zlib.net/zlib-1.2.11.tar.gz"],
 )
 
 load("@bazel_tools//tools/build_defs/repo:jvm.bzl", "jvm_maven_import_external")

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -108,6 +108,9 @@ jobs:
       /c/bazel/bazel.exe test --config windows "//tests/two-libs/..."
       /c/bazel/bazel.exe test --config windows "//tests/encoding/..."
       /c/bazel/bazel.exe test --config windows "//tests/c-compiles/..."
+      /c/bazel/bazel.exe test --config windows "//tests/haskell_cabal_library/..."
+      /c/bazel/bazel.exe run  --config windows "//tests/haskell_cabal_binary/..."
+      /c/bazel/bazel.exe test --config windows "//tests/stack-snapshot-deps/..."
 
       # Hazel tests that succeed
       /c/bazel/bazel.exe test --config windows "@ai_formation_hazel//test:ghc-paths-test"

--- a/haskell/cabal.bzl
+++ b/haskell/cabal.bzl
@@ -375,7 +375,10 @@ def _haskell_cabal_binary_impl(ctx):
         sibling = cabal,
     )
     binary = hs.actions.declare_file(
-        "_install/bin/{}".format(hs.label.name),
+        "_install/bin/{name}{ext}".format(
+            name = hs.label.name,
+            ext = ".exe" if hs.toolchain.is_windows else "",
+        ),
         sibling = cabal,
     )
     data_dir = hs.actions.declare_directory(

--- a/haskell/cabal.bzl
+++ b/haskell/cabal.bzl
@@ -142,7 +142,7 @@ def _prepare_cabal_inputs(hs, cc, dep_info, cc_info, package_id, tool_inputs, to
     args.add_all(tool_inputs, map_each = _cabal_tool_flag)
 
     inputs = depset(
-        [setup, hs.tools.ghc, hs.tools.ghc_pkg, hs.tools.runghc],
+        [cabal_wrapper, setup, hs.tools.ghc, hs.tools.ghc_pkg, hs.tools.runghc],
         transitive = [
             depset(srcs),
             depset(cc.files),
@@ -226,8 +226,8 @@ def _haskell_cabal_library_impl(ctx):
         cabal_wrapper_tpl = ctx.file._cabal_wrapper_tpl,
         package_database = package_database,
     )
-    ctx.actions.run(
-        executable = c.cabal_wrapper,
+    ctx.actions.run_shell(
+        command = '{} "$@"'.format(c.cabal_wrapper.path),
         arguments = [c.args],
         inputs = c.inputs,
         input_manifests = c.input_manifests,
@@ -397,8 +397,8 @@ def _haskell_cabal_binary_impl(ctx):
         cabal_wrapper_tpl = ctx.file._cabal_wrapper_tpl,
         package_database = package_database,
     )
-    ctx.actions.run(
-        executable = c.cabal_wrapper,
+    ctx.actions.run_shell(
+        command = '{} "$@"'.format(c.cabal_wrapper.path),
         arguments = [c.args],
         inputs = c.inputs,
         input_manifests = c.input_manifests,

--- a/haskell/cabal.bzl
+++ b/haskell/cabal.bzl
@@ -611,6 +611,16 @@ def _compute_dependency_graph(repository_ctx, snapshot, core_packages, versioned
     if not _stack_version_check(repository_ctx, stack_cmd):
         fail("Stack version not recent enough. Need version 2.1 or newer.")
     stack = [stack_cmd]
+
+    # Run `stack update` leniently to avoid hackage-security lock issues.
+    #
+    #   user error (hTryLock: lock already exists: ~/.stack/pantry/hackage/hackage-security-lock)
+    #
+    # See https://github.com/tweag/stackage-head/issues/29. If this doesn't
+    # help we may need to point --stack-root to a workspace local path. The
+    # issue appears when initializing two separate stack_snapshot instances in
+    # parallel.
+    repository_ctx.execute(stack + ["update"])
     if versioned_packages:
         _execute_or_fail_loudly(repository_ctx, stack + ["unpack"] + versioned_packages)
     stack = [stack_cmd, "--resolver", snapshot]

--- a/haskell/cabal.bzl
+++ b/haskell/cabal.bzl
@@ -110,6 +110,7 @@ def _prepare_cabal_inputs(hs, cc, dep_info, cc_info, package_id, tool_inputs, to
             # XXX Workaround
             # https://github.com/bazelbuild/bazel/issues/5980.
             "%{env}": render_env(env),
+            "%{is_windows}": str(hs.toolchain.is_windows),
         },
     )
 

--- a/haskell/private/cabal_wrapper.sh.tpl
+++ b/haskell/private/cabal_wrapper.sh.tpl
@@ -92,6 +92,11 @@ package_database=$pkgroot/package.conf.d
 
 %{ghc_pkg} recache --package-db=$package_database
 
+ENABLE_RELOCATABLE=
+if [[ %{is_windows} != True ]]; then
+    ENABLE_RELOCATABLE=--enable-relocatable
+fi
+
 # Cabal really wants the current working directory to be directory
 # where the .cabal file is located. So we have no choice but to chance
 # cd into it, but then we have to rewrite all relative references into
@@ -106,7 +111,7 @@ $execroot/%{runghc} $setup configure \
     --with-ar=$ar \
     --with-strip=$strip \
     --enable-deterministic \
-    --enable-relocatable \
+    $ENABLE_RELOCATABLE \
     --builddir=$distdir \
     --prefix=$pkgroot \
     --libdir=$libdir \


### PR DESCRIPTION
- Fix CPU architecture discovery for stack bindist download
- Give descriptive error message if OS or arch discovery fails
- `stack --> stack.exe` on Windows
- `ctx.actions.run` doesn't work with bash scripts on Windows, use `run_shell` instead
- `--enable-relocatable` is not supported on Windows
- The output of `haskell_cabal_binary` is a `.exe` file on Windows
- Provide an alternative `libz` on Windows where nixpkgs is not available
- Test `haskell_cabal_library|binary` and `stack_snapshot` on Windows CI