### PR TITLE
Call stack update once

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,20 +24,6 @@ jobs:
     displayName: "Enable da long paths"
 
   - bash: |
-        # rules_haskell can automatically install stack if it is not in $PATH,
-        # yet. However, if the index has not been updated before building. Then
-        # multiple parallel invocations of `stack` will both attempt to update
-        # the index during build. This will fail with the following error.
-        #
-        #   user error (hTryLock: lock already exists: C:\Users\VssAdministrator\AppData\Roaming\stack\pantry\hackage\hackage-security-lock)
-        #
-        # To avoid this issue we install stack and update the index beforehand.
-        # See https://github.com/tweag/stackage-head/issues/29.
-        curl -sSL https://get.haskellstack.org/ | sh
-        stack update
-    displayName: "Install Stack"
-
-  - bash: |
       set -e
       export MSYS2_ARG_CONV_EXCL="*"
 

--- a/haskell/cabal.bzl
+++ b/haskell/cabal.bzl
@@ -950,17 +950,16 @@ _stack_update = repository_rule(
     attrs = {
         "stack": attr.label(),
     },
-    doc = """\
-Execute stack update.
-
-This is extracted into a singleton repository rule to avoid concurrent
-invocations of stack update.
-See https://github.com/tweag/rules_haskell/issues/1090
-""",
     # Marked as local so that stack update is always executed before
     # _stack_snapshot is executed.
     local = True,
 )
+"""Execute stack update.
+
+This is extracted into a singleton repository rule to avoid concurrent
+invocations of stack update.
+See https://github.com/tweag/rules_haskell/issues/1090
+"""
 
 def _get_platform(repository_ctx):
     """Map OS name and architecture to Stack platform identifiers."""

--- a/haskell/cabal.bzl
+++ b/haskell/cabal.bzl
@@ -675,15 +675,6 @@ def _compute_dependency_graph(repository_ctx, snapshot, core_packages, versioned
         fail("Stack version not recent enough. Need version 2.1 or newer.")
     stack = [stack_cmd]
 
-    # Run `stack update` leniently to avoid hackage-security lock issues.
-    #
-    #   user error (hTryLock: lock already exists: ~/.stack/pantry/hackage/hackage-security-lock)
-    #
-    # See https://github.com/tweag/stackage-head/issues/29. If this doesn't
-    # help we may need to point --stack-root to a workspace local path. The
-    # issue appears when initializing two separate stack_snapshot instances in
-    # parallel.
-    repository_ctx.execute(stack + ["update"])
     if versioned_packages:
         _execute_or_fail_loudly(repository_ctx, stack + ["unpack"] + versioned_packages)
     stack = [stack_cmd, "--resolver", snapshot]


### PR DESCRIPTION
Closes https://github.com/tweag/rules_haskell/issues/1090

As suggested in #1090 (see https://github.com/tweag/rules_haskell/pull/1085#issuecomment-529912386 for related discussion) this factors out the call to `stack update` into a separate repository rule `_stack_update`. Every instance of `_stack_snapshot` depends on the same instance of `_stack_update`, so that `stack update` is only called once.

This removes the need to call `stack update` leniently within `_stack_snapshot` and the need to preinstall `stack` and run `stack update` manually on Windows CI.

I have used Bazel's [`--experimental_workspace_rules_log_file`](https://docs.bazel.build/versions/master/workspace-log.html#finding-non-hermetic-rules) to verify the following.
- `stack update` is executed on every fetch.
- `stack update` is run before calls to `stack` in `_stack_snapshot`.
- `_stack_snapshot` is not invalidated by `_stack_update`.