### PR TITLE
Load python rules from bzl

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -18,6 +18,7 @@ test:ci --test_output=errors
 # Note [backward compatible options]
 common:ci --incompatible_enable_cc_toolchain_resolution
 common:ci --incompatible_load_cc_rules_from_bzl
+common:ci --incompatible_load_python_rules_from_bzl
 
 # test environment does not propagate locales by default
 # some tests reads files written in UTF8, we need to propagate the correct

--- a/debug/linking_utils/BUILD.bazel
+++ b/debug/linking_utils/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_python//python:defs.bzl", "py_library")
 load(
     ":ldd_test.bzl",
     "ldd_test",

--- a/haskell/BUILD.bazel
+++ b/haskell/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_python//python:defs.bzl", "py_binary")
 load(
     "@rules_haskell//haskell:private/haskell_impl.bzl",
     "haskell_toolchain_libraries",

--- a/haskell/cabal_wrapper.bzl
+++ b/haskell/cabal_wrapper.bzl
@@ -1,6 +1,7 @@
 load(":private/context.bzl", "haskell_context", "render_env")
 load(":cc.bzl", "cc_interop_info")
 load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
+load("@rules_python//python:defs.bzl", "py_binary")
 
 def _cabal_wrapper_impl(ctx):
     hs = haskell_context(ctx)
@@ -63,7 +64,7 @@ def cabal_wrapper(name, **kwargs):
     _cabal_wrapper(
         name = name + ".py",
     )
-    native.py_binary(
+    py_binary(
         name = name,
         srcs = [name + ".py"],
         python_version = "PY3",

--- a/haskell/private/cc_wrapper.bzl
+++ b/haskell/private/cc_wrapper.bzl
@@ -1,5 +1,6 @@
 load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
 load("@bazel_tools//tools/build_defs/cc:action_names.bzl", "ACTION_NAMES")
+load("@rules_python//python:defs.bzl", "py_binary")
 
 def _cc_wrapper_impl(ctx):
     cc_toolchain = find_cpp_toolchain(ctx)
@@ -67,7 +68,7 @@ def cc_wrapper(name, **kwargs):
             "//conditions:default": "linux",
         }),
     )
-    native.py_binary(
+    py_binary(
         name = name + "-python",
         srcs = [name + ".py"],
         python_version = "PY3",

--- a/haskell/repositories.bzl
+++ b/haskell/repositories.bzl
@@ -32,6 +32,14 @@ def rules_haskell_dependencies():
             urls = ["https://github.com/bazelbuild/rules_cc/archive/cd7e8a690caf526e0634e3ca55b10308ee23182d.tar.gz"],
         )
 
+    if "rules_python" not in excludes:
+        http_archive(
+            name = "rules_python",
+            sha256 = "fa53cc0afe276d8f6675df1a424592e00e4f37b2a497e48399123233902e2e76",
+            strip_prefix = "rules_python-0.0.1",
+            urls = ["https://github.com/bazelbuild/rules_python/archive/0.0.1.tar.gz"],
+        )
+
     if "rules_sh" not in excludes:
         http_archive(
             name = "rules_sh",

--- a/tests/cc_haskell_import/BUILD.bazel
+++ b/tests/cc_haskell_import/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@rules_cc//cc:defs.bzl", "cc_binary")
+load("@rules_python//python:defs.bzl", "py_binary")
 load(
     "@rules_haskell//haskell:defs.bzl",
     "haskell_library",

--- a/tests/inline_tests.bzl
+++ b/tests/inline_tests.bzl
@@ -2,6 +2,7 @@
 # which are like their respective builtin rules,
 # but their scripts can be given inline as a string.
 
+load("@rules_python//python:defs.bzl", "py_test")
 load("@bazel_skylib//lib:shell.bzl", "shell")
 
 def quote_make_variables(s):
@@ -81,7 +82,7 @@ def py_inline_test(name, script, **kwargs):
     deps = kwargs.pop("deps", [])
     srcs = kwargs.pop("srcs", [])
 
-    native.py_test(
+    py_test(
         name = name,
         srcs = [script_name] + srcs,
         main = script_name,


### PR DESCRIPTION
Closes https://github.com/tweag/rules_haskell/issues/1178

- Enables `--incompatible_load_python_rules_from_bzl` on CI.
- Loads python rules from `@rules_python`.
- Imports `rules_python` from github.