### PR TITLE
Refactor `--config` setup

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,30 +1,74 @@
 # See https://docs.bazel.build/versions/master/user-manual.html#bazelrc.
 
+# Global Configuration
+# --------------------
+
+# test environment does not propagate locales by default some tests reads files
+# written in UTF8, we need to propagate the correct environment variables, such
+# as LOCALE_ARCHIVE We also need to setup an utf8 locale
+test --test_env=LANG=C.UTF-8 --test_env=LOCALE_ARCHIVE
+
+# Platform / Toolchain Selection
+# ------------------------------
+build:linux-nixpkgs --host_platform=@rules_haskell//haskell/platforms:linux_x86_64_nixpkgs
+build:macos-nixpkgs --host_platform=@rules_haskell//haskell/platforms:darwin_x86_64_nixpkgs
 # Use this configuration when targeting Windows. Eventually this will
 # no longer be required:
 # https://bazel.build/roadmaps/platforms.html#replace---cpu-and---host_cpu-flags.
-build:windows --crosstool_top=@rules_haskell_ghc_windows_amd64//:cc_toolchain -s --verbose_failures --sandbox_debug
+build:windows-bindist --crosstool_top=@rules_haskell_ghc_windows_amd64//:cc_toolchain
 
-build:ci_linux --remote_http_cache=https://storage.googleapis.com/tweag-bazel-cache-buildkite --remote_upload_local_results=true --google_default_credentials
+# Build and Test Filters
+# ----------------------
+# Note tag filters do not compose. If you wish to augment these filters on the
+# command-line you have to repeat the full list.
+build:linux-bindist --build_tag_filters -requires_lz4,-requires_proto,-requires_zlib,-requires_doctest,-requires_c2hs,-requires_shellcheck,-requires_threaded_rts,-dont_test_with_bindist
+build:linux-bindist --test_tag_filters  -requires_lz4,-requires_proto,-requires_zlib,-requires_doctest,-requires_c2hs,-requires_shellcheck,-requires_threaded_rts,-dont_test_with_bindist
+
+build:macos-nixpkgs --build_tag_filters -dont_test_on_darwin
+build:macos-nixpkgs --test_tag_filters  -dont_test_on_darwin
+
+build:macos-bindist --build_tag_filters -dont_test_on_darwin,-dont_test_on_darwin_with_bindist,-requires_lz4,-requires_proto,-requires_zlib,-requires_doctest,-requires_c2hs,-requires_shellcheck,-requires_threaded_rts,-dont_test_with_bindist
+build:macos-bindist --test_tag_filters  -dont_test_on_darwin,-dont_test_on_darwin_with_bindist,-requires_lz4,-requires_proto,-requires_zlib,-requires_doctest,-requires_c2hs,-requires_shellcheck,-requires_threaded_rts,-dont_test_with_bindist
+
+# CI Configuration
+# ----------------
+common:ci --color=no
+
 build:ci --loading_phase_threads=1
 build:ci --verbose_failures
 # Make sure we don't rely on the names of convenience symlinks because those
 # can be changed by user.
 build:ci --symlink_prefix=bazel-ci-
-common:ci --color=no
+
 test:ci --test_output=errors
 
+build:ci-linux-bindist --remote_http_cache=https://storage.googleapis.com/tweag-bazel-cache-buildkite --remote_upload_local_results=true --google_default_credentials
+build:ci-linux-nixpkgs --remote_http_cache=https://storage.googleapis.com/tweag-bazel-cache-buildkite --remote_upload_local_results=true --google_default_credentials
+
+build:ci-linux-bindist --repository_cache ~/repo_cache
+# XXX: @com_google_protobuf sets `use_default_shell_env = True`, so we enable
+#   strict action env to avoid changes in `PATH` invalidating the cache.
+build:ci-linux-bindist --experimental_strict_action_env
+
+build:ci-macos-bindist --disk_cache=~/.cache/bazel/
+build:ci-macos-nixpkgs --disk_cache=~/.cache/bazel/
+
+build:ci-windows-bindist --subcommands --sandbox_debug
+
 # Note [backward compatible options]
