### PR TITLE
haskell_cabal_library: Add haddocks

### DIFF
--- a/haskell/cabal.bzl
+++ b/haskell/cabal.bzl
@@ -9,12 +9,14 @@ load(":private/expansions.bzl", "expand_make_variables")
 load(":private/mode.bzl", "is_profiling_enabled")
 load(":private/path_utils.bzl", "join_path_list", "truly_relativize")
 load(":private/set.bzl", "set")
+load(":haddock.bzl", "generate_unified_haddock_info")
 load(
     ":private/workspace_utils.bzl",
     _execute_or_fail_loudly = "execute_or_fail_loudly",
 )
 load(
     ":providers.bzl",
+    "HaddockInfo",
     "HaskellInfo",
     "HaskellLibraryInfo",
     "get_ghci_extra_libs",
@@ -195,6 +197,14 @@ def _haskell_cabal_library_impl(ctx):
         "_install/{}_data".format(package_id),
         sibling = cabal,
     )
+    haddock_file = hs.actions.declare_file(
+        "_install/{}_haddock/{}.haddock".format(package_id, ctx.attr.name),
+        sibling = cabal,
+    )
+    haddock_html_dir = hs.actions.declare_directory(
+        "_install/{}_haddock_html".format(package_id),
+        sibling = cabal,
+    )
     static_library_filename = "_install/lib/libHS{}.a".format(package_id)
     if with_profiling:
         static_library_filename = "_install/lib/libHS{}_p.a".format(package_id)
@@ -246,6 +256,8 @@ def _haskell_cabal_library_impl(ctx):
             interfaces_dir,
             static_library,
             data_dir,
+            haddock_file,
+            haddock_html_dir,
         ] + ([dynamic_library] if dynamic_library != None else []),
         env = c.env,
         mnemonic = "HaskellCabalLibrary",
@@ -278,6 +290,12 @@ def _haskell_cabal_library_impl(ctx):
         compile_flags = [],
     )
     lib_info = HaskellLibraryInfo(package_id = package_id, version = None, exports = [])
+    doc_info = generate_unified_haddock_info(
+        this_package_id = package_id,
+        this_package_html = haddock_html_dir,
+        this_package_haddock = haddock_file,
+        deps = ctx.attr.deps,
+    )
     cc_toolchain = find_cpp_toolchain(ctx)
     feature_configuration = cc_common.configure_features(
         ctx = ctx,
@@ -305,7 +323,7 @@ def _haskell_cabal_library_impl(ctx):
             cc_info,
         ],
     )
-    return [default_info, hs_info, cc_info, lib_info]
+    return [default_info, hs_info, cc_info, lib_info, doc_info]
 
 haskell_cabal_library = rule(
     _haskell_cabal_library_impl,

--- a/haskell/haddock.bzl
+++ b/haskell/haddock.bzl
@@ -12,6 +12,29 @@ load(
 load(":private/context.bzl", "haskell_context", "render_env")
 load(":private/set.bzl", "set")
 
+def generate_unified_haddock_info(this_package_id, this_package_haddock, this_package_html, deps):
+    """Collapse dependencies into a single `HaddockInfo`.
+
+    Returns:
+      HaddockInfo: Unified information about this package and all its dependencies.
+    """
+    haddock_dict = {}
+    html_dict = {}
+
+    for dep in deps:
+        if HaddockInfo in dep:
+            html_dict.update(dep[HaddockInfo].transitive_html)
+            haddock_dict.update(dep[HaddockInfo].transitive_haddocks)
+
+    html_dict[this_package_id] = this_package_html
+    haddock_dict[this_package_id] = [this_package_haddock]
+
+    return HaddockInfo(
+        package_id = this_package_id,
+        transitive_html = html_dict,
+        transitive_haddocks = haddock_dict,
+    )
+
 def _get_haddock_path(package_id):
     """Get path to Haddock file of a package given its id.
 

--- a/haskell/private/cabal_wrapper.py.tpl
+++ b/haskell/private/cabal_wrapper.py.tpl
@@ -73,6 +73,8 @@ dynlibdir = os.path.join(pkgroot, "lib")
 bindir = os.path.join(pkgroot, "bin")
 datadir = os.path.join(pkgroot, "{}_data".format(name))
 package_database = os.path.join(pkgroot, "{}.conf.d".format(name))
+haddockdir = os.path.join(pkgroot, "{}_haddock".format(name))
+htmldir = os.path.join(pkgroot, "{}_haddock_html".format(name))
 
 runghc = find_exe(r"%{runghc}")
 ghc = find_exe(r"%{ghc}")
@@ -118,6 +120,8 @@ with tmpdir() as distdir:
     old_cwd = os.getcwd()
     os.chdir(srcdir)
     os.putenv("HOME", "/var/empty")
+    os.putenv("TMPDIR",os.path.join(distdir, "tmp"))
+    os.makedirs(os.path.join(distdir, "tmp"))
     run([runghc, setup, "configure", \
         component, \
         "--verbose=0", \
@@ -141,6 +145,8 @@ with tmpdir() as distdir:
         # Note, setting --datasubdir is required to work around
         #   https://github.com/haskell/cabal/issues/6235
         "--datasubdir=", \
+        "--haddockdir=" + haddockdir, \
+        "--htmldir=" + htmldir, \
         "--package-db=clear", \
         "--package-db=global", \
         ] + \
@@ -149,6 +155,7 @@ with tmpdir() as distdir:
         [ "--package-db=" + package_database ], # This arg must come last.
         )
     run([runghc, setup, "build", "--verbose=0", "--builddir=" + distdir])
+    run([runghc, setup, "haddock", "--verbose=0", "--builddir=" + distdir])
     run([runghc, setup, "install", "--verbose=0", "--builddir=" + distdir])
     # Bazel builds are not sandboxed on Windows and can be non-sandboxed on
     # other OSs. Operations like executing `configure` scripts can modify the


### PR DESCRIPTION
Build and export the haddocks for `haskell_cabal_library`es

This builds on top of #1097 because the cabal_wrapper part would have to
be rewritten otherwise (though it's minor and easy to port to master if
 #1097 gets delayed)