### PR TITLE
Add optional hie_bios output group to haskell_repl

### DIFF
--- a/haskell/cc.bzl
+++ b/haskell/cc.bzl
@@ -159,3 +159,32 @@ def cc_interop_info(ctx):
             if CcInfo in dep
         ]).linking_context.libraries_to_link.to_list(),
     )
+
+def ghc_cc_program_args(cc):
+    """Retruns the -pgm* flags required to override cc.
+
+    Args:
+      cc: string, path to the C compiler (cc_wrapper).
+
+    Returns:
+      list of string, GHC arguments.
+    """
+    return [
+        # GHC uses C compiler for assemly, linking and preprocessing as well.
+        "-pgma",
+        cc,
+        "-pgmc",
+        cc,
+        "-pgml",
+        cc,
+        "-pgmP",
+        cc,
+        # Setting -pgm* flags explicitly has the unfortunate side effect
+        # of resetting any program flags in the GHC settings file. So we
+        # restore them here. See
+        # https://ghc.haskell.org/trac/ghc/ticket/7929.
+        "-optc-fno-stack-protector",
+        "-optP-E",
+        "-optP-undef",
+        "-optP-traditional",
+    ]

--- a/haskell/cc.bzl
+++ b/haskell/cc.bzl
@@ -161,7 +161,7 @@ def cc_interop_info(ctx):
     )
 
 def ghc_cc_program_args(cc):
-    """Retruns the -pgm* flags required to override cc.
+    """Returns the -pgm* flags required to override cc.
 
     Args:
       cc: string, path to the C compiler (cc_wrapper).

--- a/haskell/doctest.bzl
+++ b/haskell/doctest.bzl
@@ -1,7 +1,7 @@
 """Doctest support"""
 
 load("@bazel_skylib//lib:dicts.bzl", "dicts")
