### PR TITLE
stack unpack with versioned packages

### DIFF
--- a/examples/WORKSPACE
+++ b/examples/WORKSPACE
@@ -105,6 +105,8 @@ stack_snapshot(
         "optparse-applicative",
         "text",
         "text-show",
+        # Demonstrates a Hackage dependency that is not included in the Snapshot.
+        "optparse-helper-0.2.1.1",
     ],
     snapshot = "lts-14.0",
     # This example uses an unpinned version of stack_snapshot, meaning that stack is invoked on every build.

--- a/examples/cat_hs/lib/args/BUILD.bazel
+++ b/examples/cat_hs/lib/args/BUILD.bazel
@@ -11,6 +11,7 @@ haskell_library(
     deps = [
         "@stackage//:base",
         "@stackage//:optparse-applicative",
+        "@stackage//:optparse-helper",
     ],
 )
 

--- a/examples/cat_hs/lib/args/src/Args.hs
+++ b/examples/cat_hs/lib/args/src/Args.hs
@@ -11,6 +11,7 @@ module Args
   ) where
 
 import Options.Applicative
+import Options.Applicative.Helper (fpDesc, infoHelper)
 
 
 -- | A file argument.
@@ -39,9 +40,8 @@ parse = execParser parser
 -- | Command-line parser.
 parser :: ParserInfo Args
 parser =
-  info (argsParser <**> helper)
-    ( fullDesc
-    <> progDesc "Concatenate files to standard output."
+  infoHelper argsParser
+    ( fpDesc "Concatenate files to standard output."
     <> header "cat_hs - A Haskell implementation of cat." )
 
 

--- a/haskell/cabal.bzl
+++ b/haskell/cabal.bzl
@@ -1347,11 +1347,17 @@ def _download_packages(repository_ctx, snapshot, pinned):
 
 def _download_packages_unpinned(repository_ctx, snapshot, resolved):
     """Download remote packages using `stack unpack`."""
-    remote_packages = [
+    versioned_packages = [
         "{}-{}".format(package["name"], package["version"])
         for package in resolved.values()
-        if package["location"]["type"] not in ["core", "vendored"]
+        if package["location"]["type"] == "hackage"
     ]
+    unversioned_packages = [
+        package["name"]
+        for package in resolved.values()
+        if package["location"]["type"] not in ["core", "hackage", "vendored"]
+    ]
+    remote_packages = versioned_packages + unversioned_packages
     stack = [repository_ctx.path(repository_ctx.attr.stack)]
     if remote_packages:
         _execute_or_fail_loudly(repository_ctx, stack + ["--resolver", snapshot, "unpack"] + remote_packages)

--- a/haskell/cabal.bzl
+++ b/haskell/cabal.bzl
@@ -1348,7 +1348,7 @@ def _download_packages(repository_ctx, snapshot, pinned):
 def _download_packages_unpinned(repository_ctx, snapshot, resolved):
     """Download remote packages using `stack unpack`."""
     remote_packages = [
-        package["name"]
+        "{}-{}".format(package["name"], package["version"])
         for package in resolved.values()
         if package["location"]["type"] not in ["core", "vendored"]
     ]


### PR DESCRIPTION
Closes #1447 

Calls `stack --resolver lts-16.11 unpack base haxl-2.3.0.0` instead of `stack --resolver lts-16.11 unpack base haxl`. Otherwise, `stack` will fail to download Hackage packages that are not part of the specified snapshot.

An unfortunate side effect is that fetches of Stackage packages become less reproducible as `stack` will now fetch the latest revision from Hackage instead of the revision that is pinned in the specified snapshot. However, this shouldn't break any builds in practice and a fully reproducible `stack_snapshot` is available via pinning.

Adds a non-Stackage dependency (`optparse-helper`) to the example as a regression test.

cc @jjant