### PR TITLE
Add a CI pipeline for macOS bindist

### DIFF
--- a/.ci/fetch-bazel-bindist
+++ b/.ci/fetch-bazel-bindist
@@ -11,7 +11,20 @@ esac
 VERSION=$(cat "$TOP/.ci/bazelversion")
 INSTALL="$(mktemp -d)"
 (cd "$INSTALL" && curl -LO "https://github.com/bazelbuild/bazel/releases/download/$VERSION/bazel-$VERSION-$OS$EXT" >&2)
-(cd "$INSTALL" && sha256sum --quiet -c "$TOP/.ci/bazel-$VERSION-$OS$EXT.sha256") >&2
+if command -v sha256sum &>/dev/null; then
+  (cd "$INSTALL" && sha256sum --quiet -c "$TOP/.ci/bazel-$VERSION-$OS$EXT.sha256") >&2
+elif command -v openssl &>/dev/null; then
+  # macOS typically doesn't have sha256sum (coreutils) installed.
+  IFS=' ' read -r EXPECTED_HASH FILE <"$TOP/.ci/bazel-$VERSION-$OS$EXT.sha256"
+  ACTUAL_HASH=$(openssl dgst -sha256 "$INSTALL/$FILE" | cut -d\  -f2)
+  if [[ $ACTUAL_HASH != $EXPECTED_HASH ]]; then
+    echo "sha256 mismatch, wanted '$EXPECTED_HASH', got '$ACTUAL_HASH'." >&2
+    exit 1
+  fi
+else
+  echo "sha256sum or openssl command required." >&2
+  exit 1
+fi
 mv "$INSTALL/bazel-$VERSION-$OS$EXT" "$INSTALL/bazel$EXT"
 chmod +x "$INSTALL/bazel$EXT"
 echo -n "$INSTALL"

--- a/.ci/fetch-bazel-bindist
+++ b/.ci/fetch-bazel-bindist
@@ -4,7 +4,7 @@ TOP="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." >/dev/null 2>&1 && pwd )"
 
 case "$OSTYPE" in
   linux-gnu) OS=linux-x86_64; EXT=;;
-  darwin) OS=darwin-x86_64; EXT=;;
+  darwin*) OS=darwin-x86_64; EXT=;;
   cygwin|msys|win32) OS=windows-x86_64; EXT=.exe;;
   **) echo "Unknown operating system" >&2; exit 1;;
 esac

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -173,7 +173,6 @@ jobs:
             # XXX 2019-01-22 Disable start script checking on Darwin
             # due to a clash between binutils and clang.
             # ./tests/run-start-script.sh --use-bindists
-            bazel build --config ci //tests/...
             bazel test --config ci //tests/...
 
         # see note about 'Disk cache'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,9 +113,91 @@ jobs:
           paths:
               - ~/.cache/bazel/
 
+  build-darwin-bindist:
+    macos:
+      xcode: "9.0"
+    steps:
+      - checkout
+      - run:
+          name: Install Python3
+          command: |
+            HOMEBREW_NO_AUTO_UPDATE=1 brew install python3
+      - run:
+          name: Install Bazel
+          command: |
+            BAZEL_DIR="$(.ci/fetch-bazel-bindist)"
+            mv $BAZEL_DIR $HOME/bazel
+      - run:
+          name: Configure
+          command: |
+            mkdir -p ~/.cache/bazel/
+
+            cat >$HOME/.bashrc_rules_haskell <<'EOF'
+            export PATH="$HOME/bazel:$PATH"
+            export BAZEL_USE_CPP_ONLY_TOOLCHAIN=1
+            EOF
+
+            echo "build:ci --disk_cache=~/.cache/bazel/" >> .bazelrc.local
+            EXCLUDED="-dont_test_on_darwin,-dont_test_on_darwin_with_bindist,-requires_lz4,-requires_proto,-requires_zlib,-requires_doctest,-requires_c2hs,-requires_shellcheck,-requires_threaded_rts,-dont_test_with_bindist"
+            echo "common:ci --build_tag_filters $EXCLUDED" >> .bazelrc.local
+            echo "common:ci --test_tag_filters $EXCLUDED" >> .bazelrc.local
+
+      - restore_cache:
+          keys: # see note about 'Disk cache'
+              - v1-rules_haskell-bindist-empty-{{ .Branch }}-
+              - v1-rules_haskell-bindist-cache-{{ .Branch }}-
+              - v1-rules_haskell-bindist-cache-master-
+
+      - run:
+          name: Prefetch Stackage snapshot
+          shell: /bin/bash -eilo pipefail
+          command: |
+            . $HOME/.bashrc_rules_haskell
+            # Retry if needed due to network flakiness.
+            cmd="bazel fetch @stackage//..."; $cmd || $cmd || $cmd
+      - run:
+          name: Build tests
+          shell: /bin/bash -eilo pipefail
+          command: |
+            . $HOME/.bashrc_rules_haskell
+            bazel build --config ci //tests/...
+      - run:
+          name: Run tests
+          shell: /bin/bash -eilo pipefail
+          command: |
+            . $HOME/.bashrc_rules_haskell
+
+            # Keep CI awake
+            while true; do echo "."; sleep 60; done &
+
+            # XXX 2019-01-22 Disable start script checking on Darwin
+            # due to a clash between binutils and clang.
+            # ./tests/run-start-script.sh --use-bindists
+            bazel build --config ci //tests/...
+            bazel test --config ci //tests/...
+
+        # see note about 'Disk cache'
+      - save_cache:
+          key: v1-rules_haskell-bindist-cache-{{ .Branch }}-{{ .BuildNum }}
+          paths:
+              - ~/.cache/bazel/
+
+      - run:
+          name: Clean up cache
+          shell: /bin/bash -eilo pipefail
+          command: |
+            rm -rf ~/.cache/bazel/
+            mkdir -p ~/.cache/bazel/
+
+      - save_cache:
+          key: v1-rules_haskell-bindist-empty-master-{{ .BuildNum }}
+          paths:
+              - ~/.cache/bazel/
+
 workflows:
   version: 2
   build:
     jobs:
       - build-darwin:
           context: org-global # for the cachix token
