### PR TITLE
Properly pass the CC toolchain to cabal

### DIFF
--- a/haskell/cabal_wrapper.bzl
+++ b/haskell/cabal_wrapper.bzl
@@ -1,5 +1,5 @@
 load(":private/context.bzl", "haskell_context", "render_env")
-load(":cc.bzl", "cc_interop_info")
+load(":cc.bzl", "cc_interop_info", "ghc_cc_program_args")
 load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
 load("@rules_python//python:defs.bzl", "py_binary")
 
@@ -19,6 +19,7 @@ def _cabal_wrapper_impl(ctx):
 
     cabal_wrapper_tpl = ctx.file._cabal_wrapper_tpl
     cabal_wrapper = hs.actions.declare_file("cabal_wrapper.py")
+    cc = hs_toolchain.cc_wrapper.executable.path
     hs.actions.expand_template(
         template = cabal_wrapper_tpl,
         output = cabal_wrapper,
@@ -28,10 +29,11 @@ def _cabal_wrapper_impl(ctx):
             "%{ghc_pkg}": hs.tools.ghc_pkg.path,
             "%{runghc}": hs.tools.runghc.path,
             "%{ar}": ar,
-            "%{cc}": hs_toolchain.cc_wrapper.executable.path,
+            "%{cc}": cc,
             "%{strip}": cc_toolchain.strip_executable,
             "%{is_windows}": str(hs.toolchain.is_windows),
             "%{workspace}": ctx.workspace_name,
+            "%{ghc_cc_args}": repr(ghc_cc_program_args("$CC")),
         },
     )
     return [DefaultInfo(

--- a/haskell/private/cabal_wrapper.py.tpl
+++ b/haskell/private/cabal_wrapper.py.tpl
@@ -117,7 +117,13 @@ def tmpdir():
     # Build into a sibling path of the final binary output location.
     # This is to ensure that relative `RUNPATH`s are valid in the intermediate
     # output in the `--builddir` as well as in the final output in `--bindir`.
-    distdir = tempfile.mkdtemp(dir=os.path.dirname(pkgroot))
+    # Executables are placed into `<distdir>/build/<package-name>/<binary>`.
+    # Libraries are placed into `<distdir>/build/<library>`. I.e. there is an
+    # extra subdirectory for libraries.
+    if component.startswith("exe:"):
+        distdir = tempfile.mkdtemp(dir=os.path.dirname(os.path.dirname(pkgroot)))
+    else:
+        distdir = tempfile.mkdtemp(dir=os.path.dirname(pkgroot))
     try:
         yield distdir
     finally:

--- a/haskell/private/cabal_wrapper.py.tpl
+++ b/haskell/private/cabal_wrapper.py.tpl
@@ -114,7 +114,10 @@ def tmpdir():
     """This is a reimplementation of `tempfile.TemporaryDirectory` because
     the latter isn't available in python2
     """
-    distdir = tempfile.mkdtemp()
+    # Build into a sibling path of the final binary output location.
+    # This is to ensure that relative `RUNPATH`s are valid in the intermediate
+    # output in the `--builddir` as well as in the final output in `--bindir`.
+    distdir = tempfile.mkdtemp(dir=os.path.dirname(pkgroot))
     try:
         yield distdir
     finally:
@@ -149,7 +152,12 @@ with tmpdir() as distdir:
         [ "--ghc-option=" + flag.replace("$CC", cc) for flag in %{ghc_cc_args} ] +
         enable_relocatable_flags + \
         [ \
-        "--builddir=" + distdir, \
+        # Make `--builddir` a relative path. Using an absolute path would
+        # confuse the `RUNPATH` patching logic in `cc_wrapper`. It assumes that
+        # absolute paths refer the temporary directory that GHC uses for
+        # intermediate template Haskell outputs. `cc_wrapper` should improved
+        # in that regard.
+        "--builddir=" + os.path.relpath(distdir), \
         "--prefix=" + pkgroot, \
         "--libdir=" + libdir, \
         "--dynlibdir=" + dynlibdir, \

--- a/haskell/private/cabal_wrapper.py.tpl
+++ b/haskell/private/cabal_wrapper.py.tpl
@@ -146,6 +146,7 @@ with tmpdir() as distdir:
         "--with-strip=" + strip,
         "--enable-deterministic", \
         ] +
+        [ "--ghc-option=" + flag.replace("$CC", cc) for flag in %{ghc_cc_args} ] +
         enable_relocatable_flags + \
         [ \
         "--builddir=" + distdir, \

--- a/haskell/private/cc_wrapper.py.tpl
+++ b/haskell/private/cc_wrapper.py.tpl
@@ -121,7 +121,7 @@ class Args:
         self.args = list(self._handle_args(args))
 
         if self.linking:
-            if os.path.isabs(self.output):
+            if is_temporary_output(self.output):
                 # GHC with Template Haskell or tools like hsc2hs builds
                 # temporary Haskell binaries linked against libraries, but does
                 # not speficy the required runpaths on the command-line in the
@@ -1041,7 +1041,7 @@ def is_temporary_output(output):
     # into cache keys. If this turns out to be wrong we could instead look for
     # path components matching Bazel's output directory hierarchy.
     # See https://docs.bazel.build/versions/master/output_directories.html
-    return os.path.isabs(output)
+    return os.path.isabs(output) or output.endswith("hsc_make")
 
 
 # --------------------------------------------------------------------

--- a/tests/stackage_zlib_runpath/BUILD.bazel
+++ b/tests/stackage_zlib_runpath/BUILD.bazel
@@ -139,10 +139,9 @@ def test_binary(binary, sodir):
             continue
         if runpath.startswith("$ORIGIN") or runpath.startswith("@loader_path"):
             found = True
-        # XXX: Enable once #1130 is fixed.
-        #if os.path.isabs(runpath):
-        #    print("Absolute RUNPATH entry discovered for %s: %s" % (sodir, runpath))
-        #    sys.exit(1)
+        if os.path.isabs(runpath):
+            print("Absolute RUNPATH entry discovered for %s: %s" % (sodir, runpath))
+            sys.exit(1)
 
     if not found:
         print("Did not find a relative RUNPATH entry for %s among %s." % (sodir, runpaths))

--- a/tests/stackage_zlib_runpath/BUILD.bazel
+++ b/tests/stackage_zlib_runpath/BUILD.bazel
@@ -82,8 +82,11 @@ libz_soname = r.Rlocation(os.path.join(
     sys.argv[1],
 ))
 with open(libz_soname) as fh:
-    sofile = fh.read().splitlines()[1]
-    sodir = os.path.dirname(sofile)
+    if platform.system() == "Darwin":
+        sofile = fh.read().splitlines()[2]
+    else:
+        sofile = fh.read().splitlines()[1]
+    (sodir, sobase) = os.path.split(sofile)
 
 # Locate test artifacts.
 libHSzlib = r.Rlocation(os.path.join(
@@ -95,27 +98,50 @@ cabal_binary = r.Rlocation(os.path.join(
     sys.argv[3],
 ))
 
-def read_runpaths(binary):
-    runpaths = []
+def read_runpaths(binary, sobase):
     if platform.system() == "Darwin":
+        lc_rpaths = []
+        lc_load_dylibs = []
         dynamic_section = iter(subprocess.check_output(["otool", "-l", binary]).decode().splitlines())
         # otool produces lines of the form
         #
         #   Load command ...
+        #             cmd LC_LOAD_DYLIB
+        #         cmdsize ...
+        #            name ...
+        #         ...
         #             cmd LC_RPATH
         #         cmdsize ...
         #            path ...
         #
+        # Load commands can refer to names like
+        # `@rpath/some/path/libfoo.dylib`. In that case we want to extract
+        # `some/path` and consider `RUNPATH/some/path` part of the `RUNPATH`s.
         for line in dynamic_section:
-            # Find LC_RPATH entry
+            # Find load command
+            if line.find("cmd LC_") == -1:
+                continue
             if line.find("cmd LC_RPATH") != -1:
-                break
-            # Skip until path field
-            for line in dynamic_section:
-                if line.strip().startswith("path"):
-                    break
-            runpaths.append(line.split()[1])
+                # Skip until path field
+                for line in dynamic_section:
+                    if line.strip().startswith("path"):
+                        break
+                lc_rpaths.append(line.split()[1])
+            elif line.find("cmd LC_LOAD_DYLIB") != -1:
+                # Skip until name field
+                for line in dynamic_section:
+                    if line.strip().startswith("name"):
+                        break
+                lc_load_dylib = line.split()[1]
+                if lc_load_dylib.endswith(sobase) and lc_load_dylib.startswith("@rpath"):
+                    lc_load_dylibs.append("/".join(lc_load_dylib.split("/")[1:-1]))
+        runpaths = [
+            os.path.join(rpath, libdir)
+            for rpath in lc_rpaths
+            for libdir in lc_load_dylibs
+        ]
     else:
+        runpaths = []
         dynamic_section = subprocess.check_output(["objdump", "--private-headers", binary]).decode().splitlines()
         # objdump produces lines of the form
         #
@@ -131,7 +157,7 @@ def read_runpaths(binary):
     return runpaths
 
 def test_binary(binary, sodir):
-    runpaths = read_runpaths(binary)
+    runpaths = read_runpaths(binary, sobase)
     # Check that the binary contains a relative RUNPATH for sodir.
     found = False
     for runpath in runpaths:


### PR DESCRIPTION
Cabal’s with-gcc option does not apply to the cases where GHC itself
calls the C compiler which actually happens all the time. We noticed
this in daml and tested this patch there where it works successfully.

The flags here are the same as in ghc_cc_program_args. I’m not quite
sure what the best way to deduplicate this is or if this is worth
doing.