### PR TITLE
Pass CC/GHC toolchain flags to Cabal builds

### DIFF
--- a/haskell/cabal.bzl
+++ b/haskell/cabal.bzl
@@ -211,7 +211,8 @@ def _prepare_cabal_inputs(
         for arg in ["-package-db", "./" + _dirname(package_db)]
     ], join_with = " ", format_each = "--ghc-arg=%s", omit_if_empty = False)
     args.add("--flags=" + " ".join(flags))
-    args.add_all(compiler_flags, format_each = "--ghc-option=%s")
+    args.add_all(cc.compiler_flags, format_each = "--ghc-option=-optc=%s")
+    args.add_all(hs.toolchain.compiler_flags + compiler_flags, format_each = "--ghc-option=%s")
     if dynamic_binary:
         args.add_all(
             [

--- a/tests/cabal-toolchain-flags/BUILD.bazel
+++ b/tests/cabal-toolchain-flags/BUILD.bazel
@@ -1,0 +1,6 @@
+load("@rules_haskell//haskell:cabal.bzl", "haskell_cabal_binary")
+
+haskell_cabal_binary(
+    name = "cabal-toolchain-flags",
+    srcs = glob(["**"]),
+)

--- a/tests/cabal-toolchain-flags/Main.hs
+++ b/tests/cabal-toolchain-flags/Main.hs
@@ -1,0 +1,8 @@
+{-# LANGUAGE CPP #-}
+
+module Main where
+
+#ifdef TESTS_TOOLCHAIN_COMPILER_FLAGS
+main :: IO ()
+main = pure ()
+#endif

--- a/tests/cabal-toolchain-flags/test.cabal
+++ b/tests/cabal-toolchain-flags/test.cabal
@@ -1,0 +1,9 @@
+cabal-version: >=1.10
+name: cabal-toolchain-flags
+version: 0.1.0.0
+build-type: Simple
+
+executable cabal-toolchain-flags
+  build-depends: base
+  default-language: Haskell2010
+  main-is: Main.hs


### PR DESCRIPTION
Closes https://github.com/tweag/rules_haskell/issues/1365

* `compiler_flags` defined at `haskell_register_ghc_*` will also be forwarded to Cabal builds using `haskell_cabal_binary|library`. This allows users to pass compiler flags that are required for their platform, e.g. #1365, and is also in line with what Hazel used to do.
* This adds a regression test for Cabal builds that ensures that GHC toolchain flags are forwarded to Cabal builds.