### PR TITLE
Fix API documentation for common rules

### DIFF
--- a/haskell/defs.bzl
+++ b/haskell/defs.bzl
@@ -330,7 +330,28 @@ def haskell_binary(
         **kwargs
     )
 
-def haskell_test(**kwargs):
+def haskell_test(
+        name,
+        src_strip_prefix = "",
+        srcs = [],
+        extra_srcs = [],
+        deps = [],
+        data = [],
+        compiler_flags = [],
+        repl_ghci_args = [],
+        runcompile_flags = [],
+        plugins = [],
+        tools = [],
+        worker = None,
+        linkstatic = True,
+        main_function = "Main.main",
+        version = None,
+        expected_covered_expressions_percentage = -1,
+        expected_uncovered_expression_count = -1,
+        strict_coverage_analysis = False,
+        coverage_report_format = "text",
+        experimental_coverage_source_patterns = ["//..."],
+        **kwargs):
     """Build a test suite.
 
     Additionally, it accepts [all common bazel test rule
@@ -338,8 +359,62 @@ def haskell_test(**kwargs):
     timeout and resource allocation for the test.
 
     [bazel-test-attrs]: https://docs.bazel.build/versions/master/be/common-definitions.html#common-attributes-tests
+
+    Args:
+      name: A unique name for this rule.
+      src_strip_prefix: DEPRECATED. Attribute has no effect.
+      srcs: Haskell source files.
+      extra_srcs: Extra (non-Haskell) source files that will be needed at compile time (e.g. by Template Haskell).
+      deps: List of other Haskell libraries to be linked to this target.
+      data: See [Bazel documentation](https://docs.bazel.build/versions/master/be/common-definitions.html#common.data).,
+      compiler_flags: Flags to pass to Haskell compiler. Subject to Make variable substitution.
+      repl_ghci_args: Arbitrary extra arguments to pass to GHCi. This extends `compiler_flags` and `repl_ghci_args` from the toolchain. Subject to Make variable substitution.,
+      runcompile_flags: Arbitrary extra arguments to pass to runghc. This extends `compiler_flags` and `repl_ghci_args` from the toolchain. Subject to Make variable substitution.
+      plugins: Compiler plugins to use during compilation.
+      tools: Extra tools needed at compile-time, like preprocessors.
+      worker: Experimental. Worker binary employed by Bazel's persistent worker mode. See [use-cases documentation](https://rules-haskell.readthedocs.io/en/latest/haskell-use-cases.html#persistent-worker-mode-experimental).
+      linkstatic: Link dependencies statically wherever possible. Some system libraries may still be linked dynamically, as are libraries for which there is no static library. So the resulting executable will still be dynamically linked, hence only mostly static.
+      main_function: A function with type `IO _`, either the qualified name of a function from any module or the bare name of a function from a `Main` module. It is also possible to give the qualified name of any module exposing a `main` function.
+      version:Executable version. If this is specified, CPP version macros will be generated for this build.
+      expected_covered_expressions_percentage: The expected percentage of expressions covered by testing.
+      expected_uncovered_expression_count: The expected number of expressions which are not covered by testing.
+      strict_coverage_analysis: Requires that the coverage metric is matched exactly, even doing better than expected is not allowed.
+      coverage_report_format: The format to output the coverage report in.
+
+        Supported values: "text", "html". Default: "text".
+
+        Report can be seen in the testlog XML file, or by setting --test_output=all when running bazel coverage.
+      experimental_coverage_source_patterns: The path patterns specifying which targets to analyze for test coverage metrics.
+
+          Wild-card targets such as //... or //:all are allowed. The paths must be relative to the workspace, which means they must start with "//".
+
+          Note, this attribute may leave experimental status depending on the outcome of https://github.com/bazelbuild/bazel/issues/7763.
+      **kwargs: Common rule attributes. See [Bazel documentation](https://docs.bazel.build/versions/master/be/common-definitions.html#common-attributes).
     """
