### PR TITLE
Add support for hrepl.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -141,10 +141,6 @@ rules_proto_dependencies()
 
 rules_proto_toolchains()
 
-load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
-
-protobuf_deps()  # configure and install zlib for protobuf
-
 nixpkgs_local_repository(
     name = "nixpkgs_default",
     nix_file = "//nixpkgs:default.nix",

--- a/examples/WORKSPACE
+++ b/examples/WORKSPACE
@@ -40,11 +40,11 @@ nixpkgs_python_configure(
 # For the cat_hs example.
 
 http_archive(
-    name = "zlib",
+    name = "zlib.hs",
     build_file_content = """
 load("@rules_cc//cc:defs.bzl", "cc_library")
 cc_library(
-    name = "zlib",
+    name = "zlib.hs",
     # Import `:z` as `srcs` to enforce the library name `libz.so`. Otherwise,
     # Bazel would mangle the library name and e.g. Cabal wouldn't recognize it.
     srcs = [":z"],
@@ -87,7 +87,7 @@ load("@rules_haskell//haskell:cabal.bzl", "stack_snapshot")
 
 stack_snapshot(
     name = "stackage",
-    extra_deps = {"zlib": ["@zlib"]},
+    extra_deps = {"zlib": ["@zlib.hs"]},
     flags = {
         # Sets the default explicitly to demonstrate the flags attribute.
         "zlib": [

--- a/haskell/BUILD.bazel
+++ b/haskell/BUILD.bazel
@@ -11,6 +11,10 @@ load(
     "@rules_haskell//haskell:cabal_wrapper.bzl",
     "cabal_wrapper",
 )
+load(
+    "@rules_haskell//haskell:toolchain_info.bzl",
+    "haskell_toolchain_info",
+)
 
 exports_files(
     glob(["*.bzl"]) + [
@@ -99,4 +103,8 @@ config_setting(
     define_values = {
         "use_worker": "True",
     },
+)
+
+haskell_toolchain_info(
+    name = "toolchain_info",
 )

--- a/haskell/cabal.bzl
+++ b/haskell/cabal.bzl
@@ -344,7 +344,8 @@ def _haskell_cabal_library_impl(ctx):
         name = ctx.label.name,
         hs = hs,
         hs_info = hs_info,
-        lib_info = lib_info))
+        lib_info = lib_info,
+    ))
     result = [default_info, hs_info, cc_info, lib_info, output_group_info]
     if ctx.attr.haddock:
         result.append(doc_info)

--- a/haskell/cabal.bzl
+++ b/haskell/cabal.bzl
@@ -4,6 +4,7 @@ load("@bazel_skylib//lib:paths.bzl", "paths")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
 load(":cc.bzl", "cc_interop_info")
+load(":private/actions/info.bzl", "library_info_output_groups")
 load(":private/context.bzl", "haskell_context", "render_env")
 load(":private/dependencies.bzl", "gather_dep_info")
 load(":private/expansions.bzl", "expand_make_variables")
@@ -335,7 +336,12 @@ def _haskell_cabal_library_impl(ctx):
             cc_info,
         ],
     )
-    result = [default_info, hs_info, cc_info, lib_info]
+    output_group_info = OutputGroupInfo(**library_info_output_groups(
+        name = ctx.label.name,
+        hs = hs,
+        hs_info = hs_info,
+        lib_info = lib_info))
+    result = [default_info, hs_info, cc_info, lib_info, output_group_info]
     if ctx.attr.haddock:
         result.append(doc_info)
     return result

--- a/haskell/defs.bzl
+++ b/haskell/defs.bzl
@@ -342,6 +342,9 @@ haskell_toolchain_library = rule(
             default = Label("@rules_haskell//haskell:toolchain-libraries"),
         ),
     ),
+    toolchains = [
+        "@rules_haskell//haskell:toolchain",
+    ],
 )
 """Import packages that are prebuilt outside of Bazel.
 

--- a/haskell/private/actions/info.bzl
+++ b/haskell/private/actions/info.bzl
@@ -51,13 +51,6 @@ def write_proto_file(hs, output_name, proto_type, content):
     )
     return proto_pb
 
-# Copied from haskell/repl.bzl; not sure if there's a more general solution.
-_COMMON_REPL_OPTIONS = [
-    "-hide-all-packages",
-    "-package=base",
-    "-package=directory",
-]
-
 def _filter_package_env(flags):
     # Strips out -package-env from the command-line flags.  Consumers of these output
     # groups will be responsible for setting the right GHC flags themselves,
@@ -90,7 +83,7 @@ def _write_haskell_compile_info(
             source_files = [f.path for f in c.source_files.to_list()],
             # TODO: currently, this will duplicate the common, target-independent options for
             # each build target.  We should instead move them into GhcConfig.common_options.
-            options = _filter_package_env(c.compile_flags) + _COMMON_REPL_OPTIONS,
+            options = _filter_package_env(c.compile_flags),
             transitive_cc_shared_libs = [lib.path for lib in cc_libs],
             # Follows the new runfiles tree organization of:
             # https://github.com/bazelbuild/bazel/wiki/Updating-the-runfiles-tree-structure

--- a/haskell/private/actions/info.bzl
+++ b/haskell/private/actions/info.bzl
@@ -160,7 +160,7 @@ def compile_info_output_groups(
     cc_libs = [lib for lib in ghci_extra_libs.to_list()
                 if not is_hs_library(get_lib_name(lib)) and get_lib_name(lib) != "ffi"]
     return {
-        "haskell_cdeps_shared_lib": depset(cc_libs),
+        "haskell_cdep_libs": depset(cc_libs),
         "haskell_runfiles": runfiles,
         "haskell_source_files": depset(transitive =
             [c.source_files, c.extra_source_files]),

--- a/haskell/private/actions/info.bzl
+++ b/haskell/private/actions/info.bzl
@@ -84,7 +84,7 @@ def _write_haskell_compile_info(
             # TODO: currently, this will duplicate the common, target-independent options for
             # each build target.  We should instead move them into GhcConfig.common_options.
             options = _filter_package_env(c.compile_flags),
-            transitive_cc_shared_libs = [lib.path for lib in cc_libs],
+            transitive_cc_libs = [lib.path for lib in cc_libs],
             # Follows the new runfiles tree organization of:
             # https://github.com/bazelbuild/bazel/wiki/Updating-the-runfiles-tree-structure
             runfiles = [

--- a/haskell/private/actions/info.bzl
+++ b/haskell/private/actions/info.bzl
@@ -1,0 +1,181 @@
+"""Defines output groups that are consumed by tools such as 'hrepl'."""
+load("@bazel_skylib//lib:dicts.bzl", "dicts")
+load("@bazel_skylib//lib:paths.bzl", "paths")
+load(":providers.bzl", "all_package_ids", "get_ghci_extra_libs")
+load(
+    ":private/path_utils.bzl",
+    "get_lib_name",
+    "is_hs_library",
+)
+
+def write_proto_file(hs, output_name, proto_type, content):
+    """Write an encoded .proto file.
+
+    Writes a file with the text format encoding, and then runs "protoc"
+    to convert it to the wire encoding.
+
+    Using the wire encoding allows us use released versions of tools
+    with different versions of the Haskell rules (within reason).
+
+    Args:
+      hs: The current rule context.
+      output_name: The output filename.  The text-encoded file will be named
+        {output_name}.txt, and the encoded file will be named {file_name}.pb.
+      proto_type: The type of the proto (e.g. foo.Bar).  It must be defined
+        in rule_info.proto.
+      content: The contents of the text file, as a Bazel struct.
+
+    Returns:
+      A File containing the encoded proto message, named {file_name}.pb.
+    """
+    proto_txt = hs.actions.declare_file(output_name + ".txt")
+    proto_pb = hs.actions.declare_file(output_name + ".pb")
+    hs.actions.write(output = proto_txt, content = content.to_proto())
+
+    protoc = hs.toolchain.protoc
+    rule_info_protos = hs.toolchain.rule_info_proto[ProtoInfo].direct_sources
+
+    hs.actions.run_shell(
+        outputs = [proto_pb],
+        inputs = depset([proto_txt] + rule_info_protos),
+        tools = [protoc],
+        command =
+            "{protoc} {rule_info_proto} --encode {proto_type} < {proto_txt} > {proto_pb}"
+                .format(
+                protoc = protoc.path,
+                proto_type = proto_type,
+                proto_txt = proto_txt.path,
+                proto_pb = proto_pb.path,
+                rule_info_proto = " ".join([p.path for p in rule_info_protos]),
+            ),
+    )
+    return proto_pb
+
+# Copied from haskell/repl.bzl; not sure if there's a more general solution.
+_COMMON_REPL_OPTIONS = [
+    "-hide-all-packages",
+    "-package=base",
+    "-package=directory",
+]
+
+def _filter_package_env(flags):
+    # Strips out -package-env from the command-line flags.  Consumers of these output
+    # groups will be responsible for setting the right GHC flags themselves,
+    # based on the fields of haskell.LibraryInfo.
+    result = []
+    for i in flags:
+        if not flags:
+            break
+        if flags[0] == "-package-env":
+            flags = flags[2:]
+        else:
+            result.append(flags[0])
+            flags = flags[1:]
+    return result
+
+def _write_haskell_compile_info(
+        workspace_name,
+        name,
+        hs,
+        c,
+        cc_libs,
+        runfiles):
+    return write_proto_file(
+        output_name = name,
+        hs = hs,
+        proto_type = "haskell.CompileInfo",
+        content = struct(
+            # Calling to_list on c.source_files shouldn't be a performance penalty.
+            # Despite being a depset, it only contains sources for the current rule.
+            source_files = [f.path for f in c.source_files.to_list()],
+            # TODO: currently, this will duplicate the common, target-independent options for
+            # each build target.  We should instead move them into GhcConfig.common_options.
+            options = _filter_package_env(c.compile_flags) + _COMMON_REPL_OPTIONS,
+            transitive_cc_shared_libs = [lib.path for lib in cc_libs],
+            # Follows the new runfiles tree organization of:
+            # https://github.com/bazelbuild/bazel/wiki/Updating-the-runfiles-tree-structure
+            runfiles = [
+                struct(
+                    full_path = f.path,
+                    short_path = paths.join(
+                        f.owner.workspace_name or workspace_name, f.short_path))
+                for f in runfiles.to_list()
+            ],
+        ),
+    )
+
+
+def library_info_output_groups(
+        name,
+        hs,
+        hs_info,
+        lib_info):
+    """Output groups for depending on a Haskell target.
+
+    Args:
+        name: A string; the name of the current target.
+        hs: The Haskell context.
+        hs_info: A HaskellInfo provider.
+        lib_info: A HaskellLibraryInfo provider.
+
+    Returns:
+      A dict whose keys are output groups and values are depsets of Files.
+    """
+    proto_file = write_proto_file(
+        hs = hs,
+        output_name = name + ".HaskellLibrary",
+        proto_type = "haskell.LibraryInfo",
+        content = struct(
+            # TODO(google/hrepl#4): currently, we only expose the immediate dependencies.
+            transitive_package_ids = [lib_info.package_id],
+            transitive_package_dbs =
+                [db.dirname for db in hs_info.package_databases.to_list()]))
+    return {
+        "haskell_transitive_deps": depset(
+          transitive = [
+                hs_info.package_databases,
+                hs_info.interface_dirs,
+                hs_info.dynamic_libraries,
+            ]),
+        "haskell_library_info": depset([proto_file]),
+    }
+
+def compile_info_output_groups(
+        name,
+        workspace_name,
+        hs,
+        c,
+        posix,
+        cc_info,
+        runfiles):
+    """Output groups for compiling a Haskell target.
+
+    Args:
+        name: A string; the name of the current target.
+        workspace_name: The workspace this target was defined in.
+          Used for organizing its runfiles.
+        hs: The Haskell context.
+        c: A struct with information about the compilation step.
+        posix: The posix toolchain.
+        cc_info: A CcInfo provider.
+        runfiles: A depset of Files.
+
+    Returns:
+      A dict whose keys are output groups and values are depsets of Files.
+    """
+    (ghci_extra_libs, ghc_env) = get_ghci_extra_libs(hs, posix, cc_info)
+    cc_libs = [lib for lib in ghci_extra_libs.to_list()
+                if not is_hs_library(get_lib_name(lib)) and get_lib_name(lib) != "ffi"]
+    return {
+        "haskell_cdeps_shared_lib": depset(cc_libs),
+        "haskell_runfiles": runfiles,
+        "haskell_source_files": depset(transitive =
+            [c.source_files, c.extra_source_files]),
+        "haskell_compile_info": depset([_write_haskell_compile_info(
+            workspace_name = workspace_name,
+            hs = hs,
+            name = name + ".HaskellCompile",
+            c = c,
+            cc_libs = cc_libs,
+            runfiles = runfiles)]),
+    }

--- a/haskell/private/actions/info.bzl
+++ b/haskell/private/actions/info.bzl
@@ -14,13 +14,13 @@ def write_proto_file(hs, output_name, proto_type, content):
     Writes a file with the text format encoding, and then runs "protoc"
     to convert it to the wire encoding.
 
-    Using the wire encoding allows us use released versions of tools
+    The wire encoding allows us to use released versions of tools
     with different versions of the Haskell rules (within reason).
 
     Args:
       hs: The current rule context.
       output_name: The output filename.  The text-encoded file will be named
-        {output_name}.txt, and the encoded file will be named {file_name}.pb.
+        {output_name}.txt, and the encoded file will be named {output_name}.pb.
       proto_type: The type of the proto (e.g. foo.Bar).  It must be defined
         in rule_info.proto.
       content: The contents of the text file, as a Bazel struct.

--- a/haskell/private/haskell_impl.bzl
+++ b/haskell/private/haskell_impl.bzl
@@ -368,7 +368,8 @@ def _haskell_binary_common_impl(ctx, is_test):
             c = c,
             posix = posix,
             cc_info = cc_info,
-            runfiles = ctx.runfiles(collect_data = True).files))
+            runfiles = ctx.runfiles(collect_data = True).files,
+        )),
     ]
 
 def haskell_library_impl(ctx):
@@ -659,15 +660,15 @@ def haskell_library_impl(ctx):
                 c = c,
                 posix = posix,
                 cc_info = cc_info,
-                runfiles = default_info.default_runfiles.files
-                if getattr(default_info, "default_runfiles", None) else depset(),
+                runfiles = default_info.default_runfiles.files if getattr(default_info, "default_runfiles", None) else depset(),
             ),
             library_info_output_groups(
                 name = ctx.label.name,
                 hs = hs,
                 hs_info = hs_info,
                 lib_info = lib_info,
-            )))
+            ),
+        )),
     ]
 
 # We should not need this provider. It exists purely as a workaround
