### PR TITLE
Avoid patching bindist bin symlinks

### DIFF
--- a/haskell/ghc_bindist.bzl
+++ b/haskell/ghc_bindist.bzl
@@ -281,10 +281,11 @@ def _ghc_bindist_impl(ctx):
         execute_or_fail_loudly(ctx, ["./configure", "--prefix", bindist_dir.realpath])
         execute_or_fail_loudly(ctx, ["make", "install"])
         ctx.file("patch_bins", executable = True, content = r"""#!/usr/bin/env bash
-grep --files-with-matches --null {bindist_dir} bin/* | xargs -0 -n1 \
+find bin -type f -print0 | xargs -0 \
+grep --files-with-matches --null {bindist_dir} | xargs -0 -n1 \
     sed -i.bak \
         -e '2i\
-          DISTDIR="$( dirname "$(resolved="$0"; while tmp="$(readlink "$resolved")"; do resolved="$tmp"; done; echo "$resolved")" )/.."' \
+DISTDIR="$( dirname "$(resolved="$0"; cd "$(dirname "$resolved")"; while tmp="$(readlink "$(basename "$resolved")")"; do resolved="$tmp"; cd "$(dirname "$resolved")"; done; echo "$PWD/$(basename "$resolved")")" )/.."' \
         -e 's:{bindist_dir}:$DISTDIR:'
 """.format(
             bindist_dir = bindist_dir.realpath,


### PR DESCRIPTION
On MacOS Big Sur it is no longer allowed to apply `sed` in-place changes on a symlink. This change makes sure that we only change regular files in the GHC bindist bin directory.

This uses `find -type f` as suggested in https://github.com/tweag/rules_haskell/issues/1442#issuecomment-728155624.

Closes #1442 