### PR TITLE
Move Linux CI jobs to GitHub Actions

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -12,6 +12,8 @@ test --test_env=LANG=C.UTF-8 --test_env=LOCALE_ARCHIVE
 
 # Platform / Toolchain Selection
 # ------------------------------
+build:linux-nixpkgs --config=nixpkgs
+build:macos-nixpkgs --config=nixpkgs
 build:nixpkgs --host_platform=@io_tweag_rules_nixpkgs//nixpkgs/platforms:host
 # Use this configuration when targeting Windows. Eventually this will
 # no longer be required:

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -24,10 +24,13 @@ jobs:
           nix_path: nixpkgs=./nixpkgs/default.nix
       - name: Configure
         run: |
-          [[ ${{ matrix.os }} == macos ]] && EXTRA_CONFIG=--config=macos-nixpkgs
+          case ${{ matrix.os }} in
+            macos) BUILD_CONFIG=macos-nixpkgs;;
+            ubuntu) BUILD_CONFIG=linux-nixpkgs;;
+          esac
           cat >.bazelrc.local <<EOF
           common --config=ci
-          build --config=nixpkgs $EXTRA_CONFIG
+          build --config=$BUILD_CONFIG
           EOF
       - name: Check Bazel version
         run: |

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,9 +1,10 @@
 pull_request_rules:
   - name: automatic merge
     conditions:
-      - 'status-success~=Build & Test - macOS \(Nixpkgs\).*'
-      - 'status-success~=Build & Test - macOS \(bindist\).*'
-      - "status-success~=buildkite/rules-haskell(|/pr)"
+      - 'status-success~=Build & Test - Nixpkgs \(ubuntu\).*'
+      - 'status-success~=Build & Test - Nixpkgs \(macos\).*'
+      - 'status-success~=Build & Test - bindist \(ubuntu\).*'
+      - 'status-success~=Build & Test - bindist \(macos\).*'
       - "status-success=tweag.rules_haskell"
       - "status-success=deploy/netlify"
       - "#approved-reviews-by>=1"

--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ This chooses the `cc_toolchain` bundled with GHC.
 ### Configuring your platform
 
 `rules_haskell` can be built and tested on Linux, MacOS, and Windows. Depending
-on the platform GHC can be provisioned using Nixpkgs or by downloading a binary
+on the platform GHC can be provisioned using nixpkgs or by downloading a binary
 distribution. In case of nixpkgs other toolchains (C compiler, Python, shell
 tools) will also be provided by nixpkgs, in case of bindist they will be taken
 from the environment (`$PATH`). The following `--config` options select the
@@ -262,18 +262,18 @@ corresponding combination of operating system and GHC distribution:
 
 |                     |      Linux      |      MacOS      |      Windows      |
 | ------------------- | --------------- | --------------- | ----------------- |
-| Nixpkgs             | (unneeded)      | `macos-nixpkgs` | (unsupported)     |
-| Binary distribution | `linux-bindist` | `macos-bindist` | `windows-bindist` |
+| nixpkgs             | `linux-nixpkgs` | `macos-nixpkgs` |                   |
+| binary distribution | `linux-bindist` | `macos-bindist` | `windows-bindist` |
 
 Hint: You can use Bazel's `--announce_rc` flag to see what options are being
 used for a command in a specific configuration. E.g.
 ```
-$ bazel build //tests:run-tests --config linux-bindist --nobuild --announce_rc
+$ bazel build //tests:run-tests --config linux-nixpkgs --nobuild --announce_rc
 ```
 
 Hint: To avoid repetition you can add your configuration to `.bazelrc.local`.
 ```
-echo "build --config=linux-bindist" >>.bazelrc.local
+echo "build --config=linux-nixpkgs" >>.bazelrc.local
 ```
 
 ### Saving common command-line flags to a file

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Haskell rules for [Bazel][bazel]
 
