### PR TITLE
Adding haskell-language-server 0.4

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -117,6 +117,19 @@ stack_snapshot(
     stack_snapshot_json = "//:ghcide-snapshot.json",
 )
 
+stack_snapshot(
+    name = "hls",
+    components = {"haskell-language-server": [
+        "lib",
+        "exe",
+    ]},
+    extra_deps = {"zlib": ["@zlib.dev//:zlib" if is_nix_shell else "@zlib.hs//:zlib"]},
+    haddock = False,
+    local_snapshot = "//:hls-stack-snapshot.yaml",
+    packages = ["ghcide"],
+    stack_snapshot_json = "//:hls-snapshot.json",
+)
+
 load(
     "@io_tweag_rules_nixpkgs//nixpkgs:nixpkgs.bzl",
     "nixpkgs_cc_configure",

--- a/hls-stack-snapshot.yaml
+++ b/hls-stack-snapshot.yaml
@@ -1,0 +1,63 @@
+resolver: lts-16.5
+
+# packages:
+# - .
+# - ./ghcide/
+# - ./hls-plugin-api
+
+# ghc-options:
+#   "$everything": -haddock
+
+packages:
+    # dont fetch submodules
+# - github: haskell/haskell-language-server
+- git: https://github.com/haskell/haskell-language-server.git
+  # 0.4 release
+  commit: 0a18edde24923251a148cbbc0ae993a6aac83b9c
+  subdirs:
+    - .
+    - ./ghcide/
+    - ./hls-plugin-api
+- aeson-1.5.2.0
+- apply-refact-0.7.0.0
+- github: bubba/brittany
+  commit: c59655f10d5ad295c2481537fc8abf0a297d9d1c
+- bytestring-trie-0.2.5.0
+- cabal-plan-0.6.2.0
+- clock-0.7.2
+- constrained-dynamic-0.1.0.0
+- extra-1.7.3
+- floskell-0.10.4
+- fourmolu-0.1.0.0@rev:1
+# - ghcide-0.1.0
+- haskell-src-exts-1.21.1
+- hlint-2.2.8
+- HsYAML-aeson-0.2.0.0@rev:2
+- hoogle-5.0.17.11
+- hsimport-0.11.0
+- ilist-0.3.1.0
+- lsp-test-0.11.0.5
+- monad-dijkstra-0.1.1.2
+- refinery-0.1.0.0
+- retrie-0.1.1.1
+- semigroups-0.18.5
+# - github: wz1000/shake
+#   commit: fb3859dca2e54d1bbb2c873e68ed225fa179fbef
+- stylish-haskell-0.11.0.3
+- temporary-1.2.1.1
+- implicit-hie-cradle-0.2.0.1
+- implicit-hie-0.1.1.0
+- hie-bios-0.7.1
+
+# flags:
+#   haskell-language-server:
+#     pedantic: true
+#   retrie:
+#     BuildExecutable: false
+
+# allow-newer: true
+
+# nix:
+#   packages: [ icu libcxx zlib ]
+
+# concurrent-tests: false


### PR DESCRIPTION
I wanted to give a spin to hls but this fails with
```
bazel run @hls-unpinned//:pin
Starting local Bazel server and connecting to it...
INFO: Repository hls-unpinned instantiated at:
  /home/teto/nova/rules_haskell/WORKSPACE:120:15: in <toplevel>
  /home/teto/.cache/bazel/_bazel_teto/b20af51f549240b69085971f497f86fc/external/rules_haskell/haskell/cabal.bzl:2236:29: in stack_snapshot
Repository rule _stack_snapshot_unpinned defined at:
  /home/teto/.cache/bazel/_bazel_teto/b20af51f549240b69085971f497f86fc/external/rules_haskell/haskell/cabal.bzl:1891:43: in <toplevel>
ERROR: An error occurred during the fetch of repository 'hls-unpinned':
   Traceback (most recent call last):
	File "/home/teto/.cache/bazel/_bazel_teto/b20af51f549240b69085971f497f86fc/external/rules_haskell/haskell/cabal.bzl", line 1644
		_resolve_packages(<6 more arguments>)
	File "/home/teto/.cache/bazel/_bazel_teto/b20af51f549240b69085971f497f86fc/external/rules_haskell/haskell/cabal.bzl", line 1149, in _resolve_packages
		_execute_or_fail_loudly(<2 more arguments>)
	File "/home/teto/.cache/bazel/_bazel_teto/b20af51f549240b69085971f497f86fc/external/rules_haskell/haskell/private/workspace_utils.bzl", line 18, in _execute_or_fail_loudly
		fail(<1 more arguments>)
Command failed: /home/teto/.cache/bazel/_bazel_teto/b20af51f549240b69085971f497f86fc/external/rules_haskell_stack/stack ls dependencies json --global-hints --external
Cloning 0a18edde24923251a148cbbc0ae993a6aac83b9c from https://github.com/haskell/haskell-language-server.git
No cabal file found for Repo from https://github.com/haskell/haskell-language-server.git, commit 0a18edde24923251a148cbbc0ae993a6aac83b9c in subdir ./hls-plugin-api
ERROR: Traceback (most recent call last):
	File "/home/teto/.cache/bazel/_bazel_teto/b20af51f549240b69085971f497f86fc/external/rules_haskell/haskell/cabal.bzl", line 1644
		_resolve_packages(<6 more arguments>)
	File "/home/teto/.cache/bazel/_bazel_teto/b20af51f549240b69085971f497f86fc/external/rules_haskell/haskell/cabal.bzl", line 1149, in _resolve_packages
		_execute_or_fail_loudly(<2 more arguments>)
	File "/home/teto/.cache/bazel/_bazel_teto/b20af51f549240b69085971f497f86fc/external/rules_haskell/haskell/private/workspace_utils.bzl", line 18, in _execute_or_fail_loudly
		fail(<1 more arguments>)
Command failed: /home/teto/.cache/bazel/_bazel_teto/b20af51f549240b69085971f497f86fc/external/rules_haskell_stack/stack ls dependencies json --global-hints --external
Cloning 0a18edde24923251a148cbbc0ae993a6aac83b9c from https://github.com/haskell/haskell-language-server.git
No cabal file found for Repo from https://github.com/haskell/haskell-language-server.git, commit 0a18edde24923251a148cbbc0ae993a6aac83b9c in subdir ./hls-plugin-api
INFO: Elapsed time: 11.232s
```
Seems like stack doesn't download the submodules ? I dont know how to check: where is downloaded the temporary clone in order to check ?