### PR TITLE
Add ghc-bignum to the list of core packages

### DIFF
--- a/haskell/cabal.bzl
+++ b/haskell/cabal.bzl
@@ -848,6 +848,7 @@ _CORE_PACKAGES = [
     "directory",
     "filepath",
     "ghc",
+    "ghc-bignum",
     "ghc-boot",
     "ghc-boot-th",
     "ghc-compact",


### PR DESCRIPTION
ghc-bignum is a new core package in ghc-9.0.1