### PR TITLE
cabal_wrapper: srcs_version = "PY3"

### DIFF
--- a/haskell/cabal_wrapper.bzl
+++ b/haskell/cabal_wrapper.bzl
@@ -67,6 +67,7 @@ def cabal_wrapper(name, **kwargs):
     py_binary(
         name = name,
         srcs = [name + ".py"],
+        srcs_version = "PY3",
         python_version = "PY3",
         deps = [
             "@bazel_tools//tools/python/runfiles",


### PR DESCRIPTION
The Cabal wrapper source file requires Python 3 features. However, the `py_binary` target did not specify `srcs_version`. Instead, it only specified `python_version`. As the [documentation][docs] warn:

[docs]: https://docs.bazel.build/versions/master/be/python.html#py_binary.python_version

> Bug warning: This attribute sets the version for which Bazel builds your target, but due to #4815, the resulting stub script may still invoke the wrong interpreter version at runtime. See this workaround, which involves defining a py_runtime target that points to either Python version as needed, and activating this py_runtime by setting --python_top.

Without this setting users without python 3 available (macOS) will get cryptic errors from the internals of the Cabal wrapper. With this setting they get a clear error that Python 3 is missing.