### PR TITLE
Allow GHC bindists to set locale

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,36 @@ protects against this problem. If sandboxing is not an option, simply
 put the source files for each target in a separate directory (you can
 still use a single `BUILD` file to define all targets).
 
+### hGetContents: invalid argument (invalid byte sequence)
+
+If you are using the GHC bindists and see an error message like this:
+
+```
+haddock: internal error: /tmp/tmputn68mya/doc/html/path-io/haddock-response300-1.txt: hGetContents: invalid argument (invalid byte sequence)
+```
+
+It means that the default locale (`C.UTF-8`) does not work on your system.
+You can use a locale that your system has. For example, if your system has the
+locale `en_US.UTF-8`, you can specify that locale:
+
+```bzl
+rules_haskell_toolchains(
+    locale = "en_US.UTF-8", # <----
+    version = "8.4.1",
+)
+```
+
+To find available locales, run `locale -a` in a terminal. You should see output like the following:
+
+```console
+$ locale -a
+C
+en_US
+en_US.iso88591
+en_US.utf8
+POSIX
+```
+
 ## For `rules_haskell` developers
 
 ### Saving common command-line flags to a file

--- a/haskell/ghc_bindist.bzl
+++ b/haskell/ghc_bindist.bzl
@@ -273,6 +273,7 @@ haskell_toolchain(
     haddock_flags = {haddock_flags},
     repl_ghci_args = {repl_ghci_args},
     visibility = ["//visibility:public"],
+    locale = "{locale}",
 )
     """.format(
         toolchain_libraries = toolchain_libraries,
@@ -281,6 +282,7 @@ haskell_toolchain(
         compiler_flags = ctx.attr.compiler_flags,
         haddock_flags = ctx.attr.haddock_flags,
         repl_ghci_args = ctx.attr.repl_ghci_args,
+        locale = ctx.attr.locale,
     )
 
     if os == "windows":
@@ -331,6 +333,10 @@ _ghc_bindist = repository_rule(
             default = [],
             doc = "Sequence of commands to be applied after patches are applied.",
         ),
+        "locale": attr.string(
+            default = "C.UTF-8",
+            doc = "Locale that will be set during compiler invocations.",
+        ),
     },
 )
 
@@ -375,7 +381,8 @@ def ghc_bindist(
         target,
         compiler_flags = None,
         haddock_flags = None,
-        repl_ghci_args = None):
+        repl_ghci_args = None,
+        locale = None):
     """Create a new repository from binary distributions of GHC.
 
     The repository exports two targets:
@@ -429,6 +436,7 @@ def ghc_bindist(
         haddock_flags = haddock_flags,
         repl_ghci_args = repl_ghci_args,
         target = target,
+        locale = locale,
         **extra_attrs
     )
     _ghc_bindist_toolchain(
@@ -442,7 +450,8 @@ def haskell_register_ghc_bindists(
         version = None,
         compiler_flags = None,
         haddock_flags = None,
-        repl_ghci_args = None):
+        repl_ghci_args = None,
+        locale = None):
     """Register GHC binary distributions for all platforms as toolchains.
 
     Toolchains can be used to compile Haskell code. This function
@@ -465,6 +474,7 @@ def haskell_register_ghc_bindists(
             compiler_flags = compiler_flags,
             haddock_flags = haddock_flags,
             repl_ghci_args = repl_ghci_args,
+            locale = locale,
         )
     local_sh_posix_repo_name = "rules_haskell_sh_posix_local"
     if local_sh_posix_repo_name not in native.existing_rules():


### PR DESCRIPTION
In #1248, it was discovered that the locale for GHC bindists was not able to be overridden. It would default to `C.UTF-8`. If a system didn't have the `C.UTF-8` locale, it could lead to (unclear) encoding failures later on. In particular, `haddock` might fail in an unclear way:

```
haddock: internal error: /tmp/tmputn68mya/doc/html/path-io/haddock-response300-1.txt: hGetContents: invalid argument (invalid byte sequence)
```

This PR allows setting the locale for GHC bindists and also writes up a little bit in the troubleshooting section. I wasn't 100% sure how to make this happen, but this seems to allow my [minimal reproduction](https://github.com/joneshf/rules_haskell_invalid_byte_sequence) to [build](https://github.com/joneshf/rules_haskell_invalid_byte_sequence/tree/fix-set-locale). Lemme know if anything should change, or if this is not the right approach.

I couldn't find any tests to extend for the changes I made here. Should a new test be created, or is this not an area to test?