### PR TITLE
.bazelrc: improve try-import of .bazelrc.local

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -27,4 +27,4 @@ common:ci --incompatible_load_python_rules_from_bzl
 # We also need to setup an utf8 locale
 test --test_env=LANG=C.UTF-8 --test_env=LOCALE_ARCHIVE
 
-try-import .bazelrc.local
+try-import %workspace%/.bazelrc.local


### PR DESCRIPTION
Importing the relative path fails in some cases. %workspace% always
points to the absolute directory of the WORKSPACE file.