### PR TITLE
Add the sub-workspaces to `.bazelignore`

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,0 +1,3 @@
+examples
+tutorial
+hazel


### PR DESCRIPTION
We don't want bazel to look into these when building `rules_haskell` itself as this can lead to infinite symlink expansion.

Fix #1124 