### PR TITLE
haskell: don't call cc_toolchain.ar_executable et al

### DIFF
--- a/haskell/cabal_wrapper.bzl
+++ b/haskell/cabal_wrapper.bzl
@@ -12,7 +12,7 @@ def _cabal_wrapper_impl(ctx):
     # "/usr/bin/libtool". Since we call ar directly, override it.
     # TODO: remove this if Bazel fixes its behavior.
     # Upstream ticket: https://github.com/bazelbuild/bazel/issues/5127.
-    ar = cc_toolchain.ar_executable()
+    ar = cc_toolchain.ar_executable
     if ar.find("libtool") >= 0:
         ar = "/usr/bin/ar"
 
@@ -28,7 +28,7 @@ def _cabal_wrapper_impl(ctx):
             "%{runghc}": hs.tools.runghc.path,
             "%{ar}": ar,
             "%{cc}": hs_toolchain.cc_wrapper.executable.path,
-            "%{strip}": cc_toolchain.strip_executable(),
+            "%{strip}": cc_toolchain.strip_executable,
             "%{is_windows}": str(hs.toolchain.is_windows),
             "%{workspace}": ctx.workspace_name,
         },

--- a/haskell/cc.bzl
+++ b/haskell/cc.bzl
@@ -109,12 +109,12 @@ def cc_interop_info(ctx):
     linker_flags = [flag for flag in linker_flags if flag not in ["-shared"]]
 
     tools = {
-        "ar": cc_toolchain.ar_executable(),
+        "ar": cc_toolchain.ar_executable,
         "cc": cc,
-        "ld": cc_toolchain.ld_executable(),
-        "cpp": cc_toolchain.preprocessor_executable(),
-        "nm": cc_toolchain.nm_executable(),
-        "strip": cc_toolchain.strip_executable(),
+        "ld": cc_toolchain.ld_executable,
+        "cpp": cc_toolchain.preprocessor_executable,
+        "nm": cc_toolchain.nm_executable,
+        "strip": cc_toolchain.strip_executable,
     }
 
     # If running on darwin but XCode is not installed (i.e., only the Command


### PR DESCRIPTION
The attributes of cc_toolchain, such as ar_executable and
various others, were anomalously both fields and methods,
so that expressions of the form x.f and x.f() had the same value.
This was a bug in Bazel that will soon be fixed, causing
the x.f() form to no longer be valid.

This change replaces x.f() with x for attributes of toolchain.
