### PR TITLE
Invoke a runghc for the execution platform in the cabal_wrapper

### DIFF
--- a/haskell/BUILD.bazel
+++ b/haskell/BUILD.bazel
@@ -13,6 +13,10 @@ load(
     "cabal_wrapper",
 )
 load(
+    "@rules_haskell//haskell:private/runghc.bzl",
+    "runghc",
+)
+load(
     "@rules_haskell//haskell:toolchain_info.bzl",
     "haskell_toolchain_info",
 )
@@ -97,6 +101,11 @@ py_library(
     srcs = ["private/package_configuration.py"],
     imports = ["private"],
     visibility = ["//tests/package_configuration:__subpackages__"],
+)
+
+runghc(
+    name = "runghc",
+    visibility = ["//visibility:public"],
 )
 
 py_binary(

--- a/haskell/cabal.bzl
+++ b/haskell/cabal.bzl
@@ -816,7 +816,7 @@ def _haskell_cabal_binary_impl(ctx):
             binary,
             data_dir,
         ],
-        tools = [c.cabal_wrapper],
+        tools = [c.cabal_wrapper, ctx.executable._runghc],
         env = c.env,
         mnemonic = "HaskellCabalBinary",
         progress_message = "HaskellCabalBinary {}".format(hs.label),

--- a/haskell/cabal.bzl
+++ b/haskell/cabal.bzl
@@ -350,7 +350,7 @@ def _prepare_cabal_inputs(
     )
 
     inputs = depset(
-        [setup, hs.tools.ghc, hs.tools.ghc_pkg, runghc],
+        [setup, hs.tools.ghc, hs.tools.ghc_pkg],
         transitive = [
             depset(srcs),
             depset(cc.files),

--- a/haskell/private/runghc.bzl
+++ b/haskell/private/runghc.bzl
@@ -30,7 +30,7 @@ from rules_python.python.runfiles import runfiles
 
 r = runfiles.Create()
 
-subprocess.run([r.Rlocation("{runghc}")] + sys.argv[1:], check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+subprocess.run([r.Rlocation("{runghc}")] + sys.argv[1:], check=True)
 """.format(runghc = runghc_runfile_path),
         is_executable = True,
     )

--- a/haskell/private/runghc.bzl
+++ b/haskell/private/runghc.bzl
@@ -1,0 +1,38 @@
+load("@bazel_skylib//lib:paths.bzl", "paths")
+
+# Note [Running Setup.hs when cross-compiling]
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+# When cross compiling we interpret Setup.hs in the execution
+# platform. In order to achieve this, we provide a runghc of a
+# toolchain targeting the execution platform.
+#
+# Producing runghc with a custom rule, as defined here, allows to use
+# it in rules which are using a Haskell toolchain for the target
+# platform.
+#
+
+def _runghc_impl(ctx):
+    hs_toolchain = ctx.toolchains["@rules_haskell//haskell:toolchain"]
+    (_, extension) = paths.split_extension(hs_toolchain.tools.runghc.path)
+
+    runghc_file = ctx.actions.declare_file(ctx.label.name + extension)
+    ctx.actions.symlink(
+        output = runghc_file,
+        target_file = hs_toolchain.tools.runghc,
+        is_executable = True,
+    )
+
+    return [DefaultInfo(
+        executable = runghc_file,
+        runfiles = hs_toolchain.cc_wrapper.runfiles.merge(
+            ctx.runfiles(files = [runghc_file, hs_toolchain.tools.runghc]),
+        ),
+    )]
+
+runghc = rule(
+    executable = True,
+    implementation = _runghc_impl,
+    toolchains = ["@rules_haskell//haskell:toolchain"],
+    doc = """Produces the runghc program.""",
+)


### PR DESCRIPTION
In this PR cabal_wrapper always uses a runghc binary from a toolchain that targets the execution platform. Otherwise, there would be no way to execute Setup.hs when cross-compiling.