### PR TITLE
Load proto rules from bzl

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -17,6 +17,8 @@ test:ci --test_output=errors
 # Note [backward compatible options]
 common:ci --incompatible_enable_cc_toolchain_resolution
 common:ci --incompatible_load_cc_rules_from_bzl
+# Blocked by https://github.com/bazelbuild/buildtools/issues/757
+#common:ci --incompatible_load_proto_rules_from_bzl
 common:ci --incompatible_load_python_rules_from_bzl
 
 # test environment does not propagate locales by default

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -126,14 +126,20 @@ nixpkgs_package(
 )
 
 http_archive(
-    name = "com_google_protobuf",
-    sha256 = "6adf73fd7f90409e479d6ac86529ade2d45f50494c5c10f539226693cb8fe4f7",
-    strip_prefix = "protobuf-3.10.1",
+    name = "rules_proto",
+    sha256 = "73ebe9d15ba42401c785f9d0aeebccd73bd80bf6b8ac78f74996d31f2c0ad7a6",
+    strip_prefix = "rules_proto-2c0468366367d7ed97a1f702f9cd7155ab3f73c5",
     urls = [
-        "https://mirror.bazel.build/github.com/google/protobuf/archive/v3.10.1.tar.gz",
-        "https://github.com/google/protobuf/archive/v3.10.1.tar.gz",
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_proto/archive/2c0468366367d7ed97a1f702f9cd7155ab3f73c5.tar.gz",
+        "https://github.com/bazelbuild/rules_proto/archive/2c0468366367d7ed97a1f702f9cd7155ab3f73c5.tar.gz",
     ],
 )
+
+load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies", "rules_proto_toolchains")
+
+rules_proto_dependencies()
+
+rules_proto_toolchains()
 
 load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
 

--- a/tests/haddock_protobuf/BUILD.bazel
+++ b/tests/haddock_protobuf/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_proto//proto:defs.bzl", "proto_library")
 load(
     "@rules_haskell//haskell:defs.bzl",
     "haskell_doc",

--- a/tests/haskell_proto_library/BUILD.bazel
+++ b/tests/haskell_proto_library/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_proto//proto:defs.bzl", "proto_library")
 load("//haskell:defs.bzl", "haskell_doc", "haskell_library")
 load("//haskell:protobuf.bzl", "haskell_proto_library")
 


### PR DESCRIPTION
Closes #1183 

- Enables `--incompatible_load_proto_rules_from_bzl` on CI.
- Loads proto rules from `@rules_proto`.
- Imports `rules_proto` from github (`com_google_proto` is imported via `rules_proto_dependencies`).

This only affects rules_haskell's test suite. I.e. users of rules_haskell are not affected.