### PR TITLE
run bazel test in buildkite bindist pipeline

### DIFF
--- a/.buildkite/bindists-pipeline
+++ b/.buildkite/bindists-pipeline
@@ -8,9 +8,12 @@ set -euo pipefail
 BAZEL_DIR="$(.buildkite/fetch-bazel-bindist)"
 trap "rm -rf '$BAZEL_DIR'" EXIT
 export PATH="$BAZEL_DIR:$PATH"
-echo "common:ci --build_tag_filters -requires_lz4,-requires_proto,-requires_zlib,-requires_doctest,-requires_c2hs,-requires_threaded_rts,-dont_test_with_bindist" > .bazelrc.local
+EXCLUDED="-requires_lz4,-requires_proto,-requires_zlib,-requires_doctest,-requires_c2hs,-requires_shellcheck,-requires_threaded_rts,-dont_test_with_bindist"
+echo "common:ci --build_tag_filters $EXCLUDED" > .bazelrc.local
+echo "common:ci --test_tag_filters $EXCLUDED" >> .bazelrc.local
 # XXX: @com_google_protobuf sets `use_default_shell_env = True`, so we enable
 #   strict action env to avoid changes in `PATH` invalidating the cache.
 echo "build:ci --experimental_strict_action_env" >> .bazelrc.local
 ./tests/run-start-script.sh --use-bindists
 bazel build --config ci //tests/...
+bazel test --config ci //tests/...


### PR DESCRIPTION
I noticed that the bindist pipeline on buildkite was only running `bazel build` and not `bazel test`. This PR fixes that.