### PR TITLE
Check all CI pipelines in mergify

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -2,6 +2,9 @@ pull_request_rules:
   - name: automatic merge
     conditions:
       - "status-success=build"
+      - "status-success=buildkite/rules-haskell"
+      - "status-success=tweag.rules_haskell"
+      - "status-success=deploy/netlify"
       - "#approved-reviews-by>=1"
       - "label=merge-queue"
       - "base=master"


### PR DESCRIPTION
So far the mergify configuration only considered the CircleCI pipeline
named `build`. It ignored the status of the other CI pipelines:
buildkite, azure, netlify. This adds these pipelines as `status-success`
conditions to the mergify configuration. The expected effect has been
verified using the simulator on the [mergify dashboard][1].

[1]: https://dashboard.mergify.io