### PR TITLE
haskell_repl: Track data and runfiles explicitly

### DIFF
--- a/haskell/repl.bzl
+++ b/haskell/repl.bzl
@@ -45,6 +45,7 @@ HaskellReplLoadInfo = provider(
         "cc_info": "CcInfo of transitive C dependencies.",
         "compiler_flags": "Flags to pass to the Haskell compiler.",
         "repl_ghci_args": "Arbitrary extra arguments to pass to GHCi. This extends `compiler_flags` and `repl_ghci_args` from the toolchain",
+        "data_runfiles": "Runtime data dependencies of this target, i.e. the files and runfiles of the `data` attribute.",
     },
 )
 
@@ -59,6 +60,7 @@ HaskellReplDepInfo = provider(
         "interface_dirs": "Set of interface dirs for all the dependencies",
         "cc_libraries_info": "HaskellCcLibrariesInfo of transitive C dependencies.",
         "cc_info": "CcInfo of the package itself (includes its transitive dependencies).",
+        "runfiles": "Runfiles of this target.",
     },
 )
 
@@ -86,6 +88,15 @@ HaskellReplInfo = provider(
     },
 )
 
+def _merge_runfiles(runfiles_list):
+    result = None
+    for runfiles in runfiles_list:
+        if result == None:
+            result = runfiles
+        elif runfiles != None:
+            result = result.merge(runfiles)
+    return result
+
 def _merge_HaskellReplLoadInfo(load_infos):
     source_files = depset()
     import_dirs = depset()
@@ -93,6 +104,7 @@ def _merge_HaskellReplLoadInfo(load_infos):
     cc_infos = []
     compiler_flags = []
     repl_ghci_args = []
+    data_runfiles = []
 
     for load_info in load_infos:
         source_files = depset(transitive = [source_files, load_info.source_files])
@@ -101,6 +113,7 @@ def _merge_HaskellReplLoadInfo(load_infos):
         cc_infos.append(load_info.cc_info)
         compiler_flags += load_info.compiler_flags
         repl_ghci_args += load_info.repl_ghci_args
+        data_runfiles.append(load_info.data_runfiles)
 
     return HaskellReplLoadInfo(
         source_files = source_files,
@@ -109,6 +122,7 @@ def _merge_HaskellReplLoadInfo(load_infos):
         cc_info = cc_common.merge_cc_infos(cc_infos = cc_infos),
         compiler_flags = compiler_flags,
         repl_ghci_args = repl_ghci_args,
+        data_runfiles = _merge_runfiles(data_runfiles),
     )
 
 def _merge_HaskellReplDepInfo(dep_infos):
@@ -117,6 +131,7 @@ def _merge_HaskellReplDepInfo(dep_infos):
     interface_dirs = depset()
     cc_libraries_infos = []
     cc_infos = []
+    runfiles = []
 
     for dep_info in dep_infos:
         package_ids += dep_info.package_ids
@@ -124,6 +139,7 @@ def _merge_HaskellReplDepInfo(dep_infos):
         interface_dirs = depset(transitive = [interface_dirs, dep_info.interface_dirs])
         cc_libraries_infos.append(dep_info.cc_libraries_info)
         cc_infos.append(dep_info.cc_info)
+        runfiles.append(dep_info.runfiles)
 
     return HaskellReplDepInfo(
         package_ids = package_ids,
@@ -131,6 +147,7 @@ def _merge_HaskellReplDepInfo(dep_infos):
         interface_dirs = interface_dirs,
         cc_libraries_info = merge_HaskellCcLibrariesInfo(infos = cc_libraries_infos),
         cc_info = cc_common.merge_cc_infos(cc_infos = cc_infos),
+        runfiles = _merge_runfiles(runfiles),
     )
 
 def _create_HaskellReplCollectInfo(target, ctx):
@@ -156,6 +173,10 @@ def _create_HaskellReplCollectInfo(target, ctx):
             ]),
             compiler_flags = hs_info.user_compile_flags,
             repl_ghci_args = hs_info.user_repl_flags,
