### PR TITLE
unix_configure: Support Windows platform

### DIFF
--- a/haskell/private/unix/unix_configure.bzl
+++ b/haskell/private/unix/unix_configure.bzl
@@ -43,7 +43,10 @@ toolchain(
             for (cmd, cmd_path) in commands.items()
             if cmd_path
         ]),
-        os = "osx" if cpu == "darwin" else "linux",
+        os = {
+            "darwin": "osx",
+            "x64_windows": "windows",
+        }.get(cpu, "linux"),
     ))
 
 unix_config = repository_rule(


### PR DESCRIPTION
`unix_configure` was not working on Windows, because the generated toolchain would never list `"@bazel_tools//platforms:windows"` as a compatible platform. This fixes that issue.

(`unix_configure` can be meaningful on Windows, e.g. if the tools are provided by msys2.)