### PR TITLE
Remove use_default_shell_env

### DIFF
--- a/.buildkite/bindists-pipeline
+++ b/.buildkite/bindists-pipeline
@@ -9,8 +9,8 @@ BAZEL_DIR="$(.buildkite/fetch-bazel-bindist)"
 trap "rm -rf '$BAZEL_DIR'" EXIT
 export PATH="$BAZEL_DIR:$PATH"
 echo "common:ci --build_tag_filters -requires_lz4,-requires_proto,-requires_zlib,-requires_doctest,-requires_c2hs,-requires_threaded_rts,-dont_test_with_bindist" > .bazelrc.local
-# XXX: Remove once all rules using `use_default_shell_env = True` have been
-#   converted to using `rules_sh`'s POSIX toolchain.
+# XXX: @com_google_protobuf sets `use_default_shell_env = True`, so we enable
+#   strict action env to avoid changes in `PATH` invalidating the cache.
 echo "build:ci --experimental_strict_action_env" >> .bazelrc.local
 ./tests/run-start-script.sh --use-bindists
 bazel build --config ci //tests/...

--- a/haskell/cabal.bzl
+++ b/haskell/cabal.bzl
@@ -92,7 +92,7 @@ def _prepare_cabal_inputs(hs, cc, posix, dep_info, cc_info, component, package_i
     """Compute Cabal wrapper, arguments, inputs."""
     with_profiling = is_profiling_enabled(hs)
 
-    (ghci_extra_libs, env) = get_ghci_extra_libs(hs, cc_info)
+    (ghci_extra_libs, env) = get_ghci_extra_libs(hs, posix, cc_info)
     env.update(**hs.env)
     env["PATH"] = join_path_list(hs, _binary_paths(tool_inputs) + posix.paths)
     if hs.toolchain.is_darwin:

--- a/haskell/defs.bzl
+++ b/haskell/defs.bzl
@@ -181,6 +181,7 @@ def _mk_binary_rule(**kwargs):
         },
         toolchains = [
             "@rules_haskell//haskell:toolchain",
+            "@rules_sh//sh/posix:toolchain_type",
         ],
         fragments = ["cpp"],
         **kwargs
@@ -225,6 +226,7 @@ _haskell_library = rule(
     },
     toolchains = [
         "@rules_haskell//haskell:toolchain",
+        "@rules_sh//sh/posix:toolchain_type",
     ],
     fragments = ["cpp"],
 )

--- a/haskell/doctest.bzl
+++ b/haskell/doctest.bzl
@@ -80,6 +80,7 @@ def _haskell_doctest_single(target, ctx):
         return []
 
     hs = haskell_context(ctx, ctx.attr)
+    posix = ctx.toolchains["@rules_sh//sh/posix:toolchain_type"]
 
     hs_info = target[HaskellInfo]
     cc_info = target[CcInfo]
@@ -121,7 +122,7 @@ def _haskell_doctest_single(target, ctx):
     args.add_all(ctx.attr.doctest_flags)
 
     # C library dependencies to link against.
-    (ghci_extra_libs, ghc_env) = get_ghci_extra_libs(hs, cc_info)
+    (ghci_extra_libs, ghc_env) = get_ghci_extra_libs(hs, posix, cc_info)
     link_libraries(ghci_extra_libs, args, prefix_optl = hs.toolchain.is_darwin)
 
     if ctx.attr.modules:
