### PR TITLE
Allow making the cabal builds totally silent

### DIFF
--- a/haskell/cabal.bzl
+++ b/haskell/cabal.bzl
@@ -113,7 +113,7 @@ def _prepare_cabal_inputs(hs, cc, posix, dep_info, cc_info, direct_cc_info, comp
         env["SDKROOT"] = "macosx"  # See haskell/private/actions/link.bzl
 
     if verbose:
-      env["CABAL_VERBOSE"] = "True"
+        env["CABAL_VERBOSE"] = "True"
 
     args = hs.actions.args()
     package_databases = dep_info.package_databases

--- a/haskell/cabal.bzl
+++ b/haskell/cabal.bzl
@@ -932,6 +932,7 @@ haskell_cabal_library(
     tools = {tools},
     visibility = {visibility},
     compiler_flags = ["-w", "-optF=-w"],
+    verbose = {verbose},
 )
 """.format(
                     name = package.name,
@@ -945,6 +946,7 @@ haskell_cabal_library(
                     ],
                     tools = tools,
                     visibility = visibility,
+                    verbose = repr(repository_ctx.attr.verbose),
                 ),
             )
         if package.versioned_name != None:

--- a/haskell/private/cabal_wrapper.py.tpl
+++ b/haskell/private/cabal_wrapper.py.tpl
@@ -41,8 +41,10 @@ def run(cmd, *args, **kwargs):
         try:
             subprocess.run(cmd, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, *args, **kwargs)
         except subprocess.CalledProcessError as err:
-            print(err.stdout.decode())
-            print(err.stderr.decode(), file=sys.stderr)
+            sys.stdout.buffer.write(err.stdout)
+            sys.stderr.buffer.write(err.stderr)
+            # print(err.stdout.decode())
+            # print(err.stderr.decode(), file=sys.stderr)
             raise
 
 def find_exe(exe):

--- a/haskell/private/cabal_wrapper.py.tpl
+++ b/haskell/private/cabal_wrapper.py.tpl
@@ -29,7 +29,7 @@ import sys
 import tempfile
 
 debug = False
-verbose = os.environ.get("CABAL_VERBOSE", False)
+verbose = os.environ.get("CABAL_VERBOSE", "") == "True"
 
 def run(cmd, *args, **kwargs):
     if debug:

--- a/haskell/private/cabal_wrapper.py.tpl
+++ b/haskell/private/cabal_wrapper.py.tpl
@@ -43,8 +43,6 @@ def run(cmd, *args, **kwargs):
         except subprocess.CalledProcessError as err:
             sys.stdout.buffer.write(err.stdout)
             sys.stderr.buffer.write(err.stderr)
-            # print(err.stdout.decode())
-            # print(err.stderr.decode(), file=sys.stderr)
             raise
 
 def find_exe(exe):

--- a/haskell/private/cabal_wrapper.py.tpl
+++ b/haskell/private/cabal_wrapper.py.tpl
@@ -29,12 +29,21 @@ import sys
 import tempfile
 
 debug = False
+verbose = os.environ.get("CABAL_VERBOSE", False)
 
 def run(cmd, *args, **kwargs):
     if debug:
         print("+ " + " ".join(["'{}'".format(arg) for arg in cmd]), file=sys.stderr)
         sys.stderr.flush()
-    subprocess.check_call(cmd, *args, **kwargs)
+    if verbose:
+        subprocess.run(cmd, check=True, *args, **kwargs)
+    else:
+        try:
+            subprocess.run(cmd, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, *args, **kwargs)
+        except subprocess.CalledProcessError as err:
+            print(err.stdout.decode())
+            print(err.stderr.decode(), file=sys.stderr)
+            raise
 
 def find_exe(exe):
     if os.path.isfile(exe):


### PR DESCRIPTION
Give an option in `cabal_haskell_library` and `stack_snapshot` to make the builds totally silent (except in case of failure).

This is useful to enforce quietness even for build steps for which cabal can't enforce it (like `cabal configure` or `cabal haddock`).

I didn't add a test for it because I don't know how to test for the console output of a rule in bazel. If someone knows a way, I'd be happy to add a test for it.