### PR TITLE
Document `BAZEL_USE_CPP_ONLY_TOOLCHAIN`

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ If you are on NixOS, this is the only way to set up your project,
 because the GHC toolchain provisioned through binary distributions
 cannot be executed on NixOS.
 
+If you are on macOS, you will have to set the environment variable
+`BAZEL_USE_CPP_ONLY_TOOLCHAIN = 1`, so that Bazel picks the correct C compiler.
+
 [bazel-cli-commands]: https://docs.bazel.build/versions/master/command-line-reference.html#commands
 [nixpkgs]: https://nixos.org/nixpkgs/
 


### PR DESCRIPTION
Users of nixpkgs on macOS will have to set the environment variable `BAZEL_USE_CPP_ONLY_TOOLCHAIN = 1`. See https://github.com/tweag/rules_haskell/issues/1147.