### PR TITLE
Support for package database with long package name

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -174,10 +174,16 @@ load(
 )
 
 haskell_register_ghc_nixpkgs(
-    attribute_path = "ghc",
+    attribute_path = "",
     compiler_flags = test_compiler_flags,
     haddock_flags = test_haddock_flags,
     locale_archive = "@glibc_locales//:locale-archive",
+
+    # The data-default-instances-old-locale package was is a reproduction sample for #1165
+    nix_file_content = """
+    with import <nixpkgs> {};
+    haskellPackages.ghcWithPackages(p: [p.data-default-instances-old-locale])
+    """,
     repl_ghci_args = test_repl_ghci_args,
     repository = "@nixpkgs_default",
     version = test_ghc_version,


### PR DESCRIPTION
This is a fix for #1165

GHC 8.8 changed the output format of `ghc-pkg dump` and introduce line
breaks in `id:` fields.

The parser was simply using `.split(':')` on line containing `id:`. This
no longer work.

This commit introduces a new parser which parses line by line the file
until entering a field description.

The error only appears with GHC 8.8, so I have no reproduction code
available on the current codebase. However the GHC 8.8 branch for
rules_haskell #1170 contains a non regression test for this bug.