### PR TITLE
Coverage: prefix .hpc directory with rule name

### DIFF
--- a/haskell/private/actions/compile.bzl
+++ b/haskell/private/actions/compile.bzl
@@ -352,7 +352,7 @@ def _compilation_defaults(hs, cc, java, posix, dep_info, plugin_dep_info, srcs, 
     )
 
 def _hpc_compiler_args(hs):
-    hpcdir = "{}/{}/.hpc".format(hs.bin_dir.path, hs.package_root)
+    hpcdir = "{}/{}/{}_.hpc".format(hs.bin_dir.path, hs.package_root, hs.name)
     return ["-fhpc", "-hpcdir", hpcdir]
 
 def _coverage_datum(mix_file, src_file, target_label):
@@ -404,7 +404,7 @@ def compile_binary(
         c.args.add_all(_hpc_compiler_args(hs))
         for src_file in srcs:
             module = module_name(hs, src_file)
-            mix_file = hs.actions.declare_file(".hpc/{module}.mix".format(module = module))
+            mix_file = hs.actions.declare_file("{name}_.hpc/{module}.mix".format(name=hs.name, module = module))
             coverage_data.append(_coverage_datum(mix_file, src_file, hs.label))
 
     hs.toolchain.actions.run_ghc(
@@ -467,7 +467,7 @@ def compile_library(
         for src_file in srcs:
             pkg_id_string = pkg_id.to_string(my_pkg_id)
             module = module_name(hs, src_file)
-            mix_file = hs.actions.declare_file(".hpc/{pkg}/{module}.mix".format(pkg = pkg_id_string, module = module))
+            mix_file = hs.actions.declare_file("{name}_.hpc/{pkg}/{module}.mix".format(name = hs.name, pkg = pkg_id_string, module = module))
             coverage_data.append(_coverage_datum(mix_file, src_file, hs.label))
 
     if srcs:

--- a/haskell/private/actions/compile.bzl
+++ b/haskell/private/actions/compile.bzl
@@ -404,7 +404,7 @@ def compile_binary(
         c.args.add_all(_hpc_compiler_args(hs))
         for src_file in srcs:
             module = module_name(hs, src_file)
-            mix_file = hs.actions.declare_file("{name}_.hpc/{module}.mix".format(name=hs.name, module = module))
+            mix_file = hs.actions.declare_file("{name}_.hpc/{module}.mix".format(name = hs.name, module = module))
             coverage_data.append(_coverage_datum(mix_file, src_file, hs.label))
 
     hs.toolchain.actions.run_ghc(

--- a/haskell/private/coverage_wrapper.sh.tpl
+++ b/haskell/private/coverage_wrapper.sh.tpl
@@ -58,8 +58,8 @@ for m in "${mix_file_paths[@]}"
 do
   absolute_mix_file_path=$(rlocation $m)
   hpc_parent_dir=$(dirname "$absolute_mix_file_path")
-  trimmed_hpc_parent_dir="${hpc_parent_dir%%.hpc*}"
-  hpc_dir_args+=("--hpcdir=$trimmed_hpc_parent_dir.hpc")
+  trimmed_hpc_parent_dir="${hpc_parent_dir%%_.hpc*}"
+  hpc_dir_args+=("--hpcdir=${trimmed_hpc_parent_dir}_.hpc")
 done
 
 # gather the modules to exclude from the coverage analysis

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -364,7 +364,6 @@ haskell_library(
     srcs = [
         "LZ4.hs",
     ],
-    src_strip_prefix = "src",
     tags = ["requires_lz4"],
     deps = [
         "//tests/hackage:base",

--- a/tests/two-same-file/BUILD.bazel
+++ b/tests/two-same-file/BUILD.bazel
@@ -1,0 +1,34 @@
+load(
+    "@rules_haskell//haskell:defs.bzl",
+    "haskell_library",
+    "haskell_test",
+)
+
+package(
+    default_testonly = 1,
+    default_visibility = ["//visibility:public"],
+)
+
+haskell_test(
+    name = "one",
+    srcs = ["Main.hs"],
+    coverage_report_format = "html",
+    expected_covered_expressions_percentage = 55,
+    expected_uncovered_expression_count = 4,
+    tags = ["coverage-compatible"],
+    deps = [
+        "//tests/hackage:base",
+    ],
+)
+
+haskell_test(
+    name = "two",
+    srcs = ["Main.hs"],
+    coverage_report_format = "html",
+    expected_covered_expressions_percentage = 55,
+    expected_uncovered_expression_count = 4,
+    tags = ["coverage-compatible"],
+    deps = [
+        "//tests/hackage:base",
+    ],
+)

--- a/tests/two-same-file/BUILD.bazel
+++ b/tests/two-same-file/BUILD.bazel
@@ -4,11 +4,6 @@ load(
     "haskell_test",
 )
 
-package(
-    default_testonly = 1,
-    default_visibility = ["//visibility:public"],
-)
-
 haskell_test(
     name = "one",
     srcs = ["Main.hs"],

--- a/tests/two-same-file/BUILD.bazel
+++ b/tests/two-same-file/BUILD.bazel
@@ -1,6 +1,5 @@
 load(
     "@rules_haskell//haskell:defs.bzl",
-    "haskell_library",
     "haskell_test",
 )
 

--- a/tests/two-same-file/Main.hs
+++ b/tests/two-same-file/Main.hs
@@ -1,0 +1,4 @@
+module Main where
+
+main :: IO ()
+main = putStrLn "Yiha"


### PR DESCRIPTION
Right now coverage files are generated in a `.hpc/` directory. If two rules in the same bazel package have the same input file, they will generate the same `.mix` file in the `.hpc` directory.

This leads to build failure. Actually, bazel detect this during its analysis phase and fails.

I've added tests in ` tests/two-same-file` to show this behavior.

The fix consist of moving the `.hpc` file to `RULE_NAME_.hpc`. The name is a bit convoluted, it may have been `.hpc_RULE_NAME`, but it simplifies the logic.