### PR TITLE
Update BazelCI tag filters

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -5,10 +5,10 @@ tasks:
       # haskell base uses the environment locale to decode sockets
       LANG: "C.UTF-8"
     build_flags:
-      - "--build_tag_filters=-requires_zlib,-requires_lz4,-requires_doctest,-requires_c2hs,-requires_threaded_rts,-requires_shellcheck,-dont_test_with_bindist,-dont_test_on_bazelci"
+      - "--build_tag_filters=-requires_nix,-requires_lz4,-requires_shellcheck,-requires_threaded_rts,-dont_test_with_bindist,-dont_test_on_bazelci"
     build_targets:
       - "//tests/..."
     test_flags:
-      - "--test_tag_filters=-requires_zlib,-requires_lz4,-requires_doctest,-requires_c2hs,-requires_threaded_rts,-requires_shellcheck,-dont_test_with_bindist,-dont_test_on_bazelci"
+      - "--test_tag_filters=-requires_nix,-requires_lz4,-requires_shellcheck,-requires_threaded_rts,-dont_test_with_bindist,-dont_test_on_bazelci"
     test_targets:
       - "//tests/..."


### PR DESCRIPTION
https://github.com/tweag/rules_haskell/pull/1484 changed the tag filtering on tests for the bindist pipeline. But, I overlooked to update the corresponding flags in the Bazel CI definitions. Bazel CI [failed accordingly](https://buildkite.com/bazel/rules-haskell-haskell/builds/650#609603b8-9e20-498c-85d4-aaf75ff89100). This PR updates the Bazel CI tag filters. I've manually started a [Bazel CI pipeline](https://buildkite.com/bazel/rules-haskell-haskell/builds/652#fead514e-defc-463a-ae6d-6544d94ce1c2) with these changes which passed.
