### PR TITLE
Ghci rebindable syntax

### DIFF
--- a/haskell/assets/ghci_script
+++ b/haskell/assets/ghci_script
@@ -3,6 +3,11 @@
 import qualified GHC.IO.Handle as Handle
 import qualified System.IO as IO
 import qualified System.Directory as Dir
+:set -Wno-name-shadowing
+(>>=) = (Prelude.>>=)
+(>>) = (Prelude.>>)
+return = Prelude.return
+fromString = Prelude.id
 rules_haskell_stdout_dupe <- Handle.hDuplicate IO.stdout
 :{
 (rules_haskell_stdout_copy_file, rules_haskell_stdout_copy_h) <- do

--- a/haskell/assets/ghci_script
+++ b/haskell/assets/ghci_script
@@ -3,7 +3,7 @@
 import qualified GHC.IO.Handle as Handle
 import qualified System.IO as IO
 import qualified System.Directory as Dir
-:set -Wno-name-shadowing
+:seti -Wno-name-shadowing
 (>>=) = (Prelude.>>=)
 (>>) = (Prelude.>>)
 return = Prelude.return

--- a/tests/RunTests.hs
+++ b/tests/RunTests.hs
@@ -42,6 +42,10 @@ main = hspec $ do
 
       assertSuccess (bazel ["run", "//tests/binary-indirect-cbits:binary-indirect-cbits@repl", "--", "-ignore-dot-ghci", "-e", ":main"])
 
+    it "with rebindable syntax" $ do
+      let p' (stdout, _stderr) = lines stdout == ["True"]
+      outputSatisfy p' (bazel ["run", "//tests/repl-targets:rebindable-syntax@repl", "--", "-ignore-dot-ghci", "-e", "check"])
+
     -- Test `compiler_flags` from toolchain and rule for REPL
     it "compiler flags" $ do
       assertSuccess (bazel ["run", "//tests/repl-flags:compiler_flags@repl", "--", "-ignore-dot-ghci", "-e", ":main"])

--- a/tests/repl-targets/BUILD.bazel
+++ b/tests/repl-targets/BUILD.bazel
@@ -78,3 +78,14 @@ haskell_test(
         "//tests/hackage:base",
     ],
 )
+
+haskell_library(
+    name = "rebindable-syntax",
+    srcs = ["RebindableSyntax.hs"],
+    compiler_flags = [
+        "-XRebindableSyntax",
+        "-Wname-shadowing",
+    ],
+    visibility = ["//visibility:public"],
+    deps = ["//tests/hackage:base"],
+)

--- a/tests/repl-targets/RebindableSyntax.hs
+++ b/tests/repl-targets/RebindableSyntax.hs
@@ -1,0 +1,45 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RebindableSyntax #-}
+
+module RebindableSyntax where
+
+import Control.Monad (unless)
+import System.Exit (exitFailure, exitSuccess)
+import qualified Prelude as Prelude
+import Prelude (($), (.))
+
+newtype String = String {runString :: Prelude.String -> Prelude.String}
+
+empty :: String
+empty = String Prelude.id
+
+(++) :: String -> String -> String
+s1 ++ s2 = String $ runString s1 . runString s2
+
+showString :: String -> Prelude.String
+showString s = runString s []
+
+newtype MyMonad a = MyMonad {runMyMonad :: String -> (String, a)}
+
+(>>=) :: MyMonad a -> (a -> MyMonad b) -> MyMonad b
+m >>= k = MyMonad $ \s -> let (s', a) = runMyMonad m s in runMyMonad (k a) s'
+
+(>>) :: MyMonad a -> MyMonad b -> MyMonad b
+m >> n = m >>= \_ -> n
+
+return :: a -> MyMonad a
+return a = MyMonad $ \s -> (s, a)
+
+fromString :: Prelude.String -> MyMonad ()
+fromString s' = MyMonad $ \s -> (s ++ String (s' Prelude.++), ())
+
+action :: MyMonad ()
+action = do
+  "foo"
+  bar <- return ['b', 'a', 'r']
+  fromString bar
+
+check :: Prelude.Bool
+check = showString s Prelude.== ['f', 'o', 'o', 'b', 'a', 'r']
+  where
+    (s, ()) = runMyMonad action empty


### PR DESCRIPTION
`haskell_repl` automatically executes a ghci script for module loading. This script failed if `-XRebindableSyntax` was enabled because it uses do notation. This change fixes this by binding `(>>=)` etc. to the corresponding `Prelude` functions in the ghci script. This will not affect the user's ghci session since the script calls `:reload` at the end.

This also includes a regression test that invokes the repl on a module that uses rebindable syntax.