-common:ci --incompatible_enable_cc_toolchain_resolution
-common:ci --incompatible_load_cc_rules_from_bzl
+build:ci-linux-bindist --incompatible_enable_cc_toolchain_resolution
+build:ci-macos-bindist --incompatible_enable_cc_toolchain_resolution
+# rules_nixpkgs is not yet compatible with cc toolchain resolution, see
+# https://github.com/tweag/rules_nixpkgs/issues/88
+#build:ci-linux-nixpkgs --incompatible_enable_cc_toolchain_resolution
+#build:ci-macos-nixpkgs --incompatible_enable_cc_toolchain_resolution
+# Windows still uses --crosstool_top.
+#build:ci-windows-bindist --incompatible_enable_cc_toolchain_resolution
+build:ci --incompatible_load_cc_rules_from_bzl
 # Blocked by https://github.com/bazelbuild/buildtools/issues/757
-#common:ci --incompatible_load_proto_rules_from_bzl
-common:ci --incompatible_load_python_rules_from_bzl
+#build:ci --incompatible_load_proto_rules_from_bzl
+build:ci --incompatible_load_python_rules_from_bzl
 
-# test environment does not propagate locales by default
-# some tests reads files written in UTF8, we need to propagate the correct
-# environment variables, such as LOCALE_ARCHIVE
-# We also need to setup an utf8 locale
-test --test_env=LANG=C.UTF-8 --test_env=LOCALE_ARCHIVE
-
+# User Configuration
+# ------------------
 try-import %workspace%/.bazelrc.local

--- a/.buildkite/bindists-pipeline
+++ b/.buildkite/bindists-pipeline
@@ -6,18 +6,13 @@
 set -euo pipefail
 
 BAZEL_DIR="$(.ci/fetch-bazel-bindist)"
-REPO_CACHE="$HOME/repo_cache"
 
 trap "rm -rf '$BAZEL_DIR'" EXIT
 export PATH="$BAZEL_DIR:$PATH"
-EXCLUDED="-requires_lz4,-requires_proto,-requires_zlib,-requires_doctest,-requires_c2hs,-requires_shellcheck,-requires_threaded_rts,-dont_test_with_bindist"
-echo "common:ci --build_tag_filters $EXCLUDED" > .bazelrc.local
-echo "common:ci --test_tag_filters $EXCLUDED" >> .bazelrc.local
-echo "build:ci --config=ci_linux" >> .bazelrc.local
-echo "common:ci --repository_cache $REPO_CACHE" >> .bazelrc.local
-# XXX: @com_google_protobuf sets `use_default_shell_env = True`, so we enable
-#   strict action env to avoid changes in `PATH` invalidating the cache.
-echo "build:ci --experimental_strict_action_env" >> .bazelrc.local
+cat >.bazelrc.local <<EOF
+common --config=ci
+build --config=linux-bindist --config=ci-linux-bindist
+EOF
 ./tests/run-start-script.sh --use-bindists
-bazel build --config ci //tests/...
-bazel test --config ci //tests/...
+bazel build //tests/...
+bazel test //tests/...

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,8 +1,10 @@
 steps:
   - label: "Run tests (Nixpkgs)"
     command: |
-      echo "build:ci --host_platform=@rules_haskell//haskell/platforms:linux_x86_64_nixpkgs" > .bazelrc.local
-      echo "build:ci --config=ci_linux" >> .bazelrc.local
+      cat >.bazelrc.local <<EOF
+      common --config=ci
+      build --config=linux-nixpkgs --config=ci-linux-nixpkgs
+      EOF
       nix-shell --arg docTools false --pure --run '
       set -e
       # Ensure that the Nixpkgs bazel version matches the one specified in
@@ -10,9 +12,9 @@ steps:
       # `.buildkite/bindists-pipeline` for the bindists version.
       .ci/check-bazel-version
       ./tests/run-start-script.sh --use-nix
-      bazel build --config ci //tests:run-tests
+      bazel build //tests:run-tests
       ./bazel-ci-bin/tests/run-tests
-      bazel coverage //tests/... --config ci --build_tag_filters "coverage-compatible" --test_tag_filters "coverage-compatible" --test_output=all
+      bazel coverage //tests/... --build_tag_filters "coverage-compatible" --test_tag_filters "coverage-compatible" --test_output=all
       '
     timeout: 100
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,9 +47,10 @@ jobs:
           command: |
             mkdir -p ~/.cache/bazel/
 
