### PR TITLE
Refactor implementation of `stack_snapshot`

### DIFF
--- a/haskell/cabal.bzl
+++ b/haskell/cabal.bzl
@@ -927,7 +927,12 @@ def _parse_package_spec(package_spec):
 
     # Parse simple fields.
     parsed = {
-        field: _parse_json_field(package_spec, field, ty, errmsg.format(context = "package description"))
+        field: _parse_json_field(
+            package_spec,
+            field,
+            ty,
+            errmsg.format(context = "package description"),
+        )
         for (field, ty) in [("name", "string"), ("version", "string"), ("dependencies", "list")]
     }
 
@@ -936,25 +941,55 @@ def _parse_package_spec(package_spec):
     if parsed["name"] in _CORE_PACKAGES or not "location" in package_spec:
         location["type"] = "core"
     else:
-        location_type = _parse_json_field(package_spec["location"], "type", "string", errmsg.format(context = "location description"))
+        location_type = _parse_json_field(
+            package_spec["location"],
+            "type",
+            "string",
+            errmsg.format(context = "location description"),
+        )
         if location_type == "project package":
             location["type"] = "vendored"
         elif location_type == "hackage":
             location["type"] = location_type
-            url_prefix = _parse_json_field(package_spec["location"], "url", "string", errmsg.format(context = location_type + " location description"))
+            url_prefix = _parse_json_field(
+                package_spec["location"],
+                "url",
+                "string",
+                errmsg.format(context = location_type + " location description"),
+            )
             location["url"] = url_prefix + "/{name}-{version}.tar.gz".format(**parsed)
             # stack does not expose sha-256, see https://github.com/commercialhaskell/stack/issues/5274
 
         elif location_type == "archive":
             location["type"] = location_type
-            location["url"] = _parse_json_field(package_spec["location"], "url", "string", errmsg.format(context = location_type + " location description"))
+            location["url"] = _parse_json_field(
+                package_spec["location"],
+                "url",
+                "string",
+                errmsg.format(context = location_type + " location description"),
+            )
             # stack does not yet expose sha-256, see https://github.com/commercialhaskell/stack/pull/5280
 
         elif location_type in ["git", "hg"]:
             location["type"] = location_type
-            location["url"] = _parse_json_field(package_spec["location"], "url", "string", errmsg.format(context = location_type + " location description"))
-            location["commit"] = _parse_json_field(package_spec["location"], "commit", "string", errmsg.format(context = location_type + " location description"))
-            location["subdir"] = _parse_json_field(package_spec["location"], "subdir", "string", errmsg.format(context = location_type + " location description"))
+            location["url"] = _parse_json_field(
+                package_spec["location"],
+                "url",
+                "string",
+                errmsg.format(context = location_type + " location description"),
+            )
+            location["commit"] = _parse_json_field(
+                package_spec["location"],
+                "commit",
+                "string",
+                errmsg.format(context = location_type + " location description"),
+            )
+            location["subdir"] = _parse_json_field(
+                package_spec["location"],
+                "subdir",
+                "string",
+                errmsg.format(context = location_type + " location description"),
+            )
         else:
             error = "Unexpected location type '{}'.".format(location_type)
             fail(errmsg.format(context = "location description").format(error = error))

--- a/haskell/cabal.bzl
+++ b/haskell/cabal.bzl
@@ -1190,8 +1190,12 @@ def _stack_snapshot_impl(repository_ctx):
     # Write out dependency graph as importable Starlark value.
     repository_ctx.file(
         "packages.bzl",
-        "packages = " + repr({
-            name: struct(
+        """\
+packages = {
+    %s
+}
+""" % ",\n    ".join([
+            '"%s": ' % name + repr(struct(
                 name = name,
                 version = spec["version"],
                 library = all_components[name].lib,
@@ -1207,9 +1211,9 @@ def _stack_snapshot_impl(repository_ctx):
                     for exe in all_components[dep].exe
                 ],
                 flags = repository_ctx.attr.flags.get(name, []),
-            )
+            ))
             for (name, spec) in resolved.items()
-        }),
+        ]),
         executable = False,
     )
 

--- a/haskell/cabal.bzl
+++ b/haskell/cabal.bzl
@@ -901,24 +901,24 @@ def _parse_json_field(json, field, ty, fmt):
       json: dict, The parsed JSON object.
       field: string, The name of the field.
       ty: string, The expected type of the field.
