### PR TITLE
ylecornec/move attr doc to macros

### DIFF
--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -3,6 +3,7 @@ load("@rules_python//python:defs.bzl", "py_binary")
 
 libraries = [
     "defs",
+    "toolchain",
     "cabal",
     "repositories",
     "ghc_bindist",

--- a/haskell/c2hs.bzl
+++ b/haskell/c2hs.bzl
@@ -205,7 +205,9 @@ def c2hs_toolchain(name, c2hs, **kwargs):
       ```
 
     Args:
+      name: A unique name for the toolchain.
       c2hs: The c2hs executable.
+      **kwargs: Common rule attributes. See [Bazel documentation](https://docs.bazel.build/versions/master/be/common-definitions.html#common-attributes).
 
     """
     impl_name = name + "-impl"

--- a/haskell/c2hs.bzl
+++ b/haskell/c2hs.bzl
@@ -165,7 +165,6 @@ _c2hs_toolchain = rule(
     _c2hs_toolchain_impl,
     attrs = {
         "c2hs": attr.label(
-            doc = "The c2hs executable.",
             mandatory = True,
             allow_single_file = True,
             executable = True,
@@ -204,6 +203,10 @@ def c2hs_toolchain(name, c2hs, **kwargs):
 
       register_toolchains("//:c2hs")
       ```
+
+    Args:
+      c2hs: The c2hs executable.
+
     """
     impl_name = name + "-impl"
     _c2hs_toolchain(

--- a/haskell/defs.bzl
+++ b/haskell/defs.bzl
@@ -611,7 +611,8 @@ haskell_doc_aspect = _haskell_doc_aspect
 def haskell_register_toolchains(**kwargs):
     """Register GHC binary distributions for all platforms as toolchains.
 
-    Depreciated in favor of [rules_haskell_toolchains](toolchain.html#rules_haskell_toolchains).
+      Deprecated:
+        Use [rules_haskell_toolchains](toolchain.html#rules_haskell_toolchains) instead.
 
     """
     _haskell_register_toolchains(**kwargs)

--- a/haskell/defs.bzl
+++ b/haskell/defs.bzl
@@ -608,7 +608,13 @@ haskell_doc = _haskell_doc
 
 haskell_doc_aspect = _haskell_doc_aspect
 
-haskell_register_toolchains = _haskell_register_toolchains
+def haskell_register_toolchains(**kwargs):
+    """Register GHC binary distributions for all platforms as toolchains.
+
+    Depreciated in favor of [rules_haskell_toolchains](toolchain.html#rules_haskell_toolchains).
+
+    """
+    _haskell_register_toolchains(**kwargs)
 
 haskell_repl = _haskell_repl
 

--- a/haskell/ghc_bindist.bzl
+++ b/haskell/ghc_bindist.bzl
@@ -604,6 +604,14 @@ def haskell_register_ghc_bindists(
 
     [toolchain-resolution]: https://docs.bazel.build/versions/master/toolchains.html#toolchain-resolution
 
+    Args:
+      version: [see ghc_bindist](#ghc_bindist-name)
+      compiler_flags: [see ghc_bindist](#ghc_bindist-compiler_flags)
+      haddock_flags: [see ghc_bindist](#ghc_bindist-haddock_flags)
+      repl_ghci_args: [see ghc_bindist](#ghc_bindist-repl_ghci_args)
+      cabalopts: [see ghc_bindist](#ghc_bindist-cabalopts)
+      locale: [see ghc_bindist](#ghc_bindist-local)
+
     """
     version = version or _GHC_DEFAULT_VERSION
     if not GHC_BINDIST.get(version):

--- a/haskell/ghc_bindist.bzl
+++ b/haskell/ghc_bindist.bzl
@@ -539,9 +539,13 @@ def ghc_bindist(
        ```
 
     Args:
-      version: The desired GHC version
-      locale: Locale that will be set during compiler
-        invocations. Default: C.UTF-8 (en_US.UTF-8 on MacOS)
+      name: A unique name for the repository.
+      version: The desired GHC version.
+      compiler_flags: [see rules_haskell_toolchains](toolchain.html#rules_haskell_toolchains-compiler_flags)
+      haddock_flags: [see rules_haskell_toolchains](toolchain.html#rules_haskell_toolchains-haddock_flags)
+      repl_ghci_args: [see rules_haskell_toolchains](toolchain.html#rules_haskell_toolchains-repl_ghci_args)
+      cabalopts: [see rules_haskell_toolchains](toolchain.html#rules_haskell_toolchains-cabalopts)
+      locale: [see rules_haskell_toolchains](toolchain.html#rules_haskell_toolchains-locale)
 
     """
     bindist_name = name
@@ -594,24 +598,17 @@ def haskell_register_ghc_bindists(
         repl_ghci_args = None,
         cabalopts = None,
         locale = None):
-    """Register GHC binary distributions for all platforms as toolchains.
+    """ Register GHC binary distributions for all platforms as toolchains.
 
-    Toolchains can be used to compile Haskell code. This function
-    registers one toolchain for each known binary distribution on all
-    platforms of the given GHC version. During the build, one
-    toolchain will be selected based on the host and target platforms
-    (See [toolchain resolution][toolchain-resolution]).
-
-    [toolchain-resolution]: https://docs.bazel.build/versions/master/toolchains.html#toolchain-resolution
+    See [rules_haskell_toolchains](toolchain.html#rules_haskell_toolchains).
 
     Args:
-      version: [see ghc_bindist](#ghc_bindist-name)
-      compiler_flags: [see ghc_bindist](#ghc_bindist-compiler_flags)
-      haddock_flags: [see ghc_bindist](#ghc_bindist-haddock_flags)
-      repl_ghci_args: [see ghc_bindist](#ghc_bindist-repl_ghci_args)
-      cabalopts: [see ghc_bindist](#ghc_bindist-cabalopts)
-      locale: [see ghc_bindist](#ghc_bindist-local)
-
+      version: [see rules_haskell_toolchains](toolchain.html#rules_haskell_toolchains-version)
+      compiler_flags: [see rules_haskell_toolchains](toolchain.html#rules_haskell_toolchains-compiler_flags)
+      haddock_flags: [see rules_haskell_toolchains](toolchain.html#rules_haskell_toolchains-haddock_flags)
+      repl_ghci_args: [see rules_haskell_toolchains](toolchain.html#rules_haskell_toolchains-repl_ghci_args)
+      cabalopts: [see rules_haskell_toolchains](toolchain.html#rules_haskell_toolchains-cabalopts)
+      locale: [see rules_haskell_toolchains](toolchain.html#rules_haskell_toolchains-locale)
     """
     version = version or _GHC_DEFAULT_VERSION
     if not GHC_BINDIST.get(version):

--- a/haskell/ghc_bindist.bzl
+++ b/haskell/ghc_bindist.bzl
@@ -464,7 +464,6 @@ _ghc_bindist = repository_rule(
             doc = "Sequence of commands to be applied after patches are applied.",
         ),
         "locale": attr.string(
-            doc = "Locale that will be set during compiler invocations. Default: C.UTF-8 (en_US.UTF-8 on MacOS)",
             mandatory = False,
         ),
     },
@@ -538,6 +537,12 @@ def ghc_bindist(
          version = "8.2.2",
        )
        ```
+
+    Args:
+      version: The desired GHC version
+      locale: Locale that will be set during compiler
+        invocations. Default: C.UTF-8 (en_US.UTF-8 on MacOS)
+
     """
     bindist_name = name
     toolchain_name = "{}-toolchain".format(name)

--- a/haskell/nixpkgs.bzl
+++ b/haskell/nixpkgs.bzl
@@ -251,8 +251,17 @@ def haskell_register_ghc_nixpkgs(
       fully_static_link: True if and only if fully-statically-linked binaries are to be built.
       compiler_flags_select: temporary workaround to pass conditional arguments.
         See https://github.com/bazelbuild/bazel/issues/9199 for details.
+      attribute_path: Passed to [nixpkgs_package](https://github.com/tweag/rules_nixpkgs#nixpkgs_package-attribute_path)
+      build_file: Passed to [nixpkgs_package](https://github.com/tweag/rules_nixpkgs#nixpkgs_package-build_file)
+      build_file_content: Passed to [nixpkgs_package](https://github.com/tweag/rules_nixpkgs#nixpkgs_package-build_file_content)
+      nix_file: Passed to [nixpkgs_package](https://github.com/tweag/rules_nixpkgs#nixpkgs_package-nix_file)
+      nix_file_deps: Passed to [nixpkgs_package](https://github.com/tweag/rules_nixpkgs#nixpkgs_package-nix_file_deps)
+      nix_file_content: Passed to [nixpkgs_package](https://github.com/tweag/rules_nixpkgs#nixpkgs_package-nix_file_content)
+      nixopts: Passed to [nixpkgs_package](https://github.com/tweag/rules_nixpkgs#nixpkgs_package-nixopts)
+      repositories: Passed to [nixpkgs_package](https://github.com/tweag/rules_nixpkgs#nixpkgs_package-repositories)
+      repository: Passed to [nixpkgs_package](https://github.com/tweag/rules_nixpkgs#nixpkgs_package-repository)
       sh_posix_attributes: List of attribute paths to extract standard Unix shell tools from.
-        Passed to nixpkgs_sh_posix_configure.
+        Passed to [nixpkgs_sh_posix_configure](https://github.com/tweag/rules_nixpkgs#nixpkgs_sh_posix_configure).
     """
     nixpkgs_ghc_repo_name = "{}_ghc_nixpkgs".format(name)
     nixpkgs_sh_posix_repo_name = "{}_sh_posix_nixpkgs".format(name)

--- a/haskell/protobuf.bzl
+++ b/haskell/protobuf.bzl
@@ -446,6 +446,7 @@ def haskell_proto_toolchain(
       ```
 
     Args:
+      name: A unique name for this toolchain.
       protoc: Protoc compiler.
       plugin: Proto-lens-protoc plugin for protoc.
       deps: List of other Haskell libraries to be linked to protobuf libraries.

--- a/haskell/protobuf.bzl
+++ b/haskell/protobuf.bzl
@@ -373,17 +373,14 @@ _protobuf_toolchain = rule(
             cfg = "host",
             allow_single_file = True,
             mandatory = True,
-            doc = "protoc compiler",
         ),
         "plugin": attr.label(
             executable = True,
             cfg = "host",
             allow_single_file = True,
             mandatory = True,
-            doc = "proto-lens-protoc plugin for protoc",
         ),
         "deps": attr.label_list(
-            doc = "List of other Haskell libraries to be linked to protobuf libraries.",
             aspects = [haskell_cc_libraries_aspect],
         ),
     },
@@ -447,6 +444,11 @@ def haskell_proto_toolchain(
         "//tests:protobuf-toolchain",
       )
       ```
+
+    Args:
+      protoc: Protoc compiler.
+      plugin: Proto-lens-protoc plugin for protoc.
+      deps: List of other Haskell libraries to be linked to protobuf libraries.
 
     """
     impl_name = name + "-impl"

--- a/haskell/toolchain.bzl
+++ b/haskell/toolchain.bzl
@@ -322,6 +322,7 @@ def haskell_toolchain(
       ```
 
     Args:
+      name: A unique name for this toolchain.
       version: Version of your GHC compiler. It has to match the version reported by the GHC used by bazel.
       static_runtime: Whether GHC was linked with a static runtime.
       fully_static_link: Whether GHC should build fully-statically-linked binaries.
@@ -338,6 +339,7 @@ def haskell_toolchain(
         Use `--haddock-option=--optghc=OPT` if haddock generation requires additional compiler flags.
       locale_archive: Label pointing to the locale archive file to use.\\
         Linux-specific and mostly useful on NixOS.
+      **kwargs: Common rule attributes. See [Bazel documentation](https://docs.bazel.build/versions/master/be/common-definitions.html#common-attributes).
 
     """
     corrected_ghci_args = repl_ghci_args + ["-no-user-package-db"]

--- a/haskell/toolchain.bzl
+++ b/haskell/toolchain.bzl
@@ -401,5 +401,5 @@ def rules_haskell_toolchains(
         haddock_flags = haddock_flags,
         repl_ghci_args = repl_ghci_args,
         cabalopts = cabalopts,
-        locale = locale)
-
+        locale = locale,
+    )

--- a/haskell/toolchain.bzl
+++ b/haskell/toolchain.bzl
@@ -372,6 +372,34 @@ def haskell_toolchain(
         **kwargs
     )
 
-def rules_haskell_toolchains(**kwargs):
-    """Register GHC binary distributions for all platforms as toolchains."""
-    haskell_register_ghc_bindists(**kwargs)
+def rules_haskell_toolchains(
+        version = None,
+        compiler_flags = None,
+        haddock_flags = None,
+        repl_ghci_args = None,
+        cabalopts = None,
+        locale = None):
+    """Register GHC binary distributions for all platforms as toolchains.
+
+    Toolchains can be used to compile Haskell code. This function
+    registers one toolchain for each known binary distribution on all
+    platforms of the given GHC version. During the build, one
+    toolchain will be selected based on the host and target platforms
+    (See [toolchain resolution][toolchain-resolution]).
+
+    [toolchain-resolution]: https://docs.bazel.build/versions/master/toolchains.html#toolchain-resolution
+
+    Args:
+      version: The desired GHC version
+      locale: Locale that will be set during compiler
+        invocations. Default: C.UTF-8 (en_US.UTF-8 on MacOS)
+
+    """
+    haskell_register_ghc_bindists(
+        version = version,
+        compiler_flags = compiler_flags,
+        haddock_flags = haddock_flags,
+        repl_ghci_args = repl_ghci_args,
+        cabalopts = cabalopts,
+        locale = locale)
+

--- a/haskell/toolchain.bzl
+++ b/haskell/toolchain.bzl
@@ -216,11 +216,9 @@ _haskell_toolchain = rule(
     _haskell_toolchain_impl,
     attrs = {
         "tools": attr.label_list(
-            doc = "GHC and executables that come with it. First item take precedence.",
             mandatory = True,
         ),
         "libraries": attr.label_list(
-            doc = "The set of libraries that come with GHC. Requires haskell_import targets.",
             mandatory = True,
         ),
         "libdir": attr.label_list(
@@ -235,26 +233,11 @@ _haskell_toolchain = rule(
         "docdir_path": attr.string(
             doc = "The absolute path to GHC's docdir. C.f. `GHC.Paths.docdir` from `ghc-paths`. Specify this if `docdir` is left empty. One of `docdir` or `docdir_path` is required.",
         ),
-        "compiler_flags": attr.string_list(
-            doc = "A collection of flags that will be passed to GHC on every invocation.",
-        ),
-        "repl_ghci_args": attr.string_list(
-            doc = "A collection of flags that will be passed to GHCI on repl invocation. It extends the `compiler_flags` collection. Flags set here have precedance over `compiler_flags`.",
-        ),
-        "haddock_flags": attr.string_list(
-            doc = "A collection of flags that will be passed to haddock.",
-        ),
-        "cabalopts": attr.string_list(
-            doc = """Additional flags to pass to `Setup.hs configure` for all Cabal rules.
-
-            Note, Cabal rules do not read the toolchain attributes `compiler_flags` or `haddock_flags`.
-            Use `--ghc-option=OPT` to configure additional compiler flags.
-            Use `--haddock-option=OPT` to configure additional haddock flags.
-            Use `--haddock-option=--optghc=OPT` if haddock generation requires additional compiler flags.
-            """,
-        ),
+        "compiler_flags": attr.string_list(),
+        "repl_ghci_args": attr.string_list(),
+        "haddock_flags": attr.string_list(),
+        "cabalopts": attr.string_list(),
         "version": attr.string(
-            doc = "Version of your GHC compiler. It has to match the version reported by the GHC used by bazel.",
             mandatory = True,
         ),
         "is_darwin": attr.bool(
@@ -265,21 +248,14 @@ _haskell_toolchain = rule(
             doc = "Whether compile on and for Windows.",
             mandatory = True,
         ),
-        "static_runtime": attr.bool(
-            doc = "Whether GHC was linked with a static runtime.",
-        ),
-        "fully_static_link": attr.bool(
-            doc = "Whether GHC should build fully-statically-linked binaries.",
-        ),
+        "static_runtime": attr.bool(),
+        "fully_static_link": attr.bool(),
         "locale": attr.string(
             default = "C.UTF-8",
             doc = "Locale that will be set during compiler invocations.",
         ),
         "locale_archive": attr.label(
             allow_single_file = True,
-            doc = """
-Label pointing to the locale archive file to use. Mostly useful on NixOS.
-""",
         ),
         "_cc_wrapper": attr.label(
             cfg = "host",
@@ -344,6 +320,25 @@ def haskell_toolchain(
 
       register_toolchains("//:ghc")
       ```
+
+    Args:
+      version: Version of your GHC compiler. It has to match the version reported by the GHC used by bazel.
+      static_runtime: Whether GHC was linked with a static runtime.
+      fully_static_link: Whether GHC should build fully-statically-linked binaries.
+      tools: GHC and executables that come with it. First item takes precedence.
+      libraries: The set of libraries that come with GHC. Requires haskell_import targets.
+      compiler_flags: A collection of flags that will be passed to GHC on every invocation.
+      repl_ghci_args: A collection of flags that will be passed to GHCI on repl invocation. It extends the `compiler_flags` collection.\\
+        Flags set here have precedance over `compiler_flags`.
+      haddock_flags: A collection of flags that will be passed to haddock.
+      cabalopts: Additional flags to pass to `Setup.hs configure` for all Cabal rules.\\
+        Note, Cabal rules do not read the toolchain attributes `compiler_flags` or `haddock_flags`.\\
+        Use `--ghc-option=OPT` to configure additional compiler flags.\\
+        Use `--haddock-option=OPT` to configure additional haddock flags.\\
+        Use `--haddock-option=--optghc=OPT` if haddock generation requires additional compiler flags.
+      locale_archive: Label pointing to the locale archive file to use.\\
+        Linux-specific and mostly useful on NixOS.
+
     """
     corrected_ghci_args = repl_ghci_args + ["-no-user-package-db"]
     _haskell_toolchain(


### PR DESCRIPTION
Some macros currently don't have API documentation on haskell.build, while the underlying rules contain doc attributes.

The first commit moves the documentation from the rule to the macro in the case the rule is private.

The second commit adds some fields in macro documentation,
with links to the documentation of the underlying rules when they are publics.