### PR TITLE
buildkite: Run the nixpkgs pipeline with `set -e`

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -4,6 +4,7 @@ steps:
       . /var/lib/buildkite-agent/.nix-profile/etc/profile.d/nix.sh
       echo "build:ci --host_platform=@rules_haskell//haskell/platforms:linux_x86_64_nixpkgs" > .bazelrc.local
       nix-shell --arg docTools false --pure --run '
+      set -e
       ./tests/run-start-script.sh --use-nix
       bazel build --config ci //tests:run-tests
       ./bazel-ci-bin/tests/run-tests

--- a/shell.nix
+++ b/shell.nix
@@ -27,6 +27,7 @@ mkShell {
     binutils
     # check the start script for problems
     shellcheck
+    file
   ] ++ lib.optionals docTools [graphviz python36Packages.sphinx zip unzip];
 
   shellHook = ''

--- a/start
+++ b/start
@@ -92,6 +92,7 @@ insert_if_equal () {
 parse_args "$@"
 
 if [ "$print_nix_usage_info" = "yes" ]; then
+    # shellcheck disable=SC2016
     echo 'INFO: Creating a WORKSPACE file based on GHC bindists. If you want to use a nix-based setup (e.g. on NixOS), call with `--use-nix`. See `--help` for more info.' >&2
 fi
 

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -374,23 +374,23 @@ haskell_binary(
 sh_inline_test(
     name = "shellcheck-start-script",
     size = "small",
-    tags = ["requires_shellcheck"],
     args = ["$(location //:start)"],
     data = ["//:start"],
     script = """\
 shellcheck --color=always --shell=sh "$1"
 """,
+    tags = ["requires_shellcheck"],
 )
 
 sh_inline_test(
     name = "shellcheck-cc-wrapper-windows",
     size = "small",
-    tags = ["requires_shellcheck"],
     args = ["$(location //haskell:private/cc_wrapper_windows.sh.tpl)"],
     data = ["//haskell:private/cc_wrapper_windows.sh.tpl"],
     script = """\
 shellcheck --color=always --shell=bash "$1"
 """,
+    tags = ["requires_shellcheck"],
 )
 
 haskell_library(

--- a/tests/library-linkstatic-flag/BUILD.bazel
+++ b/tests/library-linkstatic-flag/BUILD.bazel
@@ -100,7 +100,7 @@ is_dynamic () {
         file --dereference -- "$1" | grep -q "dynamically linked"
         res=$?
     else
-        echo 'file found in environment, please install either' >&2
+        echo 'file not found in environment, please install it' >&2
         exit 127
     fi
     return $res


### PR DESCRIPTION
Otherwise a failure in the middle doesn't cause the whole pipeline to fail

Fix #1104 