### PR TITLE
Python / Haskell tests: fix the type of imported functions

### DIFF
--- a/tests/cc_haskell_import/python_add_one.py
+++ b/tests/cc_haskell_import/python_add_one.py
@@ -8,6 +8,8 @@ r = runfiles.Create()
 path = r.Rlocation('rules_haskell/tests/cc_haskell_import/hs-lib-b-wrapped.so')
 
 foreignlib = ctypes.cdll.LoadLibrary(path)
+foreignlib.hs_init.restype = ctypes.c_int
+foreignlib.hs_init.argtypes = [ctypes.c_int, ctypes.POINTER(ctypes.POINTER(ctypes.c_char))]
 
-foreignlib.hs_init()
-assert(str(foreignlib.add_one_hs(1)) == "2")
+foreignlib.hs_init(0, None)
+assert(str(foreignlib.add_one_hs(ctypes.c_int(1))) == "2")


### PR DESCRIPTION
This fixs a longstanding issue. hs_init was called without arguments,
which is wrong because the right prototype is:

int hs_init(int argc, char** argv)

This was leading to some invalid read in memory and sometimes it was
segfaulting.

I force the type in the prototype of hs_init and during the call to
add_one_hs