-    _haskell_worker_wrapper("test", **kwargs)
+    _haskell_worker_wrapper(
+        "test",
+        name = name,
+        src_strip_prefix = src_strip_prefix,
+        srcs = srcs,
+        extra_srcs = extra_srcs,
+        deps = deps,
+        data = data,
+        compiler_flags = compiler_flags,
+        repl_ghci_args = repl_ghci_args,
+        runcompile_flags = runcompile_flags,
+        plugins = plugins,
+        tools = tools,
+        worker = worker,
+        linkstatic = linkstatic,
+        main_function = main_function,
+        version = version,
+        expected_covered_expressions_percentage = expected_covered_expressions_percentage,
+        expected_uncovered_expression_count = expected_uncovered_expression_count,
+        strict_coverage_analysis = strict_coverage_analysis,
+        coverage_report_format = coverage_report_format,
+        experimental_coverage_source_patterns = experimental_coverage_source_patterns,
+        **kwargs
+    )
 
 def haskell_library(**kwargs):
     """Build a library from Haskell source.

--- a/haskell/defs.bzl
+++ b/haskell/defs.bzl
@@ -416,29 +416,93 @@ def haskell_test(
         **kwargs
     )
 
-def haskell_library(**kwargs):
+def haskell_library(
+        name,
+        src_strip_prefix = "",
+        srcs = [],
+        extra_srcs = [],
+        deps = [],
+        data = [],
+        compiler_flags = [],
+        repl_ghci_args = [],
+        runcompile_flags = [],
+        plugins = [],
+        tools = [],
+        worker = None,
+        hidden_modules = [],
+        reexported_modules = {},
+        exports = [],
+        linkstatic = False,
+        package_name = "",
+        version = "",
+        **kwargs):
     """Build a library from Haskell source.
-
-    Example:
-    ```bzl
-    haskell_library(
-    name = "hello-lib",
-    srcs = glob(["src/**/*.hs"]),
-    src_strip_prefix = "src",
-    deps = [
-    "//hello-sublib:lib",
-    ],
-    reexported_modules = {
-    "//hello-sublib:lib": "Lib1 as HelloLib1, Lib2",
-    },
-    )
-    ```
 
     Every `haskell_library` target also defines an optional REPL target that is
     not built by default, but can be built on request. It works the same way as
     for `haskell_binary`.
