### PR TITLE
Add cabalopts rule and toolchain attribute

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -166,6 +166,12 @@ test_repl_ghci_args = [
     "-XOverloadedStrings",
 ]
 
+test_cabalopts = [
+    # Used by `tests/cabal-toolchain-flags`
+    "--ghc-option=-DTESTS_TOOLCHAIN_CABALOPTS",
+    "--haddock-option=--optghc=-DTESTS_TOOLCHAIN_CABALOPTS",
+]
+
 load(
     "@rules_haskell//haskell:nixpkgs.bzl",
     "haskell_register_ghc_nixpkgs",
@@ -173,6 +179,7 @@ load(
 
 haskell_register_ghc_nixpkgs(
     attribute_path = "",
+    cabalopts = test_cabalopts,
     compiler_flags = test_compiler_flags,
     haddock_flags = test_haddock_flags,
     locale_archive = "@glibc_locales//:locale-archive",
@@ -188,6 +195,7 @@ load(
 )
 
 haskell_register_ghc_bindists(
+    cabalopts = test_cabalopts,
     compiler_flags = test_compiler_flags,
     version = test_ghc_version,
 )

--- a/haskell/cabal.bzl
+++ b/haskell/cabal.bzl
@@ -215,6 +215,7 @@ def _prepare_cabal_inputs(
     if not hs.toolchain.is_darwin and not hs.toolchain.is_windows:
         # See Note [No PIE when linking] in haskell/private/actions/link.bzl
         args.add("--ghc-option=-optl-no-pie")
+    args.add_all(hs.toolchain.cabalopts)
     args.add_all(cabalopts)
     if dynamic_binary:
         args.add_all(

--- a/haskell/cabal.bzl
+++ b/haskell/cabal.bzl
@@ -134,7 +134,6 @@ def _prepare_cabal_inputs(
         setup_dep_info,
         srcs,
         cabalopts,
-        compiler_flags,
         flags,
         generate_haddock,
         cabal_wrapper,
@@ -217,7 +216,6 @@ def _prepare_cabal_inputs(
         # See Note [No PIE when linking] in haskell/private/actions/link.bzl
         args.add("--ghc-option=-optl-no-pie")
     args.add_all(cabalopts)
-    args.add_all(compiler_flags, format_each = "--ghc-option=%s")
     if dynamic_binary:
         args.add_all(
             [
@@ -315,7 +313,12 @@ def _haskell_cabal_library_impl(ctx):
     with_profiling = is_profiling_enabled(hs)
 
     user_cabalopts = _expand_make_variables("cabalopts", ctx, ctx.attr.cabalopts)
-    user_compile_flags = _expand_make_variables("compiler_flags", ctx, ctx.attr.compiler_flags)
+    if ctx.attr.compiler_flags:
+        print("WARNING: compiler_flags attribute is deprecated. Use cabalopts instead.")
+        user_cabalopts.extend([
+            "--ghc-option=" + opt
+            for opt in _expand_make_variables("compiler_flags", ctx, ctx.attr.compiler_flags)
+        ])
     cabal = _find_cabal(hs, ctx.files.srcs)
     setup = _find_setup(hs, cabal, ctx.files.srcs)
     package_database = hs.actions.declare_file(
@@ -386,7 +389,6 @@ def _haskell_cabal_library_impl(ctx):
         setup_dep_info = setup_dep_info,
         srcs = ctx.files.srcs,
         cabalopts = user_cabalopts,
-        compiler_flags = user_compile_flags,
         flags = ctx.attr.flags,
         generate_haddock = ctx.attr.haddock,
         cabal_wrapper = ctx.executable._cabal_wrapper,
@@ -519,11 +521,16 @@ haskell_cabal_library = rule(
             doc = "Dependencies for custom setup Setup.hs.",
         ),
         "cabalopts": attr.string_list(
-            doc = """Additional flags to pass to `Setup.hs configure`. Subject to make variable expansion.""",
+            doc = """Additional flags to pass to `Setup.hs configure`. Subject to make variable expansion.
+
+            Use `--ghc-option=OPT` to configure additional compiler flags.
+            Use `--haddock-option=--optghc=OPT` if these flags are required for haddock generation as well.
+            """,
         ),
         "compiler_flags": attr.string_list(
-            doc = """Flags to pass to Haskell compiler, in addition to those defined
-            the cabal file. Subject to Make variable substitution.""",
+            doc = """DEPRECATED. Use `cabalopts` with `--ghc-option` instead.
+
+            Flags to pass to Haskell compiler, in addition to those defined the cabal file. Subject to Make variable substitution.""",
         ),
         "tools": attr.label_list(
             cfg = "host",
@@ -617,7 +624,12 @@ def _haskell_cabal_binary_impl(ctx):
 
     exe_name = ctx.attr.exe_name if ctx.attr.exe_name else hs.label.name
     user_cabalopts = _expand_make_variables("cabalopts", ctx, ctx.attr.cabalopts)
-    user_compile_flags = _expand_make_variables("compiler_flags", ctx, ctx.attr.compiler_flags)
+    if ctx.attr.compiler_flags:
+        print("WARNING: compiler_flags attribute is deprecated. Use cabalopts instead.")
+        user_cabalopts.extend([
+            "--ghc-option=" + opt
+            for opt in _expand_make_variables("compiler_flags", ctx, ctx.attr.compiler_flags)
+        ])
     cabal = _find_cabal(hs, ctx.files.srcs)
     setup = _find_setup(hs, cabal, ctx.files.srcs)
     package_database = hs.actions.declare_file(
@@ -653,7 +665,6 @@ def _haskell_cabal_binary_impl(ctx):
         setup_dep_info = setup_dep_info,
         srcs = ctx.files.srcs,
         cabalopts = user_cabalopts,
-        compiler_flags = user_compile_flags,
         flags = ctx.attr.flags,
         generate_haddock = False,
         cabal_wrapper = ctx.executable._cabal_wrapper,
@@ -722,11 +733,16 @@ haskell_cabal_binary = rule(
             doc = "Dependencies for custom setup Setup.hs.",
         ),
         "cabalopts": attr.string_list(
-            doc = """Additional flags to pass to `Setup.hs configure`. Subject to make variable expansion.""",
+            doc = """Additional flags to pass to `Setup.hs configure`. Subject to make variable expansion.
+
+            Use `--ghc-option=OPT` to configure additional compiler flags.
+            Use `--haddock-option=--optghc=OPT` if these flags are required for haddock generation as well.
+            """,
         ),
         "compiler_flags": attr.string_list(
-            doc = """Flags to pass to Haskell compiler, in addition to those defined
-            the cabal file. Subject to Make variable substitution.""",
+            doc = """DEPRECATED. Use `cabalopts` with `--ghc-option` instead.
+
+            Flags to pass to Haskell compiler, in addition to those defined the cabal file. Subject to Make variable substitution.""",
         ),
         "tools": attr.label_list(
             cfg = "host",
@@ -1780,7 +1796,7 @@ haskell_cabal_library(
     setup_deps = {setup_deps},
     tools = {tools},
     visibility = {visibility},
-    compiler_flags = ["-w", "-optF=-w"],
+    cabalopts = ["--ghc-option=-w", "--ghc-option=-optF=-w"],
     verbose = {verbose},
     unique_name = True,
 )
@@ -1815,7 +1831,7 @@ haskell_cabal_binary(
     deps = {deps},
     tools = {tools},
     visibility = ["@{workspace}-exe//{name}:__pkg__"],
-    compiler_flags = ["-w", "-optF=-w"],
+    cabalopts = ["--ghc-option=-w", "--ghc-option=-optF=-w"],
     verbose = {verbose},
 )
 """.format(

--- a/haskell/ghc_bindist.bzl
+++ b/haskell/ghc_bindist.bzl
@@ -308,6 +308,7 @@ haskell_toolchain(
     compiler_flags = {compiler_flags},
     haddock_flags = {haddock_flags},
     repl_ghci_args = {repl_ghci_args},
+    cabalopts = {cabalopts},
     visibility = ["//visibility:public"],
     locale = "{locale}",
 )
@@ -318,6 +319,7 @@ haskell_toolchain(
         compiler_flags = ctx.attr.compiler_flags,
         haddock_flags = ctx.attr.haddock_flags,
         repl_ghci_args = ctx.attr.repl_ghci_args,
+        cabalopts = ctx.attr.cabalopts,
         locale = locale,
     )
 
@@ -351,6 +353,7 @@ _ghc_bindist = repository_rule(
         "compiler_flags": attr.string_list(),
         "haddock_flags": attr.string_list(),
         "repl_ghci_args": attr.string_list(),
+        "cabalopts": attr.string_list(),
         "patches": attr.label_list(
             default = [],
             doc =
@@ -418,6 +421,7 @@ def ghc_bindist(
         compiler_flags = None,
         haddock_flags = None,
         repl_ghci_args = None,
+        cabalopts = None,
         locale = None):
     """Create a new repository from binary distributions of GHC.
 
@@ -474,6 +478,7 @@ def ghc_bindist(
         compiler_flags = compiler_flags,
         haddock_flags = haddock_flags,
         repl_ghci_args = repl_ghci_args,
+        cabalopts = cabalopts,
         target = target,
         locale = locale,
         **extra_attrs
@@ -490,6 +495,7 @@ def haskell_register_ghc_bindists(
         compiler_flags = None,
         haddock_flags = None,
         repl_ghci_args = None,
+        cabalopts = None,
         locale = None):
     """Register GHC binary distributions for all platforms as toolchains.
 
@@ -513,6 +519,7 @@ def haskell_register_ghc_bindists(
             compiler_flags = compiler_flags,
             haddock_flags = haddock_flags,
             repl_ghci_args = repl_ghci_args,
+            cabalopts = cabalopts,
             locale = locale,
         )
     local_sh_posix_repo_name = "rules_haskell_sh_posix_local"

--- a/haskell/nixpkgs.bzl
+++ b/haskell/nixpkgs.bzl
@@ -79,6 +79,7 @@ haskell_toolchain(
     is_static = {is_static},
     compiler_flags = {compiler_flags} + {compiler_flags_select},
     haddock_flags = {haddock_flags},
+    cabalopts = {cabalopts},
     repl_ghci_args = {repl_ghci_args},
     # On Darwin we don't need a locale archive. It's a Linux-specific
     # hack in Nixpkgs.
@@ -94,6 +95,7 @@ haskell_toolchain(
             compiler_flags_select = compiler_flags_select,
             haddock_flags = repository_ctx.attr.haddock_flags,
             repl_ghci_args = repository_ctx.attr.repl_ghci_args,
+            cabalopts = repository_ctx.attr.cabalopts,
             locale_archive_arg = "locale_archive = {},".format(repr(locale_archive)) if locale_archive else "",
             locale = repr(repository_ctx.attr.locale),
         ),
@@ -109,6 +111,7 @@ _ghc_nixpkgs_haskell_toolchain = repository_rule(
         "compiler_flags": attr.string_list(),
         "compiler_flags_select": attr.string_list_dict(),
         "haddock_flags": attr.string_list(),
+        "cabalopts": attr.string_list(),
         "repl_ghci_args": attr.string_list(),
         "locale_archive": attr.string(),
         # Unfortunately, repositories cannot depend on each other
@@ -166,6 +169,7 @@ def haskell_register_ghc_nixpkgs(
         compiler_flags_select = None,
         haddock_flags = None,
         repl_ghci_args = None,
+        cabalopts = None,
         locale_archive = None,
         attribute_path = "haskellPackages.ghc",
         sh_posix_attributes = None,
@@ -237,6 +241,7 @@ def haskell_register_ghc_nixpkgs(
         compiler_flags = compiler_flags,
         compiler_flags_select = compiler_flags_select,
         haddock_flags = haddock_flags,
+        cabalopts = cabalopts,
         repl_ghci_args = repl_ghci_args,
         locale_archive = locale_archive,
         locale = locale,

--- a/haskell/toolchain.bzl
+++ b/haskell/toolchain.bzl
@@ -146,6 +146,7 @@ def _haskell_toolchain_impl(ctx):
             compiler_flags = ctx.attr.compiler_flags,
             repl_ghci_args = ctx.attr.repl_ghci_args,
             haddock_flags = ctx.attr.haddock_flags,
+            cabalopts = ctx.attr.cabalopts,
             locale = ctx.attr.locale,
             locale_archive = locale_archive,
             cc_wrapper = struct(
@@ -194,6 +195,15 @@ _haskell_toolchain = rule(
         ),
         "haddock_flags": attr.string_list(
             doc = "A collection of flags that will be passed to haddock.",
+        ),
+        "cabalopts": attr.string_list(
+            doc = """Additional flags to pass to `Setup.hs configure` for all Cabal rules.
+
+            Note, Cabal rules do not read the toolchain attributes `compiler_flags` or `haddock_flags`.
+            Use `--ghc-option=OPT` to configure additional compiler flags.
+            Use `--haddock-option=OPT` to configure additional haddock flags.
+            Use `--haddock-option=--optghc=OPT` if haddock generation requires additional compiler flags.
+            """,
         ),
         "version": attr.string(
             doc = "Version of your GHC compiler. It has to match the version reported by the GHC used by bazel.",
@@ -246,6 +256,7 @@ def haskell_toolchain(
         compiler_flags = [],
         repl_ghci_args = [],
         haddock_flags = [],
+        cabalopts = [],
         locale_archive = None,
         **kwargs):
     """Declare a compiler toolchain.
@@ -291,6 +302,7 @@ def haskell_toolchain(
         compiler_flags = compiler_flags,
         repl_ghci_args = corrected_ghci_args,
         haddock_flags = haddock_flags,
+        cabalopts = cabalopts,
         is_darwin = select({
             "@rules_haskell//haskell/platforms:darwin": True,
             "//conditions:default": False,

--- a/tests/cabal-toolchain-flags/BUILD.bazel
+++ b/tests/cabal-toolchain-flags/BUILD.bazel
@@ -1,0 +1,6 @@
+load("@rules_haskell//haskell:cabal.bzl", "haskell_cabal_binary")
+
+haskell_cabal_binary(
+    name = "cabal-toolchain-flags",
+    srcs = glob(["**"]),
+)

--- a/tests/cabal-toolchain-flags/Main.hs
+++ b/tests/cabal-toolchain-flags/Main.hs
@@ -1,0 +1,10 @@
+{-# LANGUAGE CPP #-}
+
+module Main where
+
+import Data.ByteString
+
+#ifdef TESTS_TOOLCHAIN_CABALOPTS
+main :: IO ()
+main = print ("hello" :: ByteString)
+#endif

--- a/tests/cabal-toolchain-flags/test.cabal
+++ b/tests/cabal-toolchain-flags/test.cabal
@@ -1,0 +1,10 @@
+cabal-version: >=1.10
+name: cabal-toolchain-flags
+version: 0.1.0.0
+build-type: Simple
+
+executable cabal-toolchain-flags
+  build-depends: base, bytestring
+  default-language: Haskell2010
+  extensions: OverloadedStrings
+  main-is: Main.hs

--- a/tests/haskell_cabal_library/BUILD.bazel
+++ b/tests/haskell_cabal_library/BUILD.bazel
@@ -21,6 +21,10 @@ haskell_cabal_library(
         "Lib.hs",
         "lib.cabal",
     ],
+    cabalopts = [
+        "--ghc-option=-DONE=1",
+        "--haddock-option=--optghc=-DONE=1",
+    ],
     flags = [
         "use-base",
         "expose-lib",

--- a/tests/haskell_cabal_library/Lib.hs
+++ b/tests/haskell_cabal_library/Lib.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE ForeignFunctionInterface #-}
 
 module Lib where
@@ -5,4 +6,4 @@ module Lib where
 foreign import ccall "add" add :: Int -> Int -> Int
 
 x :: Int
-x = add 1 1
+x = add ONE ONE


### PR DESCRIPTION
This adds a new `cabalopts` attribute to the Cabal rules `haskell_cabal_binary|library`. This attribute defines additional options that should be passed to `Setup.hs configure`. It can be used to define additional compiler flags or flags for other tools invoked by Cabal, e.g. using `--ghc-option` or `--haddock-option`. The name is chosen based on #1059.

The `cabalopts` attribute is more general than the `compiler_flags` attribute and is used as its replacement. The `compiler_flags` attribute is consequently marked as deprecated. The `cabalopts` attribute has the added benefit that it is more explicit about which tools will receive which flags. For example the `compiler_flags` attribute did not forward GHC flags to `--haddock-option=--optghc` which meant that `CPP` flags would not be available during Haddock generation which could lead to errors due to missing preprocessor macros. With `cabalopts` it is possible to specify such flags explicitly.

Additionally, this adds a toolchain attribute to globally define additional Cabal options to be passed to all instances of `haskell_cabal_binary|library`. This toolchain attribute can be used to fix issues such as #1365.

This adds test-cases for both the `cabalopts` rule attribute as well as the `cabalopts` toolchain attribute.

---

This is another approach to fixing #1365 and replaces #1374.

The approach taken in #1374 was to forward toolchain `compiler_flags` to the Cabal rules as well. The issue with that approach is that `compiler_flags` that are intended for regular `haskell_binary|library|test` rules may conflict with compiler flags required by Stackage packages built via `haskell_cabal_binary|library`. Short of https://github.com/haskell/cabal/issues/6962 there is no easy way to specify "default" GHC flags at the `Setup.hs` command-line that can still be overridden by flags specified in Cabal files.

The approach taken by this PR is to separate regular Haskell targets and Cabal targets. This way users can define compiler flags for Cabal packages separately and apply the necessary care to avoid conflicts with flags specified in Cabal files.

---

Closes #1365 
Closes #1374 
Addresses the `cabalopts` part of #1059.