### PR TITLE
Simplify transitive dynamic library dependencies on macOS

### DIFF
--- a/haskell/private/actions/compile.bzl
+++ b/haskell/private/actions/compile.bzl
@@ -152,12 +152,6 @@ def _compilation_defaults(hs, cc, java, posix, dep_info, plugin_dep_info, srcs, 
     compile_flags += hs.toolchain.compiler_flags
     compile_flags += user_compile_flags
 
-    # Work around macOS linker limits.  This fix has landed in GHC HEAD, but is
-    # not yet in a release; plus, we still want to support older versions of
-    # GHC.  For details, see: https://phabricator.haskell.org/D4714
-    if hs.toolchain.is_darwin:
-        compile_flags += ["-optl-Wl,-dead_strip_dylibs"]
-
     package_ids = []
     for plugin in plugins:
         package_ids.extend(all_dependencies_package_ids(plugin.deps))

--- a/haskell/private/actions/link.bzl
+++ b/haskell/private/actions/link.bzl
@@ -347,12 +347,6 @@ def link_library_dynamic(hs, cc, posix, dep_info, extra_srcs, objects_dir, my_pk
     args.add_all(hs.toolchain.compiler_flags)
     args.add_all(compiler_flags)
 
-    # Work around macOS linker limits.  This fix has landed in GHC HEAD, but is
-    # not yet in a release; plus, we still want to support older versions of
-    # GHC.  For details, see: https://phabricator.haskell.org/D4714
-    if hs.toolchain.is_darwin:
-        args.add("-optl-Wl,-dead_strip_dylibs")
-
     (pkg_info_inputs, pkg_info_args) = pkg_info_to_compile_flags(
         hs,
         pkg_info = expose_packages(

--- a/haskell/private/actions/link.bzl
+++ b/haskell/private/actions/link.bzl
@@ -34,66 +34,6 @@ def merge_parameter_files(hs, file1, file2):
     )
     return params_file
 
-def _darwin_create_extra_linker_flags_file(hs, cc, objects_dir, executable, dynamic, solibs):
-    """Write additional linker flags required on macOS to a parameter file.
-
-    Args:
-      hs: Haskell context.
-      cc: CcInteropInfo, information about C dependencies.
-      objects_dir: Directory storing object files.
-        Used to determine output file location.
-      executable: The executable being built.
-      dynamic: Bool: Whether to link dynamically or statically.
-      solibs: List of dynamic library dependencies.
-
-    Returns:
-      File: Parameter file with additional linker flags. To be passed to GHC.
-    """
-
-    # On Darwin GHC will pass the dead_strip_dylibs flag to the linker. This
-    # flag will remove any shared library loads from the binary's header that
-    # are not directly resolving undefined symbols in the binary. I.e. any
-    # indirect shared library dependencies will be removed. This conflicts with
-    # Bazel's builtin cc rules, which assume that the final binary will load
-    # all transitive shared library dependencies. In particlar shared libraries
-    # produced by Bazel's cc rules never load shared libraries themselves. This
-    # causes missing symbols at runtime on macOS, see #170.
-    #
-    # The following work-around applies the `-u` flag to the linker for any
-    # symbol that is undefined in any transitive shared library dependency.
-    # This forces the linker to resolve these undefined symbols in all
-    # transitive shared library dependencies and keep the corresponding load
-    # commands in the binary's header.
-    #
-    # Unfortunately, this prohibits elimination of any truly redundant shared
-    # library dependencies. Furthermore, the transitive closure of shared
-    # library dependencies can be large, so this makes it more likely to exceed
-    # the MACH-O header size limit on macOS.
-    #
-    # This is a horrendous hack, but it seems to be forced on us by how Bazel
-    # builds dynamic cc libraries.
-    suffix = ".dynamic.linker_flags" if dynamic else ".static.linker_flags"
-    linker_flags_file = hs.actions.declare_file(
-        executable.basename + suffix,
-        sibling = objects_dir,
-    )
-
-    hs.actions.run_shell(
-        inputs = solibs,
-        outputs = [linker_flags_file],
-        command = """
-        touch {out}
-        for lib in {solibs}; do
-            {nm} -u "$lib" | sed 's/^/-optl-Wl,-u,/' >> {out}
-        done
-        """.format(
-            nm = cc.tools.nm,
-            solibs = " ".join(["\"" + l.path + "\"" for l in solibs]),
-            out = linker_flags_file.path,
-        ),
-    )
-    return linker_flags_file
-
 def _create_objects_dir_manifest(hs, posix, objects_dir, dynamic, with_profiling):
     suffix = ".dynamic.manifest" if dynamic else ".static.manifest"
     objects_dir_manifest = hs.actions.declare_file(
@@ -214,7 +154,6 @@ def link_binary(
         with_profiling = with_profiling,
     )
 
-    extra_linker_flags_file = None
     if hs.toolchain.is_darwin:
         args.add("-optl-Wl,-headerpad_max_install_names")
 
@@ -224,20 +163,6 @@ def link_binary(
         # should do always when using a toolchain from Nixpkgs.
         # TODO remove this gross hack.
         args.add("-liconv")
-
-        extra_linker_flags_file = _darwin_create_extra_linker_flags_file(
-            hs,
-            cc,
-            objects_dir,
-            executable,
-            dynamic,
-            dynamic_libs,
-        )
-
-    if extra_linker_flags_file != None:
-        params_file = merge_parameter_files(hs, objects_dir_manifest, extra_linker_flags_file)
-    else:
-        params_file = objects_dir_manifest
 
     hs.toolchain.actions.run_ghc(
         hs,
@@ -254,7 +179,7 @@ def link_binary(
         outputs = [executable],
         mnemonic = "HaskellLinkBinary",
         arguments = args,
-        params_file = params_file,
+        params_file = objects_dir_manifest,
     )
 
     return (executable, dynamic_libs)

--- a/haskell/private/cc_wrapper.py.tpl
+++ b/haskell/private/cc_wrapper.py.tpl
@@ -245,25 +245,32 @@ class Args:
         #   -Xlinker <flag>
         # or
         #   -Wl,<flag1>,<flag2>...
-
-        # On Darwin GHC will pass the dead_strip_dylibs flag to the linker.
-        # This flag will remove any shared library loads from the binary's
-        # header that are not directly resolving undefined symbols in the
-        # binary. I.e. any indirect shared library dependencies will be
-        # removed. This conflicts with Bazel's builtin cc rules, which assume
-        # that the final binary will load all transitive shared library
-        # dependencies. In particlar shared libraries produced by Bazel's cc
-        # rules never load shared libraries themselves. This causes missing
-        # symbols at runtime on macOS, see #170. To avoid this issue, we drop
-        # the -dead_strip_dylibs flag if it is set.
+        ld_args = []
         if arg == "-Xlinker":
-            ld_arg = next(args)
+            ld_args.append(next(args))
+        elif arg.startswith("-Wl,"):
+            ld_args.extend(arg.split(",")[1:])
+        else:
+            # Not a linker argument, continue pattern matching in _handle_args.
+            return False
+
+        for ld_arg in ld_args:
             if self._prev_ld_arg is None:
                 if ld_arg == "-rpath":
                     self._prev_ld_arg = ld_arg
                 elif ld_arg.startswith("-rpath="):
                     self._handle_rpath(ld_arg[len("-rpath="):], out)
                 elif ld_arg == "-dead_strip_dylibs":
+                    # On Darwin GHC will pass the dead_strip_dylibs flag to the linker.
+                    # This flag will remove any shared library loads from the binary's
+                    # header that are not directly resolving undefined symbols in the
+                    # binary. I.e. any indirect shared library dependencies will be
+                    # removed. This conflicts with Bazel's builtin cc rules, which assume
+                    # that the final binary will load all transitive shared library
+                    # dependencies. In particlar shared libraries produced by Bazel's cc
+                    # rules never load shared libraries themselves. This causes missing
+                    # symbols at runtime on macOS, see #170. To avoid this issue, we drop
+                    # the -dead_strip_dylibs flag if it is set.
                     pass
                 else:
                     out.extend(["-Xlinker", ld_arg])
@@ -273,21 +280,8 @@ class Args:
             else:
                 # This indicates a programmer error and should not happen.
                 raise RuntimeError("Unhandled _prev_ld_arg '{}'.".format(self._prev_ld_arg))
-            return True
-        elif arg.startswith("-Wl,"):
-            ld_args = arg.split(",")[1:]
-            if len(ld_args) == 2 and ld_args[0] == "-rpath":
-                self._handle_rpath(ld_args[1], out)
-                return True
-            elif len(ld_args) == 1 and ld_args[0].startswith("-rpath="):
-                self._handle_rpath(ld_args[0][len("-rpath="):])
-            elif ld_args == ["-dead_strip_dylibs"]:
-                return True
-            else:
-                out.append(arg)
-                return True
-        else:
-            return False
+
+        return True
 
     def _handle_rpath(self, rpath, out):
         # Filter out all RPATH flags for now and manually add the needed ones

--- a/haskell/private/cc_wrapper.py.tpl
+++ b/haskell/private/cc_wrapper.py.tpl
@@ -100,6 +100,7 @@ class Args:
         - Detects the requested action.
         - Keeps rpath arguments for further processing when linking.
         - Keeps print-file-name arguments for further processing.
+        - Filters out -dead_strip_dylibs.
 
         Args:
           args: Iterable over command-line arguments.
@@ -244,6 +245,17 @@ class Args:
         #   -Xlinker <flag>
         # or
         #   -Wl,<flag1>,<flag2>...
+
+        # On Darwin GHC will pass the dead_strip_dylibs flag to the linker.
+        # This flag will remove any shared library loads from the binary's
+        # header that are not directly resolving undefined symbols in the
+        # binary. I.e. any indirect shared library dependencies will be
+        # removed. This conflicts with Bazel's builtin cc rules, which assume
+        # that the final binary will load all transitive shared library
+        # dependencies. In particlar shared libraries produced by Bazel's cc
+        # rules never load shared libraries themselves. This causes missing
+        # symbols at runtime on macOS, see #170. To avoid this issue, we drop
+        # the -dead_strip_dylibs flag if it is set.
         if arg == "-Xlinker":
             ld_arg = next(args)
             if self._prev_ld_arg is None:
@@ -251,6 +263,8 @@ class Args:
                     self._prev_ld_arg = ld_arg
                 elif ld_arg.startswith("-rpath="):
                     self._handle_rpath(ld_arg[len("-rpath="):], out)
+                elif ld_arg == "-dead_strip_dylibs":
+                    pass
                 else:
                     out.extend(["-Xlinker", ld_arg])
             elif self._prev_ld_arg == "-rpath":
@@ -267,6 +281,8 @@ class Args:
                 return True
             elif len(ld_args) == 1 and ld_args[0].startswith("-rpath="):
                 self._handle_rpath(ld_args[0][len("-rpath="):])
+            elif ld_args == ["-dead_strip_dylibs"]:
+                return True
             else:
                 out.append(arg)
                 return True


### PR DESCRIPTION
On Darwin GHC [will pass the `-dead_strip_dylibs` flag](https://gitlab.haskell.org/complyue/ghc/commit/b592bd98ff25730bbe3c13d6f62a427df8c78e28) to the linker. This flag will remove any shared library loads from the binary's header that are not directly resolving undefined symbols in the binary. I.e. any indirect shared library dependencies will be removed. This conflicts with Bazel's builtin cc rules, which assume that the final binary will load all transitive shared library dependencies. In particlar shared libraries produced by Bazel's cc rules never load shared libraries themselves, which causes missing symbols at runtime on macOS. https://github.com/tweag/rules_haskell/pull/627 worked around this by forcing the linker to resolve symbols in all transitive dynamic library dependencies using `-u` flags.

Now that we have `cc_wrapper` a much simpler and less costly solution is to just drop the `-dead_strip_dylibs` linker flag.

I've confirmed that removing `_darwin_create_extra_linker_flags_file` alone causes [`//tests/indirect-link:indirect-link-dynamic` to fail](https://circleci.com/gh/tweag/rules_haskell/8392). Dropping `-dead_strip_dylibs` makes it succeed again.

This PR also refactors linker flag parsing in `cc_wrapper` to avoid duplication.