+
+    Args:
+      name: A unique name for this rule.
+      src_strip_prefix: DEPRECATED. Attribute has no effect.
+      srcs: Haskell source files.
+      extra_srcs: Extra (non-Haskell) source files that will be needed at compile time (e.g. by Template Haskell).
+      deps: List of other Haskell libraries to be linked to this target.
+      data: See [Bazel documentation](https://docs.bazel.build/versions/master/be/common-definitions.html#common.data).,
+      compiler_flags: Flags to pass to Haskell compiler. Subject to Make variable substitution.
+      repl_ghci_args: Arbitrary extra arguments to pass to GHCi. This extends `compiler_flags` and `repl_ghci_args` from the toolchain. Subject to Make variable substitution.,
+      runcompile_flags: Arbitrary extra arguments to pass to runghc. This extends `compiler_flags` and `repl_ghci_args` from the toolchain. Subject to Make variable substitution.
+      plugins: Compiler plugins to use during compilation.
+      tools: Extra tools needed at compile-time, like preprocessors.
+      worker: Experimental. Worker binary employed by Bazel's persistent worker mode. See [use-cases documentation](https://rules-haskell.readthedocs.io/en/latest/haskell-use-cases.html#persistent-worker-mode-experimental).
+      hidden_modules: Modules that should be unavailable for import by dependencies.
+      reexported_modules: A dictionary mapping dependencies to module reexports that should be available for import by dependencies.
+      exports: A list of other haskell libraries that will be transparently added as a dependency to every downstream rule
+      linkstatic: Create a static library, not both a static and a shared library.
+      package_name: Library name used in version macro generation. Only used
+        if the version attribute is defined, see version attribute
+        documentation. Optional, defaults to target name.
+      version: Library version. Not normally necessary unless to build a library
+        originally defined as a Cabal package. If this is specified, CPP version macro will be generated.
+      **kwargs: Common rule attributes. See [Bazel documentation](https://docs.bazel.build/versions/master/be/common-definitions.html#common-attributes).
+
+    Example:
+      ```bzl
+      haskell_library(
+          name = "hello-lib",
+          srcs = glob(["src/**/*.hs"]),
+          src_strip_prefix = "src",
+          deps = [
+              "//hello-sublib:lib",
+          ],
+          reexported_modules = {
+              "//hello-sublib:lib": "Lib1 as HelloLib1, Lib2",
+          },
+      )
+      ```
     """
-    _haskell_worker_wrapper("library", **kwargs)
+    _haskell_worker_wrapper(
+        "library",
+        name = name,
+        src_strip_prefix = src_strip_prefix,
+        srcs = srcs,
+        extra_srcs = extra_srcs,
+        deps = deps,
+        data = data,
+        compiler_flags = compiler_flags,
+        repl_ghci_args = repl_ghci_args,
+        runcompile_flags = runcompile_flags,
+        plugins = plugins,
+        tools = tools,
+        worker = worker,
+        hidden_modules = hidden_modules,
+        reexported_modules = reexported_modules,
+        exports = exports,
+        linkstatic = linkstatic,
+        package_name = package_name,
+        version = version,
+        **kwargs
+    )
 
 haskell_import = rule(
     _haskell_import_impl,

--- a/haskell/defs.bzl
+++ b/haskell/defs.bzl
@@ -34,39 +34,23 @@ load(
 #   Currently it is not possible to automatically inherit rule documentation in
 #   wrapping macros. See https://github.com/bazelbuild/stardoc/issues/27
 _haskell_common_attrs = {
-    "src_strip_prefix": attr.string(
-        doc = "DEPRECATED. Attribute has no effect.",
-    ),
+    "src_strip_prefix": attr.string(),
     "srcs": attr.label_list(
         allow_files = [".hs", ".hsc", ".lhs", ".hs-boot", ".lhs-boot", ".h"],
-        doc = "Haskell source files.",
     ),
     "extra_srcs": attr.label_list(
         allow_files = True,
-        doc = "Extra (non-Haskell) source files that will be needed at compile time (e.g. by Template Haskell).",
     ),
-    "deps": attr.label_list(
-        doc = "List of other Haskell libraries to be linked to this target.",
-    ),
+    "deps": attr.label_list(),
     "data": attr.label_list(
-        doc = "See [Bazel documentation](https://docs.bazel.build/versions/master/be/common-definitions.html#common.data).",
         allow_files = True,
     ),
-    "compiler_flags": attr.string_list(
-        doc = "Flags to pass to Haskell compiler. Subject to Make variable substitution.",
-    ),
-    "repl_ghci_args": attr.string_list(
-        doc = "Arbitrary extra arguments to pass to GHCi. This extends `compiler_flags` and `repl_ghci_args` from the toolchain. Subject to Make variable substitution.",
-    ),
-    "runcompile_flags": attr.string_list(
-        doc = "Arbitrary extra arguments to pass to runghc. This extends `compiler_flags` and `repl_ghci_args` from the toolchain. Subject to Make variable substitution.",
-    ),
-    "plugins": attr.label_list(
-        doc = "Compiler plugins to use during compilation.",
-    ),
+    "compiler_flags": attr.string_list(),
+    "repl_ghci_args": attr.string_list(),
+    "runcompile_flags": attr.string_list(),
+    "plugins": attr.label_list(),
     "tools": attr.label_list(
         cfg = "host",
-        doc = "Extra tools needed at compile-time, like preprocessors.",
     ),
     "_ghci_script": attr.label(
         allow_single_file = True,
@@ -98,7 +82,6 @@ _haskell_common_attrs = {
         default = None,
         executable = True,
         cfg = "host",
-        doc = "Experimental. Worker binary employed by Bazel's persistent worker mode. See docs/haskell-use-cases.rst",
     ),
 }
 
@@ -117,50 +100,41 @@ def _mk_binary_rule(**kwargs):
 
     is_test = kwargs.get("test", False)
 
+    # NOTE: Documentation needs to be added to the wrapper macros below.
+    #   Currently it is not possible to automatically inherit rule documentation
+    #   in wrapping macros. See https://github.com/bazelbuild/stardoc/issues/27
     attrs = dict(
         _haskell_common_attrs,
         linkstatic = attr.bool(
             default = True,
-            doc = "Link dependencies statically wherever possible. Some system libraries may still be linked dynamically, as are libraries for which there is no static library. So the resulting executable will still be dynamically linked, hence only mostly static.",
         ),
         main_function = attr.string(
             default = "Main.main",
-            doc = """A function with type `IO _`, either the qualified name of a function from any module or the bare name of a function from a `Main` module. It is also possible to give the qualified name of any module exposing a `main` function.""",
         ),
-        version = attr.string(
-            doc = "Executable version. If this is specified, CPP version macros will be generated for this build.",
-        ),
+        version = attr.string(),
     )
 
     # Tests have an extra fields regarding code coverage.
+    #
+    # NOTE: Documentation needs to be added to the wrapper macros below.
+    #   Currently it is not possible to automatically inherit rule documentation
+    #   in wrapping macros. See https://github.com/bazelbuild/stardoc/issues/27
     if is_test:
         attrs.update({
             "expected_covered_expressions_percentage": attr.int(
                 default = -1,
-                doc = "The expected percentage of expressions covered by testing.",
             ),
             "expected_uncovered_expression_count": attr.int(
                 default = -1,
-                doc = "The expected number of expressions which are not covered by testing.",
             ),
             "strict_coverage_analysis": attr.bool(
                 default = False,
-                doc = "Requires that the coverage metric is matched exactly, even doing better than expected is not allowed.",
             ),
             "coverage_report_format": attr.string(
                 default = "text",
-                doc = """The format to output the coverage report in. Supported values: "text", "html". Default: "text".
-                Report can be seen in the testlog XML file, or by setting --test_output=all when running bazel coverage.
-                """,
             ),
             "experimental_coverage_source_patterns": attr.string_list(
                 default = ["//..."],
-                doc = """The path patterns specifying which targets to analyze for test coverage metrics.
-
-                Wild-card targets such as //... or //:all are allowed. The paths must be relative to the workspace, which means they must start with "//".
-
-                Note, this attribute may leave experimental status depending on the outcome of https://github.com/bazelbuild/bazel/issues/7763.
-                """,
             ),
             "_coverage_wrapper_template": attr.label(
                 allow_single_file = True,
@@ -197,31 +171,21 @@ _haskell_binary = _mk_binary_rule()
 
 _haskell_library = rule(
     _haskell_library_impl,
+    # NOTE: Documentation needs to be added to the wrapper macros below.
+    #   Currently it is not possible to automatically inherit rule documentation
+    #   in wrapping macros. See https://github.com/bazelbuild/stardoc/issues/27
     attrs = dict(
         _haskell_common_attrs,
-        hidden_modules = attr.string_list(
-            doc = "Modules that should be unavailable for import by dependencies.",
-        ),
-        reexported_modules = attr.label_keyed_string_dict(
-            doc = "A dictionary mapping dependencies to module reexports that should be available for import by dependencies.",
-        ),
+        hidden_modules = attr.string_list(),
+        reexported_modules = attr.label_keyed_string_dict(),
         exports = attr.label_list(
             default = [],
-            doc = "A list of other haskell libraries that will be transparently added as a dependency to every downstream rule",
         ),
         linkstatic = attr.bool(
             default = False,
-            doc = "Create a static library, not both a static and a shared library.",
         ),
-        package_name = attr.string(
-            doc = """Library name used in version macro generation. Only used
-            if the version attribute is defined, see version attribute
-            documentation. Optional, defaults to target name.""",
-        ),
-        version = attr.string(
-            doc = """Library version. Not normally necessary unless to build a library
-            originally defined as a Cabal package. If this is specified, CPP version macro will be generated.""",
-        ),
+        package_name = attr.string(),
+        version = attr.string(),
     ),
     outputs = {
         "runghc": "%{name}@runghc",


### PR DESCRIPTION
Closes #1122 

The rules `haskell_library|binary|test` are exposed through wrapper macros, the rules themselves are hidden. As a consequence the API documentation doesn't show the `doc` attribute of the rule attributes. This PR makes the attributes explicit in the wrapper macros, and moves the attribute documentation into the docstring of the wrapper macros. Unfortunately, wrapper macros cannot inherit rule documentation. See  https://github.com/bazelbuild/stardoc/issues/27