### PR TITLE
Update bazel_skylib from 0.6.0 to 1.0.2

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -14,6 +14,10 @@ load("//haskell:repositories.bzl", "rules_haskell_dependencies")
 
 rules_haskell_dependencies()
 
+load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
+
+bazel_skylib_workspace()
+
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(

--- a/haskell/repositories.bzl
+++ b/haskell/repositories.bzl
@@ -17,9 +17,9 @@ def rules_haskell_dependencies():
     if "bazel_skylib" not in excludes:
         http_archive(
             name = "bazel_skylib",
-            sha256 = "2c62d8cd4ab1e65c08647eb4afe38f51591f43f7f0885e7769832fa137633dcb",
-            strip_prefix = "bazel-skylib-0.7.0",
-            urls = ["https://github.com/bazelbuild/bazel-skylib/archive/0.7.0.tar.gz"],
+            sha256 = "e5d90f0ec952883d56747b7604e2a15ee36e288bb556c3d0ed33e818a4d971f2",
+            strip_prefix = "bazel-skylib-1.0.2",
+            urls = ["https://github.com/bazelbuild/bazel-skylib/archive/1.0.2.tar.gz"],
         )
 
     if "rules_cc" not in excludes:

--- a/haskell/repositories.bzl
+++ b/haskell/repositories.bzl
@@ -17,9 +17,9 @@ def rules_haskell_dependencies():
     if "bazel_skylib" not in excludes:
         http_archive(
             name = "bazel_skylib",
-            sha256 = "eb5c57e4c12e68c0c20bc774bfbc60a568e800d025557bc4ea022c6479acc867",
-            strip_prefix = "bazel-skylib-0.6.0",
-            urls = ["https://github.com/bazelbuild/bazel-skylib/archive/0.6.0.tar.gz"],
+            sha256 = "2c62d8cd4ab1e65c08647eb4afe38f51591f43f7f0885e7769832fa137633dcb",
+            strip_prefix = "bazel-skylib-0.7.0",
+            urls = ["https://github.com/bazelbuild/bazel-skylib/archive/0.7.0.tar.gz"],
         )
 
     if "rules_cc" not in excludes:

--- a/tests/unit-tests/tests.bzl
+++ b/tests/unit-tests/tests.bzl
@@ -13,7 +13,7 @@ def parent_dir_path_test_impl(ctx):
         expected = ctx.attr.output,
         actual = parent_dir_path(ctx.attr.filename),
     )
-    unit.end(env)
+    return unit.end(env)
 
 parent_dir_path_test = unit.make(
     parent_dir_path_test_impl,
@@ -39,7 +39,7 @@ def create_rpath_entry_test_impl(ctx):
             prefix = ctx.attr.prefix,
         ),
     )
-    unit.end(env)
+    return unit.end(env)
 
 create_rpath_entry_test = unit.make(
     create_rpath_entry_test_impl,
@@ -78,6 +78,6 @@ def dedup_on_test_impl(ctx):
             [struct(x = 3), struct(x = 4), struct(x = 3), struct(x = 5), struct(x = 3)],
         ),
     )
-    unit.end(env)
+    return unit.end(env)
 
 dedup_on_test = unit.make(dedup_on_test_impl)


### PR DESCRIPTION
This PR fixes #1268. I did a commit from 0.6.0 to 0.7.0 to highlight a requested change to `WORKSPACE` and then did another commit for the update from 0.7.0 to 1.0.2. Executed tests:

```
bazel test //...
bazel run //:buildifier
```