### PR TITLE
haskell/gen_ghc_bindist.py: use python3 in shebang

### DIFF
--- a/haskell/gen_ghc_bindist.py
+++ b/haskell/gen_ghc_bindist.py
@@ -1,10 +1,8 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # This is a happy-path tool to download the bindist
 # download paths and hashes, for maintainers.
 # It uses the hashes provided by download.haskell.org.
-
-from __future__ import print_function
 
 import pprint
 import sys


### PR DESCRIPTION
We use python3 in all other python shebangs in the repo anyways, so it's
reasonable to assume we require python3 to be present.

Debian-style distros didn't yet alias python to python3, but provide it
in the python2 package.

I don't really think we should require Python 2 too, but just Python 3
here aswell.