### PR TITLE
tests/RunTests.hs: fix failure tests

### DIFF
--- a/tests/RunTests.hs
+++ b/tests/RunTests.hs
@@ -68,7 +68,7 @@ main = hspec $ do
 
     for_ all_failure_tests $ \test -> do
       it test $ do
-        assertFailure (bazel ["build", "test"])
+        assertFailure (bazel ["build", test])
 
   -- Test that the repl still works if we shadow some Prelude functions
   it "repl name shadowing" $ do


### PR DESCRIPTION
Problem description by Andreas Herrmann:
> run-tests -m '/failures/' doesn't seem to be working as expected.
> The test should attempt to build all targets under
> //tests/failures/... that are marked with the manual tag and expect
> them to fail. However, if I add the manual tag to a suceeding target
> e.g. //tests/failures/transitive-deps:lib-c, then the overall test
> still suceeds.

Manually tested via description that a succeeding test now actually
fails.

Fixes https://github.com/tweag/rules_haskell/issues/943