### PR TITLE
haskell_cabal_binary allow target name and executable to differ

### DIFF
--- a/haskell/cabal.bzl
+++ b/haskell/cabal.bzl
@@ -551,6 +551,7 @@ def _haskell_cabal_binary_impl(ctx):
     )
     posix = ctx.toolchains["@rules_sh//sh/posix:toolchain_type"]
 
+    exe_name = ctx.attr.exe_name if ctx.attr.exe_name else hs.label.name
     user_compile_flags = _expand_make_variables("compiler_flags", ctx, ctx.attr.compiler_flags)
     cabal = _find_cabal(hs, ctx.files.srcs)
     setup = _find_setup(hs, cabal, ctx.files.srcs)
@@ -560,7 +561,7 @@ def _haskell_cabal_binary_impl(ctx):
     )
     binary = hs.actions.declare_file(
         "_install/bin/{name}{ext}".format(
-            name = hs.label.name,
+            name = exe_name,
             ext = ".exe" if hs.toolchain.is_windows else "",
         ),
         sibling = cabal,
@@ -577,7 +578,7 @@ def _haskell_cabal_binary_impl(ctx):
         dep_info,
         cc_info,
         direct_cc_info,
-        component = "exe:{}".format(hs.label.name),
+        component = "exe:{}".format(exe_name),
         package_id = hs.label.name,
         tool_inputs = tool_inputs,
         tool_input_manifests = tool_input_manifests,
@@ -636,6 +637,9 @@ haskell_cabal_binary = rule(
     _haskell_cabal_binary_impl,
     executable = True,
     attrs = {
+        "exe_name": attr.string(
+            doc = "Cabal executable component name. Defaults to name attribute.",
+        ),
         "srcs": attr.label_list(allow_files = True),
         "deps": attr.label_list(
             aspects = [haskell_cc_libraries_aspect],

--- a/haskell/cabal.bzl
+++ b/haskell/cabal.bzl
@@ -638,7 +638,7 @@ haskell_cabal_binary = rule(
     executable = True,
     attrs = {
         "exe_name": attr.string(
-            doc = "Cabal executable component name. Defaults to name attribute.",
+            doc = "Cabal executable component name. Defaults to the value of the name attribute.",
         ),
         "srcs": attr.label_list(allow_files = True),
         "deps": attr.label_list(

--- a/tests/haskell_cabal_package/BUILD.bazel
+++ b/tests/haskell_cabal_package/BUILD.bazel
@@ -18,8 +18,9 @@ haskell_cabal_library(
 )
 
 haskell_cabal_binary(
-    name = "haskell_cabal_package",
+    name = "exe",
     srcs = glob(["**"]),
+    exe_name = "haskell_cabal_package",
     deps = [
         ":base",
         ":lib",


### PR DESCRIPTION
Adds an optional attribute `exe_name` to `haskell_cabal_binary`. If set then the component `exe:<exe_name>` will be built, instead of the default `exe:<name>`. This is similar to the `package_name` attribute for `haskell_cabal_library`.

Converts `tests/haskell_cabal_package` into a test-case for this feature, `tests/haskell_cabal_binary` serves as a test-case that doesn't use `exe_name`.

The motivation for this is to lay the ground to enable `stack_snapshot` to build executable components as well as library components. E.g. in a case like `ghcide` where the target name `ghcide` is already taken by the library component, the executable component cannot be called `ghcide` as well.