-            echo "build:ci --host_platform=@rules_haskell//haskell/platforms:darwin_x86_64_nixpkgs" >> .bazelrc.local
-            echo "build:ci --disk_cache=~/.cache/bazel/" >> .bazelrc.local
-            echo "common:ci --test_tag_filters -dont_test_on_darwin" >> .bazelrc.local
+            cat >.bazelrc.local <<EOF
+            common --config=ci
+            build --config=macos-nixpkgs --config=ci-macos-nixpkgs
+            EOF
 
       - restore_cache:
           keys: # see note about 'Disk cache'
@@ -75,7 +76,7 @@ jobs:
           shell: /bin/bash -eilo pipefail
           command: |
             nix-shell --arg docTools false --pure --run \
-              'bazel build --config ci //tests/...'
+              'bazel build //tests/...'
       - run:
           name: Run tests
           shell: /bin/bash -eilo pipefail
@@ -90,9 +91,9 @@ jobs:
             #   './tests/run-start-script.sh --use-nix'
             nix-shell --arg docTools false --pure --run '
             set -euo pipefail
-            bazel build --config ci //tests:run-tests
+            bazel build //tests:run-tests
             ./bazel-ci-bin/tests/run-tests
-            bazel coverage //tests/... --config ci --build_tag_filters "coverage-compatible" --test_tag_filters "coverage-compatible" --test_output=all
+            bazel coverage //tests/... --build_tag_filters "coverage-compatible" --test_tag_filters "coverage-compatible" --test_output=all
             '
 
         # see note about 'Disk cache'
@@ -137,10 +138,10 @@ jobs:
             export BAZEL_USE_CPP_ONLY_TOOLCHAIN=1
             EOF
 
-            echo "build:ci --disk_cache=~/.cache/bazel/" >> .bazelrc.local
-            EXCLUDED="-dont_test_on_darwin,-dont_test_on_darwin_with_bindist,-requires_lz4,-requires_proto,-requires_zlib,-requires_doctest,-requires_c2hs,-requires_shellcheck,-requires_threaded_rts,-dont_test_with_bindist"
-            echo "common:ci --build_tag_filters $EXCLUDED" >> .bazelrc.local
-            echo "common:ci --test_tag_filters $EXCLUDED" >> .bazelrc.local
+            cat >.bazelrc.local <<EOF
+            common --config=ci
+            build --config=macos-bindist --config=ci-macos-bindist
+            EOF
 
       - restore_cache:
           keys: # see note about 'Disk cache'
@@ -160,7 +161,7 @@ jobs:
           shell: /bin/bash -eilo pipefail
           command: |
             . $HOME/.bashrc_rules_haskell
-            bazel build --config ci //tests/...
+            bazel build //tests/...
       - run:
           name: Run tests
           shell: /bin/bash -eilo pipefail
@@ -173,7 +174,7 @@ jobs:
             # XXX 2019-01-22 Disable start script checking on Darwin
             # due to a clash between binutils and clang.
             # ./tests/run-start-script.sh --use-bindists
-            bazel test --config ci //tests/...
+            bazel test //tests/...
 
         # see note about 'Disk cache'
       - save_cache:

--- a/README.md
+++ b/README.md
@@ -252,6 +252,31 @@ This chooses the `cc_toolchain` bundled with GHC.
 
 ## For `rules_haskell` developers
 
+### Configuring your platform
+
+`rules_haskell` can be built and tested on Linux, MacOS, and Windows. Depending
+on the platform GHC can be provisioned using nixpkgs or by downloading a binary
+distribution. In case of nixpkgs other toolchains (C compiler, Python, shell
+tools) will also be provided by nixpkgs, in case of bindist they will be taken
+from the environment (`$PATH`). The following `--config` options select the
+corresponding combination of operating system and GHC distribution:
+
+|                     |      Linux      |      MacOS      |      Windows      |
+| ------------------- | --------------- | --------------- | ----------------- |
+| nixpkgs             | `linux-nixpkgs` | `macos-nixpkgs` |                   |
+| binary distribution | `linux-bindist` | `macos-bindist` | `windows-bindist` |
+
+Hint: You can use Bazel's `--announce_rc` flag to see what options are being
+used for a command in a specific configuration. E.g.
+```
+$ bazel build //tests:run-tests --config linux-nixpkgs --nobuild --announce_rc
+```
+
+Hint: To avoid repetition you can add your configuration to `.bazelrc.local`.
+```
+echo "build --config=linux-nixpkgs" >>.bazelrc.local
+```
+
 ### Saving common command-line flags to a file
 
 If you find yourself constantly passing the same flags on the

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,6 +23,13 @@ jobs:
     displayName: "Enable da long paths"
 
   - bash: |
