### PR TITLE
Fix macOS CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,6 +83,7 @@ jobs:
             # nix-shell --arg docTools false --pure --run \
             #   './tests/run-start-script.sh --use-nix'
             nix-shell --arg docTools false --pure --run '
+            set -euo pipefail
             bazel build --config ci //tests:run-tests
             ./bazel-ci-bin/tests/run-tests
             bazel coverage //tests/... --config ci --build_tag_filters "coverage-compatible" --test_tag_filters "coverage-compatible" --test_output=all

--- a/haskell/private/cc_wrapper.py.tpl
+++ b/haskell/private/cc_wrapper.py.tpl
@@ -494,7 +494,16 @@ def darwin_shorten_rpaths(rpaths, libraries, output):
         rewrites: List of load command rewrites.
 
     """
-    input_rpaths = sort_rpaths(rpaths)
+    if rpaths:
+        input_rpaths = sort_rpaths(rpaths)
+    else:
+        # GHC with Template Haskell or tools like hsc2hs build temporary
+        # Haskell binaries linked against libraries, but do not speficy the
+        # required runpaths on the command-line in the context of Bazel. Bazel
+        # generated libraries have relative library names which don't work in a
+        # temporary directory, or the Cabal working directory. As a fall-back
+        # we use the contents of `LD_LIBRARY_PATH` in these situations.
+        input_rpaths = sort_rpaths(os.environ.get("LD_LIBRARY_PATH", "").split(":"))
 
     # Keeps track of libraries that were not yet found in an rpath.
     libs_still_missing = set(libraries)


### PR DESCRIPTION
MacOS CI was ignoring test failures if the error did not happen in the last command.
Due to that macOS CI was silently broken since https://github.com/tweag/rules_haskell/pull/1149.
This PR makes macOS fail if an error occurs in any of the test commands, and fixes the error that had been silently ignored.