### PR TITLE
Migrate to rules_nixpkgs v0.7.0

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -10,8 +10,8 @@ test --test_env=LANG=C.UTF-8 --test_env=LOCALE_ARCHIVE
 
 # Platform / Toolchain Selection
 # ------------------------------
-build:linux-nixpkgs --host_platform=@rules_haskell//haskell/platforms:linux_x86_64_nixpkgs
-build:macos-nixpkgs --host_platform=@rules_haskell//haskell/platforms:darwin_x86_64_nixpkgs
+build:linux-nixpkgs --host_platform=@io_tweag_rules_nixpkgs//nixpkgs/platforms:host
+build:macos-nixpkgs --host_platform=@io_tweag_rules_nixpkgs//nixpkgs/platforms:host
 # Use this configuration when targeting Windows. Eventually this will
 # no longer be required:
 # https://bazel.build/roadmaps/platforms.html#replace---cpu-and---host_cpu-flags.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## Upcoming release
 
-nothing yet
+### Changed
+
+* The platform name for Nix users has changed. The platforms in
+  `@//haskell/platforms/...` are still supported, but are deprecated.
+  Use `@io_tweag_rules_nixpkgs//nixpkgs/platforms:host` instead.
 
 ### [0.12.0] - 2020-03-16
 

--- a/docs/haskell-use-cases.rst
+++ b/docs/haskell-use-cases.rst
@@ -93,11 +93,10 @@ usable by Bazel's Haskell rules.
 You can register as many toolchains as you like. Nixpkgs toolchains do
 not conflict with binary distributions. For Bazel to select the
 Nixpkgs toolchain during `toolchain resolution`_, set the platform
-appropriately: ``linux_x86_64_nixpkgs``, ``darwin_x86_64_nixpkgs``
-etc. For example, you can have the following in your ``.bazelrc``
-file at the root of your project::
+accordingly. For example, you can have the following in your
+``.bazelrc`` file at the root of your project::
 
-  build --host_platform=@rules_haskell//haskell/platforms:linux_x86_64_nixpkgs
+  build --host_platform=@io_tweag_rules_nixpkgs//nixpkgs/platforms:host
 
 .. _Bazel+Nix blog post: https://www.tweag.io/posts/2018-03-15-bazel-nix.html
 .. _Nix package manager: https://nixos.org/nix

--- a/docs/haskell.rst
+++ b/docs/haskell.rst
@@ -67,7 +67,7 @@ The first thing to do is to::
 
 If you use the ``NixOS`` distribution, also run the following command::
 
-  $ echo 'test --host_platform=@rules_haskell//haskell/platforms:linux_x86_64_nixpkgs' >> .bazelrc.local
+  $ echo 'test --host_platform=@io_tweag_rules_nixpkgs//nixpkgs/platforms:host' >> .bazelrc.local
 
 Build with Bazel
 ----------------

