### PR TITLE
Add tests/pre-commit to automate `bazel test //...` and `bazel run //:buildifier-fix`

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,6 +327,15 @@ the history clean.
 
 [buildifier]: https://github.com/bazelbuild/buildtools/tree/master/buildifier
 
+To automate tests and formatting, you may use the pre-commit hook
+`tests/pre-commit`. It forbids a commit if `bazel test //...` fails
+and automatically amends commits to format `*.bz` and `*.bazel` files.
+Install it as follows:
+
+```
+ln -sr tests/pre-commit .git/hooks/
+```
+
 ### <a name="nixpkgs-pin" />How to update the nixpkgs pin
 
 You have to find a new git commit where all our `shell.nix`

--- a/tests/pre-commit
+++ b/tests/pre-commit
@@ -1,0 +1,25 @@
+#!/bin/bash
+#
+# Hook that executes the tests and format *.bz,*.bazel files automatically
+
+set -e
+
+function format_bazel() {
+  # Adapted from https://prettier.io/docs/en/precommit.html
+  FILES=$(git diff --cached --name-only --diff-filter=ACMR "*.bz" "*.bazel" | sed 's| |\\ |g')
+  [ -z "$FILES" ] && return 0
+
+  # Format all files (it's imprecise as we know only $FILES need modifications, but it'll do)
+  nix-shell --pure --command "bazel run //:buildifier-fix" || return 1
+
+  # Add back the modified files (if any) to staging
+  echo "$FILES" | xargs git add
+
+  return 0
+}
+
+# Run tests
+nix-shell --pure --command "bazel test //..."
+
+# Format *.{bz,BAZEL} files
+format_bazel


### PR DESCRIPTION
This pre-commit should avoid pushing commits that will break CI. It should be fast in case you executed `bazel test //...` already (and if you didn't, the hook has your back!).

Nevertheless, I don't know if using a pre-commit hook is a usual Tweag workflow, so please discard this PR without providing details if you dislike this.