### PR TITLE
Sandboxfs experiments [WIP]

### DIFF
--- a/haskell/defs.bzl
+++ b/haskell/defs.bzl
@@ -301,20 +301,20 @@ def haskell_binary(
         for attr in ["testonly", "tags"]
         if attr in kwargs
     }
-    native.alias(
-        # XXX Temporary backwards compatibility hack. Remove eventually.
-        # See https://github.com/tweag/rules_haskell/pull/460.
-        name = "%s-repl" % name,
-        actual = "%s@repl" % name,
-        **repl_kwargs
-    )
-    haskell_repl(
-        name = "%s@repl" % name,
-        deps = [name],
-        experimental_from_source = [":%s" % name],
-        repl_ghci_args = repl_ghci_args,
-        **repl_kwargs
-    )
+    # native.alias(
+    #     # XXX Temporary backwards compatibility hack. Remove eventually.
+    #     # See https://github.com/tweag/rules_haskell/pull/460.
+    #     name = "%s-repl" % name,
+    #     actual = "%s@repl" % name,
+    #     **repl_kwargs
+    # )
+    # haskell_repl(
+    #     name = "%s@repl" % name,
+    #     deps = [name],
+    #     experimental_from_source = [":%s" % name],
+    #     repl_ghci_args = repl_ghci_args,
+    #     **repl_kwargs
+    # )
 
 def haskell_test(
         name,

--- a/haskell/ghc_bindist.bzl
+++ b/haskell/ghc_bindist.bzl
@@ -260,6 +260,7 @@ def _ghc_bindist_impl(ctx):
         execute_or_fail_loudly(ctx, ["./bin/ghc-pkg", "recache"])
 
     # On Windows the bindist already contains the built executables
+    # TODO run this entire step in a proper build action
     if os != "windows":
         # IMPORTANT: all these scripts have to be compatible with BSD
         # tools! This means that sed -i always takes an argument.

--- a/shell.nix
+++ b/shell.nix
@@ -13,6 +13,11 @@ mkShell {
 
   buildInputs = [
     go
+
+    fuse
+    pkgconfig
+    cargo
+
     nix
     which
     perl
@@ -34,6 +39,9 @@ mkShell {
   ] ++ lib.optionals docTools [graphviz python37Packages.sphinx zip unzip];
 
   shellHook = ''
+    # Install sandboxfs
+    cargo install sandboxfs
+
     # Add nix config flags to .bazelrc.local.
     #
     BAZELRC_LOCAL=".bazelrc.local"

--- a/shell.nix
+++ b/shell.nix
@@ -53,7 +53,13 @@ mkShell {
       echo
       echo "build --host_platform=@io_tweag_rules_nixpkgs//nixpkgs/platforms:host"
       echo "run --host_platform=@io_tweag_rules_nixpkgs//nixpkgs/platforms:host"
+      echo
     fi
+  echo
+  echo "WARNING: Using temporary sandbox setup"
+  echo "- Nix shell was run with 'cargo install sandboxfs' in the shell hook"
+  echo "- Binary is in ~/.cargo/bin/sandboxfs"
+  echo "- Use like this: bazel build  --experimental_use_sandboxfs --experimental_sandboxfs_path=HOME/.cargo/bin/sandboxfs //..."
 
     # source bazel bash completion
     source ${pkgs.bazel}/share/bash-completion/completions/bazel

--- a/tests/binary-simple/BUILD.bazel
+++ b/tests/binary-simple/BUILD.bazel
@@ -1,15 +1,17 @@
 load(
     "@rules_haskell//haskell:defs.bzl",
-    "haskell_test",
+    "haskell_binary",
 )
 
 package(default_testonly = 1)
 
-haskell_test(
+# TODO this fails in the sandbox with
+# `    src/main/tools/linux-sandbox-pid1.cc:427:
+#         "execvp(external/rules_haskell_ghc_nixpkgs/bin/ghc-pkg, 0x10758c0)": No such file or directory
+# `
+
+haskell_binary(
     name = "binary-simple",
     srcs = ["Main.hs"],
-    expected_covered_expressions_percentage = 100,
-    tags = ["coverage-compatible"],
-    visibility = ["//visibility:public"],
     deps = ["//tests/hackage:base"],
 )

--- a/tests/binary-simple/BUILD.bazel
+++ b/tests/binary-simple/BUILD.bazel
@@ -10,6 +10,10 @@ package(default_testonly = 1)
 #         "execvp(external/rules_haskell_ghc_nixpkgs/bin/ghc-pkg, 0x10758c0)": No such file or directory
 # `
 
+# TODO we can view the Bazel DAG like this:
+#    bazel query 'deps(//tests/binary-simple/...)' --output graph >gr.txt
+# Understand why things like rules_haskell_ghc_nixpkgs do not show up here
+
 haskell_binary(
     name = "binary-simple",
     srcs = ["Main.hs"],


### PR DESCRIPTION
#1265 

## Overall goal

Run a command such as this to competion:

 `bazel build  --experimental_use_sandboxfs --experimental_sandboxfs_path=/home/hans/.cargo/bin/sandboxfs //tests/binary-simple/...` 

### Strategy 1: Nixpkgs toolchain

#### Test

- Set (for build/test/run) `--host_platform=@rules_haskell//haskell/platforms:linux_x86_64_nixpkgs` in `.bazelrc.local`
- Run the above inside `shell.nix`
- Note: If the build crashes this may leave sandboxfs mounts dangling.
    - List with `mount | grep sandboxfs`
    - Clean up with `sudo umount -f PATH`

#### TODO

- The build command aborts because Nix store paths are not visible inside the sandboxes. Find a way of passing (selected) store paths explicitly to build rules.

### Strategy 2: Bindist toolchain

#### Test

We need to run Bazel inside a container (_not_ the nix shell), e.g. the using the one from the CI (BuildKite). This is because the bindist toolchains expects the dynamic linker in the default Unix location which is not used in NixOS.

- Build Docker image as in https://github.com/tweag/rules_haskell/blob/master/.buildkite/pipeline.yml#L27
- Enter docker as in the same file but skip all mounted dirs except PWD (the rules_haskell dir)
      - Install Bazel and add to PATH as per this line: https://github.com/tweag/rules_haskell/blob/master/.buildkite/bindists-pipeline#L8
    - Set `build --config=linux-bindist --config=ci-linux-bindist` in `.bazelrc.local`
      - Remote all lines containing `--remote_http_cache` from `.bazelrc` (TODO why?)
      - `bazel build //tests/...`
- Install sandboxfs:
       - Get a root shell in the Docker container `docker exec -it -u 0 CONTAINER bash`
       - In root shell, run `apt-get update && apt-get install fuse cargo`. Exit root shell.
       - In *non-root* shell, install sandboxfs as per https://github.com/bazelbuild/sandboxfs/blob/master/INSTALL.md#from-cratesio

#### TODO
- The above build doesn't run because of some Docker vs FUSE issue
- The build command will fail because the paths setup by the `configure` step are not visible in the sandbox
  - Currently the bindist is downloaded from the GHC binary distro and "installed" (by running `./configure`) in the repository rules. 
    - For sandboxing/RE to work, the configure step should happen in a regular rule/action (e.g. during the execution phase).
      - Allows better caching
      - Allows passing the C toolchain to the configure step
      - We need to know the paths generated by `configure` (or pack them up as a tarball) to be able to pass them downstream to other rules (no dynamic dependencies - but see below)

#### CI vs Local

After getting the above to work locally, try CI.

### Unknown output paths from configure step

> We currently have hardcoded mappings from version numbers to sha256 hashes and URL's. We could equally have a mapping from version number to BUILD file content. This would enable us to not run `pkgdb_to_bzl.py`, which requires a python interpreter from the environment non-hermetically (since it runs in a repository rule). The BUILD file content would be different for each GHC version. But a) we can generate it automatically, and b) the content is immutable for each GHC version.