-![Continuous integration](https://github.com/tweag/rules_haskell/workflows/Continuous%20integration/badge.svg)
+[![Continuous integration](https://github.com/tweag/rules_haskell/workflows/Continuous%20integration/badge.svg)](https://github.com/tweag/rules_haskell/actions?query=branch%3Amaster)
 [![Build Status](https://dev.azure.com/tweag/rules_haskell/_apis/build/status/tweag.rules_haskell?branchName=master)](https://dev.azure.com/tweag/rules_haskell/_build/latest?definitionId=1?branchName=master)
 
 Bazel automates building and testing software. It scales to very large

--- a/tests/haddock_protobuf/BUILD.bazel
+++ b/tests/haddock_protobuf/BUILD.bazel
@@ -14,37 +14,37 @@ proto_library(
 
 haskell_proto_library(
     name = "hello_world_haskell_proto",
+    tags = ["requires_proto"],
     deps = [
         ":hello_world_proto",
     ],
-    tags = ["requires_proto"],
 )
 
 haskell_library(
     name = "hello_world_haskell",
     srcs = ["HelloWorld.hs"],  # Just imports the proto and does something trivial
+    tags = ["requires_proto"],
     deps = [
         ":hello_world_haskell_proto",
         "@stackage//:base",
     ],
-    tags = ["requires_proto"],
 )
 
 # Haddocks version A: depend on just the haskell_library
 haskell_doc(
     name = "haddocks_a",
+    tags = ["requires_proto"],
     deps = [
         ":hello_world_haskell",
     ],
-    tags = ["requires_proto"],
 )
 
 # Haddocks version B: depend on both haskell_library and haskell_proto_library
 haskell_doc(
     name = "haddocks_b",
+    tags = ["requires_proto"],
     deps = [
         ":hello_world_haskell",
         ":hello_world_haskell_proto",
     ],
-    tags = ["requires_proto"],
 )

--- a/tests/haddock_protobuf/BUILD.bazel
+++ b/tests/haddock_protobuf/BUILD.bazel
@@ -9,6 +9,7 @@ load("//haskell:protobuf.bzl", "haskell_proto_library")
 proto_library(
     name = "hello_world_proto",
     srcs = ["hello_world.proto"],
+    tags = ["requires_proto"],
 )
 
 haskell_proto_library(
@@ -16,6 +17,7 @@ haskell_proto_library(
     deps = [
         ":hello_world_proto",
     ],
+    tags = ["requires_proto"],
 )
 
 haskell_library(
@@ -25,6 +27,7 @@ haskell_library(
         ":hello_world_haskell_proto",
         "@stackage//:base",
     ],
+    tags = ["requires_proto"],
 )
 
 # Haddocks version A: depend on just the haskell_library
@@ -33,6 +36,7 @@ haskell_doc(
     deps = [
         ":hello_world_haskell",
     ],
+    tags = ["requires_proto"],
 )
 
 # Haddocks version B: depend on both haskell_library and haskell_proto_library
@@ -42,4 +46,5 @@ haskell_doc(
         ":hello_world_haskell",
         ":hello_world_haskell_proto",
     ],
+    tags = ["requires_proto"],
 )

--- a/tests/haskell_proto_simple/BUILD.bazel
+++ b/tests/haskell_proto_simple/BUILD.bazel
@@ -13,6 +13,7 @@ proto_library(
     name = "foo",
     srcs = ["foo.proto"],
     deps = ["@com_google_protobuf//:descriptor_proto"],
+    tags = ["requires_proto"],
 )
 
 haskell_proto_library(
@@ -20,18 +21,17 @@ haskell_proto_library(
     deps = [
         ":foo",
     ],
+    tags = ["requires_proto"],
 )
 
 haskell_library(
     name = "hs-lib",
     srcs = ["Bar.hs"],
-    tags = [
-        "requires_proto",
-    ],
-    visibility = ["//visibility:public"],
     deps = [
         ":foo_haskell",
         "//tests/hackage:base",
         "@stackage//:proto-lens",
     ],
+    tags = ["requires_proto"],
+    visibility = ["//visibility:public"],
 )

--- a/tests/haskell_proto_simple/BUILD.bazel
+++ b/tests/haskell_proto_simple/BUILD.bazel
@@ -12,26 +12,26 @@ load(
 proto_library(
     name = "foo",
     srcs = ["foo.proto"],
-    deps = ["@com_google_protobuf//:descriptor_proto"],
     tags = ["requires_proto"],
+    deps = ["@com_google_protobuf//:descriptor_proto"],
 )
 
 haskell_proto_library(
     name = "foo_haskell",
+    tags = ["requires_proto"],
     deps = [
         ":foo",
     ],
-    tags = ["requires_proto"],
 )
 
 haskell_library(
     name = "hs-lib",
     srcs = ["Bar.hs"],
+    tags = ["requires_proto"],
+    visibility = ["//visibility:public"],
     deps = [
         ":foo_haskell",
         "//tests/hackage:base",
         "@stackage//:proto-lens",
     ],
-    tags = ["requires_proto"],
-    visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
Hot on the heals of #1460, we move the Linux jobs to GitHub Actions as
well. In practice, BuildKite with custom runners wasn't buying us that
much time, though we may return to custom runners (via Actions) later.
The only CI job not on Actions is now the Windows one.