### PR TITLE
CircleCI: Install `xz` on MacOS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,7 @@ jobs:
       - run:
           name: Install Nix
           command: |
+            HOMEBREW_NO_AUTO_UPDATE=1 brew install xz
             curl -L https://nixos.org/nix/install | sh
 
       - run:


### PR DESCRIPTION
`xz` is required by the Nix installer to avoid the following error
```
sh: you do not have 'xz' installed, which I need to unpack the binary tarball
```

Eventually that dependency should be removed on MacOS, see https://github.com/NixOS/nix/pull/3632, but at the time of writing this change is not available, yet.
```
$ curl -L https://nixos.org/nix/install | grep -C1 require_util\ xz
require_util tar "unpack the binary tarball"
require_util xz "unpack the binary tarball"

```