### PR TITLE
mergify: Name of buildkite pipeline changed

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -2,7 +2,7 @@ pull_request_rules:
   - name: automatic merge
     conditions:
       - "status-success=build"
-      - "status-success=buildkite/rules-haskell"
+      - "status-success=buildkite/rules-haskell/pr"
       - "status-success=tweag.rules_haskell"
       - "status-success=deploy/netlify"
       - "#approved-reviews-by>=1"


### PR DESCRIPTION
From `buildkite/rules-haskell` to `buildkite/rules-haskell/pr`.

Such that e.g. [this PR](https://github.com/tweag/rules_haskell/pull/1201) was merged by mergify, while [this PR](https://github.com/tweag/rules_haskell/pull/1162) is not.

I hope such renamings do not happen often.