### PR TITLE
Use find_cpp_toolchain instead of ctx.attr._cc_toolchain directly

### DIFF
--- a/haskell/cabal_wrapper.bzl
+++ b/haskell/cabal_wrapper.bzl
@@ -6,7 +6,7 @@ load("@rules_python//python:defs.bzl", "py_binary")
 def _cabal_wrapper_impl(ctx):
     hs = haskell_context(ctx)
     hs_toolchain = ctx.toolchains["@rules_haskell//haskell:toolchain"]
-    cc_toolchain = ctx.attr._cc_toolchain[cc_common.CcToolchainInfo]
+    cc_toolchain = find_cpp_toolchain(ctx)
 
     # If running on darwin but XCode is not installed (i.e., only the Command
     # Line Tools are available), then Bazel will make ar_executable point to

--- a/haskell/protobuf.bzl
+++ b/haskell/protobuf.bzl
@@ -13,6 +13,7 @@ load(
     "HaskellLibraryInfo",
     "HaskellProtobufInfo",
 )
+load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
 load(":private/pkg_id.bzl", "pkg_id")
 load(
     ":private/cc_libraries.bzl",

--- a/tests/solib_dir/solib_test.bzl
+++ b/tests/solib_dir/solib_test.bzl
@@ -1,3 +1,5 @@
+load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
+
 _test_script_template = """#!/usr/bin/env bash
 library_path={library_path}
 is_windows={is_windows}
@@ -19,9 +21,7 @@ def _solib_test_impl(ctx):
         output = dynamic_library,
     )
 
-    # XXX Workaround https://github.com/bazelbuild/bazel/issues/6874.
-    # Should be find_cpp_toolchain() instead.
-    cc_toolchain = ctx.attr._cc_toolchain[cc_common.CcToolchainInfo]
+    cc_toolchain = find_cpp_toolchain(ctx)
     feature_configuration = cc_common.configure_features(
         ctx = ctx,
         cc_toolchain = cc_toolchain,
@@ -60,6 +60,7 @@ solib_test = rule(
     },
     executable = True,
     fragments = ["cpp"],
+    toolchains = ["@bazel_tools//tools/cpp:toolchain_type"],
     test = True,
 )
 """Test that Bazel's solib directory matches our expectations.


### PR DESCRIPTION
Closes #1467 

`find_cpp_toolchain` is compatible with both `--crosstool_top` as well as cc toolchain resolution. `ctx.attr._cc_toolchain` OTOH only works with `--crosstool_top`.