### PR TITLE
Add ghc-byteorder to empty package blacklist

### DIFF
--- a/haskell/cabal.bzl
+++ b/haskell/cabal.bzl
@@ -105,6 +105,7 @@ _EMPTY_PACKAGES_BLACKLIST = [
     "fail",
     "mtl-compat",
     "nats",
+    "ghc-byteorder",
 ]
 
 def _cabal_tool_flag(tool):


### PR DESCRIPTION
`ghc-byteorder` is another package that doesn't really have any code and just re-exports modules.