### PR TITLE
stack_snapshot_pin remove too early set -euo pipefail

### DIFF
--- a/haskell/private/stack_snapshot_pin.sh.tpl
+++ b/haskell/private/stack_snapshot_pin.sh.tpl
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-set -euo pipefail
 
 if [ "$BUILD_WORKSPACE_DIRECTORY" = "" ]; then
     cat <<EOF >&2


### PR DESCRIPTION
The `set -e` at the beginning of the script breaks the runfiles library discovery on MacOS. The `set -u` breaks the error handling on empty `$BUILD_WORKSPACE_DIRECTORY`. These flags are not required before the runfiles library discovery and already set right after wards.

Closes #1397 