### PR TITLE
Shorter dynamic library symlinks underneath _solib_<cpu>

### DIFF
--- a/haskell/private/haskell_impl.bzl
+++ b/haskell/private/haskell_impl.bzl
@@ -553,6 +553,7 @@ def haskell_library_impl(ctx):
                 actions = ctx.actions,
                 feature_configuration = feature_configuration,
                 dynamic_library = dynamic_library,
+                dynamic_library_symlink_path = dynamic_library.basename if dynamic_library else "",
                 static_library = static_library,
                 cc_toolchain = cc_toolchain,
             ),
@@ -730,6 +731,7 @@ def haskell_toolchain_libraries_impl(ctx):
                 actions = ctx.actions,
                 feature_configuration = feature_configuration,
                 dynamic_library = lib.get("dynamic", None),
+                dynamic_library_symlink_path = lib["dynamic"].basename if lib.get("dynamic") else "",
                 static_library = lib.get("static", None),
                 cc_toolchain = cc_toolchain,
             )

--- a/haskell/private/haskell_impl.bzl
+++ b/haskell/private/haskell_impl.bzl
@@ -644,6 +644,11 @@ The following toolchain libraries are available:
         )),
     ]
 
+def _toolchain_library_symlink(dynamic_library):
+    prefix = dynamic_library.owner.workspace_root.replace("_", "_U").replace("/", "_S")
+    basename = dynamic_library.basename
+    return paths.join(prefix, basename)
+
 def haskell_toolchain_libraries_impl(ctx):
     hs = haskell_context(ctx)
     with_profiling = is_profiling_enabled(hs)
@@ -731,7 +736,8 @@ def haskell_toolchain_libraries_impl(ctx):
                 actions = ctx.actions,
                 feature_configuration = feature_configuration,
                 dynamic_library = lib.get("dynamic", None),
-                dynamic_library_symlink_path = lib["dynamic"].basename if lib.get("dynamic") else "",
+                dynamic_library_symlink_path =
+                    _toolchain_library_symlink(lib["dynamic"]) if lib.get("dynamic") else "",
                 static_library = lib.get("static", None),
                 cc_toolchain = cc_toolchain,
             )

--- a/haskell/private/versions.bzl
+++ b/haskell/private/versions.bzl
@@ -44,7 +44,7 @@ def check_version(actual_version):
 
     # Please use length 3 tuples, because bazel versions has 3 members;
     # to avoid surprising behaviors (for example (2,0) >/= (2, 0, 0))
-    min_bazel = (0, 29, 0)  # Change THIS LINE when changing bazel min version
+    min_bazel = (2, 1, 0)  # Change THIS LINE when changing bazel min version
     max_bazel = (2, 1, 0)  # Change THIS LINE when changing bazel max version
 
     actual = tuple(_parse_bazel_version(actual_version))

--- a/start
+++ b/start
@@ -3,11 +3,11 @@
 # Checks the version of Bazel found in the PATH, and then initializes
 # a new Bazel workspace with dummy Haskell build targets.
 
-MIN_BAZEL_MAJOR=0
-MIN_BAZEL_MINOR=29
+MIN_BAZEL_MAJOR=2
+MIN_BAZEL_MINOR=1
 
 MAX_BAZEL_MAJOR=2
-MAX_BAZEL_MINOR=0
+MAX_BAZEL_MINOR=1
 
 set -e
 


### PR DESCRIPTION
https://github.com/bazelbuild/bazel/pull/8888 introduced the `dynamic_library_symlink_path` attribute to [`create_library_to_link`](https://docs.bazel.build/versions/2.1.0/skylark/lib/cc_common.html#create_library_to_link) and is available starting from Bazel version 2.1.0. This allows to control the paths of symbolic links created by Bazel underneath `_solib_<cpu>`.

By default Bazel will introduce a long directory name that contains the workspace and package name to avoid collisions between mutliple libraries with the same name. However, in the case of `haskell_library` this is redundant and causes long `RUNPATH` entries which can cause issues with MacOS MACH-O header size restrictions. See https://github.com/tweag/rules_haskell/issues/958.

* Haskell libraries carry a prefix `libHS` that avoids collisions with non-Haskell libraries.
*  `haskell_library` generates library names that include the full package path and the GHC version in the library name.
* `haskell_toolchain_library` libraries contain the library version and GHC version in their library name. Collisions between multiple GHC toolchains or toolchain libraries and user defined libraries are very unlikely in practice. However, to be safe, this introduces a shared prefix for a given GHC toolchain. This is still much better than the previous situation, because it re-uses the same prefix for all libraries within a given toolchain. I.e. instead of introducing an additional `RUNPATH` entry per toolchain library it only introduces one for the whole toolchain.

E.g. instead of generated symlinks of the form
```
bazel-bin/_solib_k8/_U_S_Shaskell_Ctoolchain-libraries___Uexternal_Srules_Uhaskell_Ughc_Unixpkgs_Uhaskell_Utoolchain_Slib_Sghc-8.6.5_Sbase-4.12.0.0/libHSbase-4.12.0.0-ghc8.6.5.so
bazel-bin/_solib_k8/_U_S_Shaskell_Ctoolchain-libraries___Uexternal_Srules_Uhaskell_Ughc_Unixpkgs_Uhaskell_Utoolchain_Slib_Sghc-8.6.5_Sghc-prim-0.5.3/libHSghc-prim-0.5.3-ghc8.6.5.so
bazel-bin/_solib_k8/_U_S_Shaskell_Ctoolchain-libraries___Uexternal_Srules_Uhaskell_Ughc_Unixpkgs_Uhaskell_Utoolchain_Slib_Sghc-8.6.5_Sinteger-gmp-1.0.2.0/libHSinteger-gmp-1.0.2.0-ghc8.6.5.so
bazel-bin/_solib_k8/_U_S_Shaskell_Ctoolchain-libraries___Uexternal_Srules_Uhaskell_Ughc_Unixpkgs_Uhaskell_Utoolchain_Slib_Sghc-8.6.5_Srts/libHSrts_thr-ghc8.6.5.so
bazel-bin/_solib_k8/_U_S_Stests_Sbinary-with-lib-dynamic_Clib___Utests_Sbinary-with-lib-dynamic/libHStestsZSbinary-with-lib-dynamicZSlib-ghc8.6.5.so
```

We generate the much shorter

```
bazel-bin/_solib_k8/external_Srules_Uhaskell_Ughc_Unixpkgs_Uhaskell_Utoolchain/libHSbase-4.12.0.0-ghc8.6.5.so
bazel-bin/_solib_k8/external_Srules_Uhaskell_Ughc_Unixpkgs_Uhaskell_Utoolchain/libHSghc-prim-0.5.3-ghc8.6.5.so
bazel-bin/_solib_k8/external_Srules_Uhaskell_Ughc_Unixpkgs_Uhaskell_Utoolchain/libHSinteger-gmp-1.0.2.0-ghc8.6.5.so
bazel-bin/_solib_k8/external_Srules_Uhaskell_Ughc_Unixpkgs_Uhaskell_Utoolchain/libHSrts_thr-ghc8.6.5.so
bazel-bin/_solib_k8/libHStestsZSbinary-with-lib-dynamicZSlib-ghc8.6.5.so
```

**NOTE** This raises the minimum supported Bazel version to 2.1.0. 