### PR TITLE
Enable --keep_backend_build_event_connections_alive=false

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -58,6 +58,9 @@ build:ci --bes_results_url=https://app.buildbuddy.io/invocation/
 build:ci --bes_backend=grpcs://cloud.buildbuddy.io
 build:ci --remote_cache=grpcs://cloud.buildbuddy.io
 build:ci --remote_timeout=3600
+# Avoid failures of the form `deadline exceeded after 14999958197ns DEADLINE_EXCEEDED`.
+# See https://github.com/tweag/rules_haskell/issues/1498.
+build:ci --keep_backend_build_event_connections_alive=false
 
 test:ci --test_output=errors
 


### PR DESCRIPTION
Closes #1498 

As suggested in https://github.com/tweag/rules_haskell/issues/1498#issuecomment-783579477 to fix errors of the form
```
ERROR: The Build Event Protocol upload failed: All retry attempts failed. DEADLINE_EXCEEDED: DEADLINE_EXCEEDED: deadline exceeded after 14999958197ns DEADLINE_EXCEEDED: DEADLINE_EXCEEDED: deadline exceeded after 14999958197ns
```

I ran the Linux nixpkgs three times in a row with this flag enabled and did no longer observe any `deadline exceeded after 14999958197ns DEADLINE_EXCEEDED` errors.