### PR TITLE
Escape unknown bytes in package config

### DIFF
--- a/haskell/private/cabal_wrapper.py.tpl
+++ b/haskell/private/cabal_wrapper.py.tpl
@@ -206,8 +206,8 @@ if libraries != [] and os.path.isfile(package_conf_file):
         os.rename(lib, os.path.join(dynlibdir, os.path.basename(lib)))
 
     tmp_package_conf_file = package_conf_file + ".tmp"
-    with open(package_conf_file, 'r') as package_conf:
-        with open(tmp_package_conf_file, 'w') as tmp_package_conf:
+    with open(package_conf_file, 'r', errors='surrogateescape') as package_conf:
+        with open(tmp_package_conf_file, 'w', errors='surrogateescape') as tmp_package_conf:
             for line in package_conf.readlines():
                 print(make_relocatable_paths(line), file=tmp_package_conf)
     os.remove(package_conf_file)


### PR DESCRIPTION
Another outcome of #1259. We found that the encoding wasn't always working when adjusting the package config file. The approach this PR takes is to escape unknown bytes, do the changes, then unescape unknown bytes. See the discussion starting at [this comment](https://github.com/tweag/rules_haskell/issues/1259#issuecomment-594487571) for more information.