### PR TITLE
Set runfiles attribute in haskell_doc

### DIFF
--- a/haskell/haddock.bzl
+++ b/haskell/haddock.bzl
@@ -321,9 +321,10 @@ def _haskell_doc_rule_impl(ctx):
         arguments = [args],
     )
 
+    files = html_dict_copied.values() + [index_root]
     return [DefaultInfo(
-        files = depset(html_dict_copied.values() + [index_root]),
-        runfiles = ctx.runfiles(html_dict_copied.values() + [index_root]),
+        files = depset(files),
+        runfiles = ctx.runfiles(files),
     )]
 
 haskell_doc = rule(

--- a/haskell/haddock.bzl
+++ b/haskell/haddock.bzl
@@ -323,6 +323,7 @@ def _haskell_doc_rule_impl(ctx):
 
     return [DefaultInfo(
         files = depset(html_dict_copied.values() + [index_root]),
+        runfiles = ctx.runfiles(html_dict_copied.values() + [index_root]),
     )]
 
 haskell_doc = rule(

--- a/tests/haddock/BUILD.bazel
+++ b/tests/haddock/BUILD.bazel
@@ -56,8 +56,32 @@ haskell_doc(
     deps = [":haddock-lib-b"],
 )
 
+sh_test(
+    name = "data-dependency",
+    srcs = ["data_dependency.sh"],
+    args = ["$(rootpaths :haddock)"],
+    data = [":haddock"],
+    tags = [
+        # Fails in profiling mode due to missing haddocks for Deep.
+        "requires_dynamic",
+    ],
+    deps = ["@bazel_tools//tools/bash/runfiles"],
+)
+
 haskell_doc(
     name = "haddock-transitive",
     index_transitive_deps = True,
     deps = [":haddock-lib-b"],
+)
+
+sh_test(
+    name = "data-dependency-transitive",
+    srcs = ["data_dependency.sh"],
+    args = ["$(rootpaths :haddock-transitive)"],
+    data = [":haddock-transitive"],
+    tags = [
+        # Fails in profiling mode due to missing haddocks for Deep.
+        "requires_dynamic",
+    ],
+    deps = ["@bazel_tools//tools/bash/runfiles"],
 )

--- a/tests/haddock/data_dependency.sh
+++ b/tests/haddock/data_dependency.sh
@@ -1,0 +1,19 @@
+# Copy-pasted from the Bazel Bash runfiles library v2.
+set -uo pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
+# --- end runfiles.bash initialization v2 ---
+
+set -euo pipefail
+fail=
+for data in "$@"; do
+  if [[ ! -e "$(rlocation "$TEST_WORKSPACE/$data")" ]]; then
+    echo "missing data dependency: $data" >&2
+    fail=1
+  fi
+done
+exit $fail


### PR DESCRIPTION
This is to make generated Haddocks available in the runfiles tree of targets that have a `data` dependency on a `haskell_doc` target.

Adds a regression test to `//tests/haddock`.