### PR TITLE
stack_snapshot use executable components in tools attribute

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -20,6 +20,22 @@ bazel_skylib_workspace()
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
+http_archive(
+    name = "alex",
+    build_file_content = """
+load("@rules_haskell//haskell:cabal.bzl", "haskell_cabal_binary")
+haskell_cabal_binary(
+    name = "alex",
+    srcs = glob(["**"]),
+    verbose = False,
+    visibility = ["//visibility:public"],
+)
+    """,
+    sha256 = "d58e4d708b14ff332a8a8edad4fa8989cb6a9f518a7c6834e96281ac5f8ff232",
+    strip_prefix = "alex-3.2.4",
+    urls = ["http://hackage.haskell.org/package/alex-3.2.4/alex-3.2.4.tar.gz"],
+)
+
 load(
     "@rules_haskell//:constants.bzl",
     "test_ghc_version",
@@ -30,6 +46,7 @@ load("@rules_haskell//haskell:cabal.bzl", "stack_snapshot")
 stack_snapshot(
     name = "stackage",
     components = {
+        "alex": [],
         "proto-lens-protoc": [
             "lib",
             "exe",
@@ -67,6 +84,13 @@ stack_snapshot(
     ],
     setup_deps = {"polysemy": ["cabal-doctest"]},
     snapshot = test_stack_snapshot,
+    tools = [
+        # This is not required, as `stack_snapshot` would build alex
+        # automatically, however it is used as a test for user provided
+        # `tools`. We also override alex's components to avoid building it
+        # twice.
+        "@alex",
+    ],
 )
 
 # In a separate repo because not all platforms support zlib.

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -20,32 +20,6 @@ bazel_skylib_workspace()
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-http_archive(
-    name = "alex",
-    build_file_content = """
-load("@rules_haskell//haskell:cabal.bzl", "haskell_cabal_binary")
-haskell_cabal_binary(
-    name = "alex",
-    srcs = glob(["**"]),
-    visibility = ["//visibility:public"],
-)
-    """,
-    sha256 = "d58e4d708b14ff332a8a8edad4fa8989cb6a9f518a7c6834e96281ac5f8ff232",
-    strip_prefix = "alex-3.2.4",
-    urls = ["http://hackage.haskell.org/package/alex-3.2.4/alex-3.2.4.tar.gz"],
-)
-
-http_archive(
-    name = "happy",
-    build_file_content = """
-load("@rules_haskell//haskell:cabal.bzl", "haskell_cabal_binary")
-haskell_cabal_binary(name = "happy", srcs = glob(["**"]), visibility = ["//visibility:public"])
-    """,
-    sha256 = "fb9a23e41401711a3b288f93cf0a66db9f97da1ce32ec4fffea4b78a0daeb40f",
-    strip_prefix = "happy-1.19.12",
-    urls = ["http://hackage.haskell.org/package/happy-1.19.12/happy-1.19.12.tar.gz"],
-)
-
 load(
     "@rules_haskell//:constants.bzl",
     "test_ghc_version",
@@ -93,10 +67,6 @@ stack_snapshot(
     ],
     setup_deps = {"polysemy": ["cabal-doctest"]},
     snapshot = test_stack_snapshot,
-    tools = [
-        "@alex",
-        "@happy",
-    ],
 )
 
 # In a separate repo because not all platforms support zlib.

--- a/haskell/cabal.bzl
+++ b/haskell/cabal.bzl
@@ -1450,15 +1450,19 @@ def stack_snapshot(
           name = "stackage",
           packages = ["conduit", "doctest", "lens", "zlib-0.6.2"],
           vendored_packages = {"split": "//split:split"},
-          tools = ["@happy//:happy", "@c2hs//:c2hs"],
-          components = {"doctest": ["lib", "exe"]},
+          tools = ["@happy//:happy"],  # Use externally provided `happy`
+          components = {
+              "doctest": ["lib", "exe"],  # Optional since doctest is known to have an exe component.
+              "happy": [],  # Override happy's default exe component.
+          },
           snapshot = "lts-13.15",
           extra_deps = {"zlib": ["@zlib.dev//:zlib"]},
       )
       ```
       defines `@stackage//:conduit`, `@stackage//:doctest`, `@stackage//:lens`,
       `@stackage//:zlib` library targets and a `@stackage-exe//doctest`
-      executable target.
+      executable target. It also uses an externally provided `happy` rather
+      than the one provided by the snapshot.
 
       Alternatively
 
@@ -1467,8 +1471,11 @@ def stack_snapshot(
           name = "stackage",
           packages = ["conduit", "doctest", "lens", "zlib"],
           flags = {"zlib": ["-non-blocking-ffi"]},
-          tools = ["@happy//:happy", "@c2hs//:c2hs"],
-          components = {"doctest": ["lib", "exe"]},
+          tools = ["@happy//:happy"],  # Use externally provided `happy`
+          components = {
+              "doctest": ["lib", "exe"],  # Optional since doctest is known to have an exe component.
+              "happy": [],  # Override happy's default exe component.
+          },
           local_snapshot = "//:snapshot.yaml",
           extra_deps = {"zlib": ["@zlib.dev//:zlib"]},
       ```

--- a/start
+++ b/start
@@ -143,7 +143,6 @@ haskell_register_ghc_nixpkgs(
 EOF
 )
 
-declare -r ALEX_BUILD_FILE="alex.BUILD.bazel"
 declare -r ZLIB_BUILD_FILE="zlib.BUILD.bazel"
 
 echo "Creating $ZLIB_BUILD_FILE" >&2
@@ -263,17 +262,6 @@ load(
     "rules_haskell_toolchains",
 )
 
-# Download alex and make it accessible as @alex.
-# Delete this block, alex.BUILD.bazel, and the reference in
-# stack_snapshot's tools if you don't use alex.
-http_archive(
-    name = "alex",
-    build_file = "//:$ALEX_BUILD_FILE",
-    sha256 = "d58e4d708b14ff332a8a8edad4fa8989cb6a9f518a7c6834e96281ac5f8ff232",
-    strip_prefix = "alex-3.2.4",
-    urls = ["http://hackage.haskell.org/package/alex-3.2.4/alex-3.2.4.tar.gz"],
-)
-
 load(
     "@rules_haskell//haskell:cabal.bzl",
     "stack_snapshot"
@@ -283,7 +271,6 @@ stack_snapshot(
     name = "stackage",
     extra_deps = {"zlib": ["@zlib.dev//:zlib"]},
     packages = ["zlib"],
-    tools = [ "@alex" ],
     snapshot = "lts-14.27", # Last snapshot published for ghc-8.6.5
     # the default version picked up by rules_haskell
 )
@@ -291,18 +278,6 @@ stack_snapshot(
 $(get_toolchain)
 
 $(get_zlib)
-EOF
-
-echo "Creating $ALEX_BUILD_FILE" >&2
-cat > "$ALEX_BUILD_FILE" <<EOF
-load("@rules_haskell//haskell:cabal.bzl", "haskell_cabal_binary")
-
-haskell_cabal_binary(
-    name = "alex",
-    srcs = glob(["**"]),
-    verbose = False,
-    visibility = ["//visibility:public"],
-)
 EOF
 
 echo "Creating .bazelrc" >&2


### PR DESCRIPTION
Closes #1306 

Uses executable components of package dependencies in the `tools` attribute in Cabal targets generated by `stack_snapshot`. E.g. we no longer need to build `alex` and `happy` outside of `stack_snapshot` to then pass them in via `stack_snapshot`'s `tools` attribute. Instead, `stack_snapshot` will generate targets `@stackage-exe//alex` and `@stackage-exe//happy` and pass them into the `tools` attribute of any generated `haskell_cabal_*` target that depends on `alex` or `happy` respectively.

A use-case where this becomes very useful is the tool `c2hs`. Contrary to `alex` or `happy` it does itself depend on Hackage packages, e.g. `language-c`. Meaning, if someone wants to include a package that depends on `c2hs` in a `stack_snapshot` call, say [`grpc-haskell-core`](http://hackage.haskell.org/package/grpc-haskell-core), then one has to first build `c2hs` separately. To achieve that one has to define a separate `stack_snapshot` for the dependencies of `c2hs`. This approach does not scale very well. With this PR the issue is avoided, as `stack_snapshot` will generate `@stackage-exe//c2hs` itself and pass it to `grpc-haskell-core` automatically.

The `tools` attribute to `stack_snapshot` is still available in case users do wish to provide external tools, e.g. a Nix provided `alex` binary. We keep an externally provided `alex` in `rules_haskell`'s `stack_snapshot` as a test-case for this.

This also simplifies the `start` script, as it is no longer a common use-case to have to provide an externally built tool.