### PR TITLE
Mark empty globs with allow_empty = True

### DIFF
--- a/haskell/ghc.BUILD.tpl
+++ b/haskell/ghc.BUILD.tpl
@@ -21,7 +21,7 @@ filegroup(
 
 filegroup(
     name = "mingw",
-    srcs = glob(["mingw/**"]),
+    srcs = glob(["mingw/**"], allow_empty = True),
 )
 
 cc_toolchain_suite(

--- a/haskell/private/pkgdb_to_bzl.py
+++ b/haskell/private/pkgdb_to_bzl.py
@@ -201,7 +201,7 @@ for conf in glob.glob(os.path.join(topdir, "package.conf.d", "*.conf")):
                 name = pkg.name,
                 id = pkg.id,
                 version = pkg.version,
-                hdrs = "glob({})".format([
+                hdrs = "glob({}, allow_empty = True)".format([
                     path_to_label("{}/**/*.h".format(include_dir), pkg.pkgroot)
                     for include_dir in pkg.include_dirs
                     if path_to_label(include_dir, pkg.pkgroot)
@@ -211,21 +211,21 @@ for conf in glob.glob(os.path.join(topdir, "package.conf.d", "*.conf")):
                     for include_dir in pkg.include_dirs
                     if path_to_label(include_dir, pkg.pkgroot)
                 ],
-                static_libraries = "glob({})".format([
+                static_libraries = "glob({}, allow_empty = True)".format([
                     path_to_label("{}/{}".format(library_dir, pattern), pkg.pkgroot)
                     for hs_library in pkg.hs_libraries
                     for pattern in hs_library_pattern(hs_library, mode = "static", profiling = False)
                     for library_dir in pkg.library_dirs
                     if path_to_label(library_dir, pkg.pkgroot)
                 ]),
-                static_profiling_libraries = "glob({})".format([
+                static_profiling_libraries = "glob({}, allow_empty = True)".format([
                     path_to_label("{}/{}".format(library_dir, pattern), pkg.pkgroot)
                     for hs_library in pkg.hs_libraries
                     for pattern in hs_library_pattern(hs_library, mode = "static", profiling = True)
                     for library_dir in pkg.library_dirs
                     if path_to_label(library_dir, pkg.pkgroot)
                 ]),
-                shared_libraries = "glob({})".format([
+                shared_libraries = "glob({}, allow_empty = True)".format([
                     path_to_label("{}/{}".format(dynamic_library_dir, pattern), pkg.pkgroot)
                     for hs_library in pkg.hs_libraries
                     for pattern in hs_library_pattern(hs_library, mode = "dynamic", profiling = False)


### PR DESCRIPTION
Closes https://github.com/tweag/rules_haskell/issues/1176

- `pkgdb_to_bzl.py` generates globs that may be empty. This is intentional,
so we set `allow_empty = True`.
- `ghc.BUILD.tpl` has a filegroup for mingw with a glob that is empty on
non-Windows platforms. Unfortunately, `select` cannot be used to work
around this issue, so we set `allow_empty = True`, instead.

Cannot set `--incompatible_disallow_empty_glob` because of `rules_nixpkgs` and `local_jdk` which is defined in Bazel.