### PR TITLE
Add hsc2hs to the inputs of the cabal_wrapper

### DIFF
--- a/haskell/cabal.bzl
+++ b/haskell/cabal.bzl
@@ -350,7 +350,7 @@ def _prepare_cabal_inputs(
     )
 
     inputs = depset(
-        [setup, hs.tools.ghc, hs.tools.ghc_pkg],
+        [setup, hs.tools.ghc, hs.tools.ghc_pkg, hs.tools.hsc2hs],
         transitive = [
             depset(srcs),
             depset(cc.files),


### PR DESCRIPTION
When cross-compiling, Cabal is unable to find hsc2hs next to the compiler in the nix store because it is prefixed with `aarch64-unknown-linux-gnu-`. Adding hsc2hs to the inputs of the cabal-wrapper, creates a symbolic link `hsc2hs` next to `ghc` in `external/aarch64_ghc_nixpkgs/bin`, which allows Cabal to find it.