### PR TITLE
mergify: Allow buildkite/rules-haskell and buildkite/rules-haskell/pr

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -2,7 +2,7 @@ pull_request_rules:
   - name: automatic merge
     conditions:
       - "status-success=build"
-      - "status-success=buildkite/rules-haskell/pr"
+      - "status-success~=buildkite/rules-haskell(|/pr)"
       - "status-success=tweag.rules_haskell"
       - "status-success=deploy/netlify"
       - "#approved-reviews-by>=1"


### PR DESCRIPTION
The buildkite pipeline is either called `buildkite/rules-haskell/pr` or `buildkite/rules-haskell`. See for example https://github.com/tweag/rules_haskell/pull/1215 or https://github.com/tweag/rules_haskell/pull/1210. The latter seems to be the case for external PRs where the buildkite pipeline needs to be initiated manually by pushing to a branch within the repository. However, I have also observed it for internal PRs, e.g. https://github.com/tweag/rules_haskell/pull/1214. I have not found this behavior described in the [buildkite documentation](https://buildkite.com/docs/tutorials/getting-started).

In any case, we want to accept both pipeline names as mergify merge criteria. I have tested the configuration in the [mergify simulator](https://dashboard.mergify.io/).