--- a/docs/pandoc/BUILD.bazel
+++ b/docs/pandoc/BUILD.bazel
@@ -15,7 +15,7 @@ toolchain(
     name = "nixpkgs",
     exec_compatible_with = [
         "@platforms//cpu:x86_64",
-        "@rules_haskell//haskell/platforms:nixpkgs",
+        "@io_tweag_rules_nixpkgs//nixpkgs/constraints:support_nix",
     ] + (["@platforms//os:linux"] if is_linux else ["@platforms//os:macos"]),
     toolchain = "@nixpkgs_pandoc//:pandoc_toolchain",
     toolchain_type = ":toolchain_type",

--- a/haskell/nixpkgs.bzl
+++ b/haskell/nixpkgs.bzl
@@ -136,7 +136,7 @@ def _ghc_nixpkgs_toolchain_impl(repository_ctx):
     elif repository_ctx.os.name == "mac os x":
         target_constraints.append("@platforms//os:osx")
     exec_constraints = list(target_constraints)
-    exec_constraints.append("@rules_haskell//haskell/platforms:nixpkgs")
+    exec_constraints.append("@io_tweag_rules_nixpkgs//nixpkgs/constraints:support_nix")
 
     repository_ctx.file(
         "BUILD",
@@ -181,7 +181,8 @@ def haskell_register_ghc_nixpkgs(
     Toolchains can be used to compile Haskell code. To have this
     toolchain selected during [toolchain
     resolution][toolchain-resolution], set a host platform that
-    includes the `@rules_haskell//haskell/platforms:nixpkgs`
+    includes the
+    `@io_tweag_rules_nixpkgs//nixpkgs/constraints:support_nix`
     constraint value.
 
     [toolchain-resolution]: https://docs.bazel.build/versions/master/toolchains.html#toolchain-resolution
@@ -200,7 +201,7 @@ def haskell_register_ghc_nixpkgs(
       in the following:
 
       ```
-      --host_platform=@rules_haskell//haskell/platforms:linux_x86_64_nixpkgs
+      --host_platform=@io_tweag_rules_nixpkgs//nixpkgs/platforms:host
       ```
 
     Args:

--- a/haskell/platforms/BUILD.bazel
+++ b/haskell/platforms/BUILD.bazel
@@ -16,26 +16,16 @@ alias(
     visibility = ["//visibility:public"],
 )
 
-platform(
+alias(
     name = "linux_x86_64_nixpkgs",
-    constraint_values = [
-        # XXX using the platform names defined here results in a graph
-        # cycle for some reason.
-        "@platforms//cpu:x86_64",
-        "@platforms//os:linux",
-        ":nixpkgs",
-    ],
+    actual = "@io_tweag_rules_nixpkgs//nixpkgs/platforms:host",
     deprecation = "Use @io_tweag_rules_nixpkgs//nixpkgs/platforms:host instead.",
     visibility = ["//visibility:public"],
 )
 
-platform(
+alias(
     name = "darwin_x86_64_nixpkgs",
-    constraint_values = [
-        "@platforms//cpu:x86_64",
-        "@platforms//os:osx",
-        ":nixpkgs",
-    ],
+    actual = "@io_tweag_rules_nixpkgs//nixpkgs/platforms:host",
     deprecation = "Use @io_tweag_rules_nixpkgs//nixpkgs/platforms:host instead.",
     visibility = ["//visibility:public"],
 )

--- a/haskell/platforms/BUILD.bazel
+++ b/haskell/platforms/BUILD.bazel
@@ -12,7 +12,7 @@ declare_config_settings()
 
 alias(
     name = "nixpkgs",
-    actual = "@io_tweag_rules_nixpkgs//nixpkgs/constraints:nixpkgs",
+    actual = "@io_tweag_rules_nixpkgs//nixpkgs/constraints:support_nix",
     visibility = ["//visibility:public"],
 )
 
@@ -25,6 +25,7 @@ platform(
         "@platforms//os:linux",
         ":nixpkgs",
     ],
+    deprecation = "Use @io_tweag_rules_nixpkgs//nixpkgs/platforms:host instead.",
     visibility = ["//visibility:public"],
 )
 
@@ -35,5 +36,6 @@ platform(
         "@platforms//os:osx",
         ":nixpkgs",
     ],
+    deprecation = "Use @io_tweag_rules_nixpkgs//nixpkgs/platforms:host instead.",
     visibility = ["//visibility:public"],
 )

--- a/haskell/repositories.bzl
+++ b/haskell/repositories.bzl
@@ -44,17 +44,17 @@ def rules_haskell_dependencies():
     if "rules_sh" not in excludes:
         http_archive(
             name = "rules_sh",
-            sha256 = "8371b7b7b05ef374719dbedd1fdf2c0225b158d997f6043e55a437e4dfb98a95",
-            strip_prefix = "rules_sh-0c274ad480ed3eade49250abd04ff71655a07820",
-            urls = ["https://github.com/tweag/rules_sh/archive/0c274ad480ed3eade49250abd04ff71655a07820.tar.gz"],
+            sha256 = "83a065ba6469135a35786eb741e17d50f360ca92ab2897857475ab17c0d29931",
+            strip_prefix = "rules_sh-0.2.0",
+            urls = ["https://github.com/tweag/rules_sh/archive/v0.2.0.tar.gz"],
         )
 
     if "io_tweag_rules_nixpkgs" not in excludes:
         http_archive(
             name = "io_tweag_rules_nixpkgs",
-            sha256 = "1bcc4a040b083b6ac436b49a8b4c22885274ee47c6fe8b353846a7f68bad852b",
-            strip_prefix = "rules_nixpkgs-531804b50fc373de73984e697300beaf94e260c7",
-            urls = ["https://github.com/tweag/rules_nixpkgs/archive/531804b50fc373de73984e697300beaf94e260c7.tar.gz"],
+            sha256 = "5c80f5ed7b399a857dd04aa81e66efcb012906b268ce607aaf491d8d71f456c8",
+            strip_prefix = "rules_nixpkgs-0.7.0",
+            urls = ["https://github.com/tweag/rules_nixpkgs/archive/v0.7.0.tar.gz"],
         )
 
     if "com_google_protobuf" not in excludes:

--- a/shell.nix
+++ b/shell.nix
@@ -39,16 +39,12 @@ mkShell {
     BAZELRC_LOCAL=".bazelrc.local"
     if [ ! -e "$BAZELRC_LOCAL" ]
     then
-      ARCH=""
-      if [ "$(uname)" == "Darwin" ]; then
-        ARCH="darwin"
-      elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
-        ARCH="linux"
-      fi
-      echo "[!] It looks like you are using a ''${ARCH} nix-based system. In order to build this project, you need to add the two following host_platform entries to your .bazelrc.local file."
-      echo ""
-      echo "build --host_platform=@rules_haskell//haskell/platforms:''${ARCH}_x86_64_nixpkgs"
-      echo "run --host_platform=@rules_haskell//haskell/platforms:''${ARCH}_x86_64_nixpkgs"
+      echo "[!] It looks like you are using a Nix-based system."
+      echo "In order to build this project, you need to add the two"
+      echo "following host_platform entries to your .bazelrc.local file:"
+      echo
+      echo "build --host_platform=@io_tweag_rules_nixpkgs//nixpkgs/platforms:host"
+      echo "run --host_platform=@io_tweag_rules_nixpkgs//nixpkgs/platforms:host"
     fi
 
     # source bazel bash completion

--- a/start
+++ b/start
@@ -316,8 +316,8 @@ test:ci --test_output=errors
 $(insert_if_equal $mode "nix" '
 # This project uses a GHC provisioned via nix.
 # We need to use the rules_haskell nix toolchain accordingly:
-build --host_platform=@rules_haskell//haskell/platforms:linux_x86_64_nixpkgs
-run --host_platform=@rules_haskell//haskell/platforms:linux_x86_64_nixpkgs'
+build --host_platform=@io_tweag_rules_nixpkgs//nixpkgs/platforms:host
+run --host_platform=@io_tweag_rules_nixpkgs//nixpkgs/platforms:host'
 )
 
 # test environment does not propagate locales by default


### PR DESCRIPTION
rules_nixpkgs now defines its own platform, which users should reuse.
The old ones are still around for now, but deprecated.