### PR TITLE
Optional haddock on Cabal library

### DIFF
--- a/haskell/cabal.bzl
+++ b/haskell/cabal.bzl
@@ -912,6 +912,7 @@ haskell_library(
 haskell_cabal_library(
     name = "{name}",
     version = "{version}",
+    haddock = {haddock},
     flags = {flags},
     srcs = glob(["{dir}/**"]),
     deps = {deps},
@@ -922,6 +923,7 @@ haskell_cabal_library(
 """.format(
                     name = package.name,
                     version = package.version,
+                    haddock = repr(repository_ctx.attr.haddock),
                     flags = package.flags,
                     dir = package.sdist,
                     deps = package.deps + [
@@ -951,6 +953,10 @@ _stack_snapshot = repository_rule(
         "packages": attr.string_list(),
         "vendored_packages": attr.label_keyed_string_dict(),
         "flags": attr.string_list_dict(),
+        "haddock": attr.bool(
+            default = True,
+            doc = "Whether to generate haddock documentation",
+        ),
         "extra_deps": attr.label_keyed_string_dict(),
         "tools": attr.label_list(),
         "stack": attr.label(),

--- a/haskell/private/cabal_wrapper.py.tpl
+++ b/haskell/private/cabal_wrapper.py.tpl
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# cabal_wrapper.py <COMPONENT> <PKG_NAME> <SETUP_PATH> <PKG_DIR> <PACKAGE_DB_PATH> [EXTRA_ARGS...] -- [PATH_ARGS...]
+# cabal_wrapper.py <COMPONENT> <PKG_NAME> <HADDOCK> <SETUP_PATH> <PKG_DIR> <PACKAGE_DB_PATH> [EXTRA_ARGS...] -- [PATH_ARGS...]
 #
 # This wrapper calls Cabal's configure/build/install steps one big
 # action so that we don't have to track all inputs explicitly between
@@ -8,6 +8,7 @@
 #
 # COMPONENT: Cabal component to build.
 # PKG_NAME: Package ID of the resulting package.
+# HADDOCK: Whether to generate haddock documentation.
 # SETUP_PATH: Path to Setup.hs
 # PKG_DIR: Directory containing the Cabal file
 # PACKAGE_DB_PATH: Output package DB path.
@@ -63,6 +64,7 @@ os.environ["PATH"] = canonicalize_path(os.getenv("PATH", ""))
 
 component = sys.argv.pop(1)
 name = sys.argv.pop(1)
+haddock = sys.argv.pop(1) == "true"
 execroot = os.getcwd()
 setup = os.path.join(execroot, sys.argv.pop(1))
 srcdir = os.path.join(execroot, sys.argv.pop(1))
@@ -155,7 +157,8 @@ with tmpdir() as distdir:
         [ "--package-db=" + package_database ], # This arg must come last.
         )
     run([runghc, setup, "build", "--verbose=0", "--builddir=" + distdir])
-    run([runghc, setup, "haddock", "--verbose=0", "--builddir=" + distdir])
+    if haddock:
+        run([runghc, setup, "haddock", "--verbose=0", "--builddir=" + distdir])
     run([runghc, setup, "install", "--verbose=0", "--builddir=" + distdir])
     # Bazel builds are not sandboxed on Windows and can be non-sandboxed on
     # other OSs. Operations like executing `configure` scripts can modify the

--- a/tests/haskell_cabal_library/BUILD.bazel
+++ b/tests/haskell_cabal_library/BUILD.bazel
@@ -34,6 +34,7 @@ haskell_cabal_library(
         "SecondLib.hs",
         "second-lib.cabal",
     ],
+    haddock = False,
     version = "0.1.0.0",
 )
 

--- a/tests/haskell_cabal_library/SecondLib.hs
+++ b/tests/haskell_cabal_library/SecondLib.hs
@@ -1,4 +1,4 @@
 module SecondLib where
 
 y :: Int
-y = 3
+y = 3 -- ^ Intentionally broken haddock comment to test @haddock = False@.


### PR DESCRIPTION
This allows users to disable haddock generation on `haskell_cabal_library` and `stack_snapshot`.

Some Cabal packages contain broken/illegal haddock markup. Trying to build haddock documentation unconditionally, prohibits users from using such packages with rules_haskell. This is problematic in case of Hackage packages imported using `stack_snapshot`, as users have no easy way of fixing the issue themselves. The motivating example is `ghc-lib`.

Extends one of the test cases in `//tests/haskell_cabal_library` to test this new attribute. 