+            data_runfiles = _merge_runfiles(
+                [ctx.runfiles(files = getattr(ctx.rule.files, "data", []))] +
+                [data[DefaultInfo].default_runfiles for data in getattr(ctx.rule.attr, "data", [])],
+            ),
         )
     if HaskellLibraryInfo in target:
         lib_info = target[HaskellLibraryInfo]
@@ -165,6 +186,7 @@ def _create_HaskellReplCollectInfo(target, ctx):
             interface_dirs = hs_info.interface_dirs,
             cc_libraries_info = target[HaskellCcLibrariesInfo],
             cc_info = target[CcInfo],
+            runfiles = target[DefaultInfo].default_runfiles,
         )
 
     return HaskellReplCollectInfo(
@@ -390,18 +412,23 @@ def _create_repl(hs, posix, ctx, repl_info, output):
         },
     )
 
-    return [DefaultInfo(
-        executable = output,
-        runfiles = ctx.runfiles(
+    runfiles = [
+        ctx.runfiles(
             files = [
                 hs.tools.ghci,
                 ghci_repl_script,
             ],
             transitive_files = inputs,
-            collect_data = ctx.attr.collect_data,
-        ).merge(
-            hs.toolchain.cc_wrapper.runfiles,
         ),
+        hs.toolchain.cc_wrapper.runfiles,
+    ]
+    if ctx.attr.collect_data:
+        runfiles.append(repl_info.load_info.data_runfiles)
+        runfiles.append(repl_info.dep_info.runfiles)
+
+    return [DefaultInfo(
+        executable = output,
+        runfiles = _merge_runfiles(runfiles),
     )]
 
 def _create_hie_bios(hs, posix, ctx, repl_info):

--- a/tests/RunTests.hs
+++ b/tests/RunTests.hs
@@ -43,6 +43,8 @@ main = hspec $ do
 
       assertSuccess (bazel ["run", "//tests/binary-indirect-cbits:binary-indirect-cbits@repl", "--", "-ignore-dot-ghci", "-e", ":main"])
 
+      assertSuccess (bazel ["run", "//tests/repl-targets:hs-test-bad@repl", "--", "-ignore-dot-ghci", "-e", "1 + 2"])
+
     it "with rebindable syntax" $ do
       let p' (stdout, _stderr) = lines stdout == ["True"]
       outputSatisfy p' (bazel ["run", "//tests/repl-targets:rebindable-syntax@repl", "--", "-ignore-dot-ghci", "-e", "check"])

--- a/tests/repl-targets/BUILD.bazel
+++ b/tests/repl-targets/BUILD.bazel
@@ -63,6 +63,24 @@ haskell_library(
     ],
 )
 
+haskell_test(
+    name = "hs-test-bad",
+    srcs = [
+        "Bad.hs",
+    ],
+    tags = [
+        "manual",
+        "requires_zlib",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//tests/data:ourclibrary",
+        "//tests/hackage:base",
+        "@stackage//:array",
+        "@zlib",
+    ],
+)
+
 haskell_library(
     name = "QuuxLib",
     srcs = ["QuuxLib.hs"],


### PR DESCRIPTION
In case of `haskell_binary` or `haskell_test` targets the `DefaultInfo.runfiles` will include the binary itself. This meant that if `collect_data == True` then the REPL depended on the compiled binary of targets that should be loaded into the REPL by source. I.e. if a module that should be loaded into the REPL by source cannot be compiled due to a compiler error then it can also not be loaded into a REPL with `collect_data = True`. This is very inconvenient as the REPL might help to fix the compiler error.

This changes fixes this by tracking data dependencies and runfiles explicitly rather than just relying on `ctx.runfiles(collect_data = True)`. In particular, in case of targets that should be loaded by source we will not include the full `DefaultInfo.runfiles` (which would include the final binary of a `haskell_binary|test`), but instead we only include the files and runfiles of `data` dependencies.

Closes #1380