### PR TITLE
Fix a regression of dylibs missing in runfiles

### DIFF
--- a/haskell/private/haskell_impl.bzl
+++ b/haskell/private/haskell_impl.bzl
@@ -317,7 +317,7 @@ def _haskell_binary_common_impl(ctx, is_test):
             ctx.file._bash_runfiles,
             hs.toolchain.tools.hpc,
             binary,
-        ] + mix_runfiles + srcs_runfiles + solibs
+        ] + mix_runfiles + srcs_runfiles
 
     return [
         hs_info,
@@ -326,7 +326,7 @@ def _haskell_binary_common_impl(ctx, is_test):
             executable = executable,
             files = target_files,
             runfiles = ctx.runfiles(
-                files = extra_runfiles,
+                files = extra_runfiles + solibs,
                 collect_data = True,
             ),
         ),

--- a/tests/analysis_tests.bzl
+++ b/tests/analysis_tests.bzl
@@ -1,0 +1,33 @@
+load("@bazel_skylib//lib:sets.bzl", "sets")
+load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
+
+def _dynamic_libraries_in_runfiles_test_impl(ctx):
+    env = analysistest.begin(ctx)
+
+    target_under_test = analysistest.target_under_test(env)
+    runfiles = sets.make(target_under_test[DefaultInfo].default_runfiles.files.to_list())
+
+    dynamic_libs = [
+        lib_to_link.dynamic_library
+        for target in ctx.attr.libs
+        for input in target[CcInfo].linking_context.linker_inputs.to_list()
+        for lib_to_link in input.libraries
+    ]
+    for lib in dynamic_libs:
+        asserts.true(
+            env,
+            sets.contains(runfiles, lib),
+            "Expected library {} to be contained in the runfiles, but it was missing.".format(lib.short_path),
+        )
+
+    return analysistest.end(env)
+
+dynamic_libraries_in_runfiles_test = analysistest.make(
+    _dynamic_libraries_in_runfiles_test_impl,
+    attrs = {
+        "libs": attr.label_list(
+            doc = "Check for these dynamic libraries among the runfiles.",
+            providers = [CcInfo],
+        ),
+    },
+)

--- a/tests/analysis_tests.bzl
+++ b/tests/analysis_tests.bzl
@@ -12,6 +12,7 @@ def _dynamic_libraries_in_runfiles_test_impl(ctx):
         for target in ctx.attr.libs
         for input in target[CcInfo].linking_context.linker_inputs.to_list()
         for lib_to_link in input.libraries
+        if lib_to_link.dynamic_library != None
     ]
     for lib in dynamic_libs:
         asserts.true(

--- a/tests/binary-linkstatic-flag/BUILD.bazel
+++ b/tests/binary-linkstatic-flag/BUILD.bazel
@@ -4,6 +4,10 @@ load(
     "haskell_library",
     "haskell_test",
 )
+load(
+    "//tests:analysis_tests.bzl",
+    "dynamic_libraries_in_runfiles_test",
+)
 load("//tests:inline_tests.bzl", "sh_inline_test")
 
 # test whether `linkstatic` works as expected
@@ -42,6 +46,16 @@ haskell_test(
         ":c-lib",
         "//tests/hackage:base",
     ],
+)
+
+dynamic_libraries_in_runfiles_test(
+    name = "dynamic-runfiles-test",
+    libs = [
+        ":HsLib",
+        ":c-lib",
+        "//tests/hackage:base",
+    ],
+    target_under_test = ":binary-dynamic",
 )
 
 config_setting(

--- a/tests/binary-with-lib-dynamic/BUILD.bazel
+++ b/tests/binary-with-lib-dynamic/BUILD.bazel
@@ -3,6 +3,10 @@ load(
     "haskell_library",
     "haskell_test",
 )
+load(
+    "//tests:analysis_tests.bzl",
+    "dynamic_libraries_in_runfiles_test",
+)
 
 package(default_testonly = 1)
 
@@ -22,4 +26,13 @@ haskell_test(
         ":lib",
         "//tests/hackage:base",
     ],
+)
+
+dynamic_libraries_in_runfiles_test(
+    name = "runfiles-test",
+    libs = [
+        ":lib",
+        "//tests/hackage:base",
+    ],
+    target_under_test = ":binary-with-lib-dynamic",
 )


### PR DESCRIPTION
https://github.com/tweag/rules_haskell/pull/1256 introduced a regression whereby `.so` libraries required by a dynamically linked binary were no longer contained in the runfiles. This PR fixes that. Additionally, this PR adds regression tests.