### PR TITLE
Check bazel version: print a warning if version not in range

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -57,8 +57,9 @@ nonetheless, so bumping bazel regularly is required.
 - [ ] Update all bazel rules dependencies in `WORKSPACE` (e.g.
       `io_bazel_stardoc`)
 - [ ] Update bazel in nixpkgs and bump `nixpkgs/default.nix`
-- [ ] Bump MAX_BAZEL_* in `start`
+- [ ] Bump `MAX_BAZEL_*` in `start`
 - If we are updating to a new LTS:
   - Bump `MIN_BAZEL_*` in `start`
   - TODO
+- [ ] Change `expected_version` in `haskell/private/versions.bzl`
 - [ ] Add update notice to `CHANGELOG`

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -4,8 +4,9 @@
 
 - Copy this list of steps into a `rules_haskell` issue
 - Create & checkout release branch (`release-<major>.<minor>`).
-- [ ] Fix minimal bazel version in [the `start` script](./start) and
-  [the README](./README.md), add to the [`CHANGELOG`](./CHANGELOG.md)
+- [ ] Fix minimal bazel version in [the `start` script](./start),
+  [haskell/private/versions.bzl](./haskell/private/versions.bzl), and
+  [the README](./README.md); add to the [`CHANGELOG`](./CHANGELOG.md)
   if it changed.
 - [ ] Remove any feature that is still too experimental to go into a
   release, by cherry-picking reverts (or by manually deleting the
@@ -57,9 +58,8 @@ nonetheless, so bumping bazel regularly is required.
 - [ ] Update all bazel rules dependencies in `WORKSPACE` (e.g.
       `io_bazel_stardoc`)
 - [ ] Update bazel in nixpkgs and bump `nixpkgs/default.nix`
-- [ ] Bump `MAX_BAZEL_*` in `start`
+- [ ] Bump `MAX_BAZEL_*` in `start` and `haskell/private/versions.bzl`
 - If we are updating to a new LTS:
-  - Bump `MIN_BAZEL_*` in `start`
+  - Bump `MIN_BAZEL_*` in `start` and `haskell/private/versions.bzl`
   - TODO
-- [ ] Change `expected_version` in `haskell/private/versions.bzl`
 - [ ] Add update notice to `CHANGELOG`

--- a/haskell/private/versions.bzl
+++ b/haskell/private/versions.bzl
@@ -1,0 +1,34 @@
+# check_version below cannot be called from anywhere
+# because native.bazel_version's availability is restricted:
+#   https://github.com/bazelbuild/bazel/issues/8305
+# An alternative hacky way is as follows:
+#   https://github.com/protocolbuffers/upb/blob/master/bazel/repository_defs.bzl
+#
+# There are utility functions for parsing versions numbers here:
+#   load("@bazel_skylib//lib:versions.bzl", "versions")
+# But we don't want to use them, as skylib is not yet loaded when code
+# in this file executes (and there's no way to execute it later; see first
+# paragraph above).
+
+def check_version(actual_version):
+    if type(actual_version) != "string" or len(actual_version) < 5:
+        return  # Unexpected format
+
+    expected_version = "2.0.0"  # Change THIS LINE when changing bazel version
+
+    actual_major = int(actual_version[0])
+    actual_minor = int(actual_version[2])
+    actual_patch = int(actual_version[4])
+    actual = (actual_major, actual_minor, actual_patch)
+
+    expected_major = int(expected_version[0])
+    expected_minor = int(expected_version[2])
+    expected_patch = int(expected_version[4])
+    expected = (expected_major, expected_minor, expected_patch)
+
+    if actual < expected:
+        print("WARNING: bazel version is too old. Expected {}, but found: {}".format(expected_version, actual_version))
+        return
+    if expected < actual:
+        print("WARNING: bazel version is too recent. Expected {}, but found: {}".format(expected_version, actual_version))
+        return

--- a/haskell/private/versions.bzl
+++ b/haskell/private/versions.bzl
@@ -52,8 +52,8 @@ def check_version(actual_version):
     if (min_bazel <= actual) and (actual <= max_bazel):
         return  # All good
 
-    min_bazel_string = ".".join([str(x) for x in list(min_bazel)])
-    max_bazel_string = ".".join([str(x) for x in list(max_bazel)])
+    min_bazel_string = ".".join([str(x) for x in min_bazel])
+    max_bazel_string = ".".join([str(x) for x in max_bazel])
 
     adjective = "old" if actual < min_bazel else "recent"
 

--- a/haskell/private/versions.bzl
+++ b/haskell/private/versions.bzl
@@ -10,25 +10,51 @@
 # in this file executes (and there's no way to execute it later; see first
 # paragraph above).
 
+def _parse_version_chunk(version_chunk):
+    """
+    Args:
+      version_chunk: a chunk of a semantic version, possibly with trailing
+                     content at the end; such as "29", "2", or "3 foobar".
+                     We handle trailing content because
+                     native.bazel_version can: try printing actual_version
+                     in check_version below (got for example
+                     "2.0.0- (@non-git)").
+    Returns:
+      The chunk string with trailing content removed, such as "29", "2", or "3"
+    """
+    for i in range(len(version_chunk)):
+        c = version_chunk[i]
+        if not c.isdigit():
+            return version_chunk[:i]
+    return version_chunk
+
+def _parse_bazel_version(bazel_version):
+    """
+    Args:
+      bazel_version: a string that starts with a semantic version
+                     like "2.0" or "0.29.1" or "0.29 foobar"
+    Returns:
+      The version as a int list such as [2, 0], [0, 29, 1], or [0, 29]
+    """
+    return [int(_parse_version_chunk(x)) for x in bazel_version.split(".")]
+
 def check_version(actual_version):
     if type(actual_version) != "string" or len(actual_version) < 5:
         return  # Unexpected format
 
-    expected_version = "2.0.0"  # Change THIS LINE when changing bazel version
+    # Please use length 3 tuples, because bazel versions has 3 members;
+    # to avoid surprising behaviors (for example (2,0) >/= (2, 0, 0))
+    min_bazel = (0, 29, 0)  # Change THIS LINE when changing bazel min version
+    max_bazel = (2, 0, 0)  # Change THIS LINE when changing bazel max version
 
-    actual_major = int(actual_version[0])
-    actual_minor = int(actual_version[2])
-    actual_patch = int(actual_version[4])
-    actual = (actual_major, actual_minor, actual_patch)
+    actual = tuple(_parse_bazel_version(actual_version))
 
-    expected_major = int(expected_version[0])
-    expected_minor = int(expected_version[2])
-    expected_patch = int(expected_version[4])
-    expected = (expected_major, expected_minor, expected_patch)
+    if (min_bazel <= actual) and (actual <= max_bazel):
+        return  # All good
 
-    if actual < expected:
-        print("WARNING: bazel version is too old. Expected {}, but found: {}".format(expected_version, actual_version))
-        return
-    if expected < actual:
-        print("WARNING: bazel version is too recent. Expected {}, but found: {}".format(expected_version, actual_version))
-        return
+    min_bazel_string = ".".join([str(x) for x in list(min_bazel)])
+    max_bazel_string = ".".join([str(x) for x in list(max_bazel)])
+
+    adjective = "old" if actual < min_bazel else "recent"
+
+    print("WARNING: bazel version is too {}. Supported versions range from {} to {}, but found: {}".format(adjective, min_bazel_string, max_bazel_string, actual_version))

--- a/haskell/repositories.bzl
+++ b/haskell/repositories.bzl
@@ -1,10 +1,13 @@
 """Workspace rules (repositories)"""
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load(":private/versions.bzl", "check_version")
 
 def rules_haskell_dependencies():
     """Provide all repositories that are necessary for `rules_haskell` to function."""
     excludes = native.existing_rules().keys()
+    if "bazel_version" in dir(native):
+        check_version(native.bazel_version)
 
     if "platforms" not in excludes:
         http_archive(


### PR DESCRIPTION
PR for issue #741

As discussed on slack, we don't to fail if the actual bazel version is not the expected one, we prefer to issue a warning. As a consequence, the code doesn't write anything if it cannot find the version (don't want to issue a warning about a possible warning..). 

For a reason detailed here: https://github.com/bazelbuild/bazel/issues/8305 checking bazel's version cannot be done anywhere, that is why it is done in [haskell/repositories.bzl](https://github.com/tweag/rules_haskell/blob/master/haskell/repositories.bzl).

I did not find a preferred way how to issue a warning message, so I'm simply using Starlark's `print` function for our messages, please reconsider this.

## Tests

### In `rules_haskell/tutorial`, with bazel from APT

```
> sudo apt install bazel=1.2.1
> bazel --version
bazel 1.2.1
> bazel build //...
Starting local Bazel server and connecting to it...
DEBUG: /home/churlin/.cache/bazel/_bazel_churlin/b8c8fe86b6cf2c554ee68454e2b527a7/external/rules_haskell/haskell/private/versions.bzl:28:9: WARNING: bazel version is too old. Expected 2.0.0, but found: 1.2.1
... usual output
```

```
> sudo apt purge bazel; sudo apt install bazel=2.0.0
> bazel --version
bazel 2.0.0
> bazel build //...
Starting local Bazel server and connecting to it...
... usual output
```

```
> sudo apt purge bazel; sudo apt install bazel=2.1.0
> bazel --version
bazel 2.1.0
> bazel build //...
DEBUG: /home/churlin/.cache/bazel/_bazel_churlin/b8c8fe86b6cf2c554ee68454e2b527a7/external/rules_haskell/haskell/private/versions.bzl:31:9: WARNING: bazel version is too recent. Expected 2.0.0, but found: 2.1.0
... usual output
```

### At the repo's root, with bazel from nix-shell

```
> bazel --version
bazel 2.0.0- (@non-git)
> bazel test //...
# tests pass
> bazel run //:buildifier
# nothing to format
```

Then with a modified `nixkpgs/default.nix`, to have bazel `2.1.0`:

```
-  # 2020-01-29
-  sha256 = "1iy3iz91xx58k9wgswalipa8gxxdafqq82lisg6s16ml8y232f00";
-  rev = "42a195919a10ce70309c3666dfe8206e380fae1b";
+  # 2020-03-10
+  sha256 = "1kvyrs8g1zidrcs714k8g1gawrqln9x1nndpbfnblkglnzvvrac5";
+  rev = "3eea746d74d1fdfa57eef62b9159f5a51f23562a";
```

```
> bazel --version
bazel 2.1.0- (@non-git)
> bazel test //...
Starting local Bazel server and connecting to it...
DEBUG: /media/crypt1/repos/rules_haskell_741/haskell/private/versions.bzl:31:9: WARNING: bazel version is too recent. Expected 2.0.0, but found: 2.1.0- (@non-git)
# tests fail, because of an unexpected version of ghc (8.8.2 available, 8.6.5 expected)
> bazel run //:buildifier
DEBUG: /media/crypt1/repos/rules_haskell_741/haskell/private/versions.bzl:31:9: WARNING: bazel version is too recent. Expected 2.0.0, but found: 2.1.0- (@non-git)
# nothing to format
```
