### PR TITLE
Add warnings about surprising behavior in stack_snapshot

### DIFF
--- a/haskell/cabal.bzl
+++ b/haskell/cabal.bzl
@@ -1193,7 +1193,7 @@ def stack_snapshot(stack = None, extra_deps = {}, vendored_packages = {}, **kwar
       - flags: The list of Cabal flags.
 
     **NOTE:** Make sure your GHC version matches the version expected by the
-    snapshot. e.g. if you pass `snapshot = "lts-13.15"`, make sure you use
+    snapshot. E.g. if you pass `snapshot = "lts-13.15"`, make sure you use
     GHC 8.6.4 (e.g. by invoking `rules_haskell_toolchains(version="8.6.4")`).
     Sadly, rules_haskell cannot maintain this correspondence for you. You will
     need to manage it yourself. If you have a version mismatch, you will end up

--- a/haskell/cabal.bzl
+++ b/haskell/cabal.bzl
@@ -783,7 +783,6 @@ def _compute_dependency_graph(repository_ctx, snapshot, core_packages, versioned
         )
 
     if not versioned_packages and not unversioned_packages and not vendored_packages:
-        print("WARNING: all packages listed in stack_snapshot {} are core packages. Core packages are built into GHC and stack_snapshot cannot override them. stack is not being invoked at all to create this repository, and the snapshot will be ignored.".format(repr(repository_ctx.attr.name)))
         return all_packages
 
     # Unpack all given packages, then compute the transitive closure
@@ -945,8 +944,6 @@ def _stack_snapshot_impl(repository_ctx):
             versioned_packages.append(package)
         else:
             unversioned_packages.append(package)
-    if core_packages:
-        print("WARNING: core packages are provided by your GHC distribution, not the Stack snapshot.\nTherefore, the following packages from the {} repository may have versions that do not match the corresponding snapshot:\n\t{}".format(repr(repository_ctx.attr.name), core_packages))
     all_packages = _compute_dependency_graph(
         repository_ctx,
         snapshot,
@@ -1182,16 +1179,28 @@ def stack_snapshot(stack = None, extra_deps = {}, vendored_packages = {}, **kwar
     Packages that are in the snapshot need not have their versions
     specified. But any additional packages or version overrides will have
     to be specified with a package identifier of the form
-    `<package>-<version>` in the `packages` attribute.
+    `<package>-<version>` in the `packages` attribute. Note that you cannot
+    override the version of any [packages built into GHC][ghc-builtins].
 
     In the external repository defined by the rule, all given packages are
     available as top-level targets named after each package. Additionally, the
     dependency graph is made available within `packages.bzl` as the `dict`
     `packages` mapping unversioned package names to structs holding the fields
+
       - name: The unversioned package name.
       - version: The package version.
       - deps: The list of package dependencies according to stack.
       - flags: The list of Cabal flags.
+
+    **NOTE:** Make sure your GHC version matches the version expected by the
+    snapshot. e.g. if you pass `snapshot = "lts-13.15"`, make sure you use
+    GHC 8.6.4 (e.g. by invoking `rules_haskell_toolchains(version="8.6.4")`).
+    Sadly, rules_haskell cannot maintain this correspondence for you. You will
+    need to manage it yourself. If you have a version mismatch, you will end up
+    with versions of [core GHC packages][ghc-builtins] which do not match the
+    versions listed in the snapshot, and potentially other problems.
+
+    [ghc-builtins]: https://downloads.haskell.org/ghc/latest/docs/html/users_guide/8.10.1-notes.html#included-libraries
 
     ### Examples
 


### PR DESCRIPTION
This may not be the right way to address the corresponding issue, but I wanted to start with a concrete suggestion to build from. Better ideas welcome!

---

This PR was born after I lost a bunch of hours because of having an incorrect model of what `stack_snapshot` did.

In particular, I did not realize that the core packages built into GHC are treated quite differently from other packages. (Before this, I did not even realize that those packages _were_ built into GHC.) In my ignorance, I encountered the following surprises:

1. When I added `template-haskell` to my stack snapshot, I did not get the version of `template-haskell` listed on the corresponding [stackage page](https://www.stackage.org/lts-15.12). I got an older version instead, and I had no idea why.
2. When I tried to pin the version I wanted by writing `template-haskell-2.15.0.0`, I still got the older version, and still didn't understand why.
3. When, during the debugging process, I tried changing the stack snapshot to a made-up name (eg `"this-is-not-a-snapshot"`), `stack_snapshot` ignored the fact that no such snapshot existed and gave me packages anyway. Where it got those packages from and what version they were, I had no idea.

After spending several hours tracing the issue back to `stack_snapshot` and then tracing through [its implementation](https://github.com/tweag/rules_haskell/blob/a9930c7856d251718613cca7a75f83aa911bf725/haskell/cabal.bzl#L922), I found the answers to my mysteries:

1. `template-haskell` is one of many packages built into GHC. For these packages, `stack_snapshot` will give you whatever version is built into the GHC in your toolchain, _not_ the version listed in the snapshot.
Normally when you use stack, the GHC version is itself part of the snapshot and therefore these packages have the version you expect. But in bazel, with rules_haskell as it is currently designed, your GHC version is specified separately from any `stack_snapshot` invocations, which means the versions of the builtin packages can diverge from the snapshot version.
2. `stack_snapshot` parses and _[ignores](https://github.com/tweag/rules_haskell/blob/a9930c7856d251718613cca7a75f83aa911bf725/haskell/cabal.bzl#L946)_ version strings on core packages.
3. If all of the `packages` in your `stack_snapshot` invocation are core packages, `stack_snapshot` [short circuits](https://github.com/tweag/rules_haskell/blob/a9930c7856d251718613cca7a75f83aa911bf725/haskell/cabal.bzl#L791-L792) and bypasses stack entirely. You get the versions built into GHC.

These behaviors all seem pretty surprising to me. Silently ignoring a version string particularly so.

This PR changes `stack_snapshot` to print warnings in cases 1 and 3, and to cause a build failure in case 2.

There may be smarter solutions than this -- maybe it is possible to override packages built into GHC? Maybe `stack_snapshot` can provide the GHC used in the build, or otherwise tie the snapshot to the GHC version somehow? Maybe `stack_snapshot` should refuse to handle core packages at all? I don't know. But I find the current behavior pretty surprising and I think something should change, and this seemed like a reasonable start.