### PR TITLE
Depend on cc toolchain

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -16,6 +16,7 @@ common:ci --color=no
 test:ci --test_output=errors
 
 # Note [backward compatible options]
+common:ci --incompatible_enable_cc_toolchain_resolution
 
 # test environment does not propagate locales by default
 # some tests reads files written in UTF8, we need to propagate the correct

--- a/haskell/c2hs.bzl
+++ b/haskell/c2hs.bzl
@@ -130,6 +130,7 @@ c2hs_library = rule(
         ),
     },
     toolchains = [
+        "@bazel_tools//tools/cpp:toolchain_type",
         "@rules_haskell//haskell:toolchain",
         "@rules_haskell//haskell/c2hs:toolchain",
     ],

--- a/haskell/cabal.bzl
+++ b/haskell/cabal.bzl
@@ -360,6 +360,7 @@ haskell_cabal_library = rule(
         ),
     },
     toolchains = [
+        "@bazel_tools//tools/cpp:toolchain_type",
         "@rules_haskell//haskell:toolchain",
         "@rules_sh//sh/posix:toolchain_type",
     ],
@@ -518,6 +519,7 @@ haskell_cabal_binary = rule(
         ),
     },
     toolchains = [
+        "@bazel_tools//tools/cpp:toolchain_type",
         "@rules_haskell//haskell:toolchain",
         "@rules_sh//sh/posix:toolchain_type",
     ],

--- a/haskell/cabal_wrapper.bzl
+++ b/haskell/cabal_wrapper.bzl
@@ -52,7 +52,10 @@ _cabal_wrapper = rule(
             default = Label("@bazel_tools//tools/cpp:current_cc_toolchain"),
         ),
     },
-    toolchains = ["@rules_haskell//haskell:toolchain"],
+    toolchains = [
+        "@bazel_tools//tools/cpp:toolchain_type",
+        "@rules_haskell//haskell:toolchain",
+    ],
     fragments = ["cpp"],
 )
 

--- a/haskell/defs.bzl
+++ b/haskell/defs.bzl
@@ -180,6 +180,7 @@ def _mk_binary_rule(**kwargs):
             "repl_deprecated": "%{name}-repl",
         },
         toolchains = [
+            "@bazel_tools//tools/cpp:toolchain_type",
             "@rules_haskell//haskell:toolchain",
             "@rules_sh//sh/posix:toolchain_type",
         ],
@@ -225,6 +226,7 @@ _haskell_library = rule(
         "repl_deprecated": "%{name}-repl",
     },
     toolchains = [
+        "@bazel_tools//tools/cpp:toolchain_type",
         "@rules_haskell//haskell:toolchain",
         "@rules_sh//sh/posix:toolchain_type",
     ],
@@ -327,9 +329,6 @@ haskell_import = rule(
             cfg = "host",
             default = Label("@rules_haskell//haskell:version_macros"),
         ),
-        "_cc_toolchain": attr.label(
-            default = Label("@bazel_tools//tools/cpp:current_cc_toolchain"),
-        ),
     },
 )
 
@@ -343,7 +342,6 @@ haskell_toolchain_library = rule(
             default = Label("@rules_haskell//haskell:toolchain-libraries"),
         ),
     ),
-    fragments = ["cpp"],
 )
 """Import packages that are prebuilt outside of Bazel.
 

--- a/haskell/doctest.bzl
+++ b/haskell/doctest.bzl
@@ -213,6 +213,7 @@ omitted, all exposed modules provided by `deps` will be tested.
     },
     fragments = ["cpp"],
     toolchains = [
+        "@bazel_tools//tools/cpp:toolchain_type",
         "@rules_haskell//haskell:toolchain",
         "@rules_haskell//haskell:doctest-toolchain",
         "@rules_sh//sh/posix:toolchain_type",

--- a/haskell/private/cc_wrapper.bzl
+++ b/haskell/private/cc_wrapper.bzl
@@ -45,6 +45,7 @@ _cc_wrapper = rule(
         ),
     },
     fragments = ["cpp"],
+    toolchains = ["@bazel_tools//tools/cpp:toolchain_type"],
 )
 
 def cc_wrapper(name, **kwargs):

--- a/haskell/private/haskell_impl.bzl
+++ b/haskell/private/haskell_impl.bzl
@@ -797,6 +797,7 @@ haskell_toolchain_libraries = rule(
         ),
     },
     toolchains = [
+        "@bazel_tools//tools/cpp:toolchain_type",
         "@rules_haskell//haskell:toolchain",
     ],
     fragments = ["cpp"],

--- a/haskell/protobuf.bzl
+++ b/haskell/protobuf.bzl
@@ -261,6 +261,7 @@ _haskell_proto_aspect = aspect(
         ),
     },
     toolchains = [
+        "@bazel_tools//tools/cpp:toolchain_type",
         "@rules_haskell//haskell:toolchain",
         "@rules_haskell//protobuf:toolchain",
         "@rules_sh//sh/posix:toolchain_type",


### PR DESCRIPTION
Closes #1185.

Fixes `--incompatible_enable_cc_toolchain_resolution`
Also removes no longer required cc toolchain dependencies.