### PR TITLE
Fix a bug (infinite loop) in Bazel.Runfiles.

### DIFF
--- a/tools/runfiles/src/Bazel/Runfiles.hs
+++ b/tools/runfiles/src/Bazel/Runfiles.hs
@@ -164,7 +164,7 @@ containsOneDataFile = loop
     loop fp = do
         isDir <- doesDirectoryExist fp
         if isDir
-            then anyM loop =<< listDirectory fp
+            then anyM loop =<< fmap (map (fp </>)) (listDirectory fp)
             else pure $! fp /= "MANIFEST"
 
 -- | Check if the given predicate holds on any of the given values.


### PR DESCRIPTION
The bug is triggered if you're passing the location of the
runfiles directory via `$RUNFILES_DIR` or `$RUNFILES_MANIFEST_ONLY`.
In those cases, the code calls `containsOneDataFile`, which
doesn't correctly compute the full paths of subdirectories,
and could go into an infinite loop as a result.