### PR TITLE
Document system dependencies for bindist

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ You'll need [Bazel >= 0.29][bazel-getting-started] installed.
 
 If you are on NixOS, skip to the [Nixpkgs](#Nixpkgs) section.
 
+### System dependencies
+
+Refer to the "Before you begin" section in [the documentation](docs/haskell.rst).
+
 ### The easy way
 
 In a fresh directory, run:

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The full reference documentation for rules is at https://haskell.build.
 
 ## Setup
 
-You'll need [Bazel >= 0.27][bazel-getting-started] installed.
+You'll need [Bazel >= 0.29][bazel-getting-started] installed.
 
 If you are on NixOS, skip to the [Nixpkgs](#Nixpkgs) section.
 

--- a/docs/haskell.rst
+++ b/docs/haskell.rst
@@ -25,9 +25,26 @@ In this tutorial you'll learn how to:
 Before you begin
 ----------------
 
-To prepare for the tutorial, first `install Bazel`_ if you don't have
-it installed already. Then, retrieve the ``rules_haskell`` GitHub
-repository::
+On a Unix system you will need the following tools installed.
+
+* ``gcc``
+* ``libffi``
+* ``libgmp``
+* ``libtinfo5``
+* ``make``
+* ``python3`` (``python`` also needs to be available in ``$PATH``. Depending on your distro, this might require installing the ``python`` meta-package, which might use Python 2 or 3, ``rules_haskell`` works with both.)
+
+On Ubuntu you can obtain them by installing the following packages. ::
+
+  build-essential libffi-dev libgmp-dev libtinfo5 libtinfo-dev python python3
+
+On Windows you will need.
+
+- ``msys2``
+- ``python3``
+
+Next, `install Bazel`_ if you don't have it installed already. Then, retrieve
+the ``rules_haskell`` GitHub repository::
 
   git clone https://github.com/tweag/rules_haskell/
 


### PR DESCRIPTION
Closes https://github.com/tweag/rules_haskell/issues/1160

Documents required system dependencies for GHC bindist on Unix and Windows.

I've also matched the Bazel version requirement in the README with that of the start script.