### PR TITLE
Only pass -no-pie for binary targets

### DIFF
--- a/haskell/cabal.bzl
+++ b/haskell/cabal.bzl
@@ -213,9 +213,12 @@ def _prepare_cabal_inputs(
         for arg in ["-package-db", "./" + _dirname(package_db)]
     ], join_with = " ", format_each = "--ghc-arg=%s", omit_if_empty = False)
     args.add("--flags=" + " ".join(flags))
-    if dynamic_file and not (is_library or hs.toolchain.is_darwin or hs.toolchain.is_windows):
+    if dynamic_file:
         # See Note [No PIE when linking] in haskell/private/actions/link.bzl
-        args.add("--ghc-option=-optl-no-pie")
+        if not (hs.toolchain.is_darwin or hs.toolchain.is_windows):
+            version = [int(x) for x in hs.toolchain.version.split(".")]
+            if version < [8, 10] or not is_library:
+                args.add("--ghc-option=-optl-no-pie")
     args.add_all(hs.toolchain.cabalopts)
     args.add_all(cabalopts)
     if dynamic_file:

--- a/haskell/private/actions/compile.bzl
+++ b/haskell/private/actions/compile.bzl
@@ -476,6 +476,12 @@ def compile_library(
     if with_shared:
         c.args.add("-dynamic-too")
 
+        # See Note [No PIE when linking] in haskell/private/actions/link.bzl
+        if not hs.toolchain.is_darwin and not hs.toolchain.is_windows:
+            version = [int(x) for x in hs.toolchain.version.split(".")]
+            if version < [8, 10]:
+                c.args.add("-optl-no-pie")
+
     coverage_data = []
     if hs.coverage_enabled:
         c.args.add_all(_hpc_compiler_args(hs))

--- a/haskell/private/actions/compile.bzl
+++ b/haskell/private/actions/compile.bzl
@@ -475,9 +475,6 @@ def compile_library(
     c = _compilation_defaults(hs, cc, java, posix, dep_info, plugin_dep_info, srcs, import_dir_map, extra_srcs, user_compile_flags, with_profiling, my_pkg_id = my_pkg_id, version = my_pkg_id.version, plugins = plugins, preprocessors = preprocessors)
     if with_shared:
         c.args.add("-dynamic-too")
-        if not hs.toolchain.is_darwin and not hs.toolchain.is_windows:
-            # See Note [No PIE when linking] in haskell/private/actions/link.bzl
-            c.args.add("-optl-no-pie")
 
     coverage_data = []
     if hs.coverage_enabled:

--- a/haskell/private/actions/link.bzl
+++ b/haskell/private/actions/link.bzl
@@ -213,7 +213,7 @@ def link_binary(
 # on this setting GHC would then automatically set `-no-pie`. However,
 # rules_haskell uses GHC's `-pgmc` flag to point GHC to the CC toolchain's C
 # compiler. This disables the flags configured in the `setting` file. Instead,
-# we have to pass `-no-pie` explicitly.
+# we have to pass `-no-pie` explicitly when linking binaries.
 #
 # Ideally, we would determine whether the CC toolchain's C compiler supports
 # `-no-pie` before setting it. Unfortunately, this is complicated by the fact

--- a/haskell/private/actions/link.bzl
+++ b/haskell/private/actions/link.bzl
@@ -215,6 +215,9 @@ def link_binary(
 # compiler. This disables the flags configured in the `setting` file. Instead,
 # we have to pass `-no-pie` explicitly when linking binaries.
 #
+# In GHC < 8.10, we must always pass -no-pie. In newer compilers, we
+# must take care to only pass -no-pie when compiling libraries.
+#
 # Ideally, we would determine whether the CC toolchain's C compiler supports
 # `-no-pie` before setting it. Unfortunately, this is complicated by the fact
 # that Bazel does not support dynamic dependencies in build actions and that


### PR DESCRIPTION
When using GHC 8.10, passing `-no-pie` to the linker when building
libraries leads to obscure linker errors. Since PIE pertains to
executables, it doesn't make much sense passing that flag when
building libraries anyways. Removing it, both for `haskell_library`
and `haskell_cabal_library` fixes GHC 8.10 support. We make sure to
keep the flag for executables. This would otherwise negate the effect
of #1388.

Fixes #1418 