### PR TITLE
Add bindist support for ghc 8.8.4

### DIFF
--- a/haskell/assets/ghc_8_8_4_win_base.patch
+++ b/haskell/assets/ghc_8_8_4_win_base.patch
@@ -1,0 +1,11 @@
+--- lib/package.conf.d/base-4.13.0.0.conf	2020-07-15 19:31:32.000000000 +0200
++++ lib/package.conf.d/base-4.13.0.0.conf 	2020-12-15 18:05:11.000000000 +0100
+@@ -83,7 +83,7 @@
+ dynamic-library-dirs: $topdir\base-4.13.0.0
+ data-dir:             $topdir\x86_64-windows-ghc-8.8.4\base-4.13.0.0
+ hs-libraries:         HSbase-4.13.0.0
+-extra-libraries:      wsock32 user32 shell32 msvcrt mingw32 mingwex
++extra-libraries:      wsock32 user32 shell32 msvcrt mingw32 mingwex shlwapi
+ include-dirs:         $topdir\base-4.13.0.0\include
+ includes:             HsBase.h
+ depends:              ghc-prim-0.5.3 integer-gmp-1.0.2.0 rts

--- a/haskell/ghc_bindist.bzl
+++ b/haskell/ghc_bindist.bzl
@@ -495,6 +495,7 @@ def ghc_bindist(
         "8.8.1": ["@rules_haskell//haskell:assets/ghc_8_8_1_win_base.patch"],
         "8.8.2": ["@rules_haskell//haskell:assets/ghc_8_8_2_win_base.patch"],
         "8.8.3": ["@rules_haskell//haskell:assets/ghc_8_8_3_win_base.patch"],
+        "8.8.4": ["@rules_haskell//haskell:assets/ghc_8_8_4_win_base.patch"],
     }.get(version) if target == "windows_amd64" else None
 
     extra_attrs = {"patches": patches, "patch_args": ["-p0"]} if patches else {}

--- a/haskell/ghc_bindist.bzl
+++ b/haskell/ghc_bindist.bzl
@@ -211,6 +211,20 @@ GHC_BINDIST = \
                 "e22586762af0911c06e8140f1792e3ca381a3a482a20d67b9054883038b3a422",
             ),
         },
+        "8.8.4": {
+            "darwin_amd64": (
+                "https://downloads.haskell.org/~ghc/8.8.4/ghc-8.8.4-x86_64-apple-darwin.tar.xz",
+                "e80a789e9d8cfb41dd87f3284b75432427c4461c1731d220d04ead8733ccdb5e",
+            ),
+            "linux_amd64": (
+                "https://downloads.haskell.org/~ghc/8.8.4/ghc-8.8.4-x86_64-deb8-linux.tar.xz",
+                "51a36892f1264744195274187298d13ac62bce2da86d4ddf76d8054ab90f2feb",
+            ),
+            "windows_amd64": (
+                "https://downloads.haskell.org/~ghc/8.8.4/ghc-8.8.4-x86_64-unknown-mingw32.tar.xz",
+                "d185055d2c8dc3bfe5b88afd59d6877eb1e722b672d1c9649f18296e148ed71f",
+            ),
+        },
         "8.10.1": {
             "darwin_amd64": (
                 "https://downloads.haskell.org/~ghc/8.10.1/ghc-8.10.1-x86_64-apple-darwin.tar.xz",


### PR DESCRIPTION
This adds support for ghc 8.8.4 which hasn't been added yet and which is used by Stackage LTS 16.12 onward.