### PR TITLE
Typecheck stack_snapshot's extra_deps field

### DIFF
--- a/haskell/cabal.bzl
+++ b/haskell/cabal.bzl
@@ -11,6 +11,7 @@ load(":private/expansions.bzl", "expand_make_variables")
 load(":private/mode.bzl", "is_profiling_enabled")
 load(":private/path_utils.bzl", "join_path_list", "truly_relativize")
 load(":private/set.bzl", "set")
+load(":private/typing.bzl", "typecheck_stackage_extradeps")
 load(":haddock.bzl", "generate_unified_haddock_info")
 load(
     ":private/workspace_utils.bzl",
@@ -1184,17 +1185,7 @@ def stack_snapshot(stack = None, extra_deps = {}, vendored_packages = {}, **kwar
         the tools are executed as part of the build.
       stack: The stack binary to use to enumerate package dependencies.
     """
-    if extra_deps:
-        if type(extra_deps) != "dict":
-            fail("stack_snapshot extra_deps requires a dict from dependency name to list of targets, but was given: " + type(extra_deps))
-        for extra_deps_key in extra_deps.keys():
-            if type(extra_deps_key) != "string":
-                fail("stack_snapshot extra_deps's dict requires string keys, but key \"%s\" has type %s" %
-                     (extra_deps_key, type(extra_deps_key)))
-        for extra_deps_value in extra_deps.values():
-            if type(extra_deps_value) != "list":
-                fail("stack_snapshot extra_deps's dict requires list values, but value \"%s\" has type %s" %
-                     (extra_deps_value, type(extra_deps_value)))
+    typecheck_stackage_extradeps(extra_deps)
     if not stack:
         _fetch_stack(name = "rules_haskell_stack")
         stack = Label("@rules_haskell_stack//:stack")

--- a/haskell/cabal.bzl
+++ b/haskell/cabal.bzl
@@ -1184,6 +1184,17 @@ def stack_snapshot(stack = None, extra_deps = {}, vendored_packages = {}, **kwar
         the tools are executed as part of the build.
       stack: The stack binary to use to enumerate package dependencies.
     """
+    if extra_deps:
+        if type(extra_deps) != "dict":
+            fail("stack_snapshot extra_deps requires a dict from dependency name to list of targets, but was given: " + type(extra_deps))
+        for extra_deps_key in extra_deps.keys():
+            if type(extra_deps_key) != "string":
+                fail("stack_snapshot extra_deps's dict requires string keys, but key \"%s\" has type %s" %
+                     (extra_deps_key, type(extra_deps_key)))
+        for extra_deps_value in extra_deps.values():
+            if type(extra_deps_value) != "list":
+                fail("stack_snapshot extra_deps's dict requires list values, but value \"%s\" has type %s" %
+                     (extra_deps_value, type(extra_deps_value)))
     if not stack:
         _fetch_stack(name = "rules_haskell_stack")
         stack = Label("@rules_haskell_stack//:stack")

--- a/haskell/private/typing.bzl
+++ b/haskell/private/typing.bzl
@@ -1,0 +1,17 @@
+def typecheck_stackage_extradeps(extra_deps):
+    """Check that the extra_deps field of a stackage rule is well typed.
+    If not, fail.
+
+    Args:
+      extra_deps: The value of the extra_deps field of a stackage rule
+    """
+    if not extra_deps:
+        return
+    if type(extra_deps) != "dict":
+        fail("stack_snapshot extra_deps requires a dict from dependency name to list of targets, but was given: {}".format(type(extra_deps)))
+    for extra_deps_key in extra_deps.keys():
+        if type(extra_deps_key) != "string":
+            fail("stack_snapshot extra_deps's dict requires string keys, but key \"{}\" has type {}".format(extra_deps_key, type(extra_deps_key)))
+    for extra_deps_value in extra_deps.values():
+        if type(extra_deps_value) != "list":
+            fail("stack_snapshot extra_deps's dict requires list values, but value \"{}\" has type {}".format(extra_deps_value, type(extra_deps_value)))


### PR DESCRIPTION
I've added typechecking of stackage's extra_deps field, as described in #1220 

## Tests

### Usual tests

```
bazel test //...
bazel run //:buildifier
```

### Tests specific to this issue

Using the `WORKSPACE` file described in #1211, with the following `stack_snapshot`:

``` bazel
stack_snapshot(
    name = "stackage",
    packages = [],
    extra_deps = [
        "foobar",
    ],
)
```

yields this error message: `stack_snapshot extra_deps requires a dict from dependency name to list of targets, but was given: list`

Using this `stack_snapshot`:

``` bazel
stack_snapshot(
    name = "stackage",
    packages = [],
    extra_deps = {
        1: ["zlib"]
    },
)
```

yields this error message: `stack_snapshot extra_deps's dict requires string keys, but key "1" has type int`

Using this `stack_snapshot`:

``` bazel
stack_snapshot(
    name = "stackage",
    packages = [],
    extra_deps = {
        "zlib" : { "foo" : "bar" }
    },
)
```

yields this error message: `stack_snapshot extra_deps's dict requires list values, but value "{"foo": "bar"}" has type dict`