### PR TITLE
Fix Windows CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -40,6 +40,12 @@ jobs:
   - bash: |
       set -e
       export MSYS2_ARG_CONV_EXCL="*"
+
+      # Remove 'C:\Program Files ' (ending on space) from PATH.
+      # See https://github.com/bazelbuild/bazel/issues/10481
+      export PATH="$(sed 's,:/c/Program Files $,,' <<<"$PATH")"
+      echo "PATH='$PATH'"
+
       # Tests that build but don't run
       /c/bazel/bazel.exe build --config windows "//tests/c-compiles-still/..."
       /c/bazel/bazel.exe build --config windows "//tests/binary-with-data/..."


### PR DESCRIPTION
Windows CI started failing suddenly without any relevant change in the commit history. The cause seems to be a new entry in `PATH` of the form `C:\Program Files ` (ending on space). This triggers an issue in Bazel as reported [here](https://github.com/bazelbuild/bazel/issues/10481).

This PR works around the issue by removing the offending entry from `PATH`.

I don't have access to the Azure pipeline config, so I'm not sure if this is caused by a config change on our side, or by a change to the image on Azure's side.