### PR TITLE
link_library: add `compiler_flags`

### DIFF
--- a/haskell/private/actions/link.bzl
+++ b/haskell/private/actions/link.bzl
@@ -326,7 +326,7 @@ def link_library_static(hs, cc, posix, dep_info, objects_dir, my_pkg_id, with_pr
 
     return static_library
 
-def link_library_dynamic(hs, cc, posix, dep_info, cc_info, extra_srcs, objects_dir, my_pkg_id):
+def link_library_dynamic(hs, cc, posix, dep_info, cc_info, extra_srcs, objects_dir, my_pkg_id, compiler_flags):
     """Link a dynamic library for the package using given object files.
 
     Returns:
@@ -344,6 +344,8 @@ def link_library_dynamic(hs, cc, posix, dep_info, cc_info, extra_srcs, objects_d
     args = hs.actions.args()
     args.add_all(["-optl" + f for f in cc.linker_flags])
     args.add_all(["-shared", "-dynamic"])
+    args.add_all(hs.toolchain.compiler_flags)
+    args.add_all(compiler_flags)
 
     # Work around macOS linker limits.  This fix has landed in GHC HEAD, but is
     # not yet in a release; plus, we still want to support older versions of

--- a/haskell/private/haskell_impl.bzl
+++ b/haskell/private/haskell_impl.bzl
@@ -468,6 +468,7 @@ def haskell_library_impl(ctx):
             depset(ctx.files.extra_srcs),
             c.objects_dir,
             my_pkg_id,
+            user_compile_flags,
         )
         dynamic_libraries = depset([dynamic_library], transitive = [dep_info.dynamic_libraries])
     else:


### PR DESCRIPTION
`compiler_flags` (local or global) can be used by user to override the
link phase done by GHC. The `-threaded` flag is an usuall example of
that and that's why `compiler_flags` was used in `link_binary`.

Until this commit, `link_library` was not taking `compiler_flags` into
account. This commit changes that.

One use case may be to pass custom flags to the associated link,
such as `-fsanitize=undefined` which is mandatory if we link with a C
library which uses gcc/clang sanitizers.