### PR TITLE
Make cat_hs example independent of Nix

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -10,8 +10,7 @@ for building Haskell code.
   with multiple third-party dependencies downloaded from Hackage,
   C library dependencies and split up into multiple libraries and
   a binary. We use a rule wrapping Cabal to build the Hackage
-  dependencies. This example requires Nix installed. It is used to
-  build (or download from a binary cache) the C library dependencies.
+  dependencies.
 * [**rts:**](./rts/) demonstrates foreign exports and shows how to
   link against GHC's RTS library, i.e. `libHSrts.so`.
   

--- a/examples/WORKSPACE
+++ b/examples/WORKSPACE
@@ -104,14 +104,3 @@ stack_snapshot(
     snapshot = "lts-14.0",
     vendored_packages = {"split": "@split//:split"},
 )
-
-# For the rts example.
-
-load("@io_tweag_rules_nixpkgs//nixpkgs:nixpkgs.bzl", "nixpkgs_package")
-
-nixpkgs_package(
-    name = "ghc",
-    attribute_path = "haskellPackages.ghc",
-    build_file = "@rules_haskell//haskell:ghc.BUILD",
-    repository = "@rules_haskell//nixpkgs:default.nix",
-)

--- a/examples/WORKSPACE
+++ b/examples/WORKSPACE
@@ -39,26 +39,23 @@ nixpkgs_python_configure(
 
 # For the cat_hs example.
 
-load("@io_tweag_rules_nixpkgs//nixpkgs:nixpkgs.bzl", "nixpkgs_package")
-
-nixpkgs_package(
-    name = "nixpkgs_zlib",
-    attribute_path = "zlib",
-    repository = "@rules_haskell//nixpkgs:default.nix",
-)
-
-nixpkgs_package(
-    name = "zlib.dev",
+http_archive(
+    name = "zlib",
     build_file_content = """
 cc_library(
     name = "zlib",
-    srcs = ["@nixpkgs_zlib//:lib"],
-    hdrs = glob(["include/*.h"]),
-    strip_include_prefix = "include",
+    # Import `:z` as `srcs` to enforce the library name `libz.so`. Otherwise,
+    # Bazel would mangle the library name and e.g. Cabal wouldn't recognize it.
+    srcs = [":z"],
+    hdrs = glob(["*.h"]),
+    includes = ["."],
     visibility = ["//visibility:public"],
 )
+cc_library(name = "z", srcs = glob(["*.c"]), hdrs = glob(["*.h"]))
 """,
-    repository = "@rules_haskell//nixpkgs:default.nix",
+    sha256 = "c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1",
+    strip_prefix = "zlib-1.2.11",
+    urls = ["http://zlib.net/zlib-1.2.11.tar.gz"],
 )
 
 # Demonstrates a vendored Stackage package to bump a version bound.
@@ -86,7 +83,7 @@ load("@rules_haskell//haskell:cabal.bzl", "stack_snapshot")
 
 stack_snapshot(
     name = "stackage",
-    extra_deps = {"zlib": ["@zlib.dev//:zlib"]},
+    extra_deps = {"zlib": ["@zlib"]},
     flags = {
         # Sets the default explicitly to demonstrate the flags attribute.
         "zlib": [

--- a/examples/cat_hs/README.md
+++ b/examples/cat_hs/README.md
@@ -4,19 +4,10 @@ This project re-implements a subset of the `cat` command-line tool in
 Haskell. It serves as an example of a project built using
 the [Bazel][bazel] build system, using [rules_haskell][rules_haskell]
 to define the Haskell build, including rules that wrap Cabal to build
-third-party dependencies downloadable from Hackage, and
-using [rules_nixpkgs][rules_nixpkgs] and [Nix][nix] to manage system
-dependencies.
+third-party dependencies downloadable from Hackage.
 
 [bazel]: https://bazel.build/
 [rules_haskell]: https://haskell.build/
-[rules_nixpkgs]: https://github.com/tweag/rules_nixpkgs
-[nix]: https://nixos.org/nix/
-
-## Prerequisites
-
-You need to install the [Nix package manager][nix]. All further dependencies
-will be managed using Nix.
 
 ## Instructions
 
@@ -24,18 +15,18 @@ To build the package execute the following command *in the `examples/`
 directory*:
 
 ```
-$ nix-shell --pure --run "bazel build //cat_hs/..."
+$ bazel build //cat_hs/...
 ```
 
 To run the tests execute the following command.
 
 ```
-$ nix-shell --pure --run "bazel test //cat_hs/..."
+$ bazel test //cat_hs/...
 ```
 
 To run the executable enter the following commands.
 
 ```
-$ nix-shell --pure --run "bazel run //cat_hs/exec/cat_hs -- -h"
-$ nix-shell --pure --run "bazel run //cat_hs/exec/cat_hs -- $PWD/README.md"
+$ bazel run //cat_hs/exec/cat_hs -- -h
+$ bazel run //cat_hs/exec/cat_hs -- $PWD/README.md
 ```


### PR DESCRIPTION
The `cat_hs` example required Nix to fetch `zlib`. However, `zlib` can also be built from source using Bazel. This PR does that to make the `cat_hs` example available to users who don't have Nix installed.