### PR TITLE
Load cc rules from bzl

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -17,6 +17,7 @@ test:ci --test_output=errors
 
 # Note [backward compatible options]
 common:ci --incompatible_enable_cc_toolchain_resolution
+common:ci --incompatible_load_cc_rules_from_bzl
 
 # test environment does not propagate locales by default
 # some tests reads files written in UTF8, we need to propagate the correct

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -222,6 +222,7 @@ nixpkgs_package(
     attribute_path = "lz4",
     build_file_content = """
 package(default_visibility = ["//visibility:public"])
+load("@rules_cc//cc:defs.bzl", "cc_library")
 
 cc_library(
   name = "nixpkgs_lz4",
@@ -270,6 +271,8 @@ nixpkgs_package(
 nixpkgs_package(
     name = "zlib.dev",
     build_file_content = """
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
 filegroup(
     name = "include",
     srcs = glob(["include/*.h"]),
@@ -304,6 +307,7 @@ filegroup(
 http_archive(
     name = "zlib.win",
     build_file_content = """
+load("@rules_cc//cc:defs.bzl", "cc_library")
 cc_library(
     name = "zlib",
     # Import `:z` as `srcs` to enforce the library name `libz.so`. Otherwise,

--- a/examples/WORKSPACE
+++ b/examples/WORKSPACE
@@ -42,6 +42,7 @@ nixpkgs_python_configure(
 http_archive(
     name = "zlib",
     build_file_content = """
+load("@rules_cc//cc:defs.bzl", "cc_library")
 cc_library(
     name = "zlib",
     # Import `:z` as `srcs` to enforce the library name `libz.so`. Otherwise,

--- a/examples/primitive/BUILD.bazel
+++ b/examples/primitive/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
 load(
     "@rules_haskell//haskell:defs.bzl",
     "haskell_library",

--- a/examples/rts/BUILD.bazel
+++ b/examples/rts/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_test")
 load(
     "@rules_haskell//haskell:defs.bzl",
     "haskell_library",

--- a/examples/vector/BUILD.bazel
+++ b/examples/vector/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
 load(
     "@rules_haskell//haskell:defs.bzl",
     "haskell_library",

--- a/haskell/repositories.bzl
+++ b/haskell/repositories.bzl
@@ -24,6 +24,14 @@ def rules_haskell_dependencies():
             urls = ["https://github.com/bazelbuild/bazel-skylib/archive/0.6.0.tar.gz"],
         )
 
+    if "rules_cc" not in excludes:
+        http_archive(
+            name = "rules_cc",
+            sha256 = "dafda2ff2a913028ce1718253b6b2f353b2d2163470f3069ca810a0d8d55a5a9",
+            strip_prefix = "rules_cc-cd7e8a690caf526e0634e3ca55b10308ee23182d",
+            urls = ["https://github.com/bazelbuild/rules_cc/archive/cd7e8a690caf526e0634e3ca55b10308ee23182d.tar.gz"],
+        )
+
     if "rules_sh" not in excludes:
         http_archive(
             name = "rules_sh",

--- a/tests/binary-linkstatic-flag/BUILD.bazel
+++ b/tests/binary-linkstatic-flag/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
 load(
     "@rules_haskell//haskell:defs.bzl",
     "haskell_library",

--- a/tests/cc_haskell_import/BUILD.bazel
+++ b/tests/cc_haskell_import/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary")
 load(
     "@rules_haskell//haskell:defs.bzl",
     "haskell_library",

--- a/tests/data/BUILD.bazel
+++ b/tests/data/BUILD.bazel
@@ -1,5 +1,7 @@
 # Generic data files and targets that are used by multiple tests
 
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
 cc_library(
     name = "ourclibrary",
     srcs = [":ourclibrary.c"],

--- a/tests/failing-repros/isystem-issue/BUILD.bazel
+++ b/tests/failing-repros/isystem-issue/BUILD.bazel
@@ -1,5 +1,6 @@
 # https://github.com/tweag/rules_haskell/issues/1010
 
+load("@rules_cc//cc:defs.bzl", "cc_library")
 load("@rules_haskell//haskell:defs.bzl", "haskell_binary")
 load("@rules_haskell//tests:failing-repros/should_fail.bzl", "should_fail")
 

--- a/tests/haskell_cabal_library/BUILD.bazel
+++ b/tests/haskell_cabal_library/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
 load("@rules_haskell//haskell:cabal.bzl", "haskell_cabal_library")
 load(
     "@rules_haskell//haskell:defs.bzl",

--- a/tests/haskell_import/BUILD.bazel
+++ b/tests/haskell_import/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_test")
 load(
     "@rules_haskell//haskell:defs.bzl",
     "haskell_library",

--- a/tests/indirect-link/BUILD.bazel
+++ b/tests/indirect-link/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
 load("@rules_haskell//haskell:defs.bzl", "haskell_library", "haskell_test")
 
 cc_library(

--- a/tests/library-deps/sublib/BUILD.bazel
+++ b/tests/library-deps/sublib/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
 load(
     "@rules_haskell//haskell:defs.bzl",
     "haskell_library",

--- a/tests/library-with-includes/BUILD.bazel
+++ b/tests/library-with-includes/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
 load(
     "@rules_haskell//haskell:defs.bzl",
     "haskell_library",

--- a/tests/library-with-sysincludes/BUILD.bazel
+++ b/tests/library-with-sysincludes/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
 load(
     "@rules_haskell//haskell:defs.bzl",
     "haskell_library",


### PR DESCRIPTION
Closes https://github.com/tweag/rules_haskell/issues/1180

- Enables `--incompatible_load_cc_rules_from_bzl` on CI.
- Loads cc rules from `@rules_cc`.
- Imports `rules_cc` from github.