### PR TITLE
Support for GHC 8.8

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -41,9 +41,9 @@ http_archive(
 load("@rules_haskell//haskell:cabal.bzl", "haskell_cabal_binary")
 haskell_cabal_binary(name = "happy", srcs = glob(["**"]), visibility = ["//visibility:public"])
     """,
-    sha256 = "22eb606c97105b396e1c7dc27e120ca02025a87f3e44d2ea52be6a653a52caed",
-    strip_prefix = "happy-1.19.10",
-    urls = ["http://hackage.haskell.org/package/happy-1.19.10/happy-1.19.10.tar.gz"],
+    sha256 = "fb9a23e41401711a3b288f93cf0a66db9f97da1ce32ec4fffea4b78a0daeb40f",
+    strip_prefix = "happy-1.19.12",
+    urls = ["http://hackage.haskell.org/package/happy-1.19.12/happy-1.19.12.tar.gz"],
 )
 
 http_archive(
@@ -65,11 +65,16 @@ haskell_cabal_binary(
     visibility = ["//visibility:public"],
 )
     """,
-    sha256 = "161dcee2aed780f62c01522c86afce61721cf89c0143f157efefb1bd1fa1d164",
-    strip_prefix = "proto-lens-protoc-0.5.0.0",
-    urls = ["http://hackage.haskell.org/package/proto-lens-protoc-0.5.0.0/proto-lens-protoc-0.5.0.0.tar.gz"],
+    sha256 = "b946740b94c8d300cd8e278ded9045905ef1985824cef6b81af0d79b119927be",
+    strip_prefix = "proto-lens-protoc-0.6.0.0",
+    urls = ["http://hackage.haskell.org/package/proto-lens-protoc-0.6.0.0/proto-lens-protoc-0.6.0.0.tar.gz"],
 )
 
