### PR TITLE
Avoid absolute RUNPATH to rts in GHC bindist

### DIFF
--- a/haskell/defs.bzl
+++ b/haskell/defs.bzl
@@ -313,7 +313,7 @@ haskell_import = rule(
         "version": attr.string(),
         "deps": attr.label_list(),
         "static_libraries": attr.label_list(allow_files = [".a"]),
-        "shared_libraries": attr.label_list(allow_files = [".dll", ".dylib", ".so"]),
+        "shared_libraries": attr.label_list(allow_files = True),
         "static_profiling_libraries": attr.label_list(allow_files = ["_p.a"]),
         "linkopts": attr.string_list(),
         "hdrs": attr.label_list(allow_files = True),

--- a/haskell/private/actions/package.bzl
+++ b/haskell/private/actions/package.bzl
@@ -2,7 +2,7 @@
 
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load(":private/packages.bzl", "ghc_pkg_recache", "write_package_conf")
-load(":private/path_utils.bzl", "get_lib_name", "target_unique_name")
+load(":private/path_utils.bzl", "get_lib_name", "is_hs_library", "target_unique_name")
 load(":private/pkg_id.bzl", "pkg_id")
 load(":providers.bzl", "get_extra_libs")
 
@@ -37,12 +37,12 @@ def _get_extra_libraries(hs, with_shared, cc_info):
     cc_static_libs = depset(direct = [
         lib
         for lib in static_libs.to_list()
-        if not get_lib_name(lib).startswith("HS")
+        if not is_hs_library(get_lib_name(lib))
     ])
     cc_dynamic_libs = depset(direct = [
         lib
         for lib in dynamic_libs.to_list()
-        if not get_lib_name(lib).startswith("HS")
+        if not is_hs_library(get_lib_name(lib))
     ])
     cc_libs = cc_static_libs.to_list() + cc_dynamic_libs.to_list()
 

--- a/haskell/private/path_utils.bzl
+++ b/haskell/private/path_utils.bzl
@@ -153,7 +153,7 @@ def mangle_static_library(hs, dynamic_lib, static_lib, outdir):
     if static_lib == None:
         return static_lib
     libname = get_lib_name(dynamic_lib)
-    if libname.startswith("HS"):
+    if is_hs_library(libname):
         return static_lib
     if get_lib_name(static_lib) == libname:
         return static_lib
@@ -197,6 +197,10 @@ def get_lib_extension(lib):
     n = lib.basename.find(".so.")
     end = lib.extension if n == -1 else lib.basename[n + 1:]
     return end
+
+def is_hs_library(libname):
+    """Returns True if the library belongs into the hs-libraries field."""
+    return libname.startswith("HS") or libname.startswith("Cffi")
 
 def get_dynamic_hs_lib_name(ghc_version, lib):
     """Return name of library by dropping extension,
@@ -254,7 +258,7 @@ def link_libraries(libs, args, prefix_optl = False):
     cc_libs = depset(direct = [
         lib
         for lib in libs.to_list()
-        if not get_lib_name(lib).startswith("HS")
+        if not is_hs_library(get_lib_name(lib))
     ])
 
     if prefix_optl:

--- a/haskell/private/pkgdb_to_bzl.py
+++ b/haskell/private/pkgdb_to_bzl.py
@@ -41,30 +41,45 @@ def path_to_label(path, pkgroot):
     if topdir_relative_path.find("$topdir") != -1:
         return os.path.normpath(topdir_relative_path.replace("$topdir", topdir)).replace('\\', '/')
 
-def hs_library_pattern(name, mode = "static", config = ""):
+def hs_library_pattern(name, mode = "static", profiling = False):
     """Convert hs-libraries entry to glob patterns.
 
     Args:
         name: The library name. E.g. HSrts or Cffi.
         mode: The linking mode. Either "static" or "dynamic".
-        suffix: The RTS configuration suffix. See https://gitlab.haskell.org/ghc/ghc/wikis/commentary/rts/config#rts-configurations
+        profiling: Look for profiling mode libraries.
 
     Returns:
         List of globbing patterns for the library file.
 
     """
+    # The RTS configuration suffix.
+    # See https://gitlab.haskell.org/ghc/ghc/wikis/commentary/rts/config#rts-configurations
+    configs = ["_p"] if profiling else [""]
+    # Special case HSrts or Cffi - include both libXYZ and libXYZ_thr.
+    if name == "HSrts" or name == "Cffi":
+        configs = [
+            prefix + config
+            for config in configs
+            for prefix in ["", "_thr"]
+        ]
+    # Special case libCffi - dynamic lib has no configs and is called libffi.
     if name == "Cffi" and mode == "dynamic":
         libname = "ffi"
+        configs = [""]
     else:
-        libname = name + config
-        if mode == "dynamic":
-            libname += "-ghc*"
+        libname = name
+    libnames = [libname + config for config in configs]
+    # Special case libCffi - dynamic lib has no version suffix.
+    if mode == "dynamic" and name != "Cffi":
+        libnames = [libname + "-ghc*" for libname in libnames]
     if mode == "dynamic":
         exts = ["so", "dylib", "dll"]
     else:
         exts = ["a"]
     return [
         "lib{}.{}".format(libname, ext)
+        for libname in libnames
         for ext in exts
     ]
 
@@ -195,21 +210,21 @@ for conf in glob.glob(os.path.join(topdir, "package.conf.d", "*.conf")):
                 static_libraries = "glob({})".format([
                     path_to_label("{}/{}".format(library_dir, pattern), pkg.pkgroot)
                     for hs_library in pkg.hs_libraries
-                    for pattern in hs_library_pattern(hs_library, mode = "static", config = "")
+                    for pattern in hs_library_pattern(hs_library, mode = "static", profiling = False)
                     for library_dir in pkg.library_dirs
                     if path_to_label(library_dir, pkg.pkgroot)
                 ]),
                 static_profiling_libraries = "glob({})".format([
                     path_to_label("{}/{}".format(library_dir, pattern), pkg.pkgroot)
                     for hs_library in pkg.hs_libraries
-                    for pattern in hs_library_pattern(hs_library, mode = "static", config = "_p")
+                    for pattern in hs_library_pattern(hs_library, mode = "static", profiling = True)
                     for library_dir in pkg.library_dirs
                     if path_to_label(library_dir, pkg.pkgroot)
                 ]),
                 shared_libraries = "glob({})".format([
                     path_to_label("{}/{}".format(dynamic_library_dir, pattern), pkg.pkgroot)
                     for hs_library in pkg.hs_libraries
-                    for pattern in hs_library_pattern(hs_library, mode = "dynamic", config = "")
+                    for pattern in hs_library_pattern(hs_library, mode = "dynamic", profiling = False)
                     for dynamic_library_dir in pkg.dynamic_library_dirs + pkg.library_dirs
                     if path_to_label(dynamic_library_dir, pkg.pkgroot)
                 ]),

--- a/haskell/private/pkgdb_to_bzl.py
+++ b/haskell/private/pkgdb_to_bzl.py
@@ -74,7 +74,7 @@ def hs_library_pattern(name, mode = "static", profiling = False):
     if mode == "dynamic" and name != "Cffi":
         libnames = [libname + "-ghc*" for libname in libnames]
     if mode == "dynamic":
-        exts = ["so", "dylib", "dll"]
+        exts = ["so", "so.*", "dylib", "dll"]
     else:
         exts = ["a"]
     return [

--- a/haskell/providers.bzl
+++ b/haskell/providers.bzl
@@ -10,6 +10,7 @@ load(
     ":private/path_utils.bzl",
     "create_rpath_entry",
     "get_lib_name",
+    "is_hs_library",
     "make_path",
     "mangle_static_library",
     "rel_to_pkgroot",
@@ -328,12 +329,12 @@ def create_link_config(hs, cc_info, binary, args, dynamic = None, pic = None):
     cc_static_libs = depset(direct = [
         lib
         for lib in static_libs.to_list()
-        if not get_lib_name(lib).startswith("HS")
+        if not is_hs_library(get_lib_name(lib))
     ])
     cc_dynamic_libs = depset(direct = [
         lib
         for lib in dynamic_libs.to_list()
-        if not get_lib_name(lib).startswith("HS")
+        if not is_hs_library(get_lib_name(lib))
     ])
 
     package_name = target_unique_name(hs, "link-config").replace("_", "-").replace("@", "-")


### PR DESCRIPTION
Closes #1127 

Before, rules_haskell only carried the non-threaded runtime library (`libHSrts`) as a `LibraryToLink`, while the threaded runtime library (`libHSrts_thr`) was completely ignored. Therefore `libHSrts_thr` was missing in the sandbox when linking with `-threaded` and the `cc_wrapper` could not purge the absolute `RUNPATH` to the GHC bindist that GHC generates automatically.

This PR adds `libHSrts_thr` to the tracked libraries, so that `cc_wrapper` can purge the absolute `RUNPATH` entry.

To avoid duplicate runtime libraries `haskell_toolchain_libraries_impl` chooses whether to forward the threaded or non-threaded runtime library based on whether `-threaded` is in the toolchain's `compiler_flags`. Ideally, this should be configurable on a per-target basis using Bazel configurations and transitions. However, given that previously only the non-threaded version of the library was tracked, this is no worse than the previous situation and the switch to configurations can be handled in a separate PR.