### PR TITLE
Fix Windows CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,9 +27,9 @@ jobs:
       set -e
       export MSYS2_ARG_CONV_EXCL="*"
 
-      # Remove 'C:\Program Files ' (ending on space) from PATH.
+      # Fix PATH entries ending on space as they crash Bazel.
       # See https://github.com/bazelbuild/bazel/issues/10481
-      export PATH="$(sed 's,:/c/Program Files $,,' <<<"$PATH")"
+      export PATH="$(sed 's, \+\(:\|$\),\1,g' <<<"$PATH")"
       echo "PATH='$PATH'"
 
       # Tests that build but don't run


### PR DESCRIPTION
This is another instance of https://github.com/bazelbuild/bazel/issues/10481, see https://github.com/tweag/rules_haskell/pull/1187 for the last instance.

The Azure Windows instance was extended with another entry in `PATH` that ended in a space character.
```
PATH='...:/c/Program '
```
https://dev.azure.com/tweag/rules_haskell/_build/results?buildId=3821&view=logs&j=2d2b3007-3c5c-5840-9bb0-2b1ea49925f3&t=a8035825-ecc2-53a4-dc8f-13b782b0dc20

This PR makes our workaround more generic by simply removing any white space at the end of each `$PATH` entry.