### PR TITLE
Add extra arguments to rules_haskell_worker_dependencies

### DIFF
--- a/tools/repositories.bzl
+++ b/tools/repositories.bzl
@@ -2,7 +2,7 @@
 
 load("@rules_haskell//haskell:cabal.bzl", "stack_snapshot")
 
-def rules_haskell_worker_dependencies():
+def rules_haskell_worker_dependencies(**stack_kwargs):
     """Provide all repositories that are necessary for `rules_haskell`'s tools to
     function.
     """
@@ -25,4 +25,5 @@ def rules_haskell_worker_dependencies():
                 "vector",
             ],
             snapshot = "lts-14.1",
+            **stack_kwargs
         )


### PR DESCRIPTION
This allows the user of `rules_haskell_worker_dependencies` to overload
some arguments of stack_snapshot, such as `stack`.