### PR TITLE
Add test for Protobuf name clash issue

### DIFF
--- a/tests/haskell_proto_simple/BUILD.bazel
+++ b/tests/haskell_proto_simple/BUILD.bazel
@@ -2,18 +2,17 @@
 Minimal reproduction of https://github.com/tweag/rules_haskell/issues/1111
 """
 
-
 load("//haskell:defs.bzl", "haskell_doc", "haskell_library")
-load("//haskell:protobuf.bzl",
-     "haskell_proto_library",
-     "haskell_proto_toolchain",
+load(
+    "//haskell:protobuf.bzl",
+    "haskell_proto_library",
+    "haskell_proto_toolchain",
 )
 
-
 proto_library(
-     name = "foo",
-     srcs = ["foo.proto"],
-     deps = [ "@com_google_protobuf//:descriptor_proto" ],
+    name = "foo",
+    srcs = ["foo.proto"],
+    deps = ["@com_google_protobuf//:descriptor_proto"],
 )
 
 haskell_proto_library(
@@ -32,7 +31,7 @@ haskell_library(
     visibility = ["//visibility:public"],
     deps = [
         ":foo_haskell",
-        "@stackage//:proto-lens",
         "//tests/hackage:base",
+        "@stackage//:proto-lens",
     ],
 )

--- a/tests/haskell_proto_simple/BUILD.bazel
+++ b/tests/haskell_proto_simple/BUILD.bazel
@@ -1,0 +1,38 @@
+"""
+Minimal reproduction of https://github.com/tweag/rules_haskell/issues/1111
+"""
+
+
+load("//haskell:defs.bzl", "haskell_doc", "haskell_library")
+load("//haskell:protobuf.bzl",
+     "haskell_proto_library",
+     "haskell_proto_toolchain",
+)
+
+
+proto_library(
+     name = "foo",
+     srcs = ["foo.proto"],
+     deps = [ "@com_google_protobuf//:descriptor_proto" ],
+)
+
+haskell_proto_library(
+    name = "foo_haskell",
+    deps = [
+        ":foo",
+    ],
+)
+
+haskell_library(
+    name = "hs-lib",
+    srcs = ["Bar.hs"],
+    tags = [
+        "requires_proto",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":foo_haskell",
+        "@stackage//:proto-lens",
+        "//tests/hackage:base",
+    ],
+)

--- a/tests/haskell_proto_simple/Bar.hs
+++ b/tests/haskell_proto_simple/Bar.hs
@@ -1,0 +1,15 @@
+module Bar (bar) where
+
+-- TODO this doesn't work as the Haskell packages generated for Protobuf dependencies
+-- are hidden by default.
+--
+-- As a workaround, we wrap FileDescriptorSet in a custom message.
+--
+-- import qualified Proto.Google.Protobuf.Descriptor
+
+import Proto.Tests.HaskellProtoSimple.Foo (Baz, FileDescriptorSet2)
+import Data.ProtoLens.Message (defMessage)
+
+bar :: Baz
+bar = defMessage
+

--- a/tests/haskell_proto_simple/foo.proto
+++ b/tests/haskell_proto_simple/foo.proto
@@ -1,0 +1,11 @@
+ syntax = "proto3";
+
+package foo;
+
+import "google/protobuf/descriptor.proto";
+
+message Baz {}
+
+message FileDescriptorSet2 {
+  google.protobuf.FileDescriptorSet x = 1;
+}


### PR DESCRIPTION
Add a test showing how the the name clash issue reported in #1111 does not appear with the recent proto-lens (e.g. the version of Stackage pinned in master/this commit).

Also introduces a workaround (but not a proper fix) for #1368.