### PR TITLE
Cabal: Add RUNPATH entries for transitive C library dependencies

### DIFF
--- a/tests/stackage_zlib_runpath/BUILD.bazel
+++ b/tests/stackage_zlib_runpath/BUILD.bazel
@@ -1,4 +1,8 @@
 load(
+    "@rules_haskell//haskell:cabal.bzl",
+    "haskell_cabal_binary",
+)
+load(
     "//tests:inline_tests.bzl",
     "py_inline_test",
 )
@@ -19,12 +23,23 @@ dynamic_libraries(
     tags = ["requires_zlib"],
 )
 
-# Tests that haskell_cabal_library will generate a relative RUNPATH entry for
-# the dependency on the nixpkgs provided libz. Relative meaning an entry that
-# starts with $ORIGIN (Linux) or @loader_path (MacOS). The alternative is an
-# absolute path, which would be wrong for the nixpkgs provided libz, as we want
-# the RUNPATH entry to point to Bazel's _solib_<cpu> directory and its absolute
-# path depends on the output root or execroot.
+haskell_cabal_binary(
+    name = "cabal-binary",
+    srcs = glob(["cabal-binary/**"]),
+    tags = ["requires_zlib"],
+    deps = [
+        "//tests/hackage:base",
+        # Depend transitively on libz.
+        "@stackage-zlib//:zlib",
+    ],
+)
+
+# Tests that haskell_cabal_library|binary will generate a relative RUNPATH
+# entry for the dependency on the nixpkgs provided libz. Relative meaning an
+# entry that starts with $ORIGIN (Linux) or @loader_path (MacOS). The
+# alternative is an absolute path, which would be wrong for the nixpkgs
+# provided libz, as we want the RUNPATH entry to point to Bazel's _solib_<cpu>
+# directory and its absolute path depends on the output root or execroot.
 #
 # It uses :libz_soname generated above to determine the expected RUNPATH entry
 # for the libz dependency. The :libz_soname file will contain the file names of
