### PR TITLE
shellcheck.bzl: remove unused arg + more uniform handling of quoting of arguments

### DIFF
--- a/tests/shellcheck/shellcheck.bzl
+++ b/tests/shellcheck/shellcheck.bzl
@@ -1,18 +1,17 @@
 load("//tests:inline_tests.bzl", "sh_inline_test")
-load("@bazel_skylib//lib:shell.bzl", "shell")
 
 def shellcheck(name, args, data, sh_flavor = "sh", visibility = None):
-    cmd = ["shellcheck", "--color=always"]
+    fst_args = ["--color=always"]
     if sh_flavor != None:
-        cmd += ["--shell", sh_flavor]
+        fst_args += ["--shell", sh_flavor]
     sh_inline_test(
         name = name,
         visibility = visibility,
         size = "small",
-        args = args,
+        args = fst_args + args,
         data = data,
         script = """\
-{} "$1"
-""".format(" ".join([shell.quote(x) for x in cmd])),
+shellcheck "$@"
+""",
         tags = ["requires_shellcheck"],
     )

--- a/tests/shellcheck/shellcheck.bzl
+++ b/tests/shellcheck/shellcheck.bzl
@@ -1,8 +1,10 @@
 load("//tests:inline_tests.bzl", "sh_inline_test")
+load("@bazel_skylib//lib:shell.bzl", "shell")
 
-def shellcheck(name, args, data, sh_flavor = "sh", excludes = [], visibility = None):
-    excludes_arg = "--exclude=" + ",".join(excludes) if excludes else ""
-    shell_arg = "--shell " + sh_flavor if sh_flavor else ""
+def shellcheck(name, args, data, sh_flavor = "sh", visibility = None):
+    cmd = ["shellcheck", "--color=always"]
+    if sh_flavor != None:
+        cmd += ["--shell", sh_flavor]
     sh_inline_test(
         name = name,
         visibility = visibility,
@@ -10,7 +12,7 @@ def shellcheck(name, args, data, sh_flavor = "sh", excludes = [], visibility = N
         args = args,
         data = data,
         script = """\
-shellcheck --color=always {} {} "$1"
-""".format(shell_arg, excludes_arg),
+{} "$1"
+""".format(" ".join([shell.quote(x) for x in cmd])),
         tags = ["requires_shellcheck"],
     )


### PR DESCRIPTION
This PR:

- removes the unused `exclude_args` argument from the `shellcheck` rule
- quotes more uniformly arguments to the `shellcheck` executable, to be more future-proof, using skylib's [shell.quote](https://github.com/bazelbuild/bazel-skylib/blob/master/lib/shell.bzl#L37-L49)

##  Tests:

* `bazel test //...`
* `bazel run //:buildifier`
* Break shellchecking of some scripts files, observe that `bazel test //...` fails
* Check that rule `shellcheck`'s argument `sh_flavor` is still honored by fiddling `tests/shellcheck/BUILD.bzl` `sh_flavor` values, and observing that it breaks tests.