### PR TITLE
Set the minimal requirement for Haddock and protobuf

### DIFF
--- a/haskell/protobuf.bzl
+++ b/haskell/protobuf.bzl
@@ -12,6 +12,7 @@ load(
     "HaskellLibraryInfo",
     "HaskellProtobufInfo",
 )
+load(":private/pkg_id.bzl", "pkg_id")
 
 def _capitalize_first_letter(c):
     """Capitalize the first letter of the input. Unlike the built-in
@@ -206,8 +207,20 @@ def _haskell_proto_aspect_impl(target, ctx):
             transitive_html.update(dep[HaddockInfo].transitive_html)
             transitive_haddocks.update(dep[HaddockInfo].transitive_haddocks)
 
+    package_id = library_info.package_id
+
+    # TODO
+    # Missing haddock information for this build
+    # See bug https://github.com/tweag/rules_haskell/issues/1030
+    # We instead declare empty documentation directories / file
+    haddock_files = []
+    html_dir = None
+
+    #transitive_html.update({package_id: html_dir})
+    transitive_haddocks.update({package_id: haddock_files})
+
     haddock_info = HaddockInfo(
-        package_id = None,
+        package_id = package_id,
         transitive_html = transitive_html,
         transitive_haddocks = transitive_haddocks,
     )

--- a/tests/haddock_protobuf/BUILD.bazel
+++ b/tests/haddock_protobuf/BUILD.bazel
@@ -1,0 +1,43 @@
+load("@rules_haskell//haskell:defs.bzl",
+    "haskell_library",
+    "haskell_doc")
+load("//haskell:protobuf.bzl", "haskell_proto_library")
+
+
+proto_library(
+    name = "hello_world_proto",
+    srcs = ["hello_world.proto"],
+)
+
+haskell_proto_library(
+    name = "hello_world_haskell_proto",
+    deps = [
+        ":hello_world_proto",
+    ],
+)
+
+haskell_library(
+    name = "hello_world_haskell",
+    srcs = ["HelloWorld.hs"],  # Just imports the proto and does something trivial
+    deps = [
+        ":hello_world_haskell_proto",
+        "@stackage//:base",
+    ],
+)
+
+# Haddocks version A: depend on just the haskell_library
+haskell_doc(
+    name = "haddocks_a",
+    deps = [
+        ":hello_world_haskell",
+    ],
+)
+
+# Haddocks version B: depend on both haskell_library and haskell_proto_library
+haskell_doc(
+    name = "haddocks_b",
+    deps = [
+        ":hello_world_haskell",
+        ":hello_world_haskell_proto",
+    ],
+)

--- a/tests/haddock_protobuf/BUILD.bazel
+++ b/tests/haddock_protobuf/BUILD.bazel
@@ -1,8 +1,9 @@
-load("@rules_haskell//haskell:defs.bzl",
+load(
+    "@rules_haskell//haskell:defs.bzl",
+    "haskell_doc",
     "haskell_library",
-    "haskell_doc")
+)
 load("//haskell:protobuf.bzl", "haskell_proto_library")
-
 
 proto_library(
     name = "hello_world_proto",

--- a/tests/haddock_protobuf/HelloWorld.hs
+++ b/tests/haddock_protobuf/HelloWorld.hs
@@ -1,0 +1,7 @@
+module Bar (bar) where
+
+import Proto.Tests.HaddockProtobuf.HelloWorld
+
+-- | What about 'Proto.Tests.HaddockProtobuf.HelloWorld.Person'?
+bar :: Int
+bar = 5

--- a/tests/haddock_protobuf/hello_world.proto
+++ b/tests/haddock_protobuf/hello_world.proto
@@ -1,0 +1,9 @@
+syntax = "proto3";
+
+package hello_world; // Required to generate valid code.
+
+message Person {
+  string name = 1;
+  int32 id = 2;
+  string email = 3;
+}


### PR DESCRIPTION
This is a first step to fix #1030. It comes with tests:

- `//tests/haddock_protobuf:haddocks_b` was failing, it is now fixed
- `//tests/haddock_protobuf:haddocks_a` builds, but the haddock process
does not see the documentation link for
`Proto.Tests.HaddockProtobuf.HelloWorld.Person`. Not fixed yet.