### PR TITLE
Fix deprecated bazel_skylib imports

### DIFF
--- a/haskell/cabal.bzl
+++ b/haskell/cabal.bzl
@@ -1,6 +1,6 @@
 """Cabal packages"""
 
-load("@bazel_skylib//:lib.bzl", "paths")
+load("@bazel_skylib//lib:paths.bzl", "paths")
 load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
 load(":cc.bzl", "cc_interop_info")
 load(":private/context.bzl", "haskell_context", "render_env")

--- a/hazel/third_party/cabal2bazel/bzl/cabal_package.bzl
+++ b/hazel/third_party/cabal2bazel/bzl/cabal_package.bzl
@@ -20,8 +20,8 @@ where {package} is the lower-cased package name with - replaced by _
 and {hash} is the Bazel hash of the original package name.
 """
 
-load("@bazel_skylib//:lib.bzl", "paths")
-load("@bazel_skylib//:lib.bzl", sets = "new_sets")
+load("@bazel_skylib//lib:paths.bzl", "paths")
+load("@bazel_skylib//lib:sets.bzl", new_sets = "sets")
 load(
     "@rules_haskell//haskell:defs.bzl",
     "haskell_binary",

--- a/hazel/third_party/cabal2bazel/bzl/cabal_paths.bzl
+++ b/hazel/third_party/cabal2bazel/bzl/cabal_paths.bzl
@@ -23,7 +23,7 @@ This file exports the "cabal_paths" rule for auto-generating that Paths module.
 For usage information, see the below documentation for that rule.
 """
 
-load("@bazel_skylib//:lib.bzl", "paths")
+load("@bazel_skylib//lib:paths.bzl", "paths")
 load("@rules_haskell//haskell:defs.bzl", "haskell_library")
 load("//tools:mangling.bzl", "hazel_library")
 


### PR DESCRIPTION
`bazel_skylib` has deprecated `lib.bzl`. When using the latest release (0.9) one gets a warning on every import, and `lib.bzl` will no longer exist in the following releases.

`rules_haskell` asks for version 0.6 of bazel_skylib, and the new imports work there as well.