@@ -33,17 +48,22 @@ dynamic_libraries(
 # It uses :libHSzlib to access the dynamic library output of
 # haskell_cabal_library and read the RUNPATH entries.
 #
-# Note, ideally we would test that haskell_cabal_library _only_ generates a
-# relative RUNPATH entry and no absolute entries that leak the execroot into
-# the cache. Unfortunately, haskell_cabal_library generates such an entry at
-# the moment. See https://github.com/tweag/rules_haskell/issues/1130.
+# It uses :cabal-binary to access a binary that transitively depends on libz.
+#
+# Note, ideally we would test that haskell_cabal_library|binary _only_
+# generates a relative RUNPATH entry and no absolute entries that leak the
+# execroot into the cache. Unfortunately, haskell_cabal_library|binary
+# generates such an entry at the moment. See
+# https://github.com/tweag/rules_haskell/issues/1130.
 py_inline_test(
     name = "stackage_zlib_runpath",
     args = [
         "$(rootpath :libz_soname)",
         "$(rootpath :libHSzlib)",
+        "$(rootpath :cabal-binary)",
     ],
     data = [
+        ":cabal-binary",
         ":libHSzlib",
         ":libz_soname",
     ],
@@ -65,57 +85,71 @@ with open(libz_soname) as fh:
     sofile = fh.read().splitlines()[1]
     sodir = os.path.dirname(sofile)
 
-# Determine libHSzlib RUNPATH
+# Locate test artifacts.
 libHSzlib = r.Rlocation(os.path.join(
     os.environ["TEST_WORKSPACE"],
     sys.argv[2],
 ))
-runpaths = []
-if platform.system() == "Darwin":
-    dynamic_section = iter(subprocess.check_output(["otool", "-l", libHSzlib]).decode().splitlines())
-    # otool produces lines of the form
-    #
-    #   Load command ...
-    #             cmd LC_RPATH
-    #         cmdsize ...
-    #            path ...
-    #
-    for line in dynamic_section:
-        # Find LC_RPATH entry
-        if line.find("cmd LC_RPATH") != -1:
-            break
-        # Skip until path field
+cabal_binary = r.Rlocation(os.path.join(
+    os.environ["TEST_WORKSPACE"],
+    sys.argv[3],
+))
+
+def read_runpaths(binary):
+    runpaths = []
+    if platform.system() == "Darwin":
+        dynamic_section = iter(subprocess.check_output(["otool", "-l", binary]).decode().splitlines())
+        # otool produces lines of the form
+        #
+        #   Load command ...
+        #             cmd LC_RPATH
+        #         cmdsize ...
+        #            path ...
+        #
         for line in dynamic_section:
-            if line.strip().startswith("path"):
+            # Find LC_RPATH entry
+            if line.find("cmd LC_RPATH") != -1:
                 break
-        runpaths.append(line.split()[1])
-else:
-    dynamic_section = subprocess.check_output(["objdump", "--private-headers", libHSzlib]).decode().splitlines()
-    # objdump produces lines of the form
-    #
-    #   Dynamic Section:
-    #     ...
-    #     RUNPATH              ...
-    #     ...
-    for line in dynamic_section:
-        if not line.strip().startswith("RUNPATH"):
+            # Skip until path field
+            for line in dynamic_section:
+                if line.strip().startswith("path"):
+                    break
+            runpaths.append(line.split()[1])
+    else:
+        dynamic_section = subprocess.check_output(["objdump", "--private-headers", binary]).decode().splitlines()
+        # objdump produces lines of the form
+        #
+        #   Dynamic Section:
+        #     ...
+        #     RUNPATH              ...
+        #     ...
+        for line in dynamic_section:
+            if not line.strip().startswith("RUNPATH"):
+                continue
+            runpaths.extend(line.split()[1].split(":"))
+
+    return runpaths
+
+def test_binary(binary, sodir):
+    runpaths = read_runpaths(binary)
+    # Check that the binary contains a relative RUNPATH for sodir.
+    found = False
+    for runpath in runpaths:
+        if runpath.find(sodir) == -1:
             continue
-        runpaths.extend(line.split()[1].split(":"))
+        if runpath.startswith("$ORIGIN") or runpath.startswith("@loader_path"):
+            found = True
+        # XXX: Enable once #1130 is fixed.
+        #if os.path.isabs(runpath):
+        #    print("Absolute RUNPATH entry discovered for %s: %s" % (sodir, runpath))
+        #    sys.exit(1)
 
-# Check that the binary contains a relative RUNPATH for sodir.
-found = False
-for runpath in runpaths:
-    if runpath.find(sodir) == -1:
-        continue
-    if runpath.startswith("$ORIGIN") or runpath.startswith("@loader_path"):
-        found = True
-    # XXX: Enable once #1130 is fixed.
-    #if os.path.isabs(runpath):
-    #    print("Absolute RUNPATH entry discovered for %s: %s" % (sodir, runpath))
-    #    sys.exit(1)
+    if not found:
+        print("Did not find a relative RUNPATH entry for %s among %s." % (sodir, runpaths))
 
-if not found:
-    print("Did not find a relative RUNPATH entry for %s among %s." % (sodir, runpaths))
+    return found
+
+if not all(test_binary(binary, sodir) for binary in [libHSzlib, cabal_binary]):
     sys.exit(1)
 """,
     tags = ["requires_zlib"],

--- a/tests/stackage_zlib_runpath/cabal-binary/Main.hs
+++ b/tests/stackage_zlib_runpath/cabal-binary/Main.hs
@@ -1,0 +1,4 @@
+module Main where
+
+main :: IO ()
+main = pure ()

--- a/tests/stackage_zlib_runpath/cabal-binary/cabal-binary.cabal
+++ b/tests/stackage_zlib_runpath/cabal-binary/cabal-binary.cabal
@@ -1,0 +1,11 @@
+cabal-version: >=1.10
+name: cabal-binary
+version: 0.1.0.0
+build-type: Simple
+
+executable cabal-binary
+  build-depends:
+    base,
+    zlib
+  default-language: Haskell2010
+  main-is: Main.hs


### PR DESCRIPTION
Add `RUNPATH` entries for all transitive C library dependencies to Cabal targets. GHC passes `-l` flags for all transitive C library dependencies when linking. Accordingly, we need to provide `RUNPATH` entries for all transitive C libraries. Also, to ensure that binaries can find their dynamic library dependencies, we add them to the `runfiles` attribute of the `DefaultInfo` provider.

Also, make static Haskell libraries available in Cabal build action, so that Cabal binaries can link statically against Haskell libraries.

Extends the test-case introduced in https://github.com/tweag/rules_haskell/pull/1267 to test for `RUNPATH` entries to transitive C library dependencies in Cabal binary targets.