### PR TITLE
mergify: merge, but rebase PR onto master instead of merging

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -7,16 +7,17 @@ pull_request_rules:
       - "base=master"
     actions:
       merge:
-        method: rebase
-        rebase_fallback: merge
+        method: merge
         strict: smart
-        strict_method: merge
+        strict_method: rebase
+
   - name: delete head branch after merge
     conditions:
       - merged
       - closed
     actions:
       delete_head_branch: {}
+
   - name: remove from merge-queue after merge
     conditions:
       - merged


### PR DESCRIPTION
Rebasing the PR will remove the pull request number from history, so
we merge.

But we can remove the second merge, where mergify merges
the (conflict-free) master into the PR before doing CI. Instead,
mergify should rebase (`strict_method = rebase`).

The [mergify documentation](https://doc.mergify.io/actions.html#merge)
has two warnings about strict_method rebase:

* GitHub branch protection of your repository may dismiss approved
  reviews.
* GitHub branch protection of the contributor repository may refuse
  Mergify to force push the rebased pull request.

As clarified in
https://github.com/Mergifyio/mergify-engine/issues/115#issuecomment-528329278
this only applies to contributors who manually untick the “allow
maintainers to modify my branch” (or similar) option. Since that is
not the default, we can require PR authors to either have it ticked or
rebase their PR manually when mergify requests it.