@@ -709,7 +710,8 @@ The following toolchain libraries are available:
             hs = hs,
             name = ctx.label.name,
             hs_info = target.hs_info,
-            lib_info = target.hs_lib_info)),
+            lib_info = target.hs_lib_info,
+        )),
     ]
 
 def haskell_toolchain_libraries_impl(ctx):

--- a/haskell/private/haskell_impl.bzl
+++ b/haskell/private/haskell_impl.bzl
@@ -1,5 +1,6 @@
 """Implementation of core Haskell rules"""
 
+load("@bazel_skylib//lib:dicts.bzl", "dicts")
 load(
     "@rules_haskell//haskell:providers.bzl",
     "C2hsLibraryInfo",
@@ -13,6 +14,11 @@ load(":cc.bzl", "cc_interop_info")
 load(
     ":private/actions/compile.bzl",
     "list_exposed_modules",
+)
+load(
+    ":private/actions/info.bzl",
+    "compile_info_output_groups",
+    "library_info_output_groups",
 )
 load(
     ":private/actions/link.bzl",
@@ -355,6 +361,14 @@ def _haskell_binary_common_impl(ctx, is_test):
                 collect_data = True,
             ),
         ),
+        OutputGroupInfo(**compile_info_output_groups(
+            name = ctx.label.name,
+            workspace_name = ctx.workspace_name,
+            hs = hs,
+            c = c,
+            posix = posix,
+            cc_info = cc_info,
+            runfiles = ctx.runfiles(collect_data = True).files))
     ]
 
 def haskell_library_impl(ctx):
