### PR TITLE
Add support for building fully-static binaries

### DIFF
--- a/docs/haskell-use-cases.rst
+++ b/docs/haskell-use-cases.rst
@@ -16,7 +16,7 @@ workspace in the current working directory with a few dummy build
 targets. See the following sections about customizing the workspace.
 
 Making rules_haskell available
-----------------------------------
+------------------------------
 
 First of all, the ``WORKSPACE`` file must specify how to obtain
 rules_haskell. To use a released version, do the following::
@@ -562,8 +562,175 @@ It is worth noting that Bazel's worker strategy is not sandboxed by default. Thi
 confuse our worker relatively easily. Therefore, it is recommended to supply
 ``--worker_sandboxing`` to ``bazel build`` -- possibly, via your ``.bazelrc.local`` file.
 
+Building fully-statically-linked binaries
+-----------------------------------------
+
+Fully-statically linked binaries have no runtime linkage dependencies and are
+thus typically more portable and easier to package (e.g. in containers) than
+their dynamically-linked counterparts. The trade-off is that
+fully-statically-linked binaries can be larger than dynamically-linked binaries,
+due to the fact that all symbols must be bundled into a single output.
+``rules_haskell`` has support for building fully-statically-linked binaries
+using Nix-provisioned GHC toolchains and the ``static_runtime`` and
+``fully_static_link`` attributes of the ``haskell_register_ghc_nixpkgs`` macro::
+
+  load(
+      "@rules_haskell//haskell:nixpkgs.bzl",
+      "haskell_register_ghc_nixpkgs",
+  )
+
+  haskell_register_ghc_nixpkgs(
+      version = "X.Y.Z",
+      attribute_path = "staticHaskell.ghc",
+      repositories = {"nixpkgs": "@nixpkgs"},
+      static_runtime = True,
+      fully_static_link = True,
+  )
+
+Note that the ``attribute_path`` must refer to a GHC derivation capable of
+building fully-statically-linked binaries. Often this will require you to
+customise a GHC derivation in your Nix package set. If you are unfamiliar with
+Nix, one way to add such a custom package to an existing set is with an
+*overlay*.  Detailed documentation on overlays is available at
+https://nixos.wiki/wiki/Overlays, but for the purposes of this documentation,
+it's enough to know that overlays are essentially functions which accept package
+sets (conventionally called ``super``) and produce new package sets. We can
+write an overlay that modifies the ``ghc`` derivation in its argument to add
+flags that allow it to produce fully-statically-linked binaries as follows::
+
+  let
+    # Pick a version of Nixpkgs that we will base our package set on (apply an
+    # overlay to).
+    baseCommit = "..."; # Pick a Nixpkgs version to pin to.
+    baseSha = "..."; # The SHA of the above version.
+
+    baseNixpkgs = builtins.fetchTarball {
+      name = "nixos-nixpkgs";
+      url = "https://github.com/NixOS/nixpkgs/archive/${baseCommit}.tar.gz";
+      sha256 = baseSha;
+    };
+
+    # Our overlay. We add a `staticHaskell.ghc` path matching that specified in
+    # the haskell_register_ghc_nixpkgs rule above which overrides the `ghc`
+    # derivation provided in the base set (`super.ghc`) with some necessary
+    # arguments.
+    overlay = self: super: {
+      staticHaskell = {
+        ghc = (super.ghc.override {
+          enableRelocatedStaticLibs = true;
+          enableShared = false;
+        }).overrideAttrs (oldAttrs: {
+          preConfigure = ''
+            ${oldAttrs.preConfigure or ""}
+            echo "GhcLibHcOpts += -fPIC -fexternal-dynamic-refs" >> mk/build.mk
+            echo "GhcRtsHcOpts += -fPIC -fexternal-dynamic-refs" >> mk/build.mk
+          '';
+        });
+      };
+    };
+
+  in
+    args@{ overlays ? [], ... }:
+      import baseNixpkgs (args // {
+        overlays = [overlay] ++ overlays;
+      })
+
+In this example we use the ``override`` and ``overrideAttrs`` functions to
+produce a GHC derivation suitable for our needs. Ideally,
+``enableRelocatedStaticLibs`` and ``enableShared`` should be enough, but
+upstream Nixpkgs does not at present reliably pass ``-fexternal-dynamic-refs``
+when ``-fPIC`` is passed, which is required to generate fully-statically-linked
+executables.
+
+You may wish to base your GHC derivation on one which uses Musl, a C library
+designed for static linking (unlike glibc, which can cause issues when linked
+statically). `static-haskell-nix`_ is an example of a project which provides
+such a GHC derivation and can be used like so::
+
+  let
+    baseCommit = "..."; # Pick a Nixpkgs version to pin to.
+    baseSha = "..."; # The SHA of the above version.
+
+    staticHaskellNixCommit = "..."; Pick a static-haskell-nix version to pin to.
+
+    baseNixpkgs = builtins.fetchTarball {
+      name = "nixos-nixpkgs";
+      url = "https://github.com/NixOS/nixpkgs/archive/${baseCommit}.tar.gz";
+      sha256 = baseSha;
+    };
+
+    staticHaskellNixpkgs = builtins.fetchTarball
+      "https://github.com/nh2/static-haskell-nix/archive/${staticHaskellNixCommit}.tar.gz";
+
+    # The `static-haskell-nix` repository contains several entry points for e.g.
+    # setting up a project in which Nix is used solely as the build/package
+    # management tool. We are only interested in the set of packages that underpin
+    # these entry points, which are exposed in the `survey` directory's
+    # `approachPkgs` property.
+    staticHaskellPkgs = (
+      import (staticHaskellNixpkgs + "/survey/default.nix") {}
+    ).approachPkgs;
+
+    overlay = self: super: {
+      staticHaskell = staticHaskellPkgs.extend (selfSH: superSH: {
+        ghc = (superSH.ghc.override {
+          enableRelocatedStaticLibs = true;
+          enableShared = false;
+        }).overrideAttrs (oldAttrs: {
+          preConfigure = ''
+            ${oldAttrs.preConfigure or ""}
+            echo "GhcLibHcOpts += -fPIC -fexternal-dynamic-refs" >> mk/build.mk
+            echo "GhcRtsHcOpts += -fPIC -fexternal-dynamic-refs" >> mk/build.mk
+          '';
+        });
+      });
+    };
+
+  in
+    args@{ overlays ? [], ... }:
+      import baseNixpkgs (args // {
+        overlays = [overlay] ++ overlays;
+      })
+
+If you adopt a Musl-based GHC you should also take care to ensure that the C
+toolchain used by ``rules_haskell`` also uses Musl; you can do this using the
+``nixpkgs_cc_configure`` rule from ``rules_nixpkgs`` and providing a Nix
+expression that supplies appropriate ``cc`` and ``binutils`` derivations::
+
+  nixpkgs_cc_configure(
+      repository = "@nixpkgs",
+
+      # The `staticHaskell` attribute in the previous example exposes the
+      # Musl-backed `cc` and `binutils` derivations already, so it's just a
+      # matter of exposing them to nixpkgs_cc_configure.
+      nix_file_content = """
+        with import <nixpkgs> { config = {}; overlays = []; }; buildEnv {
+          name = "bazel-cc-toolchain";
+          paths = [ staticHaskell.stdenv.cc staticHaskell.binutils ];
+        }
+      """,
+  )
+
+With the toolchain taken care of, you can then create fully-statically-linked
+binaries by passing the ``-optl-static`` and ``-optl-pthread`` flags as
+``compiler_flags`` to GHC, e.g. in ``haskell_binary``::
+
+  haskell_binary(
+      name = ...,
+      srcs = [
+          ...,
+      ],
+      ...,
+      compiler_flags = [
+          "-optl-static",
+          "-optl-pthread",
+      ],
+  )
+
+.. _static-haskell-nix: https://github.com/nh2/static-haskell-nix
+
 Containerization with rules_docker
