### PR TITLE
Pass the path to the C compiler with envvars to cc_wrapper

### DIFF
--- a/haskell/cabal.bzl
+++ b/haskell/cabal.bzl
@@ -246,7 +246,7 @@ def _prepare_cabal_inputs(
     # action.
     transitive_compile_libs = get_ghci_library_files(hs, cc.cc_libraries_info, cc.transitive_libraries)
     transitive_link_libs = _concat(get_library_files(hs, cc.cc_libraries_info, cc.transitive_libraries))
-    env = dict(hs.env)
+    env = dicts.add(hs.env, cc.env)
     env["PATH"] = join_path_list(hs, _binary_paths(tool_inputs) + posix.paths)
     if hs.toolchain.is_darwin:
         env["SDKROOT"] = "macosx"  # See haskell/private/actions/link.bzl

--- a/haskell/doctest.bzl
+++ b/haskell/doctest.bzl
@@ -152,7 +152,7 @@ def _haskell_doctest_single(target, ctx):
             env = render_env(hs.env),
         ),
         arguments = [args],
-        env = hs.env,
+        env = dicts.add(hs.env, cc.env),
         execution_requirements = {
             # Prevents a race condition among concurrent doctest tests on Linux.
             #

--- a/haskell/private/actions/compile.bzl
+++ b/haskell/private/actions/compile.bzl
@@ -363,6 +363,7 @@ def _compilation_defaults(hs, cc, java, posix, dep_info, plugin_dep_info, srcs, 
         env = dicts.add(
             java.env,
             hs.env,
+            cc.env,
         ),
     )
 

--- a/haskell/private/cc_wrapper.bzl
+++ b/haskell/private/cc_wrapper.bzl
@@ -41,6 +41,22 @@ _cc_wrapper = rule(
             allow_single_file = True,
         ),
         "platform": attr.string(),
+        # Bazel considers the cc toolchain a build dependency of the cc_wrapper,
+        # but we only need the cc toolchain at runtime. Without relying on
+        # environment variables, this is practically the only way we have to get
+        # our hands on the path to the C compiler other than using environment
+        # variables.
+        #
+        # Using environment variables wouldn't work when using hie-bios.
+        #
+        # Specifying the dependency like this, however, interferes with
+        # cross-compilation, since the provided toolchain will target
+        # the execution platform. In this case, we use environment variables
+        # in the cc_wrapper scripts to indicate the path to the cc compiler.
+        # We are not trying to cross-compile when using hie-bios.
+        #
+        # TODO: Consider using execution groups to transition the toolchain
+        # to the target platform.
         "_cc_toolchain": attr.label(
             default = Label("@bazel_tools//tools/cpp:current_cc_toolchain"),
         ),

--- a/haskell/private/cc_wrapper.py.tpl
+++ b/haskell/private/cc_wrapper.py.tpl
@@ -80,8 +80,9 @@ import sys
 import tempfile
 
 WORKSPACE = "{:workspace:}"
-CC = "{:cc:}"
-PLATFORM = "{:platform:}"
+CC = os.environ.get("CC_WRAPPER_CC_PATH", "{:cc:}")
+PLATFORM = os.environ.get("CC_WRAPPER_PLATFORM", "{:platform:}")
+CPU = os.environ.get("CC_WRAPPER_CPU", "{:cpu:}")
 INSTALL_NAME_TOOL = "/usr/bin/install_name_tool"
 OTOOL = "/usr/bin/otool"
 
@@ -787,8 +788,8 @@ def find_solib_rpath(rpaths, output):
         # the Bazel generated RPATHs are not forwarded, and the solib directory
         # is not visible on the command-line.
         for (root, dirnames, _) in breadth_first_walk(os.environ.get("RULES_HASKELL_EXEC_ROOT", ".")):
-            if "_solib_{:cpu:}" in dirnames:
-                return os.path.join(root, "_solib_{:cpu:}")
+            if "_solib_" + CPU in dirnames:
+                return os.path.join(root, "_solib_" + CPU)
 
     return None
 

--- a/haskell/private/cc_wrapper_windows.sh.tpl
+++ b/haskell/private/cc_wrapper_windows.sh.tpl
@@ -37,6 +37,8 @@
 
 set -euo pipefail
 
+CC_WRAPPER_CC_PATH=${CC_WRAPPER_CC_PATH:-"{:cc:}"}
+
 # ----------------------------------------------------------
 # Find compiler
 
@@ -81,7 +83,7 @@ find_exe() {
 }
 
 declare CC
-find_exe CC "{:cc:}"
+find_exe CC "${CC_WRAPPER_CC_PATH}"
 
 # ----------------------------------------------------------
 # Handle response file


### PR DESCRIPTION
Bazel considers the cc toolchain a build dependency of the cc_wrapper, but we only need the cc toolchain at runtime. Without relying on environment variables, this is practically the only way we have to get our hands on the path to the C compiler other than using environment variables.

Using environment variables would be inconvenient to use with hie-bios because of technical reasons.

Specifying the dependency like this, however, interferes with cross-compilation, since the provided toolchain will target the execution platform. In this case, we use environment variables in the cc_wrapper scripts to indicate the path to the cc compiler, since we are not trying to cross-compile when using hie-bios.