### PR TITLE
Use sort command from POSIX toolchain

### DIFF
--- a/haskell/private/actions/link.bzl
+++ b/haskell/private/actions/link.bzl
@@ -117,9 +117,10 @@ def _create_objects_dir_manifest(hs, posix, objects_dir, dynamic, with_profiling
         # for efficient caching. See
         # https://github.com/tweag/rules_haskell/issues/1126.
         command = """
-        "{find}" {dir} -name '*.{ext}' | sort > {out}
+        "{find}" {dir} -name '*.{ext}' | "{sort}" > {out}
         """.format(
             find = posix.commands["find"],
+            sort = posix.commands["sort"],
             dir = objects_dir.path,
             ext = ext,
             out = objects_dir_manifest.path,


### PR DESCRIPTION
Use sort command from POSIX toolchain when generating the `objects_dir_manifest` file, instead of relying on whatever `sort` is found in path. 