+load(
+    "@rules_haskell//:constants.bzl",
+    "test_ghc_version",
+    "test_stack_snapshot",
+)
 load("@rules_haskell//haskell:cabal.bzl", "stack_snapshot")
 
 stack_snapshot(
@@ -99,9 +104,10 @@ stack_snapshot(
         "data-default-class",
         "proto-lens",
         "proto-lens-protoc",
+        "proto-lens-runtime",
         "lens-family",
     ],
-    snapshot = "lts-14.4",
+    snapshot = test_stack_snapshot,
     tools = [
         "@alex",
         "@happy",
@@ -113,7 +119,7 @@ stack_snapshot(
     name = "stackage-zlib",
     extra_deps = {"zlib": ["@zlib.win//:zlib" if is_windows else "@zlib.dev//:zlib"]},
     packages = ["zlib"],
-    snapshot = "lts-13.15",
+    snapshot = test_stack_snapshot,
 )
 
 load(
@@ -126,6 +132,8 @@ load(
 
 nixpkgs_package(
     name = "ghc",
+    attribute_path = "",
+    nix_file_content = """with import <nixpkgs> {}; haskell.packages.ghc882.ghc""",
     repository = "@nixpkgs_default",
 )
 
@@ -171,19 +179,16 @@ test_repl_ghci_args = [
 ]
 
 load(
-    "@rules_haskell//:constants.bzl",
-    "test_ghc_version",
-)
-load(
     "@rules_haskell//haskell:nixpkgs.bzl",
     "haskell_register_ghc_nixpkgs",
 )
 
 haskell_register_ghc_nixpkgs(
-    attribute_path = "ghc",
+    attribute_path = "",
     compiler_flags = test_compiler_flags,
     haddock_flags = test_haddock_flags,
     locale_archive = "@glibc_locales//:locale-archive",
+    nix_file_content = """with import <nixpkgs> {}; haskell.packages.ghc882.ghc""",
     repl_ghci_args = test_repl_ghci_args,
     repository = "@nixpkgs_default",
     version = test_ghc_version,

--- a/constants.bzl
+++ b/constants.bzl
@@ -1,1 +1,2 @@
-test_ghc_version = "8.6.5"
+test_ghc_version = "8.8.2"
+test_stack_snapshot = "lts-15.4"

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -63,6 +63,7 @@ haskell_proto_toolchain(
         "@stackage//:lens-family-core",
         "@stackage//:mtl",
         "@stackage//:proto-lens",
+        "@stackage//:proto-lens-runtime",
         "@stackage//:text",
         "@stackage//:vector",
     ],
@@ -184,20 +185,21 @@ rule_test(
 rule_test(
     name = "test-haddock",
     size = "small",
-    generates = [
-        "haddock/array-0.5.3.0",
-        "haddock/base-4.12.0.0",
-        "haddock/deepseq-1.4.4.0",
-        "haddock/ghc-boot-th-8.6.5",
-        "haddock/ghc-prim-0.5.3",
-        "haddock/index",
-        "haddock/integer-gmp-1.0.2.0",
-        "haddock/pretty-1.1.3.6",
-        "haddock/template-haskell-2.14.0.0",
-        "haddock/testsZShaddockZShaddock-lib-a",
-        "haddock/testsZShaddockZShaddock-lib-b",
-        "haddock/testsZShaddockZShaddock-lib-deep",
-    ],
+    generates =
+        [
+            "haddock/array-0.5.4.0",
+            "haddock/base-4.13.0.0",
+            "haddock/deepseq-1.4.4.0",
+            "haddock/ghc-boot-th-8.8.2",
+            "haddock/ghc-prim-0.5.3",
+            "haddock/index",
+            "haddock/integer-gmp-1.0.2.0",
+            "haddock/pretty-1.1.3.6",
+            "haddock/template-haskell-2.15.0.0",
+            "haddock/testsZShaddockZShaddock-lib-a",
+            "haddock/testsZShaddockZShaddock-lib-b",
+            "haddock/testsZShaddockZShaddock-lib-deep",
+        ],
     rule = "//tests/haddock",
 )
 

--- a/tests/binary-with-plugin/Plugin.hs
+++ b/tests/binary-with-plugin/Plugin.hs
@@ -10,6 +10,6 @@ plugin = defaultPlugin { installCoreToDos = install }
 install :: [CommandLineOption] -> [CoreToDo] -> CoreM [CoreToDo]
 install [arg] todo = do
   when ('$' `elem` arg) $
-    fail "Make variable not expanded."
+    error "Make variable not expanded."
   _ <- liftIO $ readProcess arg [] ""
   return todo

--- a/tests/haskell_cabal_binary/pkg.cabal
+++ b/tests/haskell_cabal_binary/pkg.cabal
@@ -4,6 +4,6 @@ version: 0.1.0.0
 build-type: Simple
 
 executable haskell_cabal_binary
-  build-depends: base >=4.12 && <4.13
+  build-depends: base
   default-language: Haskell2010
   main-is: Main.hs

--- a/tests/haskell_cabal_library/lib.cabal
+++ b/tests/haskell_cabal_library/lib.cabal
@@ -16,7 +16,7 @@ flag expose-lib
 
 library
   if flag(use-base)
-    build-depends: base >=4.12 && <4.13
+    build-depends: base
   default-language: Haskell2010
   if flag(expose-lib)
     exposed-modules: Lib

--- a/tests/haskell_cabal_library/second-lib.cabal
+++ b/tests/haskell_cabal_library/second-lib.cabal
@@ -4,6 +4,6 @@ version: 0.1.0.0
 build-type: Simple
 
 library
-  build-depends: base >=4.12 && <4.13
+  build-depends: base
   default-language: Haskell2010
   exposed-modules: SecondLib

--- a/tests/haskell_cabal_package/lib.cabal
+++ b/tests/haskell_cabal_package/lib.cabal
@@ -4,7 +4,7 @@ version: 0.1.0.0
 build-type: Simple
 
 library
-  build-depends: base >=4.12 && <4.13
+  build-depends: base
   default-language: Haskell2010
   exposed-modules: Lib
   hs-source-dirs: lib


### PR DESCRIPTION
Work in progress for GHC 8.8 support in rules_haskell.

Rules_haskell support GHC 8.8 natively (if #1165 is fixed), but the test suite does not.

This also includes a reproduction test for #1165 