### PR TITLE
Use remote HTTP cache on CI

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -5,7 +5,8 @@
 # https://bazel.build/roadmaps/platforms.html#replace---cpu-and---host_cpu-flags.
 build:windows --crosstool_top=@rules_haskell_ghc_windows_amd64//:cc_toolchain -s --verbose_failures --sandbox_debug
 
-build:ci --disk_cache=/tmp/bazel-disk-cache
+build:ci_darwin --disk_cache=/tmp/bazel-disk-cache
+build:ci_linux --remote_http_cache=https://storage.googleapis.com/tweag-bazel-cache-buildkite --remote_upload_local_results=true --google_default_credentials
 build:ci --loading_phase_threads=1
 build:ci --verbose_failures
 # Make sure we don't rely on the names of convenience symlinks because those

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -10,12 +10,12 @@ steps:
       # `.buildkite/bindists-pipeline` for the bindists version.
       .buildkite/check-bazel-version
       ./tests/run-start-script.sh --use-nix
-      bazel build --config ci //tests:run-tests
+      bazel build --config ci --config ci_linux //tests:run-tests
       ./bazel-ci-bin/tests/run-tests
-      bazel coverage //tests/... --config ci --build_tag_filters "coverage-compatible" --test_tag_filters "coverage-compatible" --test_output=all
+      bazel coverage //tests/... --config ci --config ci_linux --build_tag_filters "coverage-compatible" --test_tag_filters "coverage-compatible" --test_output=all
       '
-    timeout: 30
+    timeout: 100
 
   - label: "Run tests (bindists)"
     command: ".buildkite/bindists-pipeline"
-    timeout: 30
+    timeout: 100

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,7 +69,7 @@ jobs:
           shell: /bin/bash -eilo pipefail
           command: |
             nix-shell --arg docTools false --pure --run \
-              'bazel build --config ci //tests/...'
+              'bazel build --config ci --config ci_darwin //tests/...'
       - run:
           name: Run tests
           shell: /bin/bash -eilo pipefail
@@ -83,9 +83,9 @@ jobs:
             # nix-shell --arg docTools false --pure --run \
             #   './tests/run-start-script.sh --use-nix'
             nix-shell --arg docTools false --pure --run '
-            bazel build --config ci //tests:run-tests
+            bazel build --config ci --config ci_darwin //tests:run-tests
             ./bazel-ci-bin/tests/run-tests
-            bazel coverage //tests/... --config ci --build_tag_filters "coverage-compatible" --test_tag_filters "coverage-compatible" --test_output=all
+            bazel coverage //tests/... --config ci --config ci_darwin --build_tag_filters "coverage-compatible" --test_tag_filters "coverage-compatible" --test_output=all
             '
 
         # see note about 'Disk cache'


### PR DESCRIPTION
Once the corresponding infrastructure changes are merged (https://github.com/tweag/infra/pull/65), this enables using
google storage bucket for caching instead of caching to the local disk.