### PR TITLE
Bump GHC/Stackage in examples

### DIFF
--- a/examples/WORKSPACE
+++ b/examples/WORKSPACE
@@ -13,14 +13,14 @@ rules_haskell_dependencies()
 load("@rules_haskell//haskell:nixpkgs.bzl", "haskell_register_ghc_nixpkgs")
 
 haskell_register_ghc_nixpkgs(
-    attribute_path = "haskell.compiler.ghc865",
+    attribute_path = "haskell.compiler.ghc883",
     repository = "@rules_haskell//nixpkgs:default.nix",
-    version = "8.6.5",
+    version = "8.8.3",
 )
 
 load("@rules_haskell//haskell:toolchain.bzl", "rules_haskell_toolchains")
 
-rules_haskell_toolchains(version = "8.6.5")
+rules_haskell_toolchains(version = "8.8.3")
 
 load(
     "@io_tweag_rules_nixpkgs//nixpkgs:nixpkgs.bzl",
@@ -64,25 +64,25 @@ cc_library(name = "z", srcs = glob(["*.c"]), hdrs = glob(["*.h"]))
 )
 
 # Demonstrates a vendored Stackage package to bump a version bound.
-http_archive(
-    name = "split",
-    build_file_content = """
-load("@rules_haskell//haskell:cabal.bzl", "haskell_cabal_library")
-load("@stackage//:packages.bzl", "packages")
-haskell_cabal_library(
-    name = "split",
-    version = packages["split"].version,
-    srcs = glob(["**"]),
-    deps = packages["split"].deps,
-    visibility = ["//visibility:public"],
-)
-    """,
-    patch_args = ["-p1"],
-    patches = ["@rules_haskell_examples//:split.patch"],
-    sha256 = "1dcd674f7c5f276f33300f5fd59e49d1ac6fc92ae949fd06a0f6d3e9d9ac1413",
-    strip_prefix = "split-0.2.3.3",
-    urls = ["http://hackage.haskell.org/package/split-0.2.3.3/split-0.2.3.3.tar.gz"],
-)
+# http_archive(
+#     name = "split",
+#     build_file_content = """
+# load("@rules_haskell//haskell:cabal.bzl", "haskell_cabal_library")
+# load("@stackage//:packages.bzl", "packages")
+# haskell_cabal_library(
+#     name = "split",
+#     version = packages["split"].version,
+#     srcs = glob(["**"]),
+#     deps = packages["split"].deps,
+#     visibility = ["//visibility:public"],
+# )
+#     """,
+#     patch_args = ["-p1"],
+#     patches = ["@rules_haskell_examples//:split.patch"],
+#     sha256 = "1dcd674f7c5f276f33300f5fd59e49d1ac6fc92ae949fd06a0f6d3e9d9ac1413",
+#     strip_prefix = "split-0.2.3.3",
+#     urls = ["http://hackage.haskell.org/package/split-0.2.3.3/split-0.2.3.3.tar.gz"],
+# )
 
 load("@rules_haskell//haskell:cabal.bzl", "stack_snapshot")
 
@@ -106,6 +106,6 @@ stack_snapshot(
         "text",
         "text-show",
     ],
-    snapshot = "lts-14.0",
-    vendored_packages = {"split": "@split//:split"},
+    snapshot = "lts-15.2",
+    # vendored_packages = {"split": "@split//:split"},
 )

--- a/examples/primitive/Data/Primitive/Array.hs
+++ b/examples/primitive/Data/Primitive/Array.hs
@@ -691,8 +691,6 @@ instance Monad Array where
      = copyArray smb off sb 0 (lsb)
          *> fill (off + lsb) sbs smb
 
-  -- fail _ = empty
-
 instance MonadPlus Array where
   mzero = empty
   mplus = (<|>)

--- a/examples/primitive/Data/Primitive/Array.hs
+++ b/examples/primitive/Data/Primitive/Array.hs
@@ -691,7 +691,7 @@ instance Monad Array where
      = copyArray smb off sb 0 (lsb)
          *> fill (off + lsb) sbs smb
 
-  fail _ = empty
+  -- fail _ = empty
 
 instance MonadPlus Array where
   mzero = empty

--- a/examples/primitive/Data/Primitive/MutVar.hs
+++ b/examples/primitive/Data/Primitive/MutVar.hs
@@ -26,7 +26,8 @@ module Data.Primitive.MutVar (
 
 import Control.Monad.Primitive ( PrimMonad(..), primitive_ )
 import GHC.Prim ( MutVar#, sameMutVar#, newMutVar#,
-                  readMutVar#, writeMutVar#, atomicModifyMutVar# )
+                  readMutVar#, writeMutVar# )
+import GHC.Exts ( atomicModifyMutVar# )
 import Data.Primitive.Internal.Compat ( isTrue# )
 import Data.Typeable ( Typeable )
 

--- a/examples/primitive/Data/Primitive/SmallArray.hs
+++ b/examples/primitive/Data/Primitive/SmallArray.hs
@@ -808,8 +808,6 @@ instance Monad SmallArray where
      copySmallArray smb off sb 0 (length sb)
        *> fill (off + length sb) sbs smb
 
-  fail _ = emptySmallArray
-
 instance MonadPlus SmallArray where
   mzero = empty
   mplus = (<|>)

--- a/examples/vector/Data/Vector.hs
+++ b/examples/vector/Data/Vector.hs
@@ -341,9 +341,6 @@ instance Monad Vector where
   {-# INLINE (>>=) #-}
   (>>=) = flip concatMap
 
-  {-# INLINE fail #-}
-  fail _ = empty
-
 instance MonadPlus Vector where
   {-# INLINE mzero #-}
   mzero = empty


### PR DESCRIPTION
This bumps the `examples` workspace to use https://www.stackage.org/lts-15.12.

Using the Nix shell most targets in the examples workspace build fine, but `bazel build //rts/...` hangs forever. Any pointers on how to debug would be very welcome.

```
[nix-shell] $ bazel build //rts/...
INFO: Analyzed 6 targets (0 packages loaded, 0 targets configured).
INFO: Found 6 targets...
[1 / 9] HaskellBuildLibrary //rts:add-one-hs; 3s linux-sandbox
^C
```