### PR TITLE
Add a missing manifest file to the cabal builds

### DIFF
--- a/haskell/cabal.bzl
+++ b/haskell/cabal.bzl
@@ -255,7 +255,7 @@ def _prepare_cabal_inputs(
             tool_inputs,
         ],
     )
-    input_manifests = tool_input_manifests
+    input_manifests = tool_input_manifests + hs.toolchain.cc_wrapper.manifests
 
     return struct(
         cabal_wrapper = cabal_wrapper,


### PR DESCRIPTION
The cabal build env was missing the cc toolchain manifest file, causing builds with `--remote_download_minimal` (and probably remote builds too) to fail with `Cannot find .runfiles directory for …/cc_wrapper_python`