### PR TITLE
Do not pass -i flags for compilation

### DIFF
--- a/haskell/doctest.bzl
+++ b/haskell/doctest.bzl
@@ -118,6 +118,7 @@ def _haskell_doctest_single(target, ctx):
 
     if ctx.attr.modules:
         inputs = ctx.attr.modules
+        args.add_all(set.to_list(hs_info.import_dirs), format_each = "-i%s")
     else:
         inputs = [source.path for source in hs_info.source_files.to_list()]
 

--- a/haskell/private/actions/compile.bzl
+++ b/haskell/private/actions/compile.bzl
@@ -214,8 +214,6 @@ def _compilation_defaults(hs, cc, java, posix, dep_info, plugin_dep_info, srcs, 
             idir = import_dir_map[s]
             set.mutable_insert(import_dirs, idir)
 
-    compile_flags += ["-i{0}".format(d) for d in set.to_list(import_dirs)]
-
     # Write the -optP flags to a parameter file because they can be very long on Windows
     # e.g. 27Kb for grpc-haskell
     # Equivalent to: compile_flags += ["-optP" + f for f in cc.cpp_flags]


### PR DESCRIPTION
Removes `-i` flags from the compilation action.

GHC uses import paths specified via `-i` to search for source files for required modules, see [1]. However, we pass all source files explicitly on the command-line during compilation, so, GHC should never have to search for source files itself.

Note, interface files of package dependencies are found using the search paths specified in the `import-dirs` field of the corresponding package configuration.

---

The `haskell_doctest` rule assumed that the `compiler_flags` field of `HaskellInfo` included `-i` flags for the package. This is required in case the `modules` attribute was set, which instructs doctest to only test the specified modules. These are then loaded by module name using GHCi following the procedure described in [1]. The `haskell_doctest` rule is adjusted to set the required `-i` flags itself.

---

This resolves an issue on Windows, where GHC would recompile modules of package dependencies if their source files reside in import directories of the current package. E.g. compiling `//tests/generated-modules` with `compiler_flags = ["-v"]` shows that the modules `BinModule` and `GenModule` are compiled twice, once in their respective targets `:GenModule` or `:BinModule` and then again when compiling `:generated-modules`. This is possible because Bazel builds are not sandboxed on Windows.

[1]: https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/separate_compilation.html#search-path