### PR TITLE
Support Cabal setup dependencies

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -94,6 +94,7 @@ stack_snapshot(
         "text",
         "vector",
         # For tests
+        "cabal-doctest",
         "network",
         "language-c",
         "streaming",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -95,6 +95,7 @@ stack_snapshot(
         "vector",
         # For tests
         "cabal-doctest",
+        "polysemy",
         "network",
         "language-c",
         "streaming",
@@ -108,6 +109,7 @@ stack_snapshot(
         "proto-lens-runtime",
         "lens-family",
     ],
+    setup_deps = {"polysemy": ["cabal-doctest"]},
     snapshot = test_stack_snapshot,
     tools = [
         "@alex",

--- a/haskell/cabal.bzl
+++ b/haskell/cabal.bzl
@@ -1004,7 +1004,6 @@ def _stack_snapshot_impl(repository_ctx):
     )
 
     extra_deps = _to_string_keyed_label_list_dict(repository_ctx.attr.extra_deps)
-    setup_deps = _to_string_keyed_label_list_dict(repository_ctx.attr.setup_deps)
     tools = [_label_to_string(label) for label in repository_ctx.attr.tools]
 
     # Write out dependency graph as importable Starlark value.
@@ -1086,8 +1085,8 @@ haskell_cabal_library(
                         for label in extra_deps.get(package.name, [])
                     ],
                     setup_deps = [
-                        _label_to_string(label)
-                        for label in setup_deps.get(package.name, [])
+                        _label_to_string(Label("@{}//:{}".format(repository_ctx.name, package.name)).relative(label))
+                        for label in repository_ctx.attr.setup_deps.get(package.name, [])
                     ],
                     tools = tools,
                     visibility = visibility,
@@ -1118,7 +1117,7 @@ _stack_snapshot = repository_rule(
             doc = "Whether to generate haddock documentation",
         ),
         "extra_deps": attr.label_keyed_string_dict(),
-        "setup_deps": attr.label_keyed_string_dict(),
+        "setup_deps": attr.string_list_dict(),
         "tools": attr.label_list(),
         "stack": attr.label(),
         "stack_update": attr.label(),
@@ -1223,7 +1222,7 @@ _fetch_stack = repository_rule(
 )
 """Find a suitably recent local Stack or download it."""
 
-def stack_snapshot(stack = None, extra_deps = {}, setup_deps = {}, vendored_packages = {}, **kwargs):
+def stack_snapshot(stack = None, extra_deps = {}, vendored_packages = {}, **kwargs):
     """Use Stack to download and extract Cabal source distributions.
 
     This rule will use Stack to compute the transitive closure of the
@@ -1325,8 +1324,7 @@ def stack_snapshot(stack = None, extra_deps = {}, setup_deps = {}, vendored_pack
         the tools are executed as part of the build.
       stack: The stack binary to use to enumerate package dependencies.
     """
-    typecheck_stackage_extradeps(extra_deps, "extra_deps")
-    typecheck_stackage_extradeps(setup_deps, "setup_deps")
+    typecheck_stackage_extradeps(extra_deps)
     if not stack:
         _fetch_stack(name = "rules_haskell_stack")
         stack = Label("@rules_haskell_stack//:stack")
@@ -1347,9 +1345,6 @@ def stack_snapshot(stack = None, extra_deps = {}, setup_deps = {}, vendored_pack
         # TODO Remove _from_string_keyed_label_list_dict once following issue
         # is resolved: https://github.com/bazelbuild/bazel/issues/7989.
         extra_deps = _from_string_keyed_label_list_dict(extra_deps),
-        # TODO Remove _from_string_keyed_label_list_dict once following issue
-        # is resolved: https://github.com/bazelbuild/bazel/issues/7989.
-        setup_deps = _from_string_keyed_label_list_dict(setup_deps),
         # TODO Remove _invert once following issue is resolved:
         # https://github.com/bazelbuild/bazel/issues/7989.
         vendored_packages = _invert(vendored_packages),

--- a/haskell/cabal.bzl
+++ b/haskell/cabal.bzl
@@ -467,6 +467,9 @@ haskell_cabal_library = rule(
         "deps": attr.label_list(
             aspects = [haskell_cc_libraries_aspect],
         ),
+        "setup_deps": attr.label_list(
+            aspects = [haskell_cc_libraries_aspect],
+        ),
         "compiler_flags": attr.string_list(
             doc = """Flags to pass to Haskell compiler, in addition to those defined
             the cabal file. Subject to Make variable substitution.""",
@@ -642,6 +645,9 @@ haskell_cabal_binary = rule(
         ),
         "srcs": attr.label_list(allow_files = True),
         "deps": attr.label_list(
+            aspects = [haskell_cc_libraries_aspect],
+        ),
+        "setup_deps": attr.label_list(
             aspects = [haskell_cc_libraries_aspect],
         ),
         "compiler_flags": attr.string_list(

--- a/haskell/cabal.bzl
+++ b/haskell/cabal.bzl
@@ -493,6 +493,7 @@ haskell_cabal_library = rule(
         ),
         "setup_deps": attr.label_list(
             aspects = [haskell_cc_libraries_aspect],
+            doc = "Dependencies for custom setup Setup.hs.",
         ),
         "compiler_flags": attr.string_list(
             doc = """Flags to pass to Haskell compiler, in addition to those defined
@@ -677,6 +678,7 @@ haskell_cabal_binary = rule(
         ),
         "setup_deps": attr.label_list(
             aspects = [haskell_cc_libraries_aspect],
+            doc = "Dependencies for custom setup Setup.hs.",
         ),
         "compiler_flags": attr.string_list(
             doc = """Flags to pass to Haskell compiler, in addition to those defined

--- a/haskell/private/typing.bzl
+++ b/haskell/private/typing.bzl
@@ -1,17 +1,18 @@
-def typecheck_stackage_extradeps(extra_deps):
-    """Check that the extra_deps field of a stackage rule is well typed.
+def typecheck_stackage_extradeps(extra_deps, field):
+    """Check that the extra_deps or setup_deps field of a stackage rule is well typed.
     If not, fail.
 
     Args:
-      extra_deps: The value of the extra_deps field of a stackage rule
+      extra_deps: The value of the extra_deps or setup_deps field of a stackage rule
+      field: The field name
     """
     if not extra_deps:
         return
     if type(extra_deps) != "dict":
-        fail("stack_snapshot extra_deps requires a dict from dependency name to list of targets, but was given: {}".format(type(extra_deps)))
+        fail("stack_snapshot {} requires a dict from dependency name to list of targets, but was given: {}".format(field, type(extra_deps)))
     for extra_deps_key in extra_deps.keys():
         if type(extra_deps_key) != "string":
-            fail("stack_snapshot extra_deps's dict requires string keys, but key \"{}\" has type {}".format(extra_deps_key, type(extra_deps_key)))
+            fail("stack_snapshot {}'s dict requires string keys, but key \"{}\" has type {}".format(field, extra_deps_key, type(extra_deps_key)))
     for extra_deps_value in extra_deps.values():
         if type(extra_deps_value) != "list":
-            fail("stack_snapshot extra_deps's dict requires list values, but value \"{}\" has type {}".format(extra_deps_value, type(extra_deps_value)))
+            fail("stack_snapshot {}'s dict requires list values, but value \"{}\" has type {}".format(field, extra_deps_value, type(extra_deps_value)))

--- a/haskell/private/typing.bzl
+++ b/haskell/private/typing.bzl
@@ -1,18 +1,17 @@
-def typecheck_stackage_extradeps(extra_deps, field):
-    """Check that the extra_deps or setup_deps field of a stackage rule is well typed.
+def typecheck_stackage_extradeps(extra_deps):
+    """Check that the extra_deps field of a stackage rule is well typed.
     If not, fail.
 
     Args:
-      extra_deps: The value of the extra_deps or setup_deps field of a stackage rule
-      field: The field name
+      extra_deps: The value of the extra_deps field of a stackage rule
     """
     if not extra_deps:
         return
     if type(extra_deps) != "dict":
-        fail("stack_snapshot {} requires a dict from dependency name to list of targets, but was given: {}".format(field, type(extra_deps)))
+        fail("stack_snapshot extra_deps requires a dict from dependency name to list of targets, but was given: {}".format(type(extra_deps)))
     for extra_deps_key in extra_deps.keys():
         if type(extra_deps_key) != "string":
-            fail("stack_snapshot {}'s dict requires string keys, but key \"{}\" has type {}".format(field, extra_deps_key, type(extra_deps_key)))
+            fail("stack_snapshot extra_deps's dict requires string keys, but key \"{}\" has type {}".format(extra_deps_key, type(extra_deps_key)))
     for extra_deps_value in extra_deps.values():
         if type(extra_deps_value) != "list":
-            fail("stack_snapshot {}'s dict requires list values, but value \"{}\" has type {}".format(field, extra_deps_value, type(extra_deps_value)))
+            fail("stack_snapshot extra_deps's dict requires list values, but value \"{}\" has type {}".format(extra_deps_value, type(extra_deps_value)))

--- a/tests/haskell_cabal_doctest/BUILD.bazel
+++ b/tests/haskell_cabal_doctest/BUILD.bazel
@@ -1,0 +1,16 @@
+load("@rules_haskell//haskell:cabal.bzl", "haskell_cabal_library")
+load("@rules_haskell//haskell:defs.bzl", "haskell_toolchain_library")
+
+haskell_toolchain_library(name = "base")
+
+haskell_cabal_library(
+    name = "uses-doctest",
+    package_name = "lib",
+    srcs = [
+        "Lib.hs",
+        "Setup.hs",
+        "lib.cabal",
+    ],
+    version = "0.1.0.0",
+    deps = [":base"],
+)

--- a/tests/haskell_cabal_doctest/BUILD.bazel
+++ b/tests/haskell_cabal_doctest/BUILD.bazel
@@ -11,6 +11,7 @@ haskell_cabal_library(
         "Setup.hs",
         "lib.cabal",
     ],
+    setup_deps = ["@stackage//:cabal-doctest"],
     version = "0.1.0.0",
     deps = [":base"],
 )

--- a/tests/haskell_cabal_doctest/Lib.hs
+++ b/tests/haskell_cabal_doctest/Lib.hs
@@ -1,0 +1,8 @@
+module Lib where
+
+-- | The string foo
+--
+-- >>> foo
+-- "foo"
+foo :: String
+foo = "foo"

--- a/tests/haskell_cabal_doctest/Setup.hs
+++ b/tests/haskell_cabal_doctest/Setup.hs
@@ -1,0 +1,6 @@
+module Main where
+
+import Distribution.Extra.Doctest (defaultMainWithDoctests)
+
+main :: IO ()
+main = defaultMainWithDoctests "doctests"

--- a/tests/haskell_cabal_doctest/lib.cabal
+++ b/tests/haskell_cabal_doctest/lib.cabal
@@ -1,0 +1,15 @@
+cabal-version: >=1.10
+name: lib
+version: 0.1.0.0
+build-type: Custom
+
+custom-setup
+ setup-depends:
+   base >= 4 && <5,
+   Cabal,
+   cabal-doctest >= 1 && <1.1
+
+library
+  build-depends: base >=4.12 && <4.13
+  default-language: Haskell2010
+  exposed-modules: Lib

--- a/tests/haskell_cabal_doctest/lib.cabal
+++ b/tests/haskell_cabal_doctest/lib.cabal
@@ -5,11 +5,11 @@ build-type: Custom
 
 custom-setup
  setup-depends:
-   base >= 4 && <5,
+   base,
    Cabal,
-   cabal-doctest >= 1 && <1.1
+   cabal-doctest
 
 library
-  build-depends: base >=4.12 && <4.13
+  build-depends: base
   default-language: Haskell2010
   exposed-modules: Lib

--- a/tests/stack-snapshot-deps/BUILD.bazel
+++ b/tests/stack-snapshot-deps/BUILD.bazel
@@ -20,5 +20,7 @@ haskell_test(
         # Packages using ./configure scripts are problematic on Windows.
         "@stackage//:network",
         "@stackage//:language-c",
+        # Package that has a setup dependency.
+        "@stackage//:polysemy",
     ],
 )


### PR DESCRIPTION
Closes https://github.com/tweag/rules_haskell/issues/1314

* Adds an attribute `setup_deps` to `haskell_cabal_library|binary` to pass in `setup-depends` libraries for `custom-setup`.
* Adds an attribute `setup_deps` to `stack_snapshot` which allows to specify per package `setup_deps`. This is implementated in a way that allows using targets from within the same snapshot. E.g. if `polysemy` depends on `cabal-doctest` then both those packages can be built by the same `stack_snapshot`.
* Adds a test case for `setup_deps` on `haskell_cabal_library`
* Adds a regression test for #1314.