+      cat >.bazelrc.local <<EOF
+      common --config=ci
+      build --config=windows-bindist --config=ci-windows-bindist
+      EOF
+    displayName: "Configure Bazel"
+
+  - bash: |
       set -e
       export MSYS2_ARG_CONV_EXCL="*"
 
@@ -32,49 +39,49 @@ jobs:
       echo "PATH='$PATH'"
 
       # Tests that build but don't run
-      /c/bazel/bazel.exe build --config windows "//tests/c-compiles-still/..."
-      /c/bazel/bazel.exe build --config windows "//tests/binary-with-data/..."
-      /c/bazel/bazel.exe build --config windows "//tests/binary-indirect-cbits"
+      /c/bazel/bazel.exe build "//tests/c-compiles-still/..."
+      /c/bazel/bazel.exe build "//tests/binary-with-data/..."
+      /c/bazel/bazel.exe build "//tests/binary-indirect-cbits"
 
       # Tests that only require building
       # (when using 'test' CI fails with:
       #     ERROR: No test targets were found, yet testing was requested
       # )
       # See https://github.com/bazelbuild/bazel/issues/7291
-      /c/bazel/bazel.exe build --config windows "//tests/data/..."
-      /c/bazel/bazel.exe build --config windows "//tests/failures/..."
-      /c/bazel/bazel.exe build --config windows "//tests/hidden-modules/..."
-      /c/bazel/bazel.exe build --config windows "//tests/package-id-clash/..."
+      /c/bazel/bazel.exe build "//tests/data/..."
+      /c/bazel/bazel.exe build "//tests/failures/..."
+      /c/bazel/bazel.exe build "//tests/hidden-modules/..."
+      /c/bazel/bazel.exe build "//tests/package-id-clash/..."
 
       # Tests that succeed
-      /c/bazel/bazel.exe test --config windows "//tests:test-binary-simple"
-      /c/bazel/bazel.exe test --config windows "//tests:test-binary-custom-main"
-      /c/bazel/bazel.exe test --config windows "//tests/binary-custom-main/..."
-      /c/bazel/bazel.exe test --config windows "//tests/binary-exe-path/..."
-      /c/bazel/bazel.exe test --config windows "//tests/binary-with-data/..."
-      /c/bazel/bazel.exe test --config windows "//tests/binary-with-lib/..."
-      /c/bazel/bazel.exe test --config windows "//tests/binary-with-main/..."
-      /c/bazel/bazel.exe test --config windows "//tests/binary-simple/..."
-      /c/bazel/bazel.exe test --config windows "//tests/binary-with-compiler-flags/..."
-      /c/bazel/bazel.exe test --config windows "//tests/binary-with-import/..."
-      /c/bazel/bazel.exe test --config windows "//tests/binary-with-link-flags/..."
-      /c/bazel/bazel.exe test --config windows "//tests/cpp_macro_conflict/..."
-      /c/bazel/bazel.exe test --config windows "//tests/extra-source-files/..."
-      /c/bazel/bazel.exe test --config windows "//tests/java_classpath/..."
-      /c/bazel/bazel.exe test --config windows "//tests/generated-modules/..."
-      /c/bazel/bazel.exe test --config windows "//tests/haskell_test/..."
-      /c/bazel/bazel.exe test --config windows "//tests/hs-boot/..."
-      /c/bazel/bazel.exe test --config windows "//tests/indirect-link/..."
-      /c/bazel/bazel.exe test --config windows "//tests/library-deps/..."
-      /c/bazel/bazel.exe test --config windows "//tests/library-exports/..."
-      /c/bazel/bazel.exe test --config windows "//tests/library-linkstatic-flag/..."
-      /c/bazel/bazel.exe test --config windows "//tests/lhs/..."
-      /c/bazel/bazel.exe test --config windows "//tests/package-id-clash-binary/..."
-      /c/bazel/bazel.exe test --config windows "//tests/package-name/..."
-      /c/bazel/bazel.exe test --config windows "//tests/textual-hdrs/..."
-      /c/bazel/bazel.exe test --config windows "//tests/two-libs/..."
-      /c/bazel/bazel.exe test --config windows "//tests/encoding/..."
-      /c/bazel/bazel.exe test --config windows "//tests/c-compiles/..."
-      /c/bazel/bazel.exe test --config windows "//tests/stack-snapshot-deps/..."
+      /c/bazel/bazel.exe test "//tests:test-binary-simple"
+      /c/bazel/bazel.exe test "//tests:test-binary-custom-main"
+      /c/bazel/bazel.exe test "//tests/binary-custom-main/..."
+      /c/bazel/bazel.exe test "//tests/binary-exe-path/..."
+      /c/bazel/bazel.exe test "//tests/binary-with-data/..."
+      /c/bazel/bazel.exe test "//tests/binary-with-lib/..."
+      /c/bazel/bazel.exe test "//tests/binary-with-main/..."
+      /c/bazel/bazel.exe test "//tests/binary-simple/..."
+      /c/bazel/bazel.exe test "//tests/binary-with-compiler-flags/..."
+      /c/bazel/bazel.exe test "//tests/binary-with-import/..."
+      /c/bazel/bazel.exe test "//tests/binary-with-link-flags/..."
+      /c/bazel/bazel.exe test "//tests/cpp_macro_conflict/..."
+      /c/bazel/bazel.exe test "//tests/extra-source-files/..."
+      /c/bazel/bazel.exe test "//tests/java_classpath/..."
+      /c/bazel/bazel.exe test "//tests/generated-modules/..."
+      /c/bazel/bazel.exe test "//tests/haskell_test/..."
+      /c/bazel/bazel.exe test "//tests/hs-boot/..."
+      /c/bazel/bazel.exe test "//tests/indirect-link/..."
+      /c/bazel/bazel.exe test "//tests/library-deps/..."
+      /c/bazel/bazel.exe test "//tests/library-exports/..."
+      /c/bazel/bazel.exe test "//tests/library-linkstatic-flag/..."
+      /c/bazel/bazel.exe test "//tests/lhs/..."
+      /c/bazel/bazel.exe test "//tests/package-id-clash-binary/..."
+      /c/bazel/bazel.exe test "//tests/package-name/..."
+      /c/bazel/bazel.exe test "//tests/textual-hdrs/..."
+      /c/bazel/bazel.exe test "//tests/two-libs/..."
+      /c/bazel/bazel.exe test "//tests/encoding/..."
+      /c/bazel/bazel.exe test "//tests/c-compiles/..."
+      /c/bazel/bazel.exe test "//tests/stack-snapshot-deps/..."
 
     displayName: 'Run Bazel'

