### PR TITLE
stack_snapshot build executable components

### DIFF
--- a/.ghcide
+++ b/.ghcide
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 build_ghcide() {
-  bazel build @ghcide//:ghcide \
+  bazel build @ghcide-exe//ghcide \
     --experimental_show_artifacts \
     2>&1 \
     | awk '

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -46,30 +46,6 @@ haskell_cabal_binary(name = "happy", srcs = glob(["**"]), visibility = ["//visib
     urls = ["http://hackage.haskell.org/package/happy-1.19.12/happy-1.19.12.tar.gz"],
 )
 
-http_archive(
-    name = "proto-lens-protoc",
-    build_file_content = """
-load("@rules_haskell//haskell:cabal.bzl", "haskell_cabal_binary")
-haskell_cabal_binary(
-    name = "proto-lens-protoc",
-    srcs = glob(["**"]),
-    deps = [
-      "@stackage//:base",
-      "@stackage//:bytestring",
-      "@stackage//:containers",
-      "@stackage//:lens-family",
-      "@stackage//:proto-lens",
-      "@stackage//:proto-lens-protoc",
-      "@stackage//:text",
-    ],
-    visibility = ["//visibility:public"],
-)
-    """,
-    sha256 = "b946740b94c8d300cd8e278ded9045905ef1985824cef6b81af0d79b119927be",
-    strip_prefix = "proto-lens-protoc-0.6.0.0",
-    urls = ["http://hackage.haskell.org/package/proto-lens-protoc-0.6.0.0/proto-lens-protoc-0.6.0.0.tar.gz"],
-)
-
 load(
     "@rules_haskell//:constants.bzl",
     "test_ghc_version",
@@ -79,6 +55,12 @@ load("@rules_haskell//haskell:cabal.bzl", "stack_snapshot")
 
 stack_snapshot(
     name = "stackage",
+    components = {
+        "proto-lens-protoc": [
+            "lib",
+            "exe",
+        ],
+    },
     packages = [
         # Core libraries
         "array",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -108,81 +108,15 @@ stack_snapshot(
 )
 
 stack_snapshot(
-    name = "stackage_ghcide",
+    name = "ghcide",
+    components = {"ghcide": [
+        "lib",
+        "exe",
+    ]},
     extra_deps = {"zlib": ["@zlib.dev//:zlib" if is_nix_shell else "@zlib.hs//:zlib"]},
     haddock = False,
     local_snapshot = "//:ghcide-stack-snapshot.yaml",
-    packages = [
-        "aeson",
-        "base",
-        "base16-bytestring",
-        "binary",
-        "bytestring",
-        "containers",
-        "cryptohash-sha1",
-        "data-default",
-        "deepseq",
-        "directory",
-        "extra",
-        "filepath",
-        "ghc",
-        "ghc-check",
-        "ghc-paths",
-        "ghcide",
-        "gitrev",
-        "hashable",
-        "haskell-lsp",
-        "haskell-lsp-types",
-        "hie-bios",
-        "hslogger",
-        "optparse-applicative",
-        "shake",
-        "text",
-        "unordered-containers",
-    ],
-)
-
-http_archive(
-    name = "ghcide",
-    build_file_content = """
-load("@rules_haskell//haskell:cabal.bzl", "haskell_cabal_binary")
-haskell_cabal_binary(
-    name = "ghcide",
-    srcs = glob(["**"]),
-    deps = [
-        "@stackage_ghcide//:hslogger",
-        "@stackage_ghcide//:aeson",
-        "@stackage_ghcide//:base",
-        "@stackage_ghcide//:binary",
-        "@stackage_ghcide//:base16-bytestring",
-        "@stackage_ghcide//:bytestring",
-        "@stackage_ghcide//:containers",
-        "@stackage_ghcide//:cryptohash-sha1",
-        "@stackage_ghcide//:data-default",
-        "@stackage_ghcide//:deepseq",
-        "@stackage_ghcide//:directory",
-        "@stackage_ghcide//:extra",
-        "@stackage_ghcide//:filepath",
-        "@stackage_ghcide//:ghc-check",
-        "@stackage_ghcide//:ghc-paths",
-        "@stackage_ghcide//:ghc",
-        "@stackage_ghcide//:gitrev",
-        "@stackage_ghcide//:hashable",
-        "@stackage_ghcide//:haskell-lsp",
-        "@stackage_ghcide//:haskell-lsp-types",
-        "@stackage_ghcide//:hie-bios",
-        "@stackage_ghcide//:ghcide",
-        "@stackage_ghcide//:optparse-applicative",
-        "@stackage_ghcide//:shake",
-        "@stackage_ghcide//:text",
-        "@stackage_ghcide//:unordered-containers",
-    ],
-    visibility = ["//visibility:public"],
-)
-    """,
-    sha256 = "fa1f0cfb0357e7bfa6c86076493f038e0ea5fcd75c470473f2ede7e32566cd9a",
-    strip_prefix = "ghcide-0c9a0961abbeef851b4117e6408f15a6d46eb1f1",
-    urls = ["https://github.com/digital-asset/ghcide/archive/0c9a0961abbeef851b4117e6408f15a6d46eb1f1.tar.gz"],
+    packages = ["ghcide"],
 )
 
 load(

--- a/haskell/protobuf.bzl
+++ b/haskell/protobuf.bzl
@@ -399,7 +399,7 @@ def haskell_proto_toolchain(
       haskell_proto_toolchain(
         name = "protobuf-toolchain",
         protoc = "@com_google_protobuf//:protoc",
-        plugin = "@hackage-proto-lens-protoc//:bin/proto-lens-protoc",
+        plugin = "@stackage//proto-lens-protoc_exe_proto-lens-protoc",
         deps = [
           "base",
           "bytestring",

--- a/haskell/protobuf.bzl
+++ b/haskell/protobuf.bzl
@@ -399,7 +399,7 @@ def haskell_proto_toolchain(
       haskell_proto_toolchain(
         name = "protobuf-toolchain",
         protoc = "@com_google_protobuf//:protoc",
-        plugin = "@stackage//proto-lens-protoc_exe_proto-lens-protoc",
+        plugin = "@stackage-exe//proto-lens-protoc",
         deps = [
           "base",
           "bytestring",

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -49,7 +49,7 @@ haskell_doctest_toolchain(
 haskell_proto_toolchain(
     name = "protobuf-toolchain",
     testonly = 0,
-    plugin = "@stackage//:proto-lens-protoc_exe_proto-lens-protoc",
+    plugin = "@stackage-exe//proto-lens-protoc",
     protoc = "@com_google_protobuf//:protoc",
     tags = [
         "requires_proto",

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -398,7 +398,7 @@ haskell_repl(
 
 sh_test(
     name = "ghcide-smoke-test",
-    srcs = ["@ghcide"],
+    srcs = ["@ghcide-exe//ghcide"],
     args = ["--version"],
     tags = [
         # Building ghcide fails in profiling mode with:

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -49,7 +49,7 @@ haskell_doctest_toolchain(
 haskell_proto_toolchain(
     name = "protobuf-toolchain",
     testonly = 0,
-    plugin = "@proto-lens-protoc",
+    plugin = "@stackage//:proto-lens-protoc_exe_proto-lens-protoc",
     protoc = "@com_google_protobuf//:protoc",
     tags = [
         "requires_proto",


### PR DESCRIPTION
Depends on #1303.

Adds a new attribute `components` to `stack_snapshot` which allows users to specify which Cabal components to build for a given package in the snapshot (defaults to building the library component). E.g. for the `proto-lens-protoc` package a user could specify the following to build both the library and executable components.
```
    components = {
        "proto-lens-protoc": [
            "lib",
            "exe",
        ],
    },
```
This reduces the need for dedicated `http_archive` definitions for executable components of Cabal packages.

The executable targets are available under labels of the form `@<snapshot>-exe//<package_name>:<exe_name>`, as discussed in https://github.com/tweag/rules_haskell/issues/1306. For executable components that share the package's name the short form `@<snapshot>-exe//<package>` applies. For technical reasons (described in #1306) these executable targets are `alias`es pointing to `haskell_cabal_binary` targets of the form `@<snapshot>//:_<package>_exe_<exe_name>`. These labels are considered an implementation detail and not publicly visible.

The dependency graph generated by `stack` captures the library and executable dependencies of a package. When generating `haskell_cabal_binary` targets based on declared `exe` components, we pass in all package dependencies as well as the library component (if present).

The dependency graph generated by `stack` does not provide information on which components a package includes. Therefore, there is no easy way to automatically determine the set of components. However, only few packages define executable components, so it is feasible for users to manually define them as needed.

A set of known executable components is included in `rules_haskell` for common packages such as `alex` or `happy`.

`proto-lens-protoc` is converted from a dedicated `http_archive` to use the `components` attribute instead. This functions as a test-case for this feature.

`ghcide` is also converted from a dedicated `http_archive` to use the `components` attribute. The `ghcide` use-case documentation is updated accordingly.

Note, this PR does not yet inject executable components into the `tools` attribute of generated Cabal targets. E.g. `alex` and `happy` still have to be passed into `stack_snapshot` using the `tools` attribute. This will be addressed in a follow-up PR.