### PR TITLE
Use https to access Maven central

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -340,7 +340,7 @@ jvm_maven_import_external(
     artifact = "org.apache.spark:spark-core_2.10:1.6.0",
     artifact_sha256 = "28aad0602a5eea97e9cfed3a7c5f2934cd5afefdb7f7c1d871bb07985453ea6e",
     licenses = ["notice"],
-    server_urls = ["http://central.maven.org/maven2"],
+    server_urls = ["https://repo.maven.apache.org/maven2"],
 )
 
 # c2hs rule in its own repository


### PR DESCRIPTION
See https://support.sonatype.com/hc/en-us/articles/360041287334
Also use the new repo.maven.apache.org instead of central.maven.org, as the latter is deprecated and causes certificate errors.

This fixes the following error:
```
ERROR: An error occurred during the fetch of repository 'org_apache_spark_spark_core_2_10':
   java.io.IOException: Error downloading [http://central.maven.org/maven2/org/apache/spark/spark-core_2.10/1.6.0/spark-core_2.10-1.6.0.jar] to C:/users/vssadministrator/_bazel_vssadministrator/w3d6ug6o/external/org_apache_spark_spark_core_2_10/spark-core_2.10-1.6.0.jar: GET returned 501 HTTPS Required
```