### PR TITLE
Fix incorrect path prefixing when linking

### DIFF
--- a/haskell/private/cc_libraries.bzl
+++ b/haskell/private/cc_libraries.bzl
@@ -141,25 +141,25 @@ def link_libraries(libs, args, path_prefix = "", prefix_optl = False):
     Args:
       libs: Sequence of File, libraries to link.
       args: Args or List, append arguments to this object.
-      path_prefix: String, a prefix to apply to search directory arguments. If
-        this is a directory, trailing slashes should be included explicitly (this
-        function will not add them automatically).
+      path_prefix: String, a prefix to apply to search directory arguments. A
+        trailing slash will automatically be added to this argument if provided
+        (you do not need to provide one).
       prefix_optl: Bool, whether to prefix linker flags by -optl
 
     """
     if prefix_optl:
         libfmt = "-optl-l%s"
-        dirfmt = "-optl-L" + path_prefix + "%s"
+        dirfmt = "-optl-L" + paths.join(path_prefix, "%s")
     else:
         libfmt = "-l%s"
-        dirfmt = "-L" + path_prefix + "%s"
+        dirfmt = "-L" + paths.join(path_prefix, "%s")
 
     if hasattr(args, "add_all"):
-        args.add_all(libs, map_each = get_lib_name, format_each = libfmt)
         args.add_all(libs, map_each = get_dirname, format_each = dirfmt, uniquify = True)
+        args.add_all(libs, map_each = get_lib_name, format_each = libfmt)
     else:
-        args.extend([libfmt % get_lib_name(lib) for lib in libs])
         args.extend([dirfmt % lib.dirname for lib in libs])
+        args.extend([libfmt % get_lib_name(lib) for lib in libs])
 
 def create_link_config(hs, posix, cc_libraries_info, libraries_to_link, binary, args, dynamic = None, pic = None):
     """Configure linker flags and inputs.


### PR DESCRIPTION
When adding support for fully-statically-linked binaries, we taught
`link_libraries` how to prefix its linker directories using
`path_prefix`. At the time it was decided that it would be up to the
caller to add trailing slashes to `path_prefix` as necessary, to keep
`link_libraries` simple. In threading this through the various callers
of `link_libraries`, we introduced a bug whereby the _empty_
`path_prefix` is transformed into `"/"`, which breaks a few things. This
commit thus makes the following changes:

* `link_libraries` _does_ now automatically add a trailing slash to a
  non-empty `path_prefix` argument. This doesn't seem overly restrictive
  and certainly at present we don't use non-directory prefixes as
  arguments to this function.

* The comment that explains why REPL scripts must pass a `path_prefix`
  to deal with the fact that they don't run in the execroot is moved to
  arguably the better position -- `_create_repl` as opposed to
  `_compiler_flags_and_inputs`. `_compiler_flags_and_inputs` is actually
  also called by `_create_hie_bios`, which needs a similar workaround
  but at present doesn't provide one (to be addressed in a future
  commit).