-load(":cc.bzl", "cc_interop_info")
+load(":cc.bzl", "cc_interop_info", "ghc_cc_program_args")
 load(":private/context.bzl", "haskell_context", "render_env")
 load(":private/set.bzl", "set")
 load(
@@ -95,25 +95,7 @@ def _haskell_doctest_single(target, ctx):
     args.add("--no-magic")
 
     cc = cc_interop_info(ctx)
-    args.add_all([
-        # GHC uses C compiler for assemly, linking and preprocessing as well.
-        "-pgma",
-        cc.tools.cc,
-        "-pgmc",
-        cc.tools.cc,
-        "-pgml",
-        cc.tools.cc,
-        "-pgmP",
-        cc.tools.cc,
-        # Setting -pgm* flags explicitly has the unfortunate side effect
-        # of resetting any program flags in the GHC settings file. So we
-        # restore them here. See
-        # https://ghc.haskell.org/trac/ghc/ticket/7929.
-        "-optc-fno-stack-protector",
-        "-optP-E",
-        "-optP-undef",
-        "-optP-traditional",
-    ])
+    args.add_all(ghc_cc_program_args(cc.tools.cc))
 
     doctest_log = ctx.actions.declare_file(
         "doctest-log-" + ctx.label.name + "-" + target.label.name,

--- a/haskell/private/ghci_repl_wrapper.sh
+++ b/haskell/private/ghci_repl_wrapper.sh
@@ -54,11 +54,6 @@ cd "$BUILD_WORKSPACE_DIRECTORY"
 
 RULES_HASKELL_EXEC_ROOT=$(dirname $(readlink ${BUILD_WORKSPACE_DIRECTORY}/bazel-out))
 TOOL_LOCATION="$RULES_HASKELL_EXEC_ROOT/{TOOL}"
-# Setting -pgm* flags explicitly has the unfortunate side effect
-# of resetting any program flags in the GHC settings file. So we
-# restore them here. See
-# https://ghc.haskell.org/trac/ghc/ticket/7929.
-PGM_ARGS="-pgma {CC} -pgmc {CC} -pgml {CC} -pgmP {CC} -optc-fno-stack-protector -optP-E -optP-undef -optP-traditional"
 
 {ENV}
-"$TOOL_LOCATION" $PGM_ARGS {ARGS} "$@"
+"$TOOL_LOCATION" {ARGS} "$@"

--- a/haskell/repl.bzl
+++ b/haskell/repl.bzl
@@ -3,6 +3,7 @@
 load("@bazel_skylib//lib:dicts.bzl", "dicts")
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load("@bazel_skylib//lib:shell.bzl", "shell")
+load(":cc.bzl", "ghc_cc_program_args")
 load(":private/context.bzl", "haskell_context", "render_env")
 load(
     ":private/path_utils.bzl",
@@ -268,6 +269,10 @@ def _compiler_flags_and_inputs(hs, repl_info, path_prefix = ""):
         args,
     )
 
+    args.extend(ghc_cc_program_args(
+        paths.join(path_prefix, hs.toolchain.cc_wrapper.executable.path),
+    ))
+
     # Add import directories
     for import_dir in repl_info.load_info.import_dirs.to_list():
         args.append("-i" + (import_dir if import_dir else "."))
@@ -352,7 +357,6 @@ def _create_repl(hs, posix, ctx, repl_info, output):
         substitutions = {
             "{ENV}": render_env(hs.env),
             "{TOOL}": hs.tools.ghci.path,
-            "{CC}": hs.toolchain.cc_wrapper.executable.path,
             "{ARGS}": " ".join(
                 args + [
                     shell.quote(a)

--- a/haskell/repl.bzl
+++ b/haskell/repl.bzl
@@ -549,5 +549,22 @@ Build a REPL for multiple targets.
 $ bazel run //:repl
 ```
 
+### IDE Support (Experimental)
+
+`haskell_repl` targets provide the `hie_bios` output group to optionally
+generate GHCi flags for [hie-bios](https://github.com/mpickering/hie-bios)'s
+`bios` cradle. You can use this for IDE support with
+[ghcide](https://github.com/digital-asset/ghcide).
+
+Given a `haskell_repl` target `//:repl` an example `.hie-bios` script could
+look as follows. Please refer to the `hie-bios` documentation for further
+information.
+
+  ```shell
+  #!/usr/bin/env bash
+  set -euo pipefail
+  bazel build //:repl --output_groups=hie_bios
+  cat bazel-bin/repl@hie-bios >"$HIE_BIOS_OUTPUT"
+  ```
 """,
 )

--- a/haskell/toolchain.bzl
+++ b/haskell/toolchain.bzl
@@ -15,6 +15,7 @@ load(
     "merge_parameter_files",
 )
 load(":private/actions/package.bzl", "package")
+load(":cc.bzl", "ghc_cc_program_args")
 
 _GHC_BINARIES = ["ghc", "ghc-pkg", "hsc2hs", "haddock", "ghci", "runghc", "hpc"]
 
@@ -40,25 +41,7 @@ def _run_ghc(hs, cc, inputs, outputs, mnemonic, arguments, params_file = None, e
 
     # XXX: We should also tether Bazel's CC toolchain to GHC's, so that we can properly mix Bazel-compiled
     # C libraries with Haskell targets.
-    args.add_all([
-        # GHC uses C compiler for assemly, linking and preprocessing as well.
-        "-pgma",
-        cc.tools.cc,
-        "-pgmc",
-        cc.tools.cc,
-        "-pgml",
-        cc.tools.cc,
-        "-pgmP",
-        cc.tools.cc,
-        # Setting -pgm* flags explicitly has the unfortunate side effect
-        # of resetting any program flags in the GHC settings file. So we
-        # restore them here. See
-        # https://ghc.haskell.org/trac/ghc/ticket/7929.
-        "-optc-fno-stack-protector",
-        "-optP-E",
-        "-optP-undef",
-        "-optP-traditional",
-    ])
+    args.add_all(ghc_cc_program_args(cc.tools.cc))
 
     compile_flags_file = hs.actions.declare_file("compile_flags_%s_%s" % (hs.name, mnemonic))
     extra_args_file = hs.actions.declare_file("extra_args_%s_%s" % (hs.name, mnemonic))


### PR DESCRIPTION
This allows users to configure [`hie-bios`](https://github.com/mpickering/hie-bios#readme) to use these outputs to determine GHC flags. See https://github.com/tweag/rules_haskell/pull/1262 (WIP) for an example setup with `ghcide`.

* Factors out the common flags for `ghci` and `hie-bios` in the `haskell_repl` implementation.
* Factors out the GHC flags required to configure `cc_wrapper` to avoid duplication.
* Creates an output group for `haskell_repl` that produces a file holding all relevant ghci flags for that target. (Excludes flags that are ghci specific, e.g. `repl_ghci_args` or flags required for `-ghci-script`)

A downside of this approach, compared to e.g. [hrepl](https://github.com/google/hrepl), is that `haskell_repl` targets are not generated on-the-fly but have to be defined in `BUILD` files. However, this is a general limitation of `haskell_repl`.