### PR TITLE
Set -i flags in hie-bios output for ghcide

### DIFF
--- a/haskell/repl.bzl
+++ b/haskell/repl.bzl
@@ -415,6 +415,12 @@ def _create_hie_bios(hs, posix, ctx, repl_info):
     args.extend(hs.toolchain.compiler_flags)
     args.extend(repl_info.load_info.compiler_flags)
 
+    # Add import directories.
+    # Note, src_strip_prefix is deprecated. However, for now ghcide depends on
+    # `-i` flags to find source files to modules.
+    for import_dir in repl_info.load_info.import_dirs.to_list():
+        args.append("-i" + (import_dir if import_dir else "."))
+
     args_file = ctx.actions.declare_file(".%s.hie-bios" % ctx.label.name)
     args_link = ctx.actions.declare_file("%s@hie-bios" % ctx.label.name)
     ctx.actions.write(args_file, "\n".join(args))

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -394,6 +394,7 @@ haskell_repl(
     collect_data = False,
     deps = [
         "//tests:run-tests",
+        "//tests/binary-with-lib",
     ],
 )
 

--- a/tests/RunTests.hs
+++ b/tests/RunTests.hs
@@ -74,6 +74,8 @@ main = hspec $ do
   describe "ghcide" $ do
     it "loads RunTests.hs" $
       assertSuccess (Process.proc "./.ghcide" ["tests/RunTests.hs"])
+    it "loads module with module dependency" $
+      assertSuccess (Process.proc "./.ghcide" ["tests/binary-with-lib/Main.hs"])
 
   describe "failures" $ do
     -- Make sure not to include haskell_repl (@repl) or alias (-repl) targets


### PR DESCRIPTION
They were removed for GHCi in https://github.com/tweag/rules_haskell/pull/1345.

ghcide requires import dirs to find source files for modules that the current file depends on. While `src_strip_prefix` has been deprecated, there is no alternative available in rules_haskell for this particular use-case, yet.

Adds a regression test for `ghcide` invoked on a source file that has module dependencies.