--- a/haskell/ghc.BUILD.tpl
+++ b/haskell/ghc.BUILD.tpl
@@ -1,4 +1,9 @@
 load(
+    "@rules_cc//cc:defs.bzl",
+    "cc_toolchain",
+    "cc_toolchain_suite",
+)
+load(
     "@rules_haskell//haskell:cc_toolchain_config.bzl",
     "cc_toolchain_config",
 )

--- a/tests/RunTests.hs
+++ b/tests/RunTests.hs
@@ -90,11 +90,7 @@ main = hspec $ do
 -- | Returns a bazel command line suitable for CI
 -- This should be called with the action as first item of the list. e.g 'bazel ["build", "//..."]'.
 bazel :: [String] -> Process.CreateProcess
--- Note: --config=ci is intercalated between the action and the list of
--- arguments. It should appear after the action, but before any @--@
--- following argument.
-bazel (command:args) = Process.proc "bazel" (command:"--config=ci":args)
-bazel [] = Process.proc "bazel" []
+bazel args = Process.proc "bazel" args
 
 -- | Runs a bazel query and return the list of matching targets
 bazelQuery :: String -> SpecM a [String]


### PR DESCRIPTION
`rules_haskell` requires different build configuration depending on the platform (Linux, MacOS, Windows) and the way of fetching the GHC distribution (`nixpkgs`, `bindist`). This PR makes sure that all this configuration is defined in `.bazelrc` and is easily accessible for developers through a top-level configuration, e.g. `--config linux-nixpkgs`. This avoids configuration issues as described in https://github.com/tweag/rules_haskell/issues/1173#issuecomment-606723360.

Additionally, CI is configured by writing the required `--config` flags to `.bazelrc.local` instead of passing them on the command-line on each `bazel` invocation. This makes sure that the same configuration is used even if Bazel is called indirectly through a script. This is useful for tools like `ghcide` and `hie-bios`, see https://github.com/tweag/rules_haskell/pull/1262.