### PR TITLE
Follow http 301 when installing nix on the CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
       - run:
           name: Install Nix
           command: |
-            curl https://nixos.org/nix/install | sh
+            curl -L https://nixos.org/nix/install | sh
 
       - run:
           name: Install cachix


### PR DESCRIPTION
For a couple of hours, curl-ing the nix installer at
https://nixos.org/nix/install returned a 301 to another location, which
broke the darwin CI because the script wasn't following the redirect.

This has apparently been reverted upstream, but in case the revert gets
reverted again, better to tell curl to follow 301s