### PR TITLE
Add mtl-compat to empty package list

### DIFF
--- a/haskell/cabal.bzl
+++ b/haskell/cabal.bzl
@@ -78,7 +78,7 @@ _CABAL_TOOL_LIBRARIES = ["cpphs", "doctest"]
 # assumption that such packages are old and rare.
 #
 # TODO: replace this with a more general solution.
-_EMPTY_PACKAGES_BLACKLIST = ["bytestring-builder", "nats"]
+_EMPTY_PACKAGES_BLACKLIST = ["bytestring-builder", "mtl-compat", "nats"]
 
 def _cabal_tool_flag(tool):
     """Return a --with-PROG=PATH flag if input is a recognized Cabal tool. None otherwise."""


### PR DESCRIPTION
This is another package present in stackage that will generate no modules (in this case, whenever `mtl` is recent enough)