### PR TITLE
No longer define (LD_)LIBRARY_PATH

### DIFF
--- a/haskell/cabal.bzl
+++ b/haskell/cabal.bzl
@@ -111,9 +111,9 @@ def _prepare_cabal_inputs(hs, cc, posix, dep_info, cc_libraries_info, cc_info, d
     # already covered by their corresponding package-db entries. We only need
     # to add libraries and headers for direct C library dependencies to the
     # command line.
-    (direct_libs, _) = get_ghci_extra_libs(hs, posix, cc_libraries_info, direct_cc_info)
-    (transitive_libs, env) = get_ghci_extra_libs(hs, posix, cc_libraries_info, cc_info)
-    env.update(**hs.env)
+    direct_libs = get_ghci_extra_libs(hs, posix, cc_libraries_info, direct_cc_info)
+    transitive_libs = get_ghci_extra_libs(hs, posix, cc_libraries_info, cc_info)
+    env = dict(hs.env)
     env["PATH"] = join_path_list(hs, _binary_paths(tool_inputs) + posix.paths)
     if hs.toolchain.is_darwin:
         env["SDKROOT"] = "macosx"  # See haskell/private/actions/link.bzl

--- a/haskell/doctest.bzl
+++ b/haskell/doctest.bzl
@@ -128,7 +128,7 @@ def _haskell_doctest_single(target, ctx):
     args.add_all(ctx.attr.doctest_flags)
 
     # C library dependencies to link against.
-    (ghci_extra_libs, ghc_env) = get_ghci_extra_libs(hs, posix, cc_libraries_info, cc_info)
+    ghci_extra_libs = get_ghci_extra_libs(hs, posix, cc_libraries_info, cc_info)
     link_libraries(ghci_extra_libs, args, prefix_optl = hs.toolchain.is_darwin)
 
     if ctx.attr.modules:
@@ -166,14 +166,7 @@ def _haskell_doctest_single(target, ctx):
             env = render_env(hs.env),
         ),
         arguments = [args],
-        # NOTE It looks like we must specify the paths here as well as via -L
-        # flags because there are at least two different "consumers" of the info
-        # (ghc and linker?) and they seem to prefer to get it in different ways
-        # in this case.
-        env = dicts.add(
-            ghc_env,
-            hs.env,
-        ),
+        env = hs.env,
         execution_requirements = {
             # Prevents a race condition among concurrent doctest tests on Linux.
             #

--- a/haskell/haddock.bzl
+++ b/haskell/haddock.bzl
@@ -133,7 +133,7 @@ def _haskell_doc_aspect_impl(target, ctx):
     )
 
     # C library dependencies for runtime.
-    (ghci_extra_libs, ghc_env) = get_ghci_extra_libs(
+    ghci_extra_libs = get_ghci_extra_libs(
         hs,
         posix,
         target[HaskellCcLibrariesInfo],
@@ -155,7 +155,7 @@ def _haskell_doc_aspect_impl(target, ctx):
             "%{haddock}": hs.tools.haddock.path,
             # XXX Workaround
             # https://github.com/bazelbuild/bazel/issues/5980.
-            "%{env}": render_env(dicts.add(hs.env, ghc_env)),
+            "%{env}": render_env(hs.env),
         },
         is_executable = True,
     )

--- a/haskell/private/actions/compile.bzl
+++ b/haskell/private/actions/compile.bzl
@@ -323,7 +323,7 @@ def _compilation_defaults(hs, cc, java, posix, dep_info, plugin_dep_info, cc_lib
     )
 
     # Transitive library dependencies for runtime.
