### PR TITLE
docs: remove redundant pthread linker flag

### DIFF
--- a/docs/haskell-use-cases.rst
+++ b/docs/haskell-use-cases.rst
@@ -712,8 +712,8 @@ expression that supplies appropriate ``cc`` and ``binutils`` derivations::
   )
 
 With the toolchain taken care of, you can then create fully-statically-linked
-binaries by passing the ``-optl-static`` and ``-optl-pthread`` flags as
-``compiler_flags`` to GHC, e.g. in ``haskell_binary``::
+binaries by passing the ``-optl-static`` flag as ``compiler_flags`` to GHC,
+e.g. in ``haskell_binary``::
 
   haskell_binary(
       name = ...,
@@ -723,7 +723,6 @@ binaries by passing the ``-optl-static`` and ``-optl-pthread`` flags as
       ...,
       compiler_flags = [
           "-optl-static",
-          "-optl-pthread",
       ],
   )
 


### PR DESCRIPTION
https://github.com/tweag/rules_haskell/pull/1390 documents that fully static linking requires `-optl-pthread`. However, that flag is already set by `rules_haskell` [during linking](https://github.com/tweag/rules_haskell/blob/a67be06b3df851a3a01aebbe42b25583044a6bba/haskell/private/actions/link.bzl#L119). ~This PR removes it.~ This PR removes the flag from the docs.

@lunaris I saw that you also [removed that flag](https://github.com/lunaris/minirepo/commit/feb51aa5faec8c61339cf7d7d8041f6f580c1948#diff-35b9415092675c95c3395c9a2db3b346L44) in `minirepo`. Can this be removed from the docs or am I missing something?