--------------------------------------
+----------------------------------
 
 Making use of both ``rules_docker`` and ``rules_nixpkgs``, it's possible to containerize
 ``rules_haskell`` ``haskell_binary`` build targets for deployment. In a nutshell, first we must use

--- a/haskell/ghc_bindist.bzl
+++ b/haskell/ghc_bindist.bzl
@@ -304,7 +304,8 @@ haskell_toolchain(
     tools = [":bin"],
     libraries = toolchain_libraries,
     version = "{version}",
-    is_static = {is_static},
+    static_runtime = {static_runtime},
+    fully_static_link = {fully_static_link},
     compiler_flags = {compiler_flags},
     haddock_flags = {haddock_flags},
     repl_ghci_args = {repl_ghci_args},
@@ -315,7 +316,11 @@ haskell_toolchain(
     """.format(
         toolchain_libraries = toolchain_libraries,
         version = ctx.attr.version,
-        is_static = os == "windows",
+        static_runtime = os == "windows",
+
+        # At present we don't support fully-statically-linked binaries with GHC
+        # bindists.
+        fully_static_link = False,
         compiler_flags = ctx.attr.compiler_flags,
         haddock_flags = ctx.attr.haddock_flags,
         repl_ghci_args = ctx.attr.repl_ghci_args,

--- a/haskell/private/cc_libraries.bzl
+++ b/haskell/private/cc_libraries.bzl
@@ -58,7 +58,7 @@ def get_ghci_library_files(hs, cc_libraries_info, libraries_to_link, include_rea
         hs,
         cc_libraries_info,
         libraries_to_link,
-        dynamic = not hs.toolchain.is_static,
+        dynamic = not hs.toolchain.static_runtime,
         pic = True,
         include_real_paths = include_real_paths,
     )
@@ -95,7 +95,7 @@ def get_library_files(hs, cc_libraries_info, libraries_to_link, dynamic = False,
         pic = dynamic
 
     # PIC is irrelevant on static GHC.
-    pic_required = pic and not hs.toolchain.is_static
+    pic_required = pic and not hs.toolchain.static_runtime
     for lib_to_link in libraries_to_link:
         cc_library_info = cc_libraries_info.libraries[cc_library_key(lib_to_link)]
         dynamic_lib = None
@@ -131,7 +131,7 @@ def get_library_files(hs, cc_libraries_info, libraries_to_link, dynamic = False,
 
     return (static_libs, dynamic_libs)
 
-def link_libraries(libs, args, prefix_optl = False):
+def link_libraries(libs, args, path_prefix = "", prefix_optl = False):
     """Add linker flags to link against the given libraries.
 
     This function is intended for linking C library dependencies. Haskell
@@ -141,15 +141,18 @@ def link_libraries(libs, args, prefix_optl = False):
     Args:
       libs: Sequence of File, libraries to link.
       args: Args or List, append arguments to this object.
+      path_prefix: String, a prefix to apply to search directory arguments. If
+        this is a directory, trailing slashes should be included explicitly (this
+        function will not add them automatically).
       prefix_optl: Bool, whether to prefix linker flags by -optl
 
     """
     if prefix_optl:
         libfmt = "-optl-l%s"
-        dirfmt = "-optl-L%s"
+        dirfmt = "-optl-L" + path_prefix + "%s"
     else:
         libfmt = "-l%s"
-        dirfmt = "-L%s"
+        dirfmt = "-L" + path_prefix + "%s"
 
     if hasattr(args, "add_all"):
         args.add_all(libs, map_each = get_lib_name, format_each = libfmt)

--- a/haskell/private/cc_wrapper.py.tpl
+++ b/haskell/private/cc_wrapper.py.tpl
@@ -46,6 +46,14 @@ used to avoid command line length limitations.
 
     See https://gitlab.haskell.org/ghc/ghc/issues/17185.
 
+- Fixes invocations that handle temporary and intermediate binaries
+
+    GHC with Template Haskell or tools like hsc2hs build temporary Haskell
+    binaries (that e.g. generate other Haskell code) as part of the build
+    process. This wrapper ensures that linking behaviour for these binaries
+    matches the characteristics of the wider build (e.g. runpath configuration,
+    etc.)
+
 """
 
 from bazel_tools.tools.python.runfiles import runfiles as bazel_runfiles

--- a/haskell/private/haskell_impl.bzl
+++ b/haskell/private/haskell_impl.bzl
@@ -180,7 +180,7 @@ def _haskell_binary_common_impl(ctx, is_test):
     inspect_coverage = _should_inspect_coverage(ctx, hs, is_test)
 
     dynamic = not ctx.attr.linkstatic
-    if with_profiling or hs.toolchain.is_static:
+    if with_profiling or hs.toolchain.static_runtime:
         # NOTE We can't have profiling and dynamic code at the
         # same time, see:
         # https://ghc.haskell.org/trac/ghc/ticket/15394
@@ -362,7 +362,7 @@ def haskell_library_impl(ctx):
     srcs_files, import_dir_map = _prepare_srcs(ctx.attr.srcs)
 
     with_shared = not ctx.attr.linkstatic
-    if with_profiling or hs.toolchain.is_static:
+    if with_profiling or hs.toolchain.static_runtime:
         # NOTE We can't have profiling and dynamic code at the
         # same time, see:
         # https://ghc.haskell.org/trac/ghc/ticket/15394

--- a/haskell/repl.bzl
+++ b/haskell/repl.bzl
@@ -316,12 +316,26 @@ def _compiler_flags_and_inputs(hs, repl_info, static = False, path_prefix = ""):
         cc_library_files = _concat(get_library_files(hs, cc_libraries_info, cc_libraries))
     else:
         cc_library_files = get_ghci_library_files(hs, cc_libraries_info, cc_libraries)
-    link_libraries(cc_library_files, args)
+
+    # REPL scripts `cd` into the workspace root. Depending on their provenance,
+    # some C libraries' files may be in subdirectories which are _only_ relative
+    # to the execroot. External static C library dependencies are an example of
+    # this -- unchanged we may end up with paths like
+    # `external/some_dependency/lib` and/or
+    # `bazel-out/k8-fastbuild/bin/_solib_k8/...`; the former containing the
+    # archive (`.a`) file we want, but only being relative to the execroot, and
+    # the latter being relative to both the workspace root and the execroot but
+    # only containing dynamic libraries.
+    #
+    # We fix this by prefixing paths with the execroot when generating linker
+    # flags so that all required libraries are visible.
+    link_libraries(cc_library_files, args, path_prefix = path_prefix + "/")
 
     if static:
         all_library_files = _concat(get_library_files(hs, cc_libraries_info, all_libraries, include_real_paths = True))
     else:
         all_library_files = get_ghci_library_files(hs, cc_libraries_info, all_libraries, include_real_paths = True)
+
     inputs = depset(transitive = [
         repl_info.load_info.source_files,
         repl_info.dep_info.package_databases,

--- a/haskell/toolchain.bzl
+++ b/haskell/toolchain.bzl
@@ -168,7 +168,8 @@ def _haskell_toolchain_impl(ctx):
             libraries = libraries,
             is_darwin = ctx.attr.is_darwin,
             is_windows = ctx.attr.is_windows,
-            is_static = ctx.attr.is_static,
+            static_runtime = ctx.attr.static_runtime,
+            fully_static_link = ctx.attr.fully_static_link,
             version = ctx.attr.version,
             global_pkg_db = pkgdb_file,
             protoc = ctx.executable._protoc,
@@ -217,8 +218,11 @@ _haskell_toolchain = rule(
             doc = "Whether compile on and for Windows.",
             mandatory = True,
         ),
-        "is_static": attr.bool(
-            doc = "Whether GHC was linked statically.",
+        "static_runtime": attr.bool(
+            doc = "Whether GHC was linked with a static runtime.",
+        ),
+        "fully_static_link": attr.bool(
+            doc = "Whether GHC should build fully-statically-linked binaries.",
         ),
         "locale": attr.string(
             default = "C.UTF-8",
@@ -250,7 +254,8 @@ Label pointing to the locale archive file to use. Mostly useful on NixOS.
 def haskell_toolchain(
         name,
         version,
-        is_static,
+        static_runtime,
+        fully_static_link,
         tools,
         libraries,
         compiler_flags = [],
@@ -274,7 +279,8 @@ def haskell_toolchain(
       haskell_toolchain(
           name = "ghc",
           version = "1.2.3",
-          is_static = is_static,
+          static_runtime = static_runtime,
+          fully_static_link = fully_static_link,
           tools = ["@sys_ghc//:bin"],
           compiler_flags = ["-Wall"],
       )
@@ -296,7 +302,8 @@ def haskell_toolchain(
     _haskell_toolchain(
         name = name,
         version = version,
-        is_static = is_static,
+        static_runtime = static_runtime,
+        fully_static_link = fully_static_link,
         tools = tools,
         libraries = libraries,
         compiler_flags = compiler_flags,


### PR DESCRIPTION
Off the back of much discussion in #379.

This commit implements support for fully-statically-linked binaries by
extending functionality linked to the `is_static` attribute of an active
Haskell toolchain. In particular:

* Packages built with Cabal will be passed fields that ensure their
  static artifacts are relocatable (`-fPIC` and
  `-fexternal-dynamic-refs`).

* Intermediate artifacts (such as binaries built by `hsc2hs` for the
  purposes of generating Haskell code) will also be built statically to
  avoid issues caused by the absences of dynamic libraries.

* Linker flags for REPLs will be generated so that they correctly find
  static C library dependencies instead of failing/finding dynamic
  counterparts.