@@ -634,6 +648,26 @@ def haskell_library_impl(ctx):
         coverage_info,
         default_info,
         lib_info,
+        OutputGroupInfo(**dicts.add(
+            compile_info_output_groups(
+                # For haskell_proto_aspect, which doesn't have a ctx.workspace_name,
+                # just set it to "".  It won't matter in practice because those rules don't
+                # have runfiles and won't be compiled directly anyway.
+                workspace_name = ctx.workspace_name if hasattr(ctx, "workspace_name") else "",
+                hs = hs,
+                name = ctx.label.name,
+                c = c,
+                posix = posix,
+                cc_info = cc_info,
+                runfiles = default_info.default_runfiles.files
+                if hasattr(default_info, "default_runfiles") and default_info.default_runfiles else depset(),
+            ),
+            library_info_output_groups(
+                name = ctx.label.name,
+                hs = hs,
+                hs_info = hs_info,
+                lib_info = lib_info,
+            )))
     ]
 
 # We should not need this provider. It exists purely as a workaround
@@ -645,6 +679,7 @@ HaskellImportHack = provider()
 HaskellToolchainLibraries = provider()
 
 def haskell_toolchain_library_impl(ctx):
+    hs = haskell_context(ctx)
     if ctx.attr.package:
         package = ctx.attr.package
     else:
