### PR TITLE
Update CircleCI config xcode version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ version: 2
 jobs:
   build-darwin:
     macos:
-      xcode: "9.0"
+      xcode: "10.0"
     steps:
       - checkout
       - run:
@@ -117,7 +117,7 @@ jobs:
 
   build-darwin-bindist:
     macos:
-      xcode: "9.0"
+      xcode: "10.0"
     steps:
       - checkout
       - run:


### PR DESCRIPTION
The current macOS pipeline stopped working due a too old version specification for xcode. See [here](https://app.circleci.com/pipelines/github/tweag/rules_haskell/401/workflows/be32ed5a-74f2-4f09-8c61-785e340a45d6/jobs/9659).
> ```
> Creating a dedicated VM with xcode:9.0 image
> failed to create host: Image xcode:9.0 is not supported
> ```

AFAIK the latest available version is 12, however the [Nix installation fails](https://app.circleci.com/pipelines/github/tweag/rules_haskell/402/workflows/665004bd-0072-48fb-bf38-856f4cd3585c/jobs/9661) in this case, so this PR is updating to version 10 only.

This is blocking #1437.