### PR TITLE
Avoid shadowing of cc_info in haskell_library_impl

### DIFF
--- a/haskell/private/haskell_impl.bzl
+++ b/haskell/private/haskell_impl.bzl
@@ -592,7 +592,7 @@ def haskell_library_impl(ctx):
     linking_context = cc_common.create_linking_context(
         libraries_to_link = libraries_to_link,
     )
-    cc_info = cc_common.merge_cc_infos(
+    out_cc_info = cc_common.merge_cc_infos(
         cc_infos = [
             CcInfo(
                 compilation_context = compilation_context,
@@ -603,7 +603,7 @@ def haskell_library_impl(ctx):
 
     return [
         hs_info,
-        cc_info,
+        out_cc_info,
         coverage_info,
         default_info,
         lib_info,


### PR DESCRIPTION
The `compile_info_output_groups` function expects a `CcInfo` of the
targets compilation dependencies. However, in `haskell_library_impl` it
was accidentally given the output `CcInfo` of the target itself due to
name shadowing. This change fixes that by not shadowing the name
`cc_info`. See `haskell_binary_impl` for reference, where no such
shadowing occurs.

This did not cause any issues because `compile_info_output_groups` only
takes C libraries from the given `CcInfo` and ignores Haskell libraries.