### PR TITLE
Refactor path list separator handling

### DIFF
--- a/haskell/private/path_utils.bzl
+++ b/haskell/private/path_utils.bzl
@@ -103,6 +103,15 @@ def declare_compiled(hs, src, ext, directory = None, rel_path = None):
 
     return hs.actions.declare_file(fp_with_dir)
 
+def join_path_list(hs, paths):
+    """Join the given paths suitable for env vars like PATH.
+
+    Joins the list of given paths into a single string separated by ':' on Unix
+    or ';' on Windows.
+    """
+    sep = ";" if hs.toolchain.is_windows else ":"
+    return sep.join(paths)
+
 def make_library_path(libs, prefix = None, sep = None):
     """Return a string value for using as LD_LIBRARY_PATH or similar.
 

--- a/haskell/private/path_utils.bzl
+++ b/haskell/private/path_utils.bzl
@@ -103,7 +103,7 @@ def declare_compiled(hs, src, ext, directory = None, rel_path = None):
 
     return hs.actions.declare_file(fp_with_dir)
 
-def make_path(libs, prefix = None, sep = None):
+def make_library_path(libs, prefix = None, sep = None):
     """Return a string value for using as LD_LIBRARY_PATH or similar.
 
     Args:

--- a/haskell/private/path_utils.bzl
+++ b/haskell/private/path_utils.bzl
@@ -112,20 +112,19 @@ def join_path_list(hs, paths):
     sep = ";" if hs.toolchain.is_windows else ":"
     return sep.join(paths)
 
-def make_library_path(libs, prefix = None, sep = None):
+def make_library_path(hs, libs, prefix = None):
     """Return a string value for using as LD_LIBRARY_PATH or similar.
 
     Args:
+      hs: Haskell context.
       libs: List of library files that should be available
       prefix: String, an optional prefix to add to every path.
-      sep: String, the path separator, defaults to ":".
 
     Returns:
-      String: paths to the given library directories separated by ":".
+      String: paths to the given library directories separated by ":" (Unix) or
+        ";" (Windows).
     """
     r = set.empty()
-
-    sep = sep if sep else ":"
 
     for lib in libs.to_list():
         lib_dir = paths.dirname(lib.path)
@@ -134,7 +133,7 @@ def make_library_path(libs, prefix = None, sep = None):
 
         set.mutable_insert(r, lib_dir)
 
-    return sep.join(set.to_list(r))
+    return join_path_list(hs, set.to_list(r))
 
 def mangle_static_library(hs, dynamic_lib, static_lib, outdir):
     """Mangle a static library to match a dynamic library name.

--- a/haskell/providers.bzl
+++ b/haskell/providers.bzl
@@ -11,7 +11,7 @@ load(
     "create_rpath_entry",
     "get_lib_name",
     "is_hs_library",
-    "make_path",
+    "make_library_path",
     "mangle_static_library",
     "rel_to_pkgroot",
     "target_unique_name",
@@ -223,7 +223,7 @@ def get_ghci_extra_libs(hs, cc_info, path_prefix = None):
     # NOTE: We can avoid constructing these in the future by instead generating
     #   a dedicated package configuration file defining the required libraries.
     sep = ";" if hs.toolchain.is_windows else None
-    library_path = make_path(libs, prefix = path_prefix, sep = sep)
+    library_path = make_library_path(libs, prefix = path_prefix, sep = sep)
     ghc_env = {
         "LIBRARY_PATH": library_path,
         "LD_LIBRARY_PATH": library_path,

--- a/haskell/providers.bzl
+++ b/haskell/providers.bzl
@@ -222,8 +222,7 @@ def get_ghci_extra_libs(hs, cc_info, path_prefix = None):
 
     # NOTE: We can avoid constructing these in the future by instead generating
     #   a dedicated package configuration file defining the required libraries.
-    sep = ";" if hs.toolchain.is_windows else None
-    library_path = make_library_path(libs, prefix = path_prefix, sep = sep)
+    library_path = make_library_path(hs, libs, prefix = path_prefix)
     ghc_env = {
         "LIBRARY_PATH": library_path,
         "LD_LIBRARY_PATH": library_path,


### PR DESCRIPTION
Refactor the code handling the OS specific path list separator (":" on Unix and ";" on Windows).

Addressing https://github.com/tweag/rules_haskell/pull/1133#discussion_r338087500
