### PR TITLE
Test start script on MacOS CI

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -44,14 +44,11 @@ jobs:
           nix-shell --arg docTools false --pure --run .ci/check-bazel-version
       - name: Build & test
         run: |
-          # XXX 2019-01-22 Disable start script checking on Darwin
-          # due to a clash between binutils and clang.
-          [[ ${{ matrix.os }} != macos ]] &&
-            nix-shell --arg docTools false --pure --run \
-              './tests/run-start-script.sh --use-nix'
           nix-shell --arg docTools false --pure --run '
-            bazel build //tests:run-tests &&
-            ./bazel-ci-bin/tests/run-tests &&
+            set -euo pipefail
+            ./tests/run-start-script.sh --use-nix
+            bazel build //tests:run-tests
+            ./bazel-ci-bin/tests/run-tests
             bazel coverage //tests/...
             '
   test-bindist:
@@ -97,10 +94,7 @@ jobs:
         run: |
           export PATH=$HOME/bazel:$PATH
           [[ ${{ matrix.os }} == macos ]] && export BAZEL_USE_CPP_ONLY_TOOLCHAIN=1
-          # XXX 2019-01-22 Disable start script checking on Darwin
-          # due to a clash between binutils and clang.
-          [[ ${{ matrix.os }} != macos ]] && \
-            ./tests/run-start-script.sh --use-bindists
+          ./tests/run-start-script.sh --use-bindists
           bazel test //tests/...
           # Test stack_snapshot pinning
           # NOTE keep in sync with tests/RunTests.hs

--- a/start
+++ b/start
@@ -199,7 +199,12 @@ cc_library(
     includes = ["."],
     visibility = ["//visibility:public"],
 )
-cc_library(name = "z", srcs = glob(["*.c"]), hdrs = glob(["*.h"]))
+cc_library(
+    name = "z",
+    srcs = glob(["*.c"]),
+    hdrs = glob(["*.h"]),
+    copts = ["-Wno-implicit-function-declaration"],
+)
 EOF
     ;;
 

--- a/start
+++ b/start
@@ -153,7 +153,7 @@ load(
 # https://github.com/tweag/rules_nixpkgs/blob/master/README.md
 nixpkgs_git_repository(
     name = "nixpkgs",
-    revision = "19.03",
+    revision = "20.09",
     # sha256 = …
 )
 
@@ -176,7 +176,7 @@ load(
 haskell_register_ghc_nixpkgs(
     repository = "@nixpkgs",
     attribute_path = "ghc",
-    version = "8.6.4",
+    version = "8.8.4",
 )
 EOF
 )


### PR DESCRIPTION
Closes #1475

Fixes and re-enables the start script tests on both nixpkgs and bindist MacOS CI pipelines.
- Adds `-Won-implicit-function-declaration` to `zlib.dev` in bindist mode. The warning causes build errors on MacOS due to `-Werror`.
- Updates the nixpkgs revision from 19.03 to 20.09 to avoid GHC build issues on MacOS (#1475). Also updates the GHC version accordingly. 