### PR TITLE
Windows support for Cabal python wrapper

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -35,6 +35,21 @@ rules_haskell_dependencies()
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
+    name = "alex",
+    build_file_content = """
+load("@rules_haskell//haskell:cabal.bzl", "haskell_cabal_binary")
+haskell_cabal_binary(
+    name = "alex",
+    srcs = glob(["**"]),
+    visibility = ["//visibility:public"],
+)
+    """,
+    sha256 = "d58e4d708b14ff332a8a8edad4fa8989cb6a9f518a7c6834e96281ac5f8ff232",
+    strip_prefix = "alex-3.2.4",
+    urls = ["http://hackage.haskell.org/package/alex-3.2.4/alex-3.2.4.tar.gz"],
+)
+
+http_archive(
     name = "happy",
     build_file_content = """
 load("@rules_haskell//haskell:cabal.bzl", "haskell_cabal_binary")
@@ -58,6 +73,8 @@ stack_snapshot(
         "ghc-heap",
         "process",
         # For tests
+        "network",
+        "language-c",
         "streaming",
         "void",
         "hspec",
@@ -69,7 +86,10 @@ stack_snapshot(
         "lens-family",
     ],
     snapshot = "lts-13.15",
-    tools = ["@happy"],
+    tools = [
+        "@alex",
+        "@happy",
+    ],
 )
 
 # In a separate repo because not all platforms support zlib.

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -122,6 +122,7 @@ jobs:
       /c/bazel/bazel.exe test --config windows "//tests/two-libs/..."
       /c/bazel/bazel.exe test --config windows "//tests/encoding/..."
       /c/bazel/bazel.exe test --config windows "//tests/c-compiles/..."
+      /c/bazel/bazel.exe test --config windows "//tests/stack-snapshot-deps/..."
 
       # Hazel tests that succeed
       /c/bazel/bazel.exe test --config windows "@ai_formation_hazel//test:ghc-paths-test"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,7 +9,7 @@ jobs:
       architecture: 'x64'
   - bash: |
       set -e
-      curl -LO https://github.com/bazelbuild/bazel/releases/download/0.28.0/bazel-0.28.0-windows-x86_64.exe
+      curl -LO https://github.com/bazelbuild/bazel/releases/download/1.1.0/bazel-1.1.0-windows-x86_64.exe
       mv bazel-*.exe bazel.exe
       mkdir /c/bazel
       mv bazel.exe /c/bazel

--- a/haskell/cabal.bzl
+++ b/haskell/cabal.bzl
@@ -86,7 +86,8 @@ def _cabal_tool_flag(tool):
         return "--with-{}={}".format(tool.basename, tool.path)
 
 def _make_path(hs, binaries):
-    return ":".join([binary.dirname for binary in binaries.to_list()])
+    path_list_sep = ";" if hs.toolchain.is_windows else ":"
+    return path_list_sep.join([binary.dirname for binary in binaries.to_list()])
 
 def _prepare_cabal_inputs(hs, cc, unix, dep_info, cc_info, component, package_id, tool_inputs, tool_input_manifests, cabal, setup, srcs, flags, cabal_wrapper, package_database):
     """Compute Cabal wrapper, arguments, inputs."""
@@ -94,7 +95,8 @@ def _prepare_cabal_inputs(hs, cc, unix, dep_info, cc_info, component, package_id
 
     (ghci_extra_libs, env) = get_ghci_extra_libs(hs, cc_info)
     env.update(**hs.env)
-    env["PATH"] = _make_path(hs, tool_inputs) + ":" + ":".join(unix.paths)
+    path_list_sep = ";" if hs.toolchain.is_windows else ":"
+    env["PATH"] = _make_path(hs, tool_inputs) + path_list_sep + path_list_sep.join(unix.paths)
     if hs.toolchain.is_darwin:
         env["SDKROOT"] = "macosx"  # See haskell/private/actions/link.bzl
 

--- a/haskell/cabal_wrapper.bzl
+++ b/haskell/cabal_wrapper.bzl
@@ -30,6 +30,7 @@ def _cabal_wrapper_impl(ctx):
             "%{cc}": hs_toolchain.cc_wrapper.executable.path,
             "%{strip}": cc_toolchain.strip_executable(),
             "%{is_windows}": str(hs.toolchain.is_windows),
+            "%{workspace}": ctx.workspace_name,
         },
     )
     return [DefaultInfo(

--- a/haskell/private/cabal_wrapper.py.tpl
+++ b/haskell/private/cabal_wrapper.py.tpl
@@ -108,12 +108,6 @@ def tmpdir():
         shutil.rmtree(distdir)
 
 with tmpdir() as distdir:
-    # Use the cc-wrapper for Cabal builds.
-    # Note, we cannot currently use it on Windows because the solution to the
-    # following issue is not released, yet.
-    #   https://github.com/bazelbuild/bazel/issues/9390
-    with_gcc_flags = ["--with-gcc=" + cc] \
-            if "%{is_windows}" != "True" else []
     enable_relocatable_flags = ["--enable-relocatable"] \
             if "%{is_windows}" != "True" else []
 
@@ -131,9 +125,7 @@ with tmpdir() as distdir:
         "--with-compiler=" + ghc,
         "--with-hc-pkg=" + ghc_pkg,
         "--with-ar=" + ar,
-        ] +
-        with_gcc_flags + \
-        [ \
+        "--with-gcc=" + cc,
         "--with-strip=" + strip,
         "--enable-deterministic", \
         ] +

--- a/haskell/private/cabal_wrapper.py.tpl
+++ b/haskell/private/cabal_wrapper.py.tpl
@@ -34,10 +34,12 @@ def run(cmd, *args, **kwargs):
         sys.stderr.flush()
     subprocess.call(cmd, *args, **kwargs)
 
+path_list_sep = ";" if "%{is_windows}" == "True" else ":"
+
 def canonicalize_path(path):
-    return ":".join([
+    return path_list_sep.join([
         os.path.abspath(entry)
-        for entry in path.split(":")
+        for entry in path.split(path_list_sep)
         if entry != ""
     ])
 

--- a/haskell/private/cabal_wrapper.py.tpl
+++ b/haskell/private/cabal_wrapper.py.tpl
@@ -166,7 +166,7 @@ def make_relocatable_paths(line):
 
     # The $execroot is an absolute path and should not leak into the output.
     # Replace each ocurrence of execroot by a path relative to ${pkgroot}.
-    line = re.sub(execroot + '\S*', make_relative_to_pkgroot, line)
+    line = re.sub(re.escape(execroot) + '\S*', make_relative_to_pkgroot, line)
     return line
 
 if libraries != [] and os.path.isfile(package_conf_file):

--- a/haskell/private/cabal_wrapper.py.tpl
+++ b/haskell/private/cabal_wrapper.py.tpl
@@ -33,7 +33,7 @@ def run(cmd, *args, **kwargs):
     if debug:
         print("+ " + " ".join(["'{}'".format(arg) for arg in cmd]), file=sys.stderr)
         sys.stderr.flush()
-    subprocess.call(cmd, *args, **kwargs)
+    subprocess.check_call(cmd, *args, **kwargs)
 
 def find_exe(exe):
     if os.path.isfile(exe):

--- a/hazel/workspace.bzl
+++ b/hazel/workspace.bzl
@@ -63,18 +63,21 @@ cc_library(
         package_name = "zlib",
         version = "0.6.2",
         build_file = "@ai_formation_hazel//third_party/haskell:BUILD.zlib",
+        sha256 = "0dcc7d925769bdbeb323f83b66884101084167501f11d74d21eb9bc515707fed",
     )
 
     hazel_custom_package_hackage(
         package_name = "vault",
         version = "0.3.1.1",
         build_file = "@ai_formation_hazel//third_party/haskell:BUILD.vault",
+        sha256 = "b2a4150699db8a45d189cc93c34c36c3bfc1082b4ca94612e242aefd4e8e2e28",
     )
 
     hazel_custom_package_hackage(
         package_name = "ghc-paths",
         version = "0.1.0.9",
         build_file = "@ai_formation_hazel//third_party/haskell:BUILD.ghc-paths",
+        sha256 = "afa68fb86123004c37c1dc354286af2d87a9dcfb12ddcb80e8bd0cd55bc87945",
     )
 
     hazel_custom_package_github(

--- a/tests/stack-snapshot-deps/BUILD.bazel
+++ b/tests/stack-snapshot-deps/BUILD.bazel
@@ -18,5 +18,8 @@ haskell_test(
         "@stackage//:base",
         # Core package that is no dependency of another item in the snapshot.
         "@stackage//:ghc-heap",
+        # Packages using ./configure scripts are problematic on Windows.
+        "@stackage//:network",
+        "@stackage//:language-c",
     ],
 )


### PR DESCRIPTION
- Support Windows paths in Cabal python wrapper (e.g. `C:\foo\bar`)
- Look for executables using bazel-runfiles in Cabal python wrapper. Necessary on Windows when no symlinks are created in the sandbox and executables need to be looked up in the runtime manifest instead.
- Use Bazel 1.1.0 on Windows - required for `cc_wrapper` on Windows, see https://github.com/bazelbuild/bazel/issues/9390.
- Test `network` and `language-c` on Windows - these use `./configure` scripts and are more problematic on Windows.