@@ -670,6 +705,11 @@ The following toolchain libraries are available:
         target.cc_info,
         target.haddock_info,
         HaskellToolchainLibraryInfo(),
+        OutputGroupInfo(**library_info_output_groups(
+            hs = hs,
+            name = ctx.label.name,
+            hs_info = target.hs_info,
+            lib_info = target.hs_lib_info)),
     ]
 
 def haskell_toolchain_libraries_impl(ctx):

--- a/haskell/private/haskell_impl.bzl
+++ b/haskell/private/haskell_impl.bzl
@@ -653,14 +653,14 @@ def haskell_library_impl(ctx):
                 # For haskell_proto_aspect, which doesn't have a ctx.workspace_name,
                 # just set it to "".  It won't matter in practice because those rules don't
                 # have runfiles and won't be compiled directly anyway.
-                workspace_name = ctx.workspace_name if hasattr(ctx, "workspace_name") else "",
+                workspace_name = getattr(ctx, "workspace_name", ""),
                 hs = hs,
                 name = ctx.label.name,
                 c = c,
                 posix = posix,
                 cc_info = cc_info,
                 runfiles = default_info.default_runfiles.files
-                if hasattr(default_info, "default_runfiles") and default_info.default_runfiles else depset(),
+                if getattr(default_info, "default_runfiles", None) else depset(),
             ),
             library_info_output_groups(
                 name = ctx.label.name,

--- a/haskell/protobuf.bzl
+++ b/haskell/protobuf.bzl
@@ -195,7 +195,7 @@ def _haskell_proto_aspect_impl(target, ctx):
     # TODO this pattern match is very brittle. Let's not do this. The
     # order should match the order in the return value expression in
     # haskell_library_impl().
-    [hs_info, cc_info, coverage_info, default_info, library_info] = _haskell_library_impl(patched_ctx)
+    [hs_info, cc_info, coverage_info, default_info, library_info, output_groups] = _haskell_library_impl(patched_ctx)
 
     # Build haddock informations
     transitive_html = {}
@@ -232,6 +232,7 @@ def _haskell_proto_aspect_impl(target, ctx):
         # We can't return DefaultInfo here because target already provides that.
         HaskellProtobufInfo(files = default_info.files),
         haddock_info,
+        output_groups
     ]
 
 _haskell_proto_aspect = aspect(

--- a/haskell/protobuf.bzl
+++ b/haskell/protobuf.bzl
@@ -232,7 +232,7 @@ def _haskell_proto_aspect_impl(target, ctx):
         # We can't return DefaultInfo here because target already provides that.
         HaskellProtobufInfo(files = default_info.files),
         haddock_info,
-        output_groups
+        output_groups,
     ]
 
 _haskell_proto_aspect = aspect(

--- a/haskell/repositories.bzl
+++ b/haskell/repositories.bzl
@@ -67,7 +67,7 @@ def rules_haskell_dependencies():
             ],
         )
 
