### PR TITLE
Set LANG=C.UTF-8 in Nix shell

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -8,6 +8,9 @@ mkShell {
   # See: https://github.com/bazelbuild/bazel/issues/4231
   BAZEL_USE_CPP_ONLY_TOOLCHAIN=1;
 
+  # Set UTF-8 local so that run-tests can parse GHC's unicode output.
+  LANG="C.UTF-8";
+
   buildInputs = [
     go
     nix


### PR DESCRIPTION
This is to fix CI failures on `run-tests -m failures`, see https://github.com/tweag/rules_haskell/pull/1117#issuecomment-539916746:

> ```
> Failures:
> --
>   |  
>   | tests/RunTests.hs:70:7:
>   | 1) failures //tests/failures/transitive-deps:lib-dFailure
>   | uncaught exception: IOException of type InvalidArgument
>   | fd:15: hGetContents: invalid argument (invalid byte sequence)
>   |  
>   | To rerun use: --match "/failures///tests/failures/transitive-deps:lib-dFailure/"
>   |  
>   | tests/RunTests.hs:70:7:
>   | 2) failures //tests/failures/transitive-deps:lib-cFailure
>   | uncaught exception: IOException of type InvalidArgument
>   | fd:15: hGetContents: invalid argument (invalid byte sequence)
>   |  
>   | To rerun use: --match "/failures///tests/failures/transitive-deps:lib-cFailure/"
> ```
> 
> That failure already exists on `master` since #1115 see CI runs [#424](https://buildkite.com/tweag-1/rules-haskell/builds/424#39bec1bc-59c7-4ec6-8e47-64f5daac7e2f) and [#426](https://buildkite.com/tweag-1/rules-haskell/builds/426#b1430639-7b7e-4d12-a368-202587369698). So, it seems to be unrelated to this PR.