-      fmt: string, Error message format string. E.g. `Error: %s`.
+      fmt: string, Error message format string. E.g. `Error: {error}`.
 
     Returns:
       The value of the field.
     """
     if not field in json:
-        fail(fmt % "Missing field '{field}'.".format(field = field))
+        fail(fmt.format(error = "Missing field '{field}'.".format(field = field)))
     actual_ty = type(json[field])
     if actual_ty != ty:
-        fail(fmt % "Expected field '{field}' of type '{expected}', but got '{got}'.".format(
+        fail(fmt.format(error = "Expected field '{field}' of type '{expected}', but got '{got}'.".format(
             field = field,
             expected = ty,
             got = actual_ty,
-        ))
+        )))
     return json[field]
 
 def _parse_package_spec(package_spec):
-    errmsg = "Unexpected output format for `stack ls dependencies json` in {context}: %s"
+    errmsg = "Unexpected output format for `stack ls dependencies json` in {context}: {{error}}"
 
     # Parse simple fields.
     parsed = {
@@ -951,8 +951,8 @@ def _parse_package_spec(package_spec):
             location["commit"] = _parse_json_field(package_spec["location"], "commit", "string", errmsg.format(context = location_type + " location description"))
             location["subdir"] = _parse_json_field(package_spec["location"], "subdir", "string", errmsg.format(context = location_type + " location description"))
         else:
-            error = "Unexpected location type '%s'." % location_type
-            fail(errmsg.format(context = "location description") % error)
+            error = "Unexpected location type '{}'.".format(location_type)
+            fail(errmsg.format(context = "location description").format(error = error))
 
     parsed["location"] = location
 

--- a/haskell/cabal.bzl
+++ b/haskell/cabal.bzl
@@ -918,6 +918,11 @@ def _parse_json_field(json, field, ty, fmt):
     return json[field]
 
 def _parse_package_spec(package_spec):
+    """Parse a package description from `stack ls dependencies json`.
+
+    The definition of the JSON format can be found in the `stack` sources:
+    https://github.com/commercialhaskell/stack/blob/v2.3.1/src/Stack/Dot.hs#L173-L198
+    """
     errmsg = "Unexpected output format for `stack ls dependencies json` in {context}: {{error}}"
 
     # Parse simple fields.

--- a/haskell/cabal.bzl
+++ b/haskell/cabal.bzl
@@ -1138,15 +1138,23 @@ def _to_string_keyed_label_list_dict(d):
 def _label_to_string(label):
     return "@{}//{}:{}".format(label.workspace_name, label.package, label.name)
 
-def _stack_snapshot_impl(repository_ctx):
-    if repository_ctx.attr.snapshot and repository_ctx.attr.local_snapshot:
+def _parse_stack_snapshot(repository_ctx, snapshot, local_snapshot):
+    if snapshot and local_snapshot:
         fail("Please specify either snapshot or local_snapshot, but not both.")
-    elif repository_ctx.attr.snapshot:
-        snapshot = repository_ctx.attr.snapshot
-    elif repository_ctx.attr.local_snapshot:
-        snapshot = repository_ctx.path(repository_ctx.attr.local_snapshot)
+    elif snapshot:
+        snapshot = snapshot
+    elif local_snapshot:
+        snapshot = repository_ctx.path(local_snapshot)
     else:
         fail("Please specify one of snapshot or local_snapshot")
+    return snapshot
+
+def _stack_snapshot_impl(repository_ctx):
+    snapshot = _parse_stack_snapshot(
+        repository_ctx,
+        repository_ctx.attr.snapshot,
+        repository_ctx.attr.local_snapshot,
+    )
 
     # Enforce dependency on stack_update
     repository_ctx.read(repository_ctx.attr.stack_update)


### PR DESCRIPTION
This PR extracts the refactorings of the `stack_snapshot` implementation that occurred in https://github.com/tweag/rules_haskell/issues/1310. It does not change the functionality of `stack_snapshot` at this point. I have confirmed that the results of `bazel fetch` don't change between `master` and this PR on `@stackage`, `@stackage-zlib`, `@ghcide`, and `@stackge` in `examples`.

- Parse instead of validating the output of `stack ls dependencies json`. In particular, consistently introduce a `location.type` field into a package specification. Before, core packages had no `location` field at all.
- Factor out checks on the `snapshot`/`local_snapshot` attributes to make them re-usable between pinned and non-pinned `stack_snapshot`.
- Factor out parsing of the user provided package list to make them re-usable between pinned and non-pinned `stack_snapshot`.
- Split `_compute_dependency_graph` into two separate functions `_resolve_packages` and `_download_packages`. The pinned version will only need to call a version of `_download_packages` but not `_resolve_packages`. This also simplifies the transformations on the output of `stack ls dependencies json` that `_compute_dependency_graph` used to perform for historical reasons. The output of `stack ls dependencies json` is already pretty close to what we need in `stack_snapshot`. The new format is also easier to de-/serialize through JSON. Notably, `_resolve_packages` sorts the packages by name to ensure that the generated `BUILD.bazel` file and `packages.bzl` are reproducible.
- The generated `packages.bzl` file is modified to contain one package per line instead of all packages in one line. This is to make the file easier to read for humans and friendlier towards diffing.