### PR TITLE
Consistently allow files in tools attribute

### DIFF
--- a/haskell/cabal.bzl
+++ b/haskell/cabal.bzl
@@ -775,6 +775,7 @@ haskell_cabal_binary = rule(
         ),
         "tools": attr.label_list(
             cfg = "host",
+            allow_files = True,
             doc = """Tool dependencies. They are built using the host configuration, since
             the tools are executed as part of the build.""",
         ),

--- a/haskell/defs.bzl
+++ b/haskell/defs.bzl
@@ -56,6 +56,7 @@ _haskell_common_attrs = {
     ),
     "tools": attr.label_list(
         cfg = "host",
+        allow_files = True,
     ),
     "_ghci_script": attr.label(
         allow_single_file = True,


### PR DESCRIPTION
This is already the case for `haskell_cabal_library` and needed for tools that are provided as prebuilt binaries, e.g. `rules_nixpkgs` provided tools.