### PR TITLE
Set cc wrapper env vars when running ghc

### DIFF
--- a/haskell/private/actions/link.bzl
+++ b/haskell/private/actions/link.bzl
@@ -1,5 +1,6 @@
 """Actions for linking object code produced by compilation"""
 
+load("@bazel_skylib//lib:dicts.bzl", "dicts")
 load(":private/packages.bzl", "expose_packages", "pkg_info_to_compile_flags")
 load(":private/pkg_id.bzl", "pkg_id")
 load(":private/cc_libraries.bzl", "create_link_config")
@@ -186,6 +187,7 @@ def link_binary(
         mnemonic = "HaskellLinkBinary",
         arguments = args,
         params_file = objects_dir_manifest,
+        env = dicts.add(hs.env, cc.env),
     )
 
     return (executable, dynamic_libs)
@@ -368,6 +370,7 @@ def link_library_dynamic(hs, cc, posix, dep_info, extra_srcs, objects_dir, my_pk
         mnemonic = "HaskellLinkDynamicLibrary",
         arguments = args,
         params_file = objects_dir_manifest,
+        env = dicts.add(hs.env, cc.env),
     )
 
     return dynamic_library

--- a/haskell/toolchain.bzl
+++ b/haskell/toolchain.bzl
@@ -1,5 +1,6 @@
 """Rules for defining toolchains"""
 
+load("@bazel_skylib//lib:dicts.bzl", "dicts")
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load(":ghc_bindist.bzl", "haskell_register_ghc_bindists")
 load(
@@ -82,7 +83,7 @@ def _run_ghc(hs, cc, inputs, outputs, mnemonic, arguments, params_file = None, e
         executable = hs.ghc_wrapper,
         mnemonic = mnemonic,
         progress_message = progress_message,
-        env = env,
+        env = dicts.add(env, cc.env),
         arguments = [compile_flags_file.path, flagsfile_prefix + flagsfile.path],
         execution_requirements = execution_requirements,
     )

--- a/haskell/toolchain.bzl
+++ b/haskell/toolchain.bzl
@@ -1,6 +1,5 @@
 """Rules for defining toolchains"""
 
-load("@bazel_skylib//lib:dicts.bzl", "dicts")
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load(":ghc_bindist.bzl", "haskell_register_ghc_bindists")
 load(
@@ -20,10 +19,7 @@ load(":cc.bzl", "ghc_cc_program_args")
 
 _GHC_BINARIES = ["ghc", "ghc-pkg", "hsc2hs", "haddock", "ghci", "runghc", "hpc"]
 
-def _run_ghc(hs, cc, inputs, outputs, mnemonic, arguments, params_file = None, env = None, progress_message = None, input_manifests = None):
-    if not env:
-        env = hs.env
-
+def _run_ghc(hs, cc, inputs, outputs, mnemonic, arguments, env, params_file = None, progress_message = None, input_manifests = None):
     args = hs.actions.args()
     extra_inputs = []
 
@@ -83,7 +79,7 @@ def _run_ghc(hs, cc, inputs, outputs, mnemonic, arguments, params_file = None, e
         executable = hs.ghc_wrapper,
         mnemonic = mnemonic,
         progress_message = progress_message,
-        env = dicts.add(env, cc.env),
+        env = env,
         arguments = [compile_flags_file.path, flagsfile_prefix + flagsfile.path],
         execution_requirements = execution_requirements,
     )


### PR DESCRIPTION
This is necessary to cross-compile with haskell_binary and haskell_library.