+      - build-darwin-bindist: {}

--- a/README.md
+++ b/README.md
@@ -220,6 +220,14 @@ en_US.utf8
 POSIX
 ```
 
+### MacOS: Error: DEVELOPER_DIR not set.
+
+Make sure to set the following environment variable:
+```
+export BAZEL_USE_CPP_ONLY_TOOLCHAIN=1
+```
+This ensures that Bazel picks the correct C compiler.
+
 ## For `rules_haskell` developers
 
 ### Saving common command-line flags to a file

--- a/haskell/ghc_bindist.bzl
+++ b/haskell/ghc_bindist.bzl
@@ -262,6 +262,12 @@ grep --files-with-matches --null {bindist_dir} bin/* | xargs -0 -n1 \
         ))
         execute_or_fail_loudly(ctx, ["./patch_bins"])
 
+    # The default locale is OS specific.
+    if ctx.attr.locale:
+        locale = ctx.attr.locale
+    else:
+        locale = "en_US.UTF-8" if os == "darwin" else "C.UTF-8"
+
     # Generate BUILD file entries describing each prebuilt package.
     # Cannot use //haskell:pkgdb_to_bzl because that's a generated
     # target. ctx.path() only works on source files.
@@ -297,7 +303,7 @@ haskell_toolchain(
         compiler_flags = ctx.attr.compiler_flags,
         haddock_flags = ctx.attr.haddock_flags,
         repl_ghci_args = ctx.attr.repl_ghci_args,
-        locale = ctx.attr.locale,
+        locale = locale,
     )
 
     if os == "windows":
@@ -349,8 +355,8 @@ _ghc_bindist = repository_rule(
             doc = "Sequence of commands to be applied after patches are applied.",
         ),
         "locale": attr.string(
-            default = "C.UTF-8",
-            doc = "Locale that will be set during compiler invocations.",
+            doc = "Locale that will be set during compiler invocations. Default: C.UTF-8 (en_US.UTF-8 on MacOS)",
+            mandatory = False,
         ),
     },
 )

--- a/tests/extra-source-files/BUILD.bazel
+++ b/tests/extra-source-files/BUILD.bazel
@@ -18,6 +18,10 @@ haskell_library(
         "file.txt",
         "ld-options.txt",
     ],
+    tags = [
+        # ld on darwin does not support response files.
+        "dont_test_on_darwin_with_bindist",
+    ],
     deps = [
         "//tests/hackage:base",
         "//tests/hackage:template-haskell",
@@ -37,6 +41,10 @@ haskell_test(
         "file.txt",
         "Foo.hs",  # Test "Multiple entries with same key" in expand_location
         "ld-options.txt",
+    ],
+    tags = [
+        # ld on darwin does not support response files.
+        "dont_test_on_darwin_with_bindist",
     ],
     deps = [
         "//tests/hackage:base",


### PR DESCRIPTION
We had a few issues in the past reported by users that tried to use or develop rules_haskell on macOS outside of Nix. On our CI it has been a blind spot so far. This PR adds a CircleCI job for testing rules_haskell on macOS using the GHC bindist outside of Nix.

In setting up the pipeline this work surfaced and fixed a few more macOS issues:
- The script to fetch a Bazel bindist uses the `OSTYPE` variable to determine the OS. On macOS it was incorrectly checking for the value `darwin` when it should be checking for the pattern `darwin*`.
- The script to fetch a Bazel bindist required `sha256sum` to verify the downloaded artifact. On macOS `coreutils` (which include `sha256sum`) are typically not pre-installed. In that case we can fall back to `openssl dgst -sha256`.
- macOS users also need to set `BAZEL_USE_CPP_ONLY_TOOLCHAIN=1` outside of Nix. This adds a corresponding entry to the troubleshooting section in the `README.md`.
- rules_haskell requires Python 3. But, macOS only pre-installs Python 2.7. Users often install Python 3 using homebrew or pyenv. However, these tools don't install Python into a system path, but `/usr/local/bin` or a user specific path. The Bazel provided [autodetecting toolchain](https://github.com/bazelbuild/bazel/blob/ed0865c3c95bcd7c9b3dd3059e5f444c48e59660/tools/python/BUILD.tools#L137) fails to find such Python installations. This PR adds a autoconfigure toolchain for the GHC bindist case similar to the POSIX autoconfigure toolchain, which looks for a Python 3 interpreter in a repository rule. Closes https://github.com/tweag/rules_haskell/pull/1250.
- rules_haskell defaults to the locale `C.UTF-8` since Haskell packages often require unicode support. However, macOS typically doesn't provide that locale. In this case we default to `en_US.UTF-8`.
- This newly defined pipeline tests the intersection of targets tested by the Linux bindist pipeline and the nixpkgs macOS pipeline. Additionally it skips the `extra-source-files` test because `ld` on macOS does not understand response files (`-Wl,@...`).