### PR TITLE
Bazel.Runfiles: Fix check for existing datafiles

### DIFF
--- a/tools/runfiles/src/Bazel/Runfiles.hs
+++ b/tools/runfiles/src/Bazel/Runfiles.hs
@@ -22,7 +22,7 @@ import GHC.Stack
 import System.Directory (doesDirectoryExist, doesFileExist, listDirectory)
 import System.Environment (getExecutablePath, lookupEnv)
 import qualified System.FilePath
-import System.FilePath (FilePath, (</>), (<.>), addTrailingPathSeparator)
+import System.FilePath (FilePath, (</>), (<.>), addTrailingPathSeparator, takeFileName)
 import System.Info (os)
 
 -- | Reference to Bazel runfiles, runfiles root or manifest file.
@@ -165,7 +165,7 @@ containsOneDataFile = loop
         isDir <- doesDirectoryExist fp
         if isDir
             then anyM loop =<< fmap (map (fp </>)) (listDirectory fp)
-            else pure $! fp /= "MANIFEST"
+            else pure $! takeFileName fp /= "MANIFEST"
 
 -- | Check if the given predicate holds on any of the given values.
 --


### PR DESCRIPTION
https://github.com/tweag/rules_haskell/pull/1209 prepended the directory path to the argument to the loop in `containsOneDataFile` to avoid infinite recursion. The check for the `MANIFEST` file name needs to be adapted accordingly. 