### PR TITLE
Use newer NixOS agents

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -22,8 +22,8 @@ steps:
       mkdir -p "$HOME/bindists/.cache/bazel"
       mkdir -p "$HOME/bindists/.stack"
       pushd .buildkite/image
-      echo "RUN useradd -ms /bin/bash --uid $(id -u buildkite-agent) buildkite-agent" >> Dockerfile
+      echo "RUN useradd -ms /bin/bash --uid $(id -u buildkite-agent-agent) buildkite-agent-agent" >> Dockerfile
       docker build . -t tweag/rules_haskell:latest
       popd
-      docker run -it --network host -v $(pwd):/home/buildkite-agent/rules_haskell:rw -v $HOME/bindists/repo_cache:/home/buildkite-agent/repo_cache:rw -v $HOME/bindists/.cache/bazel:/home/buildkite-agent/.cache/bazel:rw -v $HOME/bindists/.stack:/home/buildkite-agent/.stack:rw --workdir /home/buildkite-agent/rules_haskell --user $(id -u buildkite-agent) tweag/rules_haskell:latest .buildkite/bindists-pipeline
+      docker run -it --network host -v $(pwd):/home/buildkite-agent-agent/rules_haskell:rw -v $HOME/bindists/repo_cache:/home/buildkite-agent-agent/repo_cache:rw -v $HOME/bindists/.cache/bazel:/home/buildkite-agent-agent/.cache/bazel:rw -v $HOME/bindists/.stack:/home/buildkite-agent-agent/.stack:rw --workdir /home/buildkite-agent-agent/rules_haskell --user $(id -u buildkite-agent-agent) tweag/rules_haskell:latest .buildkite/bindists-pipeline
     timeout: 100


### PR DESCRIPTION
Newer agents allow us to have multiple Buildkite agents, so the user name
now is the combination of "buildkite-agent-" and name of a particular agent,
"agent" is our case.

Do not merge yet.