### PR TITLE
Provision proto-lens-protoc using Cabal

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -5,11 +5,11 @@ tasks:
       # haskell base uses the environment locale to decode sockets
       LANG: "C.UTF-8"
     build_flags:
-      - "--build_tag_filters=-requires_hackage,-requires_zlib,-requires_lz4,-requires_doctest,-requires_c2hs,-requires_threaded_rts,-requires_shellcheck,-dont_test_with_bindist,-dont_test_on_bazelci"
+      - "--build_tag_filters=-requires_zlib,-requires_lz4,-requires_doctest,-requires_c2hs,-requires_threaded_rts,-requires_shellcheck,-dont_test_with_bindist,-dont_test_on_bazelci"
       - "--incompatible_use_python_toolchains=false"
     build_targets:
       - "//tests/..."
     test_flags:
-      - "--test_tag_filters=-requires_hackage,-requires_zlib,-requires_lz4,-requires_doctest,-requires_c2hs,-requires_threaded_rts,-requires_shellcheck,-dont_test_with_bindist,-dont_test_on_bazelci"
+      - "--test_tag_filters=-requires_zlib,-requires_lz4,-requires_doctest,-requires_c2hs,-requires_threaded_rts,-requires_shellcheck,-dont_test_with_bindist,-dont_test_on_bazelci"
     test_targets:
       - "//tests/..."

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -60,6 +60,30 @@ haskell_cabal_binary(name = "happy", srcs = glob(["**"]), visibility = ["//visib
     urls = ["http://hackage.haskell.org/package/happy-1.19.10/happy-1.19.10.tar.gz"],
 )
 
+http_archive(
+    name = "proto-lens-protoc",
+    build_file_content = """
+load("@rules_haskell//haskell:cabal.bzl", "haskell_cabal_binary")
+haskell_cabal_binary(
+    name = "proto-lens-protoc",
+    srcs = glob(["**"]),
+    deps = [
+      "@stackage//:base",
+      "@stackage//:bytestring",
+      "@stackage//:containers",
+      "@stackage//:lens-family",
+      "@stackage//:proto-lens",
+      "@stackage//:proto-lens-protoc",
+      "@stackage//:text",
+    ],
+    visibility = ["//visibility:public"],
+)
+    """,
+    sha256 = "d10e4e43673bff435cf6256145f91fbb60dd37510320fcae56be18ac90af2fee",
+    strip_prefix = "proto-lens-protoc-0.4.0.1",
+    urls = ["http://hackage.haskell.org/package/proto-lens-protoc-0.4.0.1/proto-lens-protoc-0.4.0.1.tar.gz"],
+)
+
 load("@rules_haskell//haskell:cabal.bzl", "stack_snapshot")
 
 stack_snapshot(
@@ -68,10 +92,15 @@ stack_snapshot(
         # Core libraries
         "array",
         "base",
+        "bytestring",
+        "containers",
+        "deepseq",
         "directory",
         "filepath",
         "ghc-heap",
+        "mtl",
         "process",
+        "text",
         # For tests
         "network",
         "language-c",
@@ -83,6 +112,7 @@ stack_snapshot(
         "data-default-class",
         "lens-labels",
         "proto-lens",
+        "proto-lens-protoc",
         "lens-family",
     ],
     snapshot = "lts-13.15",
@@ -221,12 +251,6 @@ nixpkgs_package(
 nixpkgs_package(
     name = "doctest",
     attribute_path = "haskellPackages.doctest",
-    repository = "@nixpkgs",
-)
-
-nixpkgs_package(
-    name = "proto-lens-protoc",
-    attribute_path = "haskellPackages.proto-lens-protoc",
     repository = "@nixpkgs",
 )
 

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -111,7 +111,6 @@ rule_test(
     size = "small",
     generates = ["binary-with-prebuilt"],
     rule = "//tests/binary-with-prebuilt",
-    tags = ["requires_hackage"],
 )
 
 rule_test(
@@ -135,7 +134,6 @@ sh_test(
     srcs = ["//tests/binary-with-data"],
     args = ["$(location //tests/binary-with-data:bin1)"],
     data = ["//tests/binary-with-data:bin1"],
-    tags = ["requires_hackage"],
 )
 
 config_setting(
@@ -212,7 +210,6 @@ rule_test(
         "haddock/testsZShaddockZShaddock-lib-deep",
     ],
     rule = "//tests/haddock",
-    tags = ["requires_hackage"],
 )
 
 rule_test(
@@ -361,7 +358,6 @@ rule_test(
 haskell_binary(
     name = "run-tests",
     srcs = ["RunTests.hs"],
-    tags = ["requires_hackage"],
     deps = [
         "//tests/hackage:base",
         "//tests/hackage:process",

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -40,24 +40,23 @@ haskell_doctest_toolchain(
 haskell_proto_toolchain(
     name = "protobuf-toolchain",
     testonly = 0,
-    plugin = "@proto-lens-protoc//:bin/proto-lens-protoc",
+    plugin = "@proto-lens-protoc",
     protoc = "@com_google_protobuf//:protoc",
     tags = [
-        "requires_hackage",
         "requires_proto",
     ],
     deps = [
-        "//tests/hackage:base",
-        "//tests/hackage:bytestring",
-        "//tests/hackage:containers",
-        "//tests/hackage:deepseq",
-        "//tests/hackage:mtl",
-        "//tests/hackage:text",
+        "@stackage//:base",
+        "@stackage//:bytestring",
+        "@stackage//:containers",
         "@stackage//:data-default-class",
+        "@stackage//:deepseq",
         "@stackage//:lens-family",
         "@stackage//:lens-family-core",
         "@stackage//:lens-labels",
+        "@stackage//:mtl",
         "@stackage//:proto-lens",
+        "@stackage//:text",
     ],
 )
 

--- a/tests/binary-with-data/BUILD.bazel
+++ b/tests/binary-with-data/BUILD.bazel
@@ -23,7 +23,6 @@ haskell_test(
     srcs = ["bin2.hs"],
     args = ["$(location :bin1)"],
     data = [":bin1"],
-    tags = ["requires_hackage"],
     visibility = ["//visibility:public"],
     deps = [
         "//tests/hackage:base",

--- a/tests/binary-with-prebuilt/BUILD.bazel
+++ b/tests/binary-with-prebuilt/BUILD.bazel
@@ -8,7 +8,6 @@ package(default_testonly = 1)
 haskell_test(
     name = "binary-with-prebuilt",
     srcs = ["Main.hs"],
-    tags = ["requires_hackage"],
     visibility = ["//visibility:public"],
     deps = [
         "//tests/hackage:base",

--- a/tests/haddock/BUILD.bazel
+++ b/tests/haddock/BUILD.bazel
@@ -40,7 +40,6 @@ haskell_library(
         "unicode.txt",
     ],
     tags = [
-        "requires_hackage",
         "requires_zlib",
     ],
     deps = [
@@ -54,13 +53,11 @@ haskell_library(
 haskell_doc(
     name = "haddock",
     index_transitive_deps = False,
-    tags = ["requires_hackage"],
     deps = [":haddock-lib-b"],
 )
 
 haskell_doc(
     name = "haddock-transitive",
     index_transitive_deps = True,
-    tags = ["requires_hackage"],
     deps = [":haddock-lib-b"],
 )

--- a/tests/haskell_proto_library/BUILD.bazel
+++ b/tests/haskell_proto_library/BUILD.bazel
@@ -39,7 +39,6 @@ proto_library(
 haskell_proto_library(
     name = "address_haskell_proto",
     tags = [
-        "requires_hackage",
         "requires_proto",
     ],
     deps = [":address_proto"],
@@ -48,7 +47,6 @@ haskell_proto_library(
 haskell_proto_library(
     name = "stripped_address_haskell_proto",
     tags = [
-        "requires_hackage",
         "requires_proto",
     ],
     deps = [":stripped_address_proto"],
@@ -57,7 +55,6 @@ haskell_proto_library(
 haskell_proto_library(
     name = "person_haskell_proto",
     tags = [
-        "requires_hackage",
         "requires_proto",
     ],
     deps = [":person_proto"],
@@ -67,7 +64,6 @@ haskell_library(
     name = "hs-lib",
     srcs = ["Bar.hs"],
     tags = [
-        "requires_hackage",
         "requires_proto",
     ],
     visibility = ["//visibility:public"],
@@ -82,7 +78,6 @@ haskell_library(
 haskell_doc(
     name = "docs",
     tags = [
-        "requires_hackage",
         "requires_proto",
     ],
     deps = [":hs-lib"],

--- a/tests/repl-targets/BUILD.bazel
+++ b/tests/repl-targets/BUILD.bazel
@@ -34,7 +34,6 @@ haskell_library(
         ":codegen",
     ],
     tags = [
-        "requires_hackage",
         "requires_zlib",
     ],
     visibility = ["//visibility:public"],

--- a/tests/stack-snapshot-deps/BUILD.bazel
+++ b/tests/stack-snapshot-deps/BUILD.bazel
@@ -9,7 +9,6 @@ haskell_test(
     name = "stack-snapshot-deps",
     srcs = ["Main.hs"],
     tags = [
-        "requires_hackage",
         "requires_zlib",
     ],
     visibility = ["//visibility:public"],


### PR DESCRIPTION
- Replaces the nixpkgs provisioned `proto-lens-protoc` binary by one fetched from Hackage and built using Cabal.
    This allows using the proto toolchain on non-nixpkgs systems, e.g. the GHC bindist CI pipeline.
- This also removes the `requires_hackage` tag as this was intended to mark targets that require the nixpkgs provided Hackage packages. However, we no longer provision any Hackage packages through nixpkgs. These are either provided by `stack_snapshot` or by the standard GHC distribution.

Closes #1137 

Locally the following builds and tests passed without Nix being available
```
bazel build --verbose_failures --keep_going --disk_cache= --build_tag_filters=-requires_zlib,-requires_lz4,-requires_doctest,-requires_c2hs,-requires_threaded_rts,-requires_shellcheck,-dont_test_with_bindist,-dont_test_on_bazelci --incompatible_use_python_toolchains=false -- //tests/...
bazel test --verbose_failures --keep_going --disk_cache= --build_tag_filters=-requires_zlib,-requires_lz4,-requires_doctest,-requires_c2hs,-requires_threaded_rts,-requires_shellcheck,-dont_test_with_bindist,-dont_test_on_bazelci --test_tag_filters=-requires_zlib,-requires_lz4,-requires_doctest,-requires_c2hs,-requires_threaded_rts,-requires_shellcheck,-dont_test_with_bindist,-dont_test_on_bazelci --incompatible_use_python_toolchains=false -- //tests/...
```