### PR TITLE
haskell_cabal_library: fix failure when package_name differs from name

### DIFF
--- a/haskell/cabal.bzl
+++ b/haskell/cabal.bzl
@@ -252,8 +252,9 @@ def _haskell_cabal_library_impl(ctx):
         ],
     )
     posix = ctx.toolchains["@rules_sh//sh/posix:toolchain_type"]
+    package_name = ctx.attr.package_name if ctx.attr.package_name else hs.label.name
     package_id = "{}-{}".format(
-        ctx.attr.package_name if ctx.attr.package_name else hs.label.name,
+        package_name,
         ctx.attr.version,
     )
     with_profiling = is_profiling_enabled(hs)
@@ -275,7 +276,7 @@ def _haskell_cabal_library_impl(ctx):
     )
     if ctx.attr.haddock:
         haddock_file = hs.actions.declare_file(
-            "_install/{}_haddock/{}.haddock".format(package_id, ctx.attr.name),
+            "_install/{}_haddock/{}.haddock".format(package_id, package_name),
             sibling = cabal,
         )
         haddock_html_dir = hs.actions.declare_directory(

--- a/tests/haskell_cabal_library/BUILD.bazel
+++ b/tests/haskell_cabal_library/BUILD.bazel
@@ -15,7 +15,8 @@ cc_library(
 )
 
 haskell_cabal_library(
-    name = "lib",
+    name = "first-lib",
+    package_name = "lib",
     srcs = [
         "Lib.hs",
         "lib.cabal",
@@ -43,7 +44,7 @@ haskell_test(
     srcs = ["Main.hs"],
     deps = [
         ":base",
-        ":lib",
+        ":first-lib",
         ":second-lib",
     ],
 )


### PR DESCRIPTION
Fixes #1207 

I've modified an existing test to cover this case.

### Tests

1. Observe that `bazel test` fails following @regnat's procedure
2. Create this commit, observe that if fixes the failure
3. Observe that the test without @regnat's change works
4. `bazel test //...`
5. `bazel run //:buildifier`