-    # Dependencies of com_google_protobuf.
+    # Dependency of com_google_protobuf.
     # TODO(judahjacobson): this is a bit of a hack.
     # We can't call that repository's protobuf_deps() function
     # from here, because load()ing it from this .bzl file would lead
@@ -85,14 +85,6 @@ def rules_haskell_dependencies():
             sha256 = "629380c90a77b964d896ed37163f5c3a34f6e6d897311f1df2a7016355c45eff",
             strip_prefix = "zlib-1.2.11",
             urls = ["https://github.com/madler/zlib/archive/v1.2.11.tar.gz"],
-        )
-
-    if "rules_python" not in excludes:
-        http_archive(
-            name = "rules_python",
-            sha256 = "e5470e92a18aa51830db99a4d9c492cc613761d5bdb7131c04bd92b9834380f6",
-            strip_prefix = "rules_python-4b84ad270387a7c439ebdccfd530e2339601ef27",
-            urls = ["https://github.com/bazelbuild/rules_python/archive/4b84ad270387a7c439ebdccfd530e2339601ef27.tar.gz"],
         )
 
 

--- a/haskell/repositories.bzl
+++ b/haskell/repositories.bzl
@@ -56,6 +56,46 @@ def rules_haskell_dependencies():
             urls = ["https://github.com/tweag/rules_nixpkgs/archive/v0.6.0.tar.gz"],
         )
 
