### PR TITLE
doc(.github): Add a note of 8.10 linking issues to bug template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -5,6 +5,11 @@ labels: 'type: bug'
 
 ---
 
+<!-- NOTE: If you are trying to use GHC 8.10,
+     there is a known linking issue.
+     Please see https://github.com/tweag/rules_haskell/issues/1418
+    -->
+
 **Describe the bug**
 A clear and concise description of what the bug is.
 


### PR DESCRIPTION
Until we solve the issues with 8.10, we can avoid some duplicate bug reports by linking to the WIP issue.