### PR TITLE
Update to GHC 8.8

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -235,13 +235,13 @@ cc_library(
 
 nixpkgs_package(
     name = "c2hs",
-    attribute_path = "haskell.packages.ghc865.c2hs",
+    attribute_path = "haskell.packages.ghc883.c2hs",
     repository = "@nixpkgs_default",
 )
 
 nixpkgs_package(
     name = "doctest",
-    attribute_path = "haskell.packages.ghc865.doctest",
+    attribute_path = "haskell.packages.ghc883.doctest",
     repository = "@nixpkgs_default",
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -41,9 +41,9 @@ http_archive(
 load("@rules_haskell//haskell:cabal.bzl", "haskell_cabal_binary")
 haskell_cabal_binary(name = "happy", srcs = glob(["**"]), visibility = ["//visibility:public"])
     """,
-    sha256 = "22eb606c97105b396e1c7dc27e120ca02025a87f3e44d2ea52be6a653a52caed",
-    strip_prefix = "happy-1.19.10",
-    urls = ["http://hackage.haskell.org/package/happy-1.19.10/happy-1.19.10.tar.gz"],
+    sha256 = "fb9a23e41401711a3b288f93cf0a66db9f97da1ce32ec4fffea4b78a0daeb40f",
+    strip_prefix = "happy-1.19.12",
+    urls = ["http://hackage.haskell.org/package/happy-1.19.12/happy-1.19.12.tar.gz"],
 )
 
 http_archive(
@@ -65,11 +65,16 @@ haskell_cabal_binary(
     visibility = ["//visibility:public"],
 )
     """,
-    sha256 = "161dcee2aed780f62c01522c86afce61721cf89c0143f157efefb1bd1fa1d164",
-    strip_prefix = "proto-lens-protoc-0.5.0.0",
-    urls = ["http://hackage.haskell.org/package/proto-lens-protoc-0.5.0.0/proto-lens-protoc-0.5.0.0.tar.gz"],
+    sha256 = "b946740b94c8d300cd8e278ded9045905ef1985824cef6b81af0d79b119927be",
+    strip_prefix = "proto-lens-protoc-0.6.0.0",
+    urls = ["http://hackage.haskell.org/package/proto-lens-protoc-0.6.0.0/proto-lens-protoc-0.6.0.0.tar.gz"],
 )
 
+load(
+    "@rules_haskell//:constants.bzl",
+    "test_ghc_version",
+    "test_stack_snapshot",
+)
 load("@rules_haskell//haskell:cabal.bzl", "stack_snapshot")
 
 stack_snapshot(
@@ -99,9 +104,10 @@ stack_snapshot(
         "data-default-class",
         "proto-lens",
         "proto-lens-protoc",
+        "proto-lens-runtime",
         "lens-family",
     ],
-    snapshot = "lts-14.4",
+    snapshot = test_stack_snapshot,
     tools = [
         "@alex",
         "@happy",
@@ -113,7 +119,7 @@ stack_snapshot(
     name = "stackage-zlib",
     extra_deps = {"zlib": ["@zlib.win//:zlib" if is_windows else "@zlib.dev//:zlib"]},
     packages = ["zlib"],
-    snapshot = "lts-13.15",
+    snapshot = test_stack_snapshot,
 )
 
 load(
@@ -166,19 +172,16 @@ test_repl_ghci_args = [
 ]
 
 load(
-    "@rules_haskell//:constants.bzl",
-    "test_ghc_version",
-)
-load(
     "@rules_haskell//haskell:nixpkgs.bzl",
     "haskell_register_ghc_nixpkgs",
 )
 
 haskell_register_ghc_nixpkgs(
-    attribute_path = "haskell.compiler.ghc865",
+    attribute_path = "",
     compiler_flags = test_compiler_flags,
     haddock_flags = test_haddock_flags,
     locale_archive = "@glibc_locales//:locale-archive",
+    nix_file_content = """with import <nixpkgs> {}; haskell.packages.ghc883.ghc""",
     repl_ghci_args = test_repl_ghci_args,
     repository = "@nixpkgs_default",
     version = test_ghc_version,

--- a/constants.bzl
+++ b/constants.bzl
@@ -1,2 +1,17 @@
-test_ghc_version = "8.8.3"
-test_stack_snapshot = "lts-15.4"
+load("@os_info//:os_info.bzl", "is_linux", "is_nix_shell", "is_windows")
+
+# Windows builds fail with the following error on CI
+#
+#   Access violation in generated code when writing 0x0
+#
+#    Attempting to reconstruct a stack trace...
+#
+#      Frame	Code address
+#    * 0x461dab0	0x37f7b66 C:\users\vssadministrator\_bazel_vssadministrator\w3d6ug6o\execroot\rules_haskell\external\rules_haskell_ghc_windows_amd64\bin\ghc.exe+0x33f7b66
+#    * 0x461dab8	0x3277bb9 C:\users\vssadministrator\_bazel_vssadministrator\w3d6ug6o\execroot\rules_haskell\external\rules_haskell_ghc_windows_amd64\bin\ghc.exe+0x2e77bb9
+#    * 0x461dac0	0x3
+#
+# This seems to be an instance of https://gitlab.haskell.org/ghc/ghc/issues/17926.
+# Until a fix is released we fall back to an older GHC release on Windows.
+test_ghc_version = "8.8.3" if not is_windows else "8.6.5"
+test_stack_snapshot = "lts-15.4" if not is_windows else "lts-14.4"

--- a/constants.bzl
+++ b/constants.bzl
@@ -1,1 +1,2 @@
-test_ghc_version = "8.6.5"
+test_ghc_version = "8.8.3"
+test_stack_snapshot = "lts-15.4"

--- a/haskell/BUILD.bazel
+++ b/haskell/BUILD.bazel
@@ -62,6 +62,7 @@ bzl_library(
         "@bazel_skylib//lib:dicts",
         "@bazel_skylib//lib:paths",
         "@bazel_skylib//lib:shell",
+        "@bazel_skylib//lib:versions",
         "@io_tweag_rules_nixpkgs//nixpkgs",
         "@rules_sh//sh:posix",
     ],

--- a/haskell/assets/ghc_8_8_1_win_base.patch
+++ b/haskell/assets/ghc_8_8_1_win_base.patch
@@ -1,0 +1,11 @@
+--- lib/package.conf.d/base-4.13.0.0.conf     2020-05-15 18:12:39.720103041 +0200
++++ lib/package.conf.d/base-4.13.0.0.conf     2020-05-15 18:12:33.996061352 +0200
+@@ -83,7 +83,7 @@
+ dynamic-library-dirs: $topdir\base-4.13.0.0
+ data-dir:             $topdir\x86_64-windows-ghc-8.8.1\base-4.13.0.0
+ hs-libraries:         HSbase-4.13.0.0
+-extra-libraries:      wsock32 user32 shell32 msvcrt mingw32 mingwex
++extra-libraries:      wsock32 user32 shell32 msvcrt mingw32 mingwex shlwapi
+ include-dirs:         $topdir\base-4.13.0.0\include
+ includes:             HsBase.h
+ depends:              ghc-prim-0.5.3 integer-gmp-1.0.2.0 rts

--- a/haskell/assets/ghc_8_8_2_win_base.patch
+++ b/haskell/assets/ghc_8_8_2_win_base.patch
@@ -1,0 +1,11 @@
+--- lib/package.conf.d/base-4.13.0.0.conf     2020-05-15 18:14:01.100696756 +0200
++++ lib/package.conf.d/base-4.13.0.0.conf     2020-05-15 18:13:58.168675334 +0200
+@@ -83,7 +83,7 @@
+ dynamic-library-dirs: $topdir\base-4.13.0.0
+ data-dir:             $topdir\x86_64-windows-ghc-8.8.2\base-4.13.0.0
+ hs-libraries:         HSbase-4.13.0.0
+-extra-libraries:      wsock32 user32 shell32 msvcrt mingw32 mingwex
++extra-libraries:      wsock32 user32 shell32 msvcrt mingw32 mingwex shlwapi
+ include-dirs:         $topdir\base-4.13.0.0\include
+ includes:             HsBase.h
+ depends:              ghc-prim-0.5.3 integer-gmp-1.0.2.0 rts

--- a/haskell/assets/ghc_8_8_3_win_base.patch
+++ b/haskell/assets/ghc_8_8_3_win_base.patch
@@ -1,0 +1,11 @@
+--- lib/package.conf.d/base-4.13.0.0.conf     2020-05-15 18:14:57.233107286 +0200
++++ lib/package.conf.d/base-4.13.0.0.conf     2020-05-15 18:14:55.009091007 +0200
+@@ -83,7 +83,7 @@
+ dynamic-library-dirs: $topdir\base-4.13.0.0
+ data-dir:             $topdir\x86_64-windows-ghc-8.8.3\base-4.13.0.0
+ hs-libraries:         HSbase-4.13.0.0
+-extra-libraries:      wsock32 user32 shell32 msvcrt mingw32 mingwex
++extra-libraries:      wsock32 user32 shell32 msvcrt mingw32 mingwex shlwapi
+ include-dirs:         $topdir\base-4.13.0.0\include
+ includes:             HsBase.h
+ depends:              ghc-prim-0.5.3 integer-gmp-1.0.2.0 rts

--- a/haskell/cc.bzl
+++ b/haskell/cc.bzl
@@ -170,7 +170,7 @@ def ghc_cc_program_args(cc):
     Returns:
       list of string, GHC arguments.
     """
-    return [
+    args = [
         # GHC uses C compiler for assemly, linking and preprocessing as well.
         "-pgma",
         cc,
@@ -178,14 +178,19 @@ def ghc_cc_program_args(cc):
         cc,
         "-pgml",
         cc,
-        "-pgmP",
-        cc,
         # Setting -pgm* flags explicitly has the unfortunate side effect
         # of resetting any program flags in the GHC settings file. So we
         # restore them here. See
         # https://ghc.haskell.org/trac/ghc/ticket/7929.
+        #
+        # Since GHC 8.8 the semantics of `-optP` have changed and these flags
+        # are now also forwarded to `cc` via `-Xpreprocessor`, which breaks the
+        # default flags `-E -undef -traditional`. GHC happens to word split the
+        # argument to `-pgmP` which allows to pass these flags to `gcc` itself
+        # as the preprocessor. See
+        # https://gitlab.haskell.org/ghc/ghc/issues/17185#note_261599.
+        "-pgmP",
+        cc + " -E -undef -traditional",
         "-optc-fno-stack-protector",
-        "-optP-E",
-        "-optP-undef",
-        "-optP-traditional",
     ]
+    return args

--- a/haskell/ghc_bindist.bzl
+++ b/haskell/ghc_bindist.bzl
@@ -454,6 +454,9 @@ def ghc_bindist(
         "8.6.2": ["@rules_haskell//haskell:assets/ghc_8_6_2_win_base.patch"],
         "8.6.4": ["@rules_haskell//haskell:assets/ghc_8_6_4_win_base.patch"],
         "8.6.5": ["@rules_haskell//haskell:assets/ghc_8_6_5_win_base.patch"],
+        "8.8.1": ["@rules_haskell//haskell:assets/ghc_8_8_1_win_base.patch"],
+        "8.8.2": ["@rules_haskell//haskell:assets/ghc_8_8_2_win_base.patch"],
+        "8.8.3": ["@rules_haskell//haskell:assets/ghc_8_8_3_win_base.patch"],
     }.get(version) if target == "windows_amd64" else None
 
     extra_attrs = {"patches": patches, "patch_args": ["-p0"]} if patches else {}

--- a/haskell/private/cc_wrapper.py.tpl
+++ b/haskell/private/cc_wrapper.py.tpl
@@ -402,8 +402,7 @@ def load_response_files(args, max_depth=100):
     """
     def response_file_iter(filename):
         if max_depth == 0:
-            sys.stderr.write("Exceeded maximum response file nesting depth.")
-            sys.exit(1)
+            raise RuntimeError("Exceeded maximum response file nesting depth.")
         with open(filename, "r") as rsp:
             rsp_args = (
                 arg

--- a/haskell/repl.bzl
+++ b/haskell/repl.bzl
@@ -270,9 +270,13 @@ def _compiler_flags_and_inputs(hs, repl_info, path_prefix = ""):
         args,
     )
 
-    args.extend(ghc_cc_program_args(
-        paths.join(path_prefix, hs.toolchain.cc_wrapper.executable.path),
-    ))
+    # The `-pgmP` argument needs to be quoted.
+    args.extend([
+        '"{}"'.format(arg)
+        for arg in ghc_cc_program_args(
+            paths.join(path_prefix, hs.toolchain.cc_wrapper.executable.path),
+        )
+    ])
 
     # Add import directories
     for import_dir in repl_info.load_info.import_dirs.to_list():

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -186,7 +186,20 @@ rule_test(
     name = "test-haddock",
     size = "small",
     generates =
-    ["haddock/array-0.5.4.0", "haddock/base-4.13.0.0", "haddock/deepseq-1.4.4.0", "haddock/ghc-boot-th-8.8.3", "haddock/ghc-prim-0.5.3", "haddock/index", "haddock/integer-gmp-1.0.2.0", "haddock/pretty-1.1.3.6", "haddock/template-haskell-2.15.0.0", "haddock/testsZShaddockZShaddock-lib-a", "haddock/testsZShaddockZShaddock-lib-b", "haddock/testsZShaddockZShaddock-lib-deep"],
+        [
+            "haddock/array-0.5.4.0",
+            "haddock/base-4.13.0.0",
+            "haddock/deepseq-1.4.4.0",
+            "haddock/ghc-boot-th-8.8.3",
+            "haddock/ghc-prim-0.5.3",
+            "haddock/index",
+            "haddock/integer-gmp-1.0.2.0",
+            "haddock/pretty-1.1.3.6",
+            "haddock/template-haskell-2.15.0.0",
+            "haddock/testsZShaddockZShaddock-lib-a",
+            "haddock/testsZShaddockZShaddock-lib-b",
+            "haddock/testsZShaddockZShaddock-lib-deep",
+        ],
     rule = "//tests/haddock",
 )
 

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -63,6 +63,7 @@ haskell_proto_toolchain(
         "@stackage//:lens-family-core",
         "@stackage//:mtl",
         "@stackage//:proto-lens",
+        "@stackage//:proto-lens-runtime",
         "@stackage//:text",
         "@stackage//:vector",
     ],
@@ -184,20 +185,8 @@ rule_test(
 rule_test(
     name = "test-haddock",
     size = "small",
-    generates = [
-        "haddock/array-0.5.3.0",
-        "haddock/base-4.12.0.0",
-        "haddock/deepseq-1.4.4.0",
-        "haddock/ghc-boot-th-8.6.5",
-        "haddock/ghc-prim-0.5.3",
-        "haddock/index",
-        "haddock/integer-gmp-1.0.2.0",
-        "haddock/pretty-1.1.3.6",
-        "haddock/template-haskell-2.14.0.0",
-        "haddock/testsZShaddockZShaddock-lib-a",
-        "haddock/testsZShaddockZShaddock-lib-b",
-        "haddock/testsZShaddockZShaddock-lib-deep",
-    ],
+    generates =
+    ["haddock/array-0.5.4.0", "haddock/base-4.13.0.0", "haddock/deepseq-1.4.4.0", "haddock/ghc-boot-th-8.8.3", "haddock/ghc-prim-0.5.3", "haddock/index", "haddock/integer-gmp-1.0.2.0", "haddock/pretty-1.1.3.6", "haddock/template-haskell-2.15.0.0", "haddock/testsZShaddockZShaddock-lib-a", "haddock/testsZShaddockZShaddock-lib-b", "haddock/testsZShaddockZShaddock-lib-deep"],
     rule = "//tests/haddock",
 )
 

--- a/tests/binary-with-plugin/Plugin.hs
+++ b/tests/binary-with-plugin/Plugin.hs
@@ -10,6 +10,6 @@ plugin = defaultPlugin { installCoreToDos = install }
 install :: [CommandLineOption] -> [CoreToDo] -> CoreM [CoreToDo]
 install [arg] todo = do
   when ('$' `elem` arg) $
-    fail "Make variable not expanded."
+    error "Make variable not expanded."
   _ <- liftIO $ readProcess arg [] ""
   return todo

--- a/tests/haskell_cabal_binary/pkg.cabal
+++ b/tests/haskell_cabal_binary/pkg.cabal
@@ -4,6 +4,6 @@ version: 0.1.0.0
 build-type: Simple
 
 executable haskell_cabal_binary
-  build-depends: base >=4.12 && <4.13
+  build-depends: base
   default-language: Haskell2010
   main-is: Main.hs

--- a/tests/haskell_cabal_library/lib.cabal
+++ b/tests/haskell_cabal_library/lib.cabal
@@ -16,7 +16,7 @@ flag expose-lib
 
 library
   if flag(use-base)
-    build-depends: base >=4.12 && <4.13
+    build-depends: base
   default-language: Haskell2010
   if flag(expose-lib)
     exposed-modules: Lib

--- a/tests/haskell_cabal_library/second-lib.cabal
+++ b/tests/haskell_cabal_library/second-lib.cabal
@@ -4,6 +4,6 @@ version: 0.1.0.0
 build-type: Simple
 
 library
-  build-depends: base >=4.12 && <4.13
+  build-depends: base
   default-language: Haskell2010
   exposed-modules: SecondLib

--- a/tests/haskell_cabal_package/lib.cabal
+++ b/tests/haskell_cabal_package/lib.cabal
@@ -4,7 +4,7 @@ version: 0.1.0.0
 build-type: Simple
 
 library
-  build-depends: base >=4.12 && <4.13
+  build-depends: base
   default-language: Haskell2010
   exposed-modules: Lib
   hs-source-dirs: lib

--- a/tools/repositories.bzl
+++ b/tools/repositories.bzl
@@ -24,6 +24,6 @@ def rules_haskell_worker_dependencies(**stack_kwargs):
                 "text",
                 "vector",
             ],
-            snapshot = "lts-14.1",
+            snapshot = "lts-15.4",
             **stack_kwargs
         )

--- a/tools/worker/worker.cabal
+++ b/tools/worker/worker.cabal
@@ -10,7 +10,7 @@ executable bin
   main-is:             Main.hs
   other-modules:       Server, Compile, Proto.Worker, Proto.Worker_Fields
   ghc-options: -threaded "-with-rtsopts=-N2"
-  build-depends:       base ^>=4.12.0.0,
+  build-depends:       base ^>=4.13.0.0,
                        bytestring,
                        filepath,
                        ghc,


### PR DESCRIPTION
Closes https://github.com/tweag/rules_haskell/issues/1323
Closes https://github.com/tweag/rules_haskell/issues/1324

This is the continuation of https://github.com/tweag/rules_haskell/pull/1170

* Upgrades GHC to version 8.8.3
* Upgrades the stack snapshot and `c2hs` and `doctest` accordingly.
* Starting from version 8.8 GHC passes `-optP` flags to `gcc` prefixed by `-Xpreprocessor`. This causes a number of issues, see #1323, #1324, https://gitlab.haskell.org/ghc/ghc/issues/17185, and https://gitlab.haskell.org/ghc/ghc/issues/18177.
  This PR works around these issues by inlining the toolchain's `-optP` flags into `-pgmP` as described [here](https://gitlab.haskell.org/ghc/ghc/issues/17185#note_261599).
  Furthermore, we catch instances of `-Xpreprocessor @rsp` in `cc_wrapper`, load the arguments in `rsp`, and prefix each with `-Xpreprocessor`.

~TODO~:
* [x] This fails on Windows with the following error
  ```
  Access violation in generated code when writing 0x0

   Attempting to reconstruct a stack trace...

     Frame	Code address
   * 0x461dab0	0x37f7b66 C:\users\vssadministrator\_bazel_vssadministrator\w3d6ug6o\execroot\rules_haskell\external\rules_haskell_ghc_windows_amd64\bin\ghc.exe+0x33f7b66
   * 0x461dab8	0x3277bb9 C:\users\vssadministrator\_bazel_vssadministrator\w3d6ug6o\execroot\rules_haskell\external\rules_haskell_ghc_windows_amd64\bin\ghc.exe+0x2e77bb9
   * 0x461dac0	0x3
  ```
  This is an instance of https://gitlab.haskell.org/ghc/ghc/issues/17926. There is little we can do but wait for GHC 8.8.4 or 8.10.2 to come out. For now this PR sticks to GHC 8.6.5 on Windows.