+    if "com_google_protobuf" not in excludes:
+        http_archive(
+            name = "com_google_protobuf",
+            sha256 = "e8c7601439dbd4489fe5069c33d374804990a56c2f710e00227ee5d8fd650e67",
+            strip_prefix = "protobuf-3.11.2",
+            urls = [
+                "https://mirror.bazel.build/github.com/google/protobuf/archive/v3.11.2.tar.gz",
+                "https://github.com/google/protobuf/archive/v3.11.2.tar.gz",
+            ],
+        )
+
+    # Dependencies of com_google_protobuf.
+    # TODO(judahjacobson): this is a bit of a hack.
+    # We can't call that repository's protobuf_deps() function
+    # from here, because load()ing it from this .bzl file would lead
+    # to a cycle:
+    # https://github.com/bazelbuild/bazel/issues/1550
+    # https://github.com/bazelbuild/bazel/issues/1943
+    # For now, just hard-code the subset that's needed to use `protoc`.
+    # Alternately, consider adding another function from another
+    # .bzl file that needs to be called from WORKSPACE, similar to:
+    # https://github.com/grpc/grpc/blob/8c9dcf7c35e489c2072a9ad86635dbc4e28f88ea/bazel/grpc_extra_deps.bzl#L10
+    if "zlib" not in excludes:
+        http_archive(
+            name = "zlib",
+            build_file = "@com_google_protobuf//:third_party/zlib.BUILD",
+            sha256 = "629380c90a77b964d896ed37163f5c3a34f6e6d897311f1df2a7016355c45eff",
+            strip_prefix = "zlib-1.2.11",
+            urls = ["https://github.com/madler/zlib/archive/v1.2.11.tar.gz"],
+        )
+
+    if "rules_python" not in excludes:
+        http_archive(
+            name = "rules_python",
+            sha256 = "e5470e92a18aa51830db99a4d9c492cc613761d5bdb7131c04bd92b9834380f6",
+            strip_prefix = "rules_python-4b84ad270387a7c439ebdccfd530e2339601ef27",
+            urls = ["https://github.com/bazelbuild/rules_python/archive/4b84ad270387a7c439ebdccfd530e2339601ef27.tar.gz"],
+        )
+
+
 def haskell_repositories():
     """DEPRECATED alias for rules_haskell_dependencies"""
     rules_haskell_dependencies()

--- a/haskell/repositories.bzl
+++ b/haskell/repositories.bzl
@@ -87,7 +87,6 @@ def rules_haskell_dependencies():
             urls = ["https://github.com/madler/zlib/archive/v1.2.11.tar.gz"],
         )
 
-
 def haskell_repositories():
     """DEPRECATED alias for rules_haskell_dependencies"""
     rules_haskell_dependencies()

--- a/haskell/toolchain.bzl
+++ b/haskell/toolchain.bzl
@@ -251,7 +251,6 @@ Label pointing to the locale archive file to use. Mostly useful on NixOS.
             allow_single_file = True,
             default = Label("@rules_haskell//rule_info:rule_info_proto"),
         ),
-
     },
 )
 

--- a/haskell/toolchain.bzl
+++ b/haskell/toolchain.bzl
@@ -187,6 +187,8 @@ def _haskell_toolchain_impl(ctx):
             is_static = ctx.attr.is_static,
             version = ctx.attr.version,
             global_pkg_db = pkgdb_file,
+            protoc = ctx.executable._protoc,
+            rule_info_proto = ctx.attr._rule_info_proto,
         ),
     ]
 
@@ -240,6 +242,16 @@ Label pointing to the locale archive file to use. Mostly useful on NixOS.
             default = Label("@rules_haskell//haskell:cc_wrapper"),
             executable = True,
         ),
+        "_protoc": attr.label(
+            executable = True,
+            cfg = "host",
+            default = Label("@com_google_protobuf//:protoc"),
+        ),
+        "_rule_info_proto": attr.label(
+            allow_single_file = True,
+            default = Label("@rules_haskell//rule_info:rule_info_proto"),
+        ),
+
     },
 )
 

