### PR TITLE
Cabal: Set TMP and TEMP as well

### DIFF
--- a/haskell/private/cabal_wrapper.py.tpl
+++ b/haskell/private/cabal_wrapper.py.tpl
@@ -131,7 +131,9 @@ with tmpdir() as distdir:
     old_cwd = os.getcwd()
     os.chdir(srcdir)
     os.putenv("HOME", "/var/empty")
-    os.putenv("TMPDIR",os.path.join(distdir, "tmp"))
+    os.putenv("TMPDIR", os.path.join(distdir, "tmp"))
+    os.putenv("TMP", os.path.join(distdir, "tmp"))
+    os.putenv("TEMP", os.path.join(distdir, "tmp"))
     os.makedirs(os.path.join(distdir, "tmp"))
     run([runghc, setup, "configure", \
         component, \


### PR DESCRIPTION
Windows does not use `TMPDIR` but `TMP` or `TEMP` instead.

This is for consistency and to avoid occasional "permission denied" errors on Windows during `Setup.hs configure`, when the configure phase wants to remove temporary files it generated.