### PR TITLE
Fix broken links to api.haskell.build

### DIFF
--- a/docs/haskell-use-cases.rst
+++ b/docs/haskell-use-cases.rst
@@ -101,10 +101,10 @@ accordingly. For example, you can have the following in your
 .. _Bazel+Nix blog post: https://www.tweag.io/posts/2018-03-15-bazel-nix.html
 .. _Nix package manager: https://nixos.org/nix
 .. _Nixpkgs: https://nixos.org/nixpkgs/manual/
-.. _ghc_bindist: http://api.haskell.build/haskell/ghc_bindist.html#ghc_bindist
+.. _ghc_bindist: https://api.haskell.build/haskell/ghc_bindist.html#ghc_bindist
 .. _haskell.org: https://haskell.org
-.. _haskell_binary: http://api.haskell.build/haskell/haskell.html#haskell_binary
-.. _haskell_library: http://api.haskell.build/haskell/haskell.html#haskell_library
+.. _haskell_binary: https://api.haskell.build/haskell/haskell.html#haskell_binary
+.. _haskell_library: https://api.haskell.build/haskell/haskell.html#haskell_library
 .. _rules_nixpkgs: https://github.com/tweag/rules_nixpkgs
 .. _toolchain resolution: https://docs.bazel.build/versions/master/toolchains.html#toolchain-resolution
 
@@ -366,7 +366,7 @@ construct a compiler with all the packages you depend on in scope::
 Each package mentioned in ``ghc.nix`` can then be imported using
 `haskell_toolchain_library`_ in ``BUILD`` files.
 
-.. _haskell_toolchain_library: http://api.haskell.build/haskell/haskell.html#haskell_toolchain_library
+.. _haskell_toolchain_library: https://api.haskell.build/haskell/haskell.html#haskell_toolchain_library
 
 Generating API documentation
 ----------------------------
@@ -386,7 +386,7 @@ any given target (or indeed all targets), like in the following:
   $ bazel build //my/pkg:mylib \
       --aspects @rules_haskell//haskell:defs.bzl%haskell_doc_aspect
 
-.. _haskell_doc: http://api.haskell.build/haskell/haddock.html#haskell_doc
+.. _haskell_doc: https://api.haskell.build/haskell/haddock.html#haskell_doc
 
 Linting your code
 -----------------

--- a/docs/haskell-use-cases.rst
+++ b/docs/haskell-use-cases.rst
@@ -103,8 +103,8 @@ accordingly. For example, you can have the following in your
 .. _Nixpkgs: https://nixos.org/nixpkgs/manual/
 .. _ghc_bindist: https://api.haskell.build/haskell/ghc_bindist.html#ghc_bindist
 .. _haskell.org: https://haskell.org
-.. _haskell_binary: https://api.haskell.build/haskell/haskell.html#haskell_binary
-.. _haskell_library: https://api.haskell.build/haskell/haskell.html#haskell_library
+.. _haskell_binary: https://api.haskell.build/haskell/defs.html#haskell_binary
+.. _haskell_library: https://api.haskell.build/haskell/defs.html#haskell_library
 .. _rules_nixpkgs: https://github.com/tweag/rules_nixpkgs
 .. _toolchain resolution: https://docs.bazel.build/versions/master/toolchains.html#toolchain-resolution
 
@@ -366,7 +366,7 @@ construct a compiler with all the packages you depend on in scope::
 Each package mentioned in ``ghc.nix`` can then be imported using
 `haskell_toolchain_library`_ in ``BUILD`` files.
 
-.. _haskell_toolchain_library: https://api.haskell.build/haskell/haskell.html#haskell_toolchain_library
+.. _haskell_toolchain_library: https://api.haskell.build/haskell/defs.html#haskell_toolchain_library
 
 Generating API documentation
 ----------------------------

--- a/docs/haskell.rst
+++ b/docs/haskell.rst
@@ -388,9 +388,9 @@ Happy building!
 
 .. _cat_hs: https://github.com/tweag/rules_haskell/tree/master/examples/cat_hs
 .. _install Bazel: https://docs.bazel.build/versions/master/install.html
-.. _haskell_binary: https://api.haskell.build/haskell/haskell.html#haskell_binary
-.. _haskell_toolchain_library: https://api.haskell.build/haskell/haskell.html#haskell_toolchain_library
-.. _haskell_library: https://api.haskell.build/haskell/haskell.html#haskell_library
+.. _haskell_binary: https://api.haskell.build/haskell/defs.html#haskell_binary
+.. _haskell_toolchain_library: https://api.haskell.build/haskell/defs.html#haskell_toolchain_library
+.. _haskell_library: https://api.haskell.build/haskell/defs.html#haskell_library
 .. _graphviz: https://www.graphviz.org/
 .. _start: https://rules-haskell.readthedocs.io/en/latest/haskell-use-cases.html#starting-a-new-project
 .. _downloading it: https://rules-haskell.readthedocs.io/en/latest/haskell-use-cases.html#making-rules-haskell-available

--- a/docs/haskell.rst
+++ b/docs/haskell.rst
@@ -388,9 +388,9 @@ Happy building!
 
 .. _cat_hs: https://github.com/tweag/rules_haskell/tree/master/examples/cat_hs
 .. _install Bazel: https://docs.bazel.build/versions/master/install.html
-.. _haskell_binary: http://api.haskell.build/haskell/haskell.html#haskell_binary
-.. _haskell_toolchain_library: http://api.haskell.build/haskell/haskell.html#haskell_toolchain_library
-.. _haskell_library: http://api.haskell.build/haskell/haskell.html#haskell_library
+.. _haskell_binary: https://api.haskell.build/haskell/haskell.html#haskell_binary
+.. _haskell_toolchain_library: https://api.haskell.build/haskell/haskell.html#haskell_toolchain_library
+.. _haskell_library: https://api.haskell.build/haskell/haskell.html#haskell_library
 .. _graphviz: https://www.graphviz.org/
 .. _start: https://rules-haskell.readthedocs.io/en/latest/haskell-use-cases.html#starting-a-new-project
 .. _downloading it: https://rules-haskell.readthedocs.io/en/latest/haskell-use-cases.html#making-rules-haskell-available

--- a/docs/why-bazel.rst
+++ b/docs/why-bazel.rst
@@ -97,6 +97,6 @@ have any of the other features that follow them above.
 .. _Maven: https://maven.apache.org/index.html
 .. _Gradle: https://gradle.org/
 .. _Cabal: https://www.haskell.org/cabal/
-.. _Stack: http://haskellstack.org/
+.. _Stack: https://haskellstack.org/
 .. _Shake: https://shakebuild.com/
 .. _monorepos: https://en.wikipedia.org/wiki/Monorepo


### PR DESCRIPTION
Also, use https for all links since, well, nobody uses http anymore.