### PR TITLE
Simplify GH actions cache key

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -1,5 +1,8 @@
 name: Continuous integration
 on: [push]
+env:
+  # Bump this number to invalidate the GH actions cache
+  cache-version: 0
 
 jobs:
   test-macos-nixpkgs:
@@ -11,7 +14,7 @@ jobs:
         uses: actions/cache@v1
         with:
           path: ~/repo-cache
-          key: repo-cache-${{ secrets.REPO_CACHE_VERSION }}
+          key: repo-cache-${{ runner.os }}-nixpkgs-${{ env.cache-version }}
       - uses: cachix/install-nix-action@v12
         with:
           nix_path: nixpkgs=./nixpkgs/default.nix
@@ -50,7 +53,7 @@ jobs:
         uses: actions/cache@v1
         with:
           path: ~/repo-cache
-          key: repo-cache-${{ secrets.REPO_CACHE_VERSION }}
+          key: repo-cache-${{ runner.os }}-bindist-${{ env.cache-version }}
       - name: Install Bazel
         run: |
           BAZEL_DIR="$(.ci/fetch-bazel-bindist)"

--- a/README.md
+++ b/README.md
@@ -373,14 +373,13 @@ You copy that hash to `url` in
 change the `sha256` or it will use the old version. Please update the
 date comment to the date of the `nixpkgs` commit you are pinning to.
 
-### CircleCI
+### GitHub Actions Cache
 
-Pull Requests are checked by CircleCI.
-
-If a check fails and you cannot reproduce it locally (e.g. it failed on Darwin
-and you only run Linux), you can [ssh into CircleCI to aid debugging][ci-ssh].
-
-[ci-ssh]: https://circleci.com/docs/2.0/ssh-access-jobs/
+The GitHub actions CI pipeline uses
+[`actions/cache`](https://github.com/actions/cache) to store the Bazel
+repository cache. The `cache-version` must be updated manually in the `env`
+section in the [workflow](./.github/workflows/workflow.yaml) to invalidate the
+cache if any cacheable external dependencies are changed.
 
 #### “unable to start any build”
 


### PR DESCRIPTION
Using a GH secret to invalidate the cache requires an out of band change. With this change the cache version is defined in code instead.

This also separates the caches by OS and nixpkgs vs. bindist.

The README is updated with a section about the GH actions cache.

Related discussion in https://github.com/tweag/rules_haskell/pull/1460#discussion_r555625646