### PR TITLE
Fix linker errors on Ubuntu >= 18.04 with GHC bindist

### DIFF
--- a/.buildkite/image/Dockerfile
+++ b/.buildkite/image/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:xenial-20200114
+FROM ubuntu:bionic-20200403
 
 WORKDIR /home/
 

--- a/haskell/cabal.bzl
+++ b/haskell/cabal.bzl
@@ -213,13 +213,7 @@ def _prepare_cabal_inputs(
     ], join_with = " ", format_each = "--ghc-arg=%s", omit_if_empty = False)
     args.add("--flags=" + " ".join(flags))
     if not hs.toolchain.is_darwin and not hs.toolchain.is_windows:
-        # On some more recent Linux distributions (e.g. Ubuntu 18.04) `gcc`
-        # defaults to linking with `-pie`. At the same time Cabal passes `-r`
-        # to the linker. In order to avoid errors of the form
-        #
-        #     /usr/bin/ld: -r and -pie may not be used together
-        #
-        # we need to pass `-no-pie` to the linker.
+        # See Note [No PIE when linking] in haskell/private/actions/link.bzl
         args.add("--ghc-option=-optl-no-pie")
     args.add_all(compiler_flags, format_each = "--ghc-option=%s")
     if dynamic_binary:

--- a/haskell/cabal.bzl
+++ b/haskell/cabal.bzl
@@ -212,6 +212,15 @@ def _prepare_cabal_inputs(
         for arg in ["-package-db", "./" + _dirname(package_db)]
     ], join_with = " ", format_each = "--ghc-arg=%s", omit_if_empty = False)
     args.add("--flags=" + " ".join(flags))
+    if not hs.toolchain.is_darwin and not hs.toolchain.is_windows:
+        # On some more recent Linux distributions (e.g. Ubuntu 18.04) `gcc`
+        # defaults to linking with `-pie`. At the same time Cabal passes `-r`
+        # to the linker. In order to avoid errors of the form
+        #
+        #     /usr/bin/ld: -r and -pie may not be used together
+        #
+        # we need to pass `-no-pie` to the linker.
+        args.add("--ghc-option=-optl-no-pie")
     args.add_all(compiler_flags, format_each = "--ghc-option=%s")
     if dynamic_binary:
         args.add_all(

--- a/haskell/cc.bzl
+++ b/haskell/cc.bzl
@@ -5,7 +5,7 @@ These rules are deprecated.
 
 load(
     "@bazel_tools//tools/build_defs/cc:action_names.bzl",
-    "CPP_LINK_DYNAMIC_LIBRARY_ACTION_NAME",
+    "CPP_LINK_EXECUTABLE_ACTION_NAME",
     "C_COMPILE_ACTION_NAME",
 )
 load(
@@ -101,7 +101,8 @@ def cc_interop_info(ctx):
     )
     linker_flags = cc_common.get_memory_inefficient_command_line(
         feature_configuration = feature_configuration,
-        action_name = CPP_LINK_DYNAMIC_LIBRARY_ACTION_NAME,
+        # See https://github.com/bazelbuild/bazel/issues/6876
+        action_name = CPP_LINK_EXECUTABLE_ACTION_NAME,
         variables = link_variables,
     )
 
@@ -111,9 +112,6 @@ def cc_interop_info(ctx):
     cc = cc_wrapper.executable.path
     cc_files = ctx.files._cc_toolchain + cc_wrapper.inputs.to_list()
     cc_manifests = cc_wrapper.manifests
-
-    # XXX Workaround https://github.com/bazelbuild/bazel/issues/6876.
-    linker_flags = [flag for flag in linker_flags if flag not in ["-shared"]]
 
     tools = {
         "ar": cc_toolchain.ar_executable,

--- a/haskell/private/actions/compile.bzl
+++ b/haskell/private/actions/compile.bzl
@@ -460,6 +460,16 @@ def compile_library(
     c = _compilation_defaults(hs, cc, java, posix, dep_info, plugin_dep_info, srcs, import_dir_map, extra_srcs, user_compile_flags, with_profiling, my_pkg_id = my_pkg_id, version = my_pkg_id.version, plugins = plugins, preprocessors = preprocessors)
     if with_shared:
         c.args.add("-dynamic-too")
+        if not hs.toolchain.is_darwin and not hs.toolchain.is_windows:
+            # On some more recent Linux distributions (e.g. Ubuntu 18.04) `gcc`
+            # defaults to linking with `-pie`. At the same time GHC passes `-r`
+            # to the linker when joining object files. In order to avoid errors
+            # of the form
+            #
+            #     /usr/bin/ld: -r and -pie may not be used together
+            #
+            # we need to pass `-no-pie` to the linker.
+            c.args.add("-optl-no-pie")
 
     coverage_data = []
     if hs.coverage_enabled:

--- a/haskell/private/actions/compile.bzl
+++ b/haskell/private/actions/compile.bzl
@@ -461,14 +461,7 @@ def compile_library(
     if with_shared:
         c.args.add("-dynamic-too")
         if not hs.toolchain.is_darwin and not hs.toolchain.is_windows:
-            # On some more recent Linux distributions (e.g. Ubuntu 18.04) `gcc`
-            # defaults to linking with `-pie`. At the same time GHC passes `-r`
-            # to the linker when joining object files. In order to avoid errors
-            # of the form
-            #
-            #     /usr/bin/ld: -r and -pie may not be used together
-            #
-            # we need to pass `-no-pie` to the linker.
+            # See Note [No PIE when linking] in haskell/private/actions/link.bzl
             c.args.add("-optl-no-pie")
 
     coverage_data = []


### PR DESCRIPTION
Closes #1349

On some more recent Linux distributions (e.g. Ubuntu 18.04) `gcc` defaults to linking with `-pie`. At the same time GHC passes `-r` to the linker when joining object files. In order to avoid errors of the form 

     /usr/bin/ld: -r and -pie may not be used together

we need to pass `-no-pie` to the linker. Additionally, GHC compiles the `main` function during linking with non-position independent code. Attempting to link this code with `-pie` will cause the following error:

    /usr/bin/ld.gold: error: /tmp/ghc3_0/ghc_2.o: requires dynamic R_X86_64_32 reloc against 'ZCMain_main_closure' which may overflow at runtime; recompile with -fPIC
    /usr/bin/ld.gold: error: ../../../../../external/rules_haskell_ghc_linux_amd64/lib/base-4.13.0.0/libHSbase-4.13.0.0.a(Base.o): requires unsupported dynamic reloc 11; recompile with -fPIC

This was not caught on rules_haskell's bindist CI since it was still running on Ubuntu 16.04 which hadn't enabled `-pie` by default, yet. I've upgraded the rules_haskell bindist CI image to Ubuntu 18.04. I've [confirmed](https://buildkite.com/tweag-1/rules-haskell/builds/1560#c75bf4be-df7a-4f67-9499-c75b5c6c5326) that this does not break the build on Ubuntu 16.04.