### PR TITLE
Windows CI: Install stack & update index once

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,6 +24,20 @@ jobs:
     displayName: "Enable da long paths"
 
   - bash: |
+        # rules_haskell can automatically install stack if it is not in $PATH,
+        # yet. However, if the index has not been updated before building. Then
+        # multiple parallel invocations of `stack` will both attempt to update
+        # the index during build. This will fail with the following error.
+        #
+        #   user error (hTryLock: lock already exists: C:\Users\VssAdministrator\AppData\Roaming\stack\pantry\hackage\hackage-security-lock)
+        #
+        # To avoid this issue we install stack and update the index beforehand.
+        # See https://github.com/tweag/stackage-head/issues/29.
+        curl -sSL https://get.haskellstack.org/ | sh
+        stack update
+    displayName: "Install Stack"
+
+  - bash: |
       set -e
       export MSYS2_ARG_CONV_EXCL="*"
 


### PR DESCRIPTION
Work around flakiness of `stack update` on Windows.

The rules_haskell workspace contains two separate `stack_snapshot` calls. This can lead to parallel calls to `stack update` which fails with "lock busy" errors on Windows CI. This PR works around that issue by installing stack globally and running `stack update` before the Bazel run.

See https://github.com/tweag/rules_haskell/commit/81e6b3ac27128c0ec1d980df9381b4dd7161cb13#r35008281