### PR TITLE
Configure `-optl-static` via feature flag

### DIFF
--- a/docs/haskell-use-cases.rst
+++ b/docs/haskell-use-cases.rst
@@ -712,8 +712,7 @@ expression that supplies appropriate ``cc`` and ``binutils`` derivations::
   )
 
 With the toolchain taken care of, you can then create fully-statically-linked
-binaries by passing the ``-optl-static`` flag as ``compiler_flags`` to GHC,
-e.g. in ``haskell_binary``::
+binaries by enabling the ``fully_static_link`` feature flag, e.g. in ``haskell_binary``::
 
   haskell_binary(
       name = ...,
@@ -721,12 +720,18 @@ e.g. in ``haskell_binary``::
           ...,
       ],
       ...,
-      compiler_flags = [
-          "-optl-static",
+      features = [
+          "fully_static_link",
       ],
   )
 
+Note, feature flags can be configured `per target`_, `per package`_, or
+globally on the `command line`_.
+
 .. _static-haskell-nix: https://github.com/nh2/static-haskell-nix
+.. _per target: https://docs.bazel.build/versions/master/be/common-definitions.html#common.features
+.. _per package: https://docs.bazel.build/versions/master/be/functions.html#package.features
+.. _command line: https://docs.bazel.build/versions/master/command-line-reference.html#flag--features
 
 Containerization with rules_docker
 ----------------------------------

--- a/haskell/cabal.bzl
+++ b/haskell/cabal.bzl
@@ -258,6 +258,9 @@ def _prepare_cabal_inputs(
     if hs.toolchain.fully_static_link:
         args.add("--hsc2hs-option=--lflag=-static")
 
+    if hs.features.fully_static_link:
+        args.add("--ghc-option=-optl-static")
+
     args.add("--")
     args.add_all(package_databases, map_each = _dirname, format_each = "--package-db=%s")
     args.add_all(direct_include_dirs, format_each = "--extra-include-dirs=%s")

--- a/haskell/private/actions/link.bzl
+++ b/haskell/private/actions/link.bzl
@@ -118,6 +118,10 @@ def link_binary(
     # so we just default to passing it.
     args.add("-optl-pthread")
 
+    if hs.features.fully_static_link:
+        # Create a fully statically linked binary.
+        args.add("-optl-static")
+
     args.add_all(["-o", executable.path])
 
     (pkg_info_inputs, pkg_info_args) = pkg_info_to_compile_flags(

--- a/haskell/private/context.bzl
+++ b/haskell/private/context.bzl
@@ -59,6 +59,9 @@ def haskell_context(ctx, attr = None):
         bin_dir = ctx.bin_dir,
         genfiles_dir = ctx.genfiles_dir,
         coverage_enabled = coverage_enabled,
+        features = struct(
+            fully_static_link = "fully_static_link" in ctx.features,
+        ),
     )
 
 def render_env(env):


### PR DESCRIPTION
As discussed in #1408 this replaces the need to configure `compiler_flags` directly by setting `features = ["fully_static_link"]` to configure a fully statically linked binary. This does not yet address how to configure fully static linking for binaries generated by `stack_snapshot`. However, configuring the feature flag globally via the command-line flag `--features fully_static_link` will already produce fully statically linked `stack_snapshot` binaries.
