### PR TITLE
Do not pass -i flags to REPL

### DIFF
--- a/haskell/repl.bzl
+++ b/haskell/repl.bzl
@@ -282,10 +282,6 @@ def _compiler_flags_and_inputs(hs, repl_info, static = False, path_prefix = ""):
         cc_library_files = get_ghci_library_files(hs, cc_libraries_info, cc_libraries)
     link_libraries(cc_library_files, args)
 
-    # Add import directories
-    for import_dir in repl_info.load_info.import_dirs.to_list():
-        args.append("-i" + (import_dir if import_dir else "."))
-
     if static:
         all_library_files = _concat(get_library_files(hs, cc_libraries_info, all_libraries, include_real_paths = True))
     else:

--- a/tests/RunTests.hs
+++ b/tests/RunTests.hs
@@ -55,6 +55,9 @@ main = hspec $ do
     it "repl flags" $ do
       assertSuccess (bazel ["run", "//tests/repl-flags:repl_flags@repl", "--", "-ignore-dot-ghci", "-e", "foo"])
 
+    it "fails on multiple definitions" $ do
+      assertFailure (bazel ["run", "//tests/repl-multiple-definition:repl", "--", "-ignore-dot-ghci", "-e", "final"])
+
   describe "multi_repl" $ do
     it "loads transitive library dependencies" $ do
       let p' (stdout, _stderr) = lines stdout == ["tests/multi_repl/bc/src/BC/C.hs"]

--- a/tests/RunTests.hs
+++ b/tests/RunTests.hs
@@ -56,7 +56,7 @@ main = hspec $ do
       assertSuccess (bazel ["run", "//tests/repl-flags:repl_flags@repl", "--", "-ignore-dot-ghci", "-e", "foo"])
 
     it "fails on multiple definitions" $ do
-      assertFailure (bazel ["run", "//tests/repl-multiple-definition:repl", "--", "-ignore-dot-ghci", "-e", "final"])
+      assertSuccess (bazel ["run", "//tests/repl-multiple-definition:repl", "--", "-ignore-dot-ghci", "-e", "final"])
 
   describe "multi_repl" $ do
     it "loads transitive library dependencies" $ do
@@ -68,8 +68,8 @@ main = hspec $ do
     it "loads core library dependencies" $ do
       let p' (stdout, _stderr) = sort (lines stdout) == ["tests/multi_repl/core_package_dep/Lib.hs"]
       outputSatisfy p' (bazel ["run", "//tests/multi_repl:core_package_dep", "--", "-ignore-dot-ghci", "-e", ":show targets"])
-    it "allows to manually load modules" $ do
-      assertSuccess (bazel ["run", "//tests/multi_repl:c_multi_repl", "--", "-ignore-dot-ghci", "-e", ":load BC.C", "-e", "c"])
+    it "doesn't allow to manually load modules" $ do
+      assertFailure (bazel ["run", "//tests/multi_repl:c_multi_repl", "--", "-ignore-dot-ghci", "-e", ":load BC.C", "-e", "c"])
 
   describe "ghcide" $ do
     it "loads RunTests.hs" $

--- a/tests/repl-multiple-definition/BUILD.bazel
+++ b/tests/repl-multiple-definition/BUILD.bazel
@@ -1,0 +1,67 @@
+load(
+    "@rules_haskell//haskell:defs.bzl",
+    "haskell_library",
+    "haskell_repl",
+)
+
+haskell_library(
+    name = "root",
+    srcs = ["src/Root.hs"],
+    src_strip_prefix = "src",
+    deps = ["//tests/hackage:base"],
+)
+
+haskell_library(
+    name = "intermediate",
+    srcs = ["intermediate/Intermediate.hs"],
+    src_strip_prefix = "intermediate",
+    deps = [
+        ":root",
+        "//tests/hackage:base",
+    ],
+)
+
+haskell_library(
+    name = "final",
+    srcs = ["src/Final.hs"],
+    src_strip_prefix = "src",
+    deps = [
+        ":intermediate",
+        ":root",
+        "//tests/hackage:base",
+    ],
+)
+
+# The REPL final@repl should only load `src/Final.hs` from source and all other
+# modules should be loaded from binary. If `src/Root.hs` is also loaded from
+# source erroneously, then the REPL will fail with a multiple definitions
+# error:
+#
+#   tests/repl-multiple-definition/src/Final.hs:7:23: error:
+#       • Couldn't match expected type ‘root:Root.Root’
+#                     with actual type ‘Root’
+#         NB: ‘Root’ is defined at
+#               tests/repl-multiple-definition/src/Root.hs:3:1-19
+#             ‘root:Root.Root’ is defined in ‘Root’ in package ‘root’
+#       • In the first argument of ‘intermediate’, namely ‘(Root ())’
+#         In the expression: intermediate (Root ())
+#         In an equation for ‘final’: final = intermediate (Root ())
+#     |
+#   7 | final = intermediate (Root ())
+#     |                       ^^^^^^^
+#
+# This is because `:intermediate` will use the `Root` type from the compiled
+# `:root` package. However, if `src/Root.hs` is also loaded from source, then
+# GHCi will have a separate definition of `data Root` in scope from the
+# interpreted `Root` module.
+#
+# This error is triggered when `haskell_repl` passes `-isrc` to `ghci` due to
+# the shared `src_strip_prefix` between `:root` and `:final`. GHCi will prefer
+# to load modules from source if possible over loading them from compiled
+# packages.
+haskell_repl(
+    name = "repl",
+    collect_data = False,
+    experimental_from_source = [":final"],
+    deps = [":final"],
+)

--- a/tests/repl-multiple-definition/intermediate/Intermediate.hs
+++ b/tests/repl-multiple-definition/intermediate/Intermediate.hs
@@ -1,0 +1,6 @@
+module Intermediate where
+
+import Root
+
+intermediate :: Root -> ()
+intermediate (Root ()) = ()

--- a/tests/repl-multiple-definition/src/Final.hs
+++ b/tests/repl-multiple-definition/src/Final.hs
@@ -1,0 +1,7 @@
+module Final where
+
+import Intermediate
+import Root
+
+final :: ()
+final = intermediate (Root ())

--- a/tests/repl-multiple-definition/src/Root.hs
+++ b/tests/repl-multiple-definition/src/Root.hs
@@ -1,0 +1,3 @@
+module Root where
+
+data Root = Root ()


### PR DESCRIPTION
Closes https://github.com/tweag/rules_haskell/issues/1344

As laid out in the issue this avoids loading modules both by source and from a compiled package erroneously due to a shared `src_strip_prefix`.

This change affects users in that `:load <ModuleName>` will no longer work in `haskell_repl`. `:load` relies on import directories specified via `-i` flags to find module sources. However, [`src_strip_prefix`](https://api.haskell.build/haskell/defs.html#haskell_library-src_strip_prefix) is marked as deprecated. Instead of `:load` users can use `:m +/-` to bring modules that have been defined on GHCi's command line by `haskell_repl` in and out of scope.

Side note, `ghcide` support as implemented in #1262 may still require `-i` flags to function. We can set those separately in the hie-bios output if needed, until a better solution is found that doesn't rely on the deprecated `src_strip_prefix` attribute.