### PR TITLE
Check each file we might overwrite or clash with.

### DIFF
--- a/start
+++ b/start
@@ -48,19 +48,41 @@ parse_args () {
     esac
 }
 
-check_clash () {
-    if [ -f "$1" ] # directories don't clash, we're only writing files
+check_dir () {
+    if [ -d "$1" ] # we can't write a file when a directory of that name exists
     then
-        echo "ERROR: The current directory already has a $1 file we don't want to overwrite." >&2
+        echo "STOP: There's a directory named $1 but we want to write a file with the same name. Please delete or rename the $1 directory." >&2
+        exit 1
+    fi
+}
+
+check_alt () {
+    check_dir $2
+    if [ -f "$1" ]
+    then
+        echo "STOP: There's a $1 file but we intend to write a $2 file. When both exist, bazel will pick the one with the .bazel extension, ignoring the other one. Please delete the $1 file." >&2
+        exit 1
+    fi
+}
+
+check_clash () {
+    check_dir $1
+    if [ -f "$1" ]
+    then
+        echo "STOP: The current directory already has a $1 file and we don't want to overwrite it." >&2
         exit 1
     fi
 }
 
 check_files_dont_exist () {
-    # Writing BUILD.bazel does not overwrite a BUILD file but include it anyway.
-    # If we're uncomfortable with the slightly off clash message then write
-    # a separate test and message for that case.
-    for clash in .bazelrc WORKSPACE BUILD BUILD.bazel Example.hs
+    # A BUILD.bazel file takes precedence over a BUILD file and likewise
+    # a WORKSPACE.bazel file takes precedence over a WORKSPACE file. We write
+    # BUILD.bazel and WORKSPACE files. Seems an odd mix.
+    check_alt WORKSPACE.bazel WORKSPACE
+    check_alt BUILD BUILD.bazel
+    check_alt zlib.BUILD zlib.BUILD.bazel
+
+    for clash in .bazelrc WORKSPACE BUILD.bazel zlib.BUILD.bazel Example.hs
     do
         check_clash $clash
     done

--- a/start
+++ b/start
@@ -77,7 +77,9 @@ check_clash () {
 check_files_dont_exist () {
     # A BUILD.bazel file takes precedence over a BUILD file and likewise
     # a WORKSPACE.bazel file takes precedence over a WORKSPACE file. We write
-    # BUILD.bazel and WORKSPACE files. Seems an odd mix.
+    # BUILD.bazel and WORKSPACE files.
+    # Some Bazel tooling may fail on WORKSPACE.bazel files,
+    # e.g. https://github.com/bazelbuild/bazel-gazelle/issues/678
     check_alt WORKSPACE.bazel WORKSPACE
     check_alt BUILD BUILD.bazel
 

--- a/start
+++ b/start
@@ -57,7 +57,7 @@ check_dir () {
 }
 
 check_alt () {
-    check_dir $2
+    check_dir "$2"
     if [ -f "$1" ]
     then
         echo "STOP: There's a $1 file but we intend to write a $2 file. When both exist, bazel will pick the one with the .bazel extension, ignoring the other one. Please delete the $1 file." >&2
@@ -66,7 +66,7 @@ check_alt () {
 }
 
 check_clash () {
-    check_dir $1
+    check_dir "$1"
     if [ -e "$1" ]
     then
         echo "STOP: The current directory already has a $1 file and we don't want to overwrite it." >&2

--- a/start
+++ b/start
@@ -48,12 +48,22 @@ parse_args () {
     esac
 }
 
-check_files_dont_exist () {
-    if [ -e WORKSPACE ] || [ -e BUILD ] || [ -e BazelExample.hs ]
+check_clash () {
+    if [ -f "$1" ] # directories don't clash, we're only writing files
     then
-        echo "Current directory already has WORKSPACE and/or BUILD and/or BazelExample.hs files." >&2
+        echo "ERROR: The current directory already has a $1 file we don't want to overwrite." >&2
         exit 1
     fi
+}
+
+check_files_dont_exist () {
+    # Writing BUILD.bazel does not overwrite a BUILD file but include it anyway.
+    # If we're uncomfortable with the slightly off clash message then write
+    # a separate test and message for that case.
+    for clash in .bazelrc WORKSPACE BUILD BUILD.bazel BazelExample.hs
+    do
+        check_clash $clash
+    done
 }
 
 check_bazel_version () {

--- a/start
+++ b/start
@@ -60,7 +60,7 @@ check_files_dont_exist () {
     # Writing BUILD.bazel does not overwrite a BUILD file but include it anyway.
     # If we're uncomfortable with the slightly off clash message then write
     # a separate test and message for that case.
-    for clash in .bazelrc WORKSPACE BUILD BUILD.bazel BazelExample.hs
+    for clash in .bazelrc WORKSPACE BUILD BUILD.bazel Example.hs
     do
         check_clash $clash
     done

--- a/start
+++ b/start
@@ -80,7 +80,6 @@ check_files_dont_exist () {
     # BUILD.bazel and WORKSPACE files. Seems an odd mix.
     check_alt WORKSPACE.bazel WORKSPACE
     check_alt BUILD BUILD.bazel
-    check_alt zlib.BUILD zlib.BUILD.bazel
 
     for clash in .bazelrc WORKSPACE BUILD.bazel zlib.BUILD.bazel Example.hs
     do

--- a/start
+++ b/start
@@ -67,7 +67,7 @@ check_alt () {
 
 check_clash () {
     check_dir $1
-    if [ -f "$1" ]
+    if [ -e "$1" ]
     then
         echo "STOP: The current directory already has a $1 file and we don't want to overwrite it." >&2
         exit 1


### PR DESCRIPTION
This change is more explicit in its messaging about each file that exists and that we'd be overwriting. It avoids false positive clashes with directories such as the common `build` directory in many repos.

```
> ./rules-haskell-start
INFO: Creating a WORKSPACE file based on GHC bindists. If you want to use a nix-based setup (e.g. on NixOS), call with `--use-nix`. See `--help` for more info.
ERROR: The current directory already has a .bazelrc file we don't want to overwrite.
```