### PR TITLE
Update rules_sh 0.1.0 --> 0.1.1

### DIFF
--- a/haskell/repositories.bzl
+++ b/haskell/repositories.bzl
@@ -43,9 +43,9 @@ def rules_haskell_dependencies():
     if "rules_sh" not in excludes:
         http_archive(
             name = "rules_sh",
-            sha256 = "2613156e96b41fe0f91ac86a65edaea7da910b7130f2392ca02e8270f674a734",
-            strip_prefix = "rules_sh-0.1.0",
-            urls = ["https://github.com/tweag/rules_sh/archive/v0.1.0.tar.gz"],
+            sha256 = "8f2722359c0e13a258c341aac69b8faa96b21e8f3382bd375d78c52f8b5a3d34",
+            strip_prefix = "rules_sh-0.1.1",
+            urls = ["https://github.com/tweag/rules_sh/archive/v0.1.1.tar.gz"],
         )
 
     if "io_tweag_rules_nixpkgs" not in excludes:


### PR DESCRIPTION
This is make `sh_posix_configure` safer on Windows and avoid
errors due to non-POSIX compliant `find` on Windows:
```
SUBCOMMAND: # //tests/binary-with-data:binary-with-data [action 'Action tests/binary-with-data/_obj/binary-with-data.static.manifest', configuration: ec1b41fa35525e50d5e902ade5e0952a]
cd C:/users/vssadministrator/_bazel_vssadministrator/w3d6ug6o/execroot/rules_haskell
C:/Program Files/Git/usr/bin/bash.exe -c
        "C:/windows/system32/find.exe" bazel-out/x64_windows-fastbuild/bin/tests/binary-with-data/_obj/binary-with-data -name '*.o' | sort > bazel-out/x64_windows-fastbuild/bin/tests/binary-with-data/_obj/binary-with-data.static.manifest

INFO: From Action tests/binary-with-data/_obj/binary-with-data.static.manifest:
File not found - *.o
```
See https://dev.azure.com/tweag/rules_haskell/_build/results?buildId=3631&view=logs&j=2d2b3007-3c5c-5840-9bb0-2b1ea49925f3&t=a8035825-ecc2-53a4-dc8f-13b782b0dc20&l=187