### PR TITLE
Bazel CI config: remove --incompatible_use_python_toolchains=false

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -6,7 +6,6 @@ tasks:
       LANG: "C.UTF-8"
     build_flags:
       - "--build_tag_filters=-requires_zlib,-requires_lz4,-requires_doctest,-requires_c2hs,-requires_threaded_rts,-requires_shellcheck,-dont_test_with_bindist,-dont_test_on_bazelci"
-      - "--incompatible_use_python_toolchains=false"
     build_targets:
       - "//tests/..."
     test_flags:


### PR DESCRIPTION
We removed that flag on our own CI configuration in #1142 but left the Bazel CI untouched. The flag seems to be causing #1217. At least I was able to reproduce the same error on our CI by upgrading to Bazel 2.0.0 and setting `--incompatible_use_python_toolchains=false`, see https://buildkite.com/tweag-1/rules-haskell/builds/956#5d3f6ff7-596b-4720-bceb-87d79ae80839/21-2292.

Closes #1217 