--- a/haskell/toolchain_info.bzl
+++ b/haskell/toolchain_info.bzl
@@ -4,10 +4,13 @@ load(":private/actions/info.bzl", "write_proto_file")
 def _haskell_toolchain_info_impl(ctx):
     hs = haskell_context(ctx)
     pb = write_proto_file(
-        hs, ctx.label.name, "haskell.GhcConfig",
-        struct(ghc = hs.tools.ghc.path))
+        hs,
+        ctx.label.name,
+        "haskell.GhcConfig",
+        struct(ghc = hs.tools.ghc.path),
+    )
 
-    return [DefaultInfo(files=depset([pb]))]
+    return [DefaultInfo(files = depset([pb]))]
 
 haskell_toolchain_info = rule(
     implementation = _haskell_toolchain_info_impl,

--- a/haskell/toolchain_info.bzl
+++ b/haskell/toolchain_info.bzl
@@ -1,0 +1,15 @@
+load(":private/context.bzl", "haskell_context")
+load(":private/actions/info.bzl", "write_proto_file")
+
+def _haskell_toolchain_info_impl(ctx):
+    hs = haskell_context(ctx)
+    pb = write_proto_file(
+        hs, ctx.label.name, "haskell.GhcConfig",
+        struct(ghc = hs.tools.ghc.path))
+
+    return [DefaultInfo(files=depset([pb]))]
+
+haskell_toolchain_info = rule(
+    implementation = _haskell_toolchain_info_impl,
+    toolchains = ["@rules_haskell//haskell:toolchain"],
+)

--- a/rule_info/BUILD.bazel
+++ b/rule_info/BUILD.bazel
@@ -10,6 +10,6 @@ proto_library(
 
 haskell_proto_library(
     name = "rule_info_haskell_proto",
-    deps = [":rule_info_proto"],
     visibility = ["//visibility:public"],
+    deps = [":rule_info_proto"],
 )

--- a/rule_info/BUILD.bazel
+++ b/rule_info/BUILD.bazel
@@ -1,0 +1,15 @@
+load("@rules_haskell//haskell:protobuf.bzl", "haskell_proto_library")
+load("@rules_proto//proto:defs.bzl", "proto_library")
+
+proto_library(
+    name = "rule_info_proto",
+    srcs = ["rule_info.proto"],
+    strip_import_prefix = "",
+    visibility = ["//visibility:public"],
+)
+
+haskell_proto_library(
+    name = "rule_info_haskell_proto",
+    deps = [":rule_info_proto"],
+    visibility = ["//visibility:public"],
+)

--- a/rule_info/rule_info.proto
+++ b/rule_info/rule_info.proto
@@ -29,6 +29,7 @@ message CompileInfo {
 
 // Information about a built library.
 message LibraryInfo {
+  reserved 3;
   // The GHC package ID of this target.
   string package_id = 1;
 
@@ -38,10 +39,6 @@ message LibraryInfo {
   // Does not include the "core" package DB which is part of the GHC build
   // itself and produces packages like "base", "ghc", etc.
   repeated string transitive_package_dbs = 2;
-
-  // Shared libraries containing built Haskell code for this library
-  // and its dependencies.
-  repeated string transitive_haskell_shared_libs = 3;
 
   // The package IDs of all libraries that this target depends on transitively,
   // including itself.

--- a/rule_info/rule_info.proto
+++ b/rule_info/rule_info.proto
@@ -1,0 +1,77 @@
+// Proto messages that Haskell build rules output, for use by tools like
+// "hrepl".
+syntax = "proto3";
+
+package haskell;
+
+// Information about a HaskellCompile action.
+message CompileInfo {
+  reserved 1, 3, 4, 7, 8, 10, 13, 14;
+  // The source files that are being compiled (.hs and .lhs files).
+  // Does not contain "boot" files (e.g. ".hs-boot").
+  repeated string source_files = 2;
+  // Modules that should not be exposed.  (For libraries only.)
+  repeated string hidden_modules = 12;
+  // The runfiles that should be collected for this target.
+  repeated Runfile runfiles = 5;
+  // The Haskell package name.  Should only be set for third-party libraries
+  // (namely, those with the "cabal_version" attribute).
+  string package_name = 6;
+
+  // Arguments to GHC for compiling this target.  Does not include source files,
+  // nor flags related to dependent packages ("-package-id" and "-package-db").
+  repeated string options = 9;
+
+  // Shared libraries for cc_library rules that this target depends on
+  // transitively.
+  repeated string transitive_cc_shared_libs = 11;
+}
+
+// Information about a built library.
+message LibraryInfo {
+  // The GHC package ID of this target.
+  string package_id = 1;
+
+  // The package DBs that we need to explicitly pass to GHC in order to use
+  // this target.  Namely, the DBs needed for all dependencies transitively,
+  // including itself.
+  // Does not include the "core" package DB which is part of the GHC build
+  // itself and produces packages like "base", "ghc", etc.
+  repeated string transitive_package_dbs = 2;
+
+  // Shared libraries containing built Haskell code for this library
+  // and its dependencies.
+  repeated string transitive_haskell_shared_libs = 3;
+
+  // The package IDs of all libraries that this target depends on transitively,
+  // including itself.
+  repeated string transitive_package_ids = 4;
+}
+
+message Runfile {
+  // The path under the execution root.  For example, "foo/bar.txt"
+  // for a source file, or "bazel-out/k8-fastbuild/bin/foo/bar.txt" for a
+  // generated file.
+  string full_path = 1;
+  // The path where this file is expected to be in the runfiles directory.
+  // For example, "foo/bar.txt" in both of the above cases.
+  string short_path = 2;
+}
+
+// Information about the Haskell compiler.
+// This is similar information as in the ghc_paths library, but comes directly
+// from the build rules, rather than being embedded in a Haskell binary (which
+// might have been compiled with a different version of GHC).
+message GhcConfig {
+  // The path to the GHC executable.
+  string ghc = 1;
+  // The directory containing GHC's libraries, which should be the
+  // argument of the "-B" flag.
+  // TODO(judahjacobson): Currently, rules_haskell does not set this
+  // flag.  hrepl doesn't need it since it calls GHC as a binary.
+  string library_root = 2;
+  // Arguments that should be passed to every invocation of GHC.
+  // Note that this does *not* contain "-B".  It is not relevant for users of
+  // the GHC API, which should pull that value from library_root instead.
+  repeated string common_options = 3;
+}

--- a/rule_info/rule_info.proto
+++ b/rule_info/rule_info.proto
@@ -22,9 +22,10 @@ message CompileInfo {
   // nor flags related to dependent packages ("-package-id" and "-package-db").
   repeated string options = 9;
 
-  // Shared libraries for cc_library rules that this target depends on
-  // transitively.
-  repeated string transitive_cc_shared_libs = 11;
+  // Libraries for cc_library rules that this target depends on
+  // transitively.  Should be either static or dynamic, depending on how the
+  // GHC RTS was linked.
+  repeated string transitive_cc_libs = 11;
 }
 
 // Information about a built library.


### PR DESCRIPTION
`hrepl` is a standalone binary that runs REPLS for Bazel Haskell targets.
Its repository is located at: https://github.com/google/hrepl

`hrel` takes a list of labels on the command-line, in contrast to `haskell_repl()`
which requires editing BUILD files maually.  For example:

```
$ hrepl tests/binary-with-lib:lib
```

This change adds specific output groups to `rules_haskell` which allow `hrepl`
to understand its rule types. Internally, `hrepl` runs the following steps:

- Run `bazel build --output_groups=... haskell:toolchain_info` and read the resulting
  protobuf file to get the path to GHC as well as any relevant command-line options.
- Use `bazel query` to figure out exactly what targets to build.
- "bazel build --output_groups=..." to compile the immediate dependencies of
  the targets.
- Read the "LibraryInfo" protobuf file which contains information about
  them (e.g., the paths of the package DBs).
- "bazel build --output_groups=..." the targets to be interpreted.  This makes
  sure their `srcs`, runfiles, C++ dependencies, etc are available, but doesn't
  actually compile them.  Instead, it writes the necessary information to a "CompileInfo"
  protobuf file.
- Run `ghc --interactive`, combining the flags obtained from all the previous steps.

So this change adds two kinds of output groups:

- Library info: For targets that `hrepl` should recognize as dependencies, such as
  `haskell_library`, `haskell_toolchain_library` and `haskell_cabal_library`.
- Compilation info: For targets that `hrepl` should load directly, such as `haskell_library`
  and `haskell_binary`.

This change also makes the `protoc` binary a dependency of all Haskell build rules,
rather than just `haskell_proto_library`.  It writes files in the human-readable
text format, and then uses the `protoc` binary to convert them to the binary proto format.
The text format itself doesn't have a good forwards/backwards compatibility story,
which is important since `hrepl` is a separate, standalone executable.  (For example,
a text format parser will fail if it encounters a field name that it doesn't understand,
which makes it more difficult to deprecate old fields.)