### PR TITLE
cabal: Cleanup the temporary dist directory after the build

### DIFF
--- a/haskell/private/cabal_wrapper.sh.tpl
+++ b/haskell/private/cabal_wrapper.sh.tpl
@@ -90,6 +90,11 @@ bindir=$pkgroot/bin
 datadir=$pkgroot/data
 package_database=$pkgroot/package.conf.d
 
+cleanup () {
+  rm -rf "$distdir"
+}
+trap cleanup EXIT
+
 %{ghc_pkg} recache --package-db=$package_database
 
 # Cabal really wants the current working directory to be directory


### PR DESCRIPTION
Otherwise each call to `haskell_cabal_library` leaves a dangling temporary directory that's never cleared