### PR TITLE
Sorted manifest files

### DIFF
--- a/haskell/private/actions/link.bzl
+++ b/haskell/private/actions/link.bzl
@@ -111,7 +111,7 @@ def _create_objects_dir_manifest(hs, objects_dir, dynamic, with_profiling):
         inputs = [objects_dir],
         outputs = [objects_dir_manifest],
         command = """
-        find {dir} -name '*.{ext}' > {out}
+        find {dir} -name '*.{ext}' | sort > {out}
         """.format(
             dir = objects_dir.path,
             ext = ext,


### PR DESCRIPTION
Fix for #1126.

`find` output is not stable, resulting on generated files with similar
content but in a different order.

This is not good for caching. The trivial solution is to use `sort` to
fix the output.