-    (ghci_extra_libs, ghc_env) = get_ghci_extra_libs(hs, posix, cc_libraries_info, cc_info)
+    ghci_extra_libs = get_ghci_extra_libs(hs, posix, cc_libraries_info, cc_info)
     link_libraries(ghci_extra_libs, args)
 
     return struct(
@@ -354,7 +354,6 @@ def _compilation_defaults(hs, cc, java, posix, dep_info, plugin_dep_info, cc_lib
         extra_source_files = extra_source_files,
         import_dirs = import_dirs,
         env = dicts.add(
-            ghc_env,
             java.env,
             hs.env,
         ),

--- a/haskell/private/actions/info.bzl
+++ b/haskell/private/actions/info.bzl
@@ -164,7 +164,7 @@ def compile_info_output_groups(
     Returns:
       A dict whose keys are output groups and values are depsets of Files.
     """
-    (ghci_extra_libs, ghc_env) = get_ghci_extra_libs(hs, posix, cc_libraries_info, cc_info)
+    ghci_extra_libs = get_ghci_extra_libs(hs, posix, cc_libraries_info, cc_info)
     cc_libs = [
         lib
         for lib in ghci_extra_libs.to_list()

--- a/haskell/private/actions/runghc.bzl
+++ b/haskell/private/actions/runghc.bzl
@@ -57,7 +57,7 @@ def build_haskell_runghc(
         for idir in set.to_list(hs_info.import_dirs):
             args += ["-i{0}".format(idir)]
 
-    (ghci_extra_libs, ghc_env) = get_ghci_extra_libs(
+    ghci_extra_libs = get_ghci_extra_libs(
         hs,
         posix,
         cc_libraries_info,
@@ -89,7 +89,7 @@ def build_haskell_runghc(
         template = runghc_wrapper,
         output = runghc_file,
         substitutions = {
-            "{ENV}": render_env(ghc_env),
+            "{ENV}": "",
             "{TOOL}": hs.tools.runghc.path,
             "{CC}": hs.toolchain.cc_wrapper.executable.path,
             "{ARGS}": " ".join([shell.quote(a) for a in runcompile_flags]),

--- a/haskell/private/cc_libraries.bzl
+++ b/haskell/private/cc_libraries.bzl
@@ -16,7 +16,6 @@ load(
     "create_rpath_entry",
     "get_lib_name",
     "is_hs_library",
-    "make_library_path",
     "mangle_static_library",
     "rel_to_pkgroot",
     "target_unique_name",
@@ -132,9 +131,7 @@ def get_ghci_extra_libs(hs, posix, cc_libraries_info, cc_info, path_prefix = Non
       path_prefix: (optional) Prefix for the entries in the generated library path.
 
     Returns:
-      (libs, ghc_env):
-        libs: depset of File, the libraries that should be passed to GHCi.
-        ghc_env: dict, environment variables to set for GHCi.
+      libs: depset of File, the libraries that should be passed to GHCi.
 
     """
     (static_libs, dynamic_libs) = get_extra_libs(
@@ -148,15 +145,7 @@ def get_ghci_extra_libs(hs, posix, cc_libraries_info, cc_info, path_prefix = Non
     )
     libs = depset(transitive = [static_libs, dynamic_libs])
 
-    # NOTE: We can avoid constructing these in the future by instead generating
-    #   a dedicated package configuration file defining the required libraries.
-    library_path = make_library_path(hs, libs, prefix = path_prefix)
-    ghc_env = {
-        "LIBRARY_PATH": library_path,
-        "LD_LIBRARY_PATH": library_path,
-    }
-
-    return (libs, ghc_env)
+    return libs
 
 def get_extra_libs(hs, posix, cc_libraries_info, cc_info, dynamic = False, pic = None, fixup_dir = "_libs"):
     """Get libraries appropriate for linking with GHC.

--- a/haskell/private/path_utils.bzl
+++ b/haskell/private/path_utils.bzl
@@ -112,29 +112,6 @@ def join_path_list(hs, paths):
     sep = ";" if hs.toolchain.is_windows else ":"
     return sep.join(paths)
 
-def make_library_path(hs, libs, prefix = None):
-    """Return a string value for using as LD_LIBRARY_PATH or similar.
-
-    Args:
-      hs: Haskell context.
-      libs: List of library files that should be available
-      prefix: String, an optional prefix to add to every path.
-
-    Returns:
-      String: paths to the given library directories separated by ":" (Unix) or
-        ";" (Windows).
-    """
-    r = set.empty()
-
-    for lib in libs.to_list():
-        lib_dir = paths.dirname(lib.path)
-        if prefix:
-            lib_dir = paths.join(prefix, lib_dir)
-
-        set.mutable_insert(r, lib_dir)
-
-    return join_path_list(hs, set.to_list(r))
-
 def mangle_static_library(hs, posix, dynamic_lib, static_lib, outdir):
     """Mangle a static library to match a dynamic library name.
 

--- a/haskell/repl.bzl
+++ b/haskell/repl.bzl
@@ -256,7 +256,7 @@ def _create_repl(hs, posix, ctx, repl_info, output):
         repl_info.load_info.cc_info,
         repl_info.dep_info.cc_info,
     ])
-    (ghci_extra_libs, ghc_env) = get_ghci_extra_libs(
+    ghci_extra_libs = get_ghci_extra_libs(
         hs,
         posix,
         cc_libraries_info,
@@ -316,7 +316,7 @@ def _create_repl(hs, posix, ctx, repl_info, output):
         output = output,
         is_executable = True,
         substitutions = {
-            "{ENV}": render_env(dicts.add(hs.env, ghc_env)),
+            "{ENV}": render_env(hs.env),
             "{TOOL}": hs.tools.ghci.path,
             "{CC}": hs.toolchain.cc_wrapper.executable.path,
             "{ARGS}": " ".join(


### PR DESCRIPTION
**depends on https://github.com/tweag/rules_haskell/pull/1241**

With https://github.com/tweag/rules_haskell/pull/1241 available, the library search paths defined in a Haskell library's package configuration are also valid for Haskell targets depending on it. With this we no longer need to define `(LD_)LIBRARY_PATH`.

* Update the packaging logic to distinguish `library-dirs` and `dynamic-library-dirs` in package configuration. Uses dynamic library dependencies for the latter, so that GHC uses the correct search paths for dynamic library dependencies.
* Replaces a workaround for missing runpaths in `cc_wrapper` that relied on `LD_LIBRARY_PATH` by one that uses `-L` flags instead.
* No longer define `(LD_)LIBRARY_PATH`
* Remove unused code