### PR TITLE
MAINTAINERS: add release merge item to release checklist

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -32,10 +32,11 @@
     - copy the changelog section into the description
     - release
 - [ ] Push `rules_haskell` version in start script to new release tag,
-  test it in a temporary directory, create PR against master, publish
-  start script.
-- [ ] Check whether https://haskell.build/start has the newest start
-      script (netlify has problems sometimes).
+  test it in a temporary directory, create PR against master
+  - [ ] Publish start script and website by merging the commit into
+        the `release` branch.
+  - [ ] Check whether https://haskell.build/start has the newest start
+        script (netlify has problems sometimes).
 - [ ] Announce the new version (on Twitter)
 
 ### Remove these PRs from minor releases


### PR DESCRIPTION
The website will only be updated to the next release, if it lands on
the `release` branch.

Closes https://github.com/tweag/rules_haskell/issues/1093