### PR TITLE
Fix issues around cc_wrapper with Cabal builds

### DIFF
--- a/haskell/private/cabal_wrapper.py.tpl
+++ b/haskell/private/cabal_wrapper.py.tpl
@@ -140,6 +140,7 @@ with tmpdir() as distdir:
     # absolute ones before doing so (using $execroot).
     old_cwd = os.getcwd()
     os.chdir(srcdir)
+    os.putenv("RULES_HASKELL_EXEC_ROOT", old_cwd)
     os.putenv("HOME", "/var/empty")
     os.putenv("TMPDIR", os.path.join(distdir, "tmp"))
     os.putenv("TMP", os.path.join(distdir, "tmp"))

--- a/haskell/private/cc_wrapper.py.tpl
+++ b/haskell/private/cc_wrapper.py.tpl
@@ -711,17 +711,17 @@ def find_solib_rpath(rpaths, output):
     """
     for rpath in rpaths:
         components = rpath.replace("\\", "/").split("/")
-        solib_rpath = []
+        solib_rpath = ""
         for comp in components:
-            solib_rpath.append(comp)
-            if comp.startswith("_solib_"):
-                return "/".join(solib_rpath)
+            solib_rpath = os.path.join(solib_rpath, comp)
+            if comp.startswith("_solib_") and os.path.isdir(resolve_rpath(solib_rpath, output)[1]):
+                return solib_rpath
 
     if is_temporary_output(output):
         # GHC generates temporary libraries outside the execroot. In that case
         # the Bazel generated RPATHs are not forwarded, and the solib directory
         # is not visible on the command-line.
-        for (root, dirnames, _) in breadth_first_walk("."):
+        for (root, dirnames, _) in breadth_first_walk(os.environ.get("RULES_HASKELL_EXEC_ROOT", ".")):
             if "_solib_{:cpu:}" in dirnames:
                 return os.path.join(root, "_solib_{:cpu:}")
 


### PR DESCRIPTION
* https://github.com/tweag/rules_haskell/pull/1325 changed the Cabal build directory to fix dangling relative RUNPATH entries in Cabal build outputs. The lengthens the path to the build directory which can cause build failures when the path exceeds `MAX_PATH` on Windows. Since we don't use dynamic Haskell libraries on Windows, we can stick to a shorter build directory path on Windows.
* The `cc_wrapper`'s logic to fix RUNPATHs in temporary outputs of GHC didn't work in a working directory outside of the Bazel execroot as is the case in Cabal builds. This triggered build failures with intermediate outputs exceeding the MACH-O header size limit on MacOS, see https://github.com/tweag/rules_haskell/pull/1262#issuecomment-638193222. This PR extends the corresponding logic in the cc_wrapper to look for the solib directory under the execroot which can be specified by Cabal wrapper via an environment variable.