### PR TITLE
replace glob by faster directory search

### DIFF
--- a/haskell/private/cc_wrapper.bzl
+++ b/haskell/private/cc_wrapper.bzl
@@ -20,6 +20,7 @@ def _cc_wrapper_impl(ctx):
         is_executable = True,
         substitutions = {
             "{:cc:}": cc,
+            "{:cpu:}": cc_toolchain.cpu,
             "{:workspace:}": ctx.workspace_name,
             "{:platform:}": ctx.attr.platform,
         },


### PR DESCRIPTION
globbing to search for the solib directory can be slow if the working directory contains a large number of files or directories.

This change uses a breadth first recursive directory walk instead of `glob`. We are looking for the shortest path matching the solib directory, the first match in a breadth first search will be the shortest one.