### PR TITLE
Use Github API token in stack_snapshot pinning 

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -32,6 +32,10 @@ jobs:
           common --config=ci
           build --config=$BUILD_CONFIG
           EOF
+          cat >~/.netrc <<EOF
+          machine api.github.com
+                  password ${{ secrets.GITHUB_TOKEN }}
+          EOF
       - name: Check Bazel version
         run: |
           nix-shell --arg docTools false --pure --run .ci/check-bazel-version
@@ -74,6 +78,10 @@ jobs:
           cat >.bazelrc.local <<EOF
           common --config=ci
           build --config=$BUILD_CONFIG
+          EOF
+          cat >~/.netrc <<EOF
+          machine api.github.com
+                  password ${{ secrets.GITHUB_TOKEN }}
           EOF
       - name: Build & test
         run: |

--- a/haskell/cabal.bzl
+++ b/haskell/cabal.bzl
@@ -43,7 +43,15 @@ load(
 )
 
 def _get_auth(ctx, urls):
-    """Find the .netrc file and obtain the auth dict for the required URLs."""
+    """Find the .netrc file and obtain the auth dict for the required URLs.
+
+    Refer to the [authentication in downloads proposal][auth-proposal] and the
+    [`http_archive` API documentation][http-archive] for a definition of the
+    auth dict.
+
+    [auth-proposal]: https://github.com/bazelbuild/proposals/blob/master/designs/2019-05-27-auth.md
+    [http-archive]: https://docs.bazel.build/versions/master/repo/http.html#http_archive-auth_patterns
+    """
     auth_patterns = {"api.github.com": "Bearer <password>"}
 
     # Taken from @bazel_tools//tools/build_defs/repo:http.bzl


### PR DESCRIPTION
Closes #1492 

`stack_snapshot` pinning uses GitHub's API to determine the current revision of the `all-cabal-hashes` repository. As described in https://github.com/tweag/rules_haskell/issues/1492#issuecomment-778110085 GH API requests are rate limited to a low threshold for unauthenticated requests.

This change uses Bazel's support for authentication on [`repository_ctx.download`](https://docs.bazel.build/versions/master/skylark/lib/repository_ctx.html#download) to make this GH API request authenticated if possible. I.e. if an access token is provided in the `.netrc` file. The GH actions workflow is extended to write the GH access token to the default netrc file.