### PR TITLE
[WIP] Start fix of --experimental_use_sandboxfs

### DIFF
--- a/haskell/c2hs.bzl
+++ b/haskell/c2hs.bzl
@@ -75,6 +75,7 @@ def _c2hs_library_impl(ctx):
             depset(cc.files),
             set.to_depset(version_macro_headers),
             inputs,
+            hs.toolchain.full_ghc,
         ]),
         input_manifests = input_manifests,
         tools = [hs.tools.ghc, c2hs_exe],

--- a/haskell/cabal.bzl
+++ b/haskell/cabal.bzl
@@ -220,6 +220,7 @@ def _prepare_cabal_inputs(
             dep_info.static_libraries,
             dep_info.dynamic_libraries,
             tool_inputs,
+            hs.toolchain.full_ghc,
         ],
     )
     input_manifests = tool_input_manifests

--- a/haskell/ghc.BUILD.tpl
+++ b/haskell/ghc.BUILD.tpl
@@ -17,6 +17,11 @@ filegroup(
     srcs = glob(["bin/*"]),
 )
 
+filegroup(
+    name = "bin-extras",
+    srcs = glob(["lib/**"]),
+)
+
 # Expose embedded MinGW toolchain when on Windows.
 
 filegroup(

--- a/haskell/ghc_bindist.bzl
+++ b/haskell/ghc_bindist.bzl
@@ -288,6 +288,7 @@ grep --files-with-matches --null {bindist_dir} bin/* | xargs -0 -n1 \
 haskell_toolchain(
     name = "toolchain-impl",
     tools = [":bin"],
+    full_ghc = [":bin-extras"],
     libraries = toolchain_libraries,
     version = "{version}",
     is_static = {is_static},

--- a/haskell/private/actions/compile.bzl
+++ b/haskell/private/actions/compile.bzl
@@ -73,6 +73,7 @@ def _process_hsc_file(hs, cc, hsc_flags, hsc_inputs, hsc_file):
             depset([hsc_file]),
             depset(cc.files),
             depset(hsc_inputs),
+            hs.toolchain.full_ghc,
         ]),
         outputs = [hs_out],
         mnemonic = "HaskellHsc2hs",

--- a/haskell/private/actions/runghc.bzl
+++ b/haskell/private/actions/runghc.bzl
@@ -109,5 +109,6 @@ def build_haskell_runghc(
         depset(get_ghci_library_files(hs, cc.cc_libraries_info, cc.transitive_libraries + cc.plugin_libraries)),
         hs_info.source_files,
         hs.toolchain.cc_wrapper.runfiles.files,
+        hs.toolchain.full_ghc,
     ])
     ln(hs, posix, runghc_file, output, extra_inputs)

--- a/haskell/private/packages.bzl
+++ b/haskell/private/packages.bzl
@@ -153,7 +153,7 @@ def ghc_pkg_recache(hs, posix, conf_file):
 
     # Make the call to ghc-pkg and use the package configuration file
     hs.actions.run(
-        inputs = depset(direct = [conf_file]),
+        inputs = depset(direct = [conf_file], transitive = [hs.toolchain.full_ghc]),
         outputs = [cache_file],
         mnemonic = "HaskellRegisterPackage",
         progress_message = "HaskellRegisterPackage {}".format(conf_file.short_path),


### PR DESCRIPTION
Fixes #1265 

This draft PR starts implementing the solution drafted by @aherrmann in https://github.com/tweag/rules_haskell/issues/1265#issuecomment-607196384 to make `--experimental_use_sandboxfs` work when using bindists (no `NixOS`, no `nix-shell` context). Let me record that the intended setup to test this PR is [described here](https://github.com/tweag/rules_haskell/issues/1173#issuecomment-606723360).

It fixes the issue that executables - within `ghc`'s install `bin` directory - need content in the sibling `lib` directory. Because this content is not tracked precisely right now, it is missing when executing within [sandboxfs](https://github.com/bazelbuild/sandboxfs) with `--experimental_use_sandboxfs` (see [bazel+sandboxfs](https://blog.bazel.build/2018/04/13/preliminary-sandboxfs-support.html) usage).

The first commit fixes failures of the form `../lib/path` being missing. I made a checkpoint here because with this commit, `bazel test //tests/...` now fails in a different manner:

```
  File "bazel-out/host/bin/haskell/cc_wrapper-python", line 111, in FindModuleSpace
    raise AssertionError('Cannot find .runfiles directory for %s' % sys.argv[0])
AssertionError: Cannot find .runfiles directory for bazel-out/host/bin/haskell/cc_wrapper-python
compiling bazel-out/k8-fastbuild/bin/tests/library-with-cbits/_hsc/library-with-cbits-static/AddOne_hsc_make.c failed (exit code 1)
command was: bazel-out/host/bin/haskell/cc_wrapper-python -c bazel-out/k8-fastbuild/bin/tests/library-with-cbits/_hsc/library-with-cbits-static/AddOne_hsc_make.c -o bazel-out/k8-fastbuild/bin/tests/library-with-cbits/_hsc/library-with-cbits-static/AddOne_hsc_make.o -fno-stack-protector -iquote . -iquote bazel-out/k8-fastbuild/bin -U_FORTIFY_SOURCE -fstack-protector -Wall -Wunused-but-set-parameter -Wno-free-nonheap-object -fno-omit-frame-pointer -fno-canonical-system-headers -Wno-builtin-macro-redefined -D__DATE__="redacted" -D__TIMESTAMP__="redacted" -D__TIME__="redacted" -Iexternal/rules_haskell_ghc_linux_amd64/bin/../lib/include/
```

And here's one specific failure when running `bazel test --experimental_use_sandboxfs --sandbox_debug //tests/cc_haskell_import/...`:

```
ERROR: /media/crypt1/repos/rules_haskell/rules_haskell_1265_alt/tests/cc_haskell_import/BUILD.bazel:19:1: HaskellBuildLibrary //tests/cc_haskell_import:hs-lib-b failed (Exit 1) linux-sandbox failed: error executing command 
  (cd /home/churlin/.cache/bazel/_bazel_churlin/31b8c33fa4dcf9eee06a0a8329314f3e/sandbox/sandboxfs/75 && \
  exec env - \
    LANG=C.UTF-8 \
    TMPDIR=/tmp \
  /home/churlin/.cache/bazel/_bazel_churlin/install/d687aca87a7669724cc958527f2423da/linux-sandbox -t 15 -w /home/churlin/.cache/bazel/_bazel_churlin/31b8c33fa4dcf9eee06a0a8329314f3e/sandbox/linux-sandbox/80/execroot/rules_haskell -w /tmp -w /dev/shm -D -- bazel-out/host/bin/haskell/ghc_wrapper bazel-out/k8-fastbuild/bin/tests/cc_haskell_import/compile_flags_hs-lib-b_HaskellBuildLibrary bazel-out/k8-fastbuild/bin/tests/cc_haskell_import/extra_args_hs-lib-b_HaskellBuildLibrary)
...
tests/cc_haskell_import/LibB_stub.h: openFile: permission denied (Permission denied)
```