@@ -214,6 +215,7 @@ omitted, all exposed modules provided by `deps` will be tested.
     toolchains = [
         "@rules_haskell//haskell:toolchain",
         "@rules_haskell//haskell:doctest-toolchain",
+        "@rules_sh//sh/posix:toolchain_type",
     ],
 )
 """Run doctest test on targets in `deps`.

--- a/haskell/haddock.bzl
+++ b/haskell/haddock.bzl
@@ -155,7 +155,9 @@ def _haskell_doc_aspect_impl(target, ctx):
             args,
             compile_flags,
         ],
-        use_default_shell_env = True,
+        env = {
+            "PATH": (";" if hs.toolchain.is_windows else ":").join(posix.paths),
+        },
     )
 
     transitive_html.update({package_id: html_dir})

--- a/haskell/haddock.bzl
+++ b/haskell/haddock.bzl
@@ -33,6 +33,7 @@ def _haskell_doc_aspect_impl(target, ctx):
         return []
 
     hs = haskell_context(ctx, ctx.rule.attr)
+    posix = ctx.toolchains["@rules_sh//sh/posix:toolchain_type"]
 
     package_id = target[HaskellLibraryInfo].package_id
 
@@ -106,6 +107,7 @@ def _haskell_doc_aspect_impl(target, ctx):
     # C library dependencies for runtime.
     (ghci_extra_libs, ghc_env) = get_ghci_extra_libs(
         hs,
+        posix,
         target[CcInfo],
         # haddock changes directory during its execution. We prefix
         # LD_LIBRARY_PATH with the current working directory on wrapper script
@@ -177,7 +179,10 @@ haskell_doc_aspect = aspect(
         ),
     },
     attr_aspects = ["deps", "exports"],
-    toolchains = ["@rules_haskell//haskell:toolchain"],
+    toolchains = [
+        "@rules_haskell//haskell:toolchain",
+        "@rules_sh//sh/posix:toolchain_type",
+    ],
 )
 
 def _dirname(file):

--- a/haskell/private/actions/compile.bzl
+++ b/haskell/private/actions/compile.bzl
@@ -86,7 +86,7 @@ def _process_hsc_file(hs, cc, hsc_flags, hsc_inputs, hsc_file):
 
     return hs_out, idir
 
-def _compilation_defaults(hs, cc, java, dep_info, plugin_dep_info, cc_info, srcs, import_dir_map, extra_srcs, user_compile_flags, with_profiling, my_pkg_id, version, plugins, preprocessors):
+def _compilation_defaults(hs, cc, java, posix, dep_info, plugin_dep_info, cc_info, srcs, import_dir_map, extra_srcs, user_compile_flags, with_profiling, my_pkg_id, version, plugins, preprocessors):
     """Compute variables common to all compilation targets (binary and library).
 
     Returns:
@@ -320,7 +320,7 @@ def _compilation_defaults(hs, cc, java, dep_info, plugin_dep_info, cc_info, srcs
     )
 
     # Transitive library dependencies for runtime.
-    (ghci_extra_libs, ghc_env) = get_ghci_extra_libs(hs, cc_info)
+    (ghci_extra_libs, ghc_env) = get_ghci_extra_libs(hs, posix, cc_info)
     link_libraries(ghci_extra_libs, args)
 
     return struct(
@@ -372,6 +372,7 @@ def compile_binary(
         hs,
         cc,
         java,
+        posix,
         dep_info,
         plugin_dep_info,
         cc_info,
@@ -396,7 +397,7 @@ def compile_binary(
         modules: set of module names
         source_files: set of Haskell source files
     """
-    c = _compilation_defaults(hs, cc, java, dep_info, plugin_dep_info, cc_info, srcs, import_dir_map, extra_srcs, user_compile_flags, with_profiling, my_pkg_id = None, version = version, plugins = plugins, preprocessors = preprocessors)
+    c = _compilation_defaults(hs, cc, java, posix, dep_info, plugin_dep_info, cc_info, srcs, import_dir_map, extra_srcs, user_compile_flags, with_profiling, my_pkg_id = None, version = version, plugins = plugins, preprocessors = preprocessors)
     c.args.add_all(["-main-is", main_function])
     if dynamic:
         # For binaries, GHC creates .o files even for code to be
@@ -438,6 +439,7 @@ def compile_library(
         hs,
         cc,
         java,
+        posix,
         dep_info,
         plugin_dep_info,
         cc_info,
@@ -463,7 +465,7 @@ def compile_library(
         source_files: set of Haskell module files
         import_dirs: import directories that should make all modules visible (for GHCi)
     """
-    c = _compilation_defaults(hs, cc, java, dep_info, plugin_dep_info, cc_info, srcs, import_dir_map, extra_srcs, user_compile_flags, with_profiling, my_pkg_id = my_pkg_id, version = my_pkg_id.version, plugins = plugins, preprocessors = preprocessors)
+    c = _compilation_defaults(hs, cc, java, posix, dep_info, plugin_dep_info, cc_info, srcs, import_dir_map, extra_srcs, user_compile_flags, with_profiling, my_pkg_id = my_pkg_id, version = my_pkg_id.version, plugins = plugins, preprocessors = preprocessors)
     if with_shared:
         c.args.add("-dynamic-too")
 

--- a/haskell/private/actions/link.bzl
+++ b/haskell/private/actions/link.bzl
@@ -190,6 +190,7 @@ def link_binary(
 
     (cache_file, static_libs, dynamic_libs) = create_link_config(
         hs = hs,
+        posix = posix,
         cc_info = cc_info,
         dynamic = dynamic,
         binary = executable,
@@ -363,6 +364,7 @@ def link_library_dynamic(hs, cc, posix, dep_info, cc_info, extra_srcs, objects_d
 
     (cache_file, static_libs, dynamic_libs) = create_link_config(
         hs = hs,
+        posix = posix,
         cc_info = cc_info,
         dynamic = True,
         pic = True,

--- a/haskell/private/actions/package.bzl
+++ b/haskell/private/actions/package.bzl
@@ -6,7 +6,7 @@ load(":private/path_utils.bzl", "get_lib_name", "is_hs_library", "target_unique_
 load(":private/pkg_id.bzl", "pkg_id")
 load(":providers.bzl", "get_extra_libs")
 
-def _get_extra_libraries(hs, with_shared, cc_info):
+def _get_extra_libraries(hs, posix, with_shared, cc_info):
     """Get directories and library names for extra library dependencies.
 
     Args:
@@ -23,6 +23,7 @@ def _get_extra_libraries(hs, with_shared, cc_info):
     # configuration files.
     (static_libs, dynamic_libs) = get_extra_libs(
         hs,
+        posix,
         cc_info,
         pic = with_shared,
     )
@@ -94,7 +95,7 @@ def package(
         paths.join(pkg_db_dir, "_iface"),
     )
 
-    (extra_lib_dirs, extra_libs) = _get_extra_libraries(hs, with_shared, cc_info)
+    (extra_lib_dirs, extra_libs) = _get_extra_libraries(hs, posix, with_shared, cc_info)
 
     # Create a file from which ghc-pkg will create the actual package
     # from. List of exposed modules generated below.

--- a/haskell/private/actions/package.bzl
+++ b/haskell/private/actions/package.bzl
@@ -132,6 +132,6 @@ def package(
         ],
     )
 
-    cache_file = ghc_pkg_recache(hs, conf_file)
+    cache_file = ghc_pkg_recache(hs, posix, conf_file)
 
     return conf_file, cache_file

--- a/haskell/private/actions/package.bzl
+++ b/haskell/private/actions/package.bzl
@@ -60,6 +60,7 @@ def _get_extra_libraries(hs, with_shared, cc_info):
 
 def package(
         hs,
+        posix,
         dep_info,
         cc_info,
         with_shared,
@@ -71,6 +72,7 @@ def package(
 
     Args:
       hs: Haskell context.
+      posix: POSIX toolchain.
       dep_info: Combined HaskellInfo of dependencies.
       cc_info: Combined CcInfo of dependencies.
       with_shared: Whether to link dynamic libraries.
@@ -119,15 +121,15 @@ def package(
         inputs = [metadata_file, exposed_modules_file],
         outputs = [conf_file],
         command = """
-            cat $1 > $3
-            echo "exposed-modules: `cat $2`" >> $3
+            "$1" $2 > $4
+            echo "exposed-modules: `"$1" $3`" >> $4
 """,
         arguments = [
+            posix.commands["cat"],
             metadata_file.path,
             exposed_modules_file.path,
             conf_file.path,
         ],
-        use_default_shell_env = True,
     )
 
     cache_file = ghc_pkg_recache(hs, conf_file)

--- a/haskell/private/actions/repl.bzl
+++ b/haskell/private/actions/repl.bzl
@@ -19,6 +19,7 @@ load("@bazel_skylib//lib:shell.bzl", "shell")
 
 def build_haskell_repl(
         hs,
+        posix,
         ghci_script,
         ghci_repl_wrapper,
         user_compile_flags,
@@ -72,6 +73,7 @@ def build_haskell_repl(
     # Link C library dependencies
     (ghci_extra_libs, ghc_env) = get_ghci_extra_libs(
         hs,
+        posix,
         cc_info,
         path_prefix = "$RULES_HASKELL_EXEC_ROOT",
     )
@@ -177,4 +179,4 @@ def build_haskell_repl(
         hs_info.source_files,
         hs.toolchain.cc_wrapper.runfiles.files,
     ])
-    ln(hs, repl_file, output, extra_inputs)
+    ln(hs, posix, repl_file, output, extra_inputs)

--- a/haskell/private/actions/runghc.bzl
+++ b/haskell/private/actions/runghc.bzl
@@ -17,6 +17,7 @@ load("@bazel_skylib//lib:shell.bzl", "shell")
 
 def build_haskell_runghc(
         hs,
+        posix,
         runghc_wrapper,
         user_compile_flags,
         extra_args,
@@ -57,6 +58,7 @@ def build_haskell_runghc(
 
     (ghci_extra_libs, ghc_env) = get_ghci_extra_libs(
         hs,
+        posix,
         cc_info,
         path_prefix = "$RULES_HASKELL_EXEC_ROOT",
     )
@@ -108,4 +110,4 @@ def build_haskell_runghc(
         hs_info.source_files,
         hs.toolchain.cc_wrapper.runfiles.files,
     ])
-    ln(hs, runghc_file, output, extra_inputs)
+    ln(hs, posix, runghc_file, output, extra_inputs)

--- a/haskell/private/context.bzl
+++ b/haskell/private/context.bzl
@@ -67,11 +67,11 @@ def render_env(env):
     Example:
 
       >>> render_env({"PATH": "foo:bar", "LANG": "lang"})
-      export PATH=foo:bar
-      export LANG=lang
+      export PATH="foo:bar"
+      export LANG="lang"
 
     """
     return "\n".join([
-        "export {}={}".format(k, v)
+        'export {}="{}"'.format(k, v)
         for k, v in env.items()
     ])

--- a/haskell/private/haskell_impl.bzl
+++ b/haskell/private/haskell_impl.bzl
@@ -189,6 +189,9 @@ def _haskell_binary_common_impl(ctx, is_test):
     cc = cc_interop_info(ctx)
     java = java_interop_info(ctx)
 
+    # Make shell tools available.
+    posix = ctx.toolchains["@rules_sh//sh/posix:toolchain_type"]
+
     with_profiling = is_profiling_enabled(hs)
     srcs_files, import_dir_map = _prepare_srcs(ctx.attr.srcs)
     inspect_coverage = _should_inspect_coverage(ctx, hs, is_test)
@@ -236,6 +239,7 @@ def _haskell_binary_common_impl(ctx, is_test):
     (binary, solibs) = link_binary(
         hs,
         cc,
+        posix,
         dep_info,
         cc_info,
         ctx.files.extra_srcs,
@@ -390,6 +394,9 @@ def haskell_library_impl(ctx):
     cc = cc_interop_info(ctx)
     java = java_interop_info(ctx)
 
+    # Make shell tools available.
+    posix = ctx.toolchains["@rules_sh//sh/posix:toolchain_type"]
+
     with_profiling = is_profiling_enabled(hs)
     srcs_files, import_dir_map = _prepare_srcs(ctx.attr.srcs)
 
@@ -441,6 +448,7 @@ def haskell_library_impl(ctx):
         static_library = link_library_static(
             hs,
             cc,
+            posix,
             dep_info,
             c.objects_dir,
             my_pkg_id,
@@ -464,6 +472,7 @@ def haskell_library_impl(ctx):
         dynamic_library = link_library_dynamic(
             hs,
             cc,
+            posix,
             dep_info,
             cc_info,
             depset(ctx.files.extra_srcs),

--- a/haskell/private/haskell_impl.bzl
+++ b/haskell/private/haskell_impl.bzl
@@ -211,6 +211,7 @@ def _haskell_binary_common_impl(ctx, is_test):
         hs,
         cc,
         java,
+        posix,
         dep_info,
         plugin_dep_info,
         cc_info,
@@ -271,6 +272,7 @@ def _haskell_binary_common_impl(ctx, is_test):
     repl_ghci_args = _expand_make_variables("repl_ghci_args", ctx, ctx.attr.repl_ghci_args)
     build_haskell_repl(
         hs,
+        posix,
         ghci_script = ctx.file._ghci_script,
         ghci_repl_wrapper = ctx.file._ghci_repl_wrapper,
         user_compile_flags = user_compile_flags,
@@ -284,12 +286,13 @@ def _haskell_binary_common_impl(ctx, is_test):
 
     # XXX Temporary backwards compatibility hack. Remove eventually.
     # See https://github.com/tweag/rules_haskell/pull/460.
-    ln(hs, ctx.outputs.repl, ctx.outputs.repl_deprecated)
+    ln(hs, posix, ctx.outputs.repl, ctx.outputs.repl_deprecated)
 
     user_compile_flags = _expand_make_variables("compiler_flags", ctx, ctx.attr.compiler_flags)
     extra_args = _expand_make_variables("runcompile_flags", ctx, ctx.attr.runcompile_flags)
     build_haskell_runghc(
         hs,
+        posix,
         runghc_wrapper = ctx.file._ghci_repl_wrapper,
         extra_args = extra_args,
         user_compile_flags = user_compile_flags,
@@ -419,6 +422,7 @@ def haskell_library_impl(ctx):
         hs,
         cc,
         java,
+        posix,
         dep_info,
         plugin_dep_info,
         cc_info,
@@ -553,6 +557,7 @@ def haskell_library_impl(ctx):
         repl_ghci_args = _expand_make_variables("repl_ghci_args", ctx, ctx.attr.repl_ghci_args)
         build_haskell_repl(
             hs,
+            posix,
             ghci_script = ctx.file._ghci_script,
             ghci_repl_wrapper = ctx.file._ghci_repl_wrapper,
             repl_ghci_args = repl_ghci_args,
@@ -567,12 +572,13 @@ def haskell_library_impl(ctx):
 
         # XXX Temporary backwards compatibility hack. Remove eventually.
         # See https://github.com/tweag/rules_haskell/pull/460.
-        ln(hs, ctx.outputs.repl, ctx.outputs.repl_deprecated)
+        ln(hs, posix, ctx.outputs.repl, ctx.outputs.repl_deprecated)
 
         extra_args = _expand_make_variables("runcompile_flags", ctx, ctx.attr.runcompile_flags)
         user_compile_flags = _expand_make_variables("compiler_flags", ctx, ctx.attr.compiler_flags)
         build_haskell_runghc(
             hs,
+            posix,
             runghc_wrapper = ctx.file._ghci_repl_wrapper,
             extra_args = extra_args,
             user_compile_flags = user_compile_flags,

--- a/haskell/private/haskell_impl.bzl
+++ b/haskell/private/haskell_impl.bzl
@@ -486,6 +486,7 @@ def haskell_library_impl(ctx):
 
     conf_file, cache_file = package(
         hs,
+        posix,
         dep_info,
         cc_info,
         with_shared,

--- a/haskell/private/packages.bzl
+++ b/haskell/private/packages.bzl
@@ -132,7 +132,7 @@ def write_package_conf(hs, conf_file, metadata):
 
     hs.actions.write(conf_file, package_conf)
 
-def ghc_pkg_recache(hs, conf_file):
+def ghc_pkg_recache(hs, posix, conf_file):
     """Run ghc-pkg recache on the given package configuration file.
 
     Note, this will generate the file package.cache in the same directory as
@@ -185,8 +185,9 @@ def ghc_pkg_recache(hs, conf_file):
             "-v0",
             "--no-expand-pkgroot",
         ],
-        # XXX: Seems required for this to work on Windows
-        use_default_shell_env = hs.toolchain.is_windows,
+        env = {
+            "PATH": (";" if hs.toolchain.is_windows else ":").join(posix.paths),
+        },
     )
 
     return cache_file

--- a/haskell/private/path_utils.bzl
+++ b/haskell/private/path_utils.bzl
@@ -135,7 +135,7 @@ def make_library_path(hs, libs, prefix = None):
 
     return join_path_list(hs, set.to_list(r))
 
-def mangle_static_library(hs, dynamic_lib, static_lib, outdir):
+def mangle_static_library(hs, posix, dynamic_lib, static_lib, outdir):
     """Mangle a static library to match a dynamic library name.
 
     GHC expects static and dynamic C libraries to have matching library names.
@@ -169,7 +169,7 @@ def mangle_static_library(hs, dynamic_lib, static_lib, outdir):
         link = hs.actions.declare_file(
             paths.join(outdir, "lib" + libname + "." + static_lib.extension),
         )
-        ln(hs, static_lib, link)
+        ln(hs, posix, static_lib, link)
         return link
 
 def get_dirname(file):
@@ -487,7 +487,7 @@ def rel_to_pkgroot(target, pkgdb):
         truly_relativize(target, paths.dirname(pkgdb)),
     )
 
-def ln(hs, target, link, extra_inputs = depset()):
+def ln(hs, posix, target, link, extra_inputs = depset()):
     """Create a symlink to target.
 
     Args:
@@ -502,11 +502,11 @@ def ln(hs, target, link, extra_inputs = depset()):
         inputs = depset([target], transitive = [extra_inputs]),
         outputs = [link],
         mnemonic = "Symlink",
-        command = "ln -s {target} {link}".format(
+        command = '"{ln}" -s {target} {link}'.format(
+            ln = posix.commands["ln"],
             target = relative_target,
             link = link.path,
         ),
-        use_default_shell_env = True,
         # Don't sandbox symlinking to reduce overhead.
         # See https://github.com/tweag/rules_haskell/issues/958.
         execution_requirements = {

--- a/haskell/protobuf.bzl
+++ b/haskell/protobuf.bzl
@@ -263,6 +263,7 @@ _haskell_proto_aspect = aspect(
     toolchains = [
         "@rules_haskell//haskell:toolchain",
         "@rules_haskell//protobuf:toolchain",
+        "@rules_sh//sh/posix:toolchain_type",
     ],
     fragments = ["cpp"],
 )

--- a/haskell/providers.bzl
+++ b/haskell/providers.bzl
@@ -186,7 +186,7 @@ def _get_unique_lib_files(cc_info):
         for filename in filenames
     ]
 
-def get_ghci_extra_libs(hs, cc_info, path_prefix = None):
+def get_ghci_extra_libs(hs, posix, cc_info, path_prefix = None):
     """Get libraries appropriate for GHCi's linker.
 
     GHC expects dynamic and static versions of the same library to have the
@@ -213,6 +213,7 @@ def get_ghci_extra_libs(hs, cc_info, path_prefix = None):
     """
     (static_libs, dynamic_libs) = get_extra_libs(
         hs,
+        posix,
         cc_info,
         dynamic = not hs.toolchain.is_static,
         pic = True,
@@ -230,7 +231,7 @@ def get_ghci_extra_libs(hs, cc_info, path_prefix = None):
 
     return (libs, ghc_env)
 
-def get_extra_libs(hs, cc_info, dynamic = False, pic = None, fixup_dir = "_libs"):
+def get_extra_libs(hs, posix, cc_info, dynamic = False, pic = None, fixup_dir = "_libs"):
     """Get libraries appropriate for linking with GHC.
 
     GHC expects dynamic and static versions of the same library to have the
@@ -273,7 +274,7 @@ def get_extra_libs(hs, cc_info, dynamic = False, pic = None, fixup_dir = "_libs"
         elif lib_to_link.static_library and not pic_required:
             static_lib = lib_to_link.static_library
 
-        static_lib = mangle_static_library(hs, dynamic_lib, static_lib, fixed_lib_dir)
+        static_lib = mangle_static_library(hs, posix, dynamic_lib, static_lib, fixed_lib_dir)
 
         if static_lib and not (dynamic and dynamic_lib):
             static_libs.append(static_lib)
@@ -313,6 +314,7 @@ def create_link_config(hs, posix, cc_info, binary, args, dynamic = None, pic = N
 
     (static_libs, dynamic_libs) = get_extra_libs(
         hs,
+        posix,
         cc_info,
         dynamic = dynamic,
         pic = pic,

--- a/haskell/providers.bzl
+++ b/haskell/providers.bzl
@@ -288,7 +288,7 @@ def get_extra_libs(hs, cc_info, dynamic = False, pic = None, fixup_dir = "_libs"
     dynamic_libs = depset(direct = dynamic_libs)
     return (static_libs, dynamic_libs)
 
-def create_link_config(hs, cc_info, binary, args, dynamic = None, pic = None):
+def create_link_config(hs, posix, cc_info, binary, args, dynamic = None, pic = None):
     """Configure linker flags and inputs.
 
     Configure linker flags for C library dependencies and runtime dynamic
@@ -365,7 +365,7 @@ def create_link_config(hs, cc_info, binary, args, dynamic = None, pic = None):
             for lib in dynamic_libs.to_list()
         ]),
     })
-    cache_file = ghc_pkg_recache(hs, conf_file)
+    cache_file = ghc_pkg_recache(hs, posix, conf_file)
 
     args.add_all([
         "-package-db",

--- a/haskell/repl.bzl
+++ b/haskell/repl.bzl
@@ -200,7 +200,7 @@ def _create_HaskellReplInfo(from_source, from_binary, collect_info):
         dep_info = dep_info,
     )
 
-def _create_repl(hs, ctx, repl_info, output):
+def _create_repl(hs, posix, ctx, repl_info, output):
     """Build a multi target REPL.
 
     Args:
@@ -235,6 +235,7 @@ def _create_repl(hs, ctx, repl_info, output):
     ])
     (ghci_extra_libs, ghc_env) = get_ghci_extra_libs(
         hs,
+        posix,
         cc_info,
         path_prefix = "$RULES_HASKELL_EXEC_ROOT",
     )
@@ -364,7 +365,8 @@ def _haskell_repl_impl(ctx):
     from_binary = [parse_pattern(ctx, pat) for pat in ctx.attr.experimental_from_binary]
     repl_info = _create_HaskellReplInfo(from_source, from_binary, collect_info)
     hs = haskell_context(ctx)
-    return _create_repl(hs, ctx, repl_info, ctx.outputs.repl)
+    posix = ctx.toolchains["@rules_sh//sh/posix:toolchain_type"]
+    return _create_repl(hs, posix, ctx, repl_info, ctx.outputs.repl)
 
 haskell_repl = rule(
     implementation = _haskell_repl_impl,
@@ -422,7 +424,10 @@ haskell_repl = rule(
     outputs = {
         "repl": "%{name}@repl",
     },
-    toolchains = ["@rules_haskell//haskell:toolchain"],
+    toolchains = [
+        "@rules_haskell//haskell:toolchain",
+        "@rules_sh//sh/posix:toolchain_type",
+    ],
 )
 """Build a REPL for multiple targets.
 


### PR DESCRIPTION
**depends on #1136 change base branch before merging**

- Remove all instances of `use_default_shell_env = True`.
  Replaces them using the POSIX toolchain provided by `rules_sh`.
- On Windows some tools are found in paths containing spaces, e.g. `C:\Program Files\...`.
  This requires additional quoting in some places.