### PR TITLE
Use host Go SDK in Nix shell and fetch otherwise

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -13,7 +13,7 @@ load("//tools:os_info.bzl", "os_info")
 
 os_info(name = "os_info")
 
-load("@os_info//:os_info.bzl", "is_linux", "is_windows")
+load("@os_info//:os_info.bzl", "is_linux", "is_nix_shell", "is_windows")
 
 # bazel dependencies
 load("//haskell:repositories.bzl", "rules_haskell_dependencies")
@@ -462,9 +462,9 @@ load(
 
 go_rules_dependencies()
 
-# If Windows, ask Bazel to download a Go SDK. Otherwise use the nix-shell
-# provided GO SDK.
-go_register_toolchains() if is_windows else go_register_toolchains(go_version = "host")
+# If in nix-shell, use the Go SDK provided by Nix.
+# Otherwise, ask Bazel to download a Go SDK.
+go_register_toolchains(go_version = "host") if is_nix_shell else go_register_toolchains()
 
 load("@com_github_bazelbuild_buildtools//buildifier:deps.bzl", "buildifier_dependencies")
 

--- a/tools/os_info.bzl
+++ b/tools/os_info.bzl
@@ -5,12 +5,16 @@ cpu_value = "{CPU_VALUE}"
 is_darwin = cpu_value == "darwin"
 is_linux = cpu_value == "k8"
 is_windows = cpu_value == "x64_windows"
+nix_shell = {NIX_SHELL}
+is_nix_shell = nix_shell != None
 """
 
 def _os_info_impl(repository_ctx):
     cpu = get_cpu_value(repository_ctx)
+    nix_shell = repository_ctx.os.environ.get("IN_NIX_SHELL")
     os_info_substitutions = {
         "CPU_VALUE": cpu,
+        "NIX_SHELL": repr(nix_shell),
     }
     repository_ctx.file(
         "os_info.bzl",
@@ -25,5 +29,7 @@ def _os_info_impl(repository_ctx):
 
 os_info = repository_rule(
     implementation = _os_info_impl,
+    environ = ["IN_NIX_SHELL"],
+    configure = True,
     local = True,
 )


### PR DESCRIPTION
- Adds `is_nix_shell` to `os_info` to know whether we're in a Nix shell within `WORKSPACE`
  Unfortunately, repository rules don't get access to the `host_platform` flag. Instead, we use the `IN_NIX_SHELL` environment variable.
- Sets `go_version = "host"` only when inside a Nix shell, fetches a Go SDK otherwise.