### PR TITLE
rename `compiler_flags` options to `ghcopts`

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -160,7 +160,7 @@ nixpkgs_local_repository(
     nix_file = "//nixpkgs:default.nix",
 )
 
-test_compiler_flags = [
+test_ghcopts = [
     "-XStandaloneDeriving",  # Flag used at compile time
     "-threaded",  # Flag used at link time
 
@@ -194,7 +194,7 @@ load(
 haskell_register_ghc_nixpkgs(
     attribute_path = "",
     cabalopts = test_cabalopts,
-    compiler_flags = test_compiler_flags,
+    ghcopts = test_ghcopts,
     haddock_flags = test_haddock_flags,
     locale_archive = "@glibc_locales//:locale-archive",
     nix_file_content = """with import <nixpkgs> {}; haskell.packages.ghc883.ghc""",
@@ -210,7 +210,7 @@ load(
 
 haskell_register_ghc_bindists(
     cabalopts = test_cabalopts,
-    compiler_flags = test_compiler_flags,
+    ghcopts = test_ghcopts,
     version = test_ghc_version,
 )
 

--- a/docs/haskell-use-cases.rst
+++ b/docs/haskell-use-cases.rst
@@ -396,7 +396,7 @@ apply warning flags using the ``compiler_flags`` attribute, for example ::
 
   haskell_library(
       ...
-      compiler_flags = [
+      ghcopts = [
           "-Werror",
           "-Wall",
           "-Wcompat",
@@ -411,12 +411,12 @@ apply warning flags using the ``compiler_flags`` attribute, for example ::
 For larger projects it can make sense to define a custom macro that
 applies such common flags by default. ::
 
-  common_compiler_flags = [ ... ]
+  common_ghcopts = [ ... ]
 
-  def my_haskell_library(name, compiler_flags = [], ...):
+  def my_haskell_library(name, ghcopts = [], ...):
       haskell_library(
           name = name,
-          compiler_flags = common_compiler_flags + compiler_flags,
+          ghcopts = common_ghcopts + ghcopts,
           ...
       )
 
@@ -470,7 +470,7 @@ the location of the tool in source code pragmas. Example: ::
   haskell_test(
       name = "tests",
       srcs = ["Main.hs", "Spec.hs"],
-      compiler_flags = ["-DHSPEC_DISCOVER=$(location @stackage-exe//hspec-discover)"],
+      ghcopts = ["-DHSPEC_DISCOVER=$(location @stackage-exe//hspec-discover)"],
       tools = ["@stackage-exe//hspec-discover"],
       deps = ["@stackage//:base"],
   )
@@ -845,7 +845,7 @@ Step three pulls all this together in a build file to actually assemble our fina
   haskell_binary(
       name = "my_binary,
       srcs = ["Main.hs"],
-      compiler_flags = [
+      ghcopts = [
           "-O2",
           "-threaded",
           "-rtsopts",

--- a/haskell/cabal.bzl
+++ b/haskell/cabal.bzl
@@ -20,7 +20,7 @@ load(
     "truly_relativize",
 )
 load(":private/set.bzl", "set")
-load(":private/typing.bzl", "typecheck_stackage_extradeps")
+load(":private/validate_attrs.bzl", "typecheck_stackage_extradeps")
 load(":haddock.bzl", "generate_unified_haddock_info")
 load(
     ":private/workspace_utils.bzl",

--- a/haskell/defs.bzl
+++ b/haskell/defs.bzl
@@ -30,18 +30,10 @@ load(
     ":plugins.bzl",
     _ghc_plugin = "ghc_plugin",
 )
-
-def _name_change_deprecation(old_attr, new_attr, kwargs):
-    """ pre: the attributes must have a falsy default value. """
-    if kwargs[old_attr]:
-        message = "{} is deprecated. Use its new name {} instead.".format(old_attr, new_attr)
-        if kwargs[new_attr]:
-            fail(message)
-
-        print("WARNING: {}".format(message))
-        kwargs[new_attr] = kwargs[old_attr]
-    kwargs.pop(old_attr)
-    return kwargs
+load(
+    ":private/workspace_utils.bzl",
+    "name_change_deprecation",
+)
 
 # NOTE: Documentation needs to be added to the wrapper macros below.
 #   Currently it is not possible to automatically inherit rule documentation in
@@ -216,7 +208,7 @@ _haskell_library = rule(
 )
 
 def _haskell_worker_wrapper(rule_type, **kwargs):
-    kwargs = _name_change_deprecation("compiler_flags", "ghcopts", kwargs)
+    kwargs = name_change_deprecation("compiler_flags", "ghcopts", kwargs)
     defaults = dict(
         worker = select({
             "@rules_haskell//haskell:use_worker": Label("@rules_haskell//tools/worker:bin"),

--- a/haskell/defs.bzl
+++ b/haskell/defs.bzl
@@ -31,7 +31,7 @@ load(
     _ghc_plugin = "ghc_plugin",
 )
 load(
-    ":private/workspace_utils.bzl",
+    ":private/validate_attrs.bzl",
     "check_deprecated_attribute_usage",
 )
 

--- a/haskell/defs.bzl
+++ b/haskell/defs.bzl
@@ -31,6 +31,18 @@ load(
     _ghc_plugin = "ghc_plugin",
 )
 
+def _name_change_deprecation(old_attr, new_attr, kwargs):
+    """ pre: the attributes must have a falsy default value. """
+    if kwargs[old_attr]:
+        message = "{} is deprecated. Use its new name {} instead.".format(old_attr, new_attr)
+        if kwargs[new_attr]:
+            fail(message)
+
+        print("WARNING: {}".format(message))
+        kwargs[new_attr] = kwargs[old_attr]
+    kwargs.pop(old_attr)
+    return kwargs
+
 # NOTE: Documentation needs to be added to the wrapper macros below.
 #   Currently it is not possible to automatically inherit rule documentation in
 #   wrapping macros. See https://github.com/bazelbuild/stardoc/issues/27
@@ -48,7 +60,7 @@ _haskell_common_attrs = {
     "data": attr.label_list(
         allow_files = True,
     ),
-    "compiler_flags": attr.string_list(),
+    "ghcopts": attr.string_list(),
     "repl_ghci_args": attr.string_list(),
     "runcompile_flags": attr.string_list(),
     "plugins": attr.label_list(
@@ -204,6 +216,7 @@ _haskell_library = rule(
 )
 
 def _haskell_worker_wrapper(rule_type, **kwargs):
+    kwargs = _name_change_deprecation("compiler_flags", "ghcopts", kwargs)
     defaults = dict(
         worker = select({
             "@rules_haskell//haskell:use_worker": Label("@rules_haskell//tools/worker:bin"),
@@ -227,6 +240,7 @@ def haskell_binary(
         deps = [],
         data = [],
         compiler_flags = [],
+        ghcopts = [],
         repl_ghci_args = [],
         runcompile_flags = [],
         plugins = [],
@@ -266,9 +280,10 @@ def haskell_binary(
       extra_srcs: Extra (non-Haskell) source files that will be needed at compile time (e.g. by Template Haskell).
       deps: List of other Haskell libraries to be linked to this target.
       data: See [Bazel documentation](https://docs.bazel.build/versions/master/be/common-definitions.html#common.data).,
-      compiler_flags: Flags to pass to Haskell compiler. Subject to Make variable substitution.
-      repl_ghci_args: Arbitrary extra arguments to pass to GHCi. This extends `compiler_flags` and `repl_ghci_args` from the toolchain. Subject to Make variable substitution.,
-      runcompile_flags: Arbitrary extra arguments to pass to runghc. This extends `compiler_flags` and `repl_ghci_args` from the toolchain. Subject to Make variable substitution.
+      compiler_flags: DEPRECATED. Use new name ghcopts.
+      ghcopts: Flags to pass to Haskell compiler. Subject to Make variable substitution.
+      repl_ghci_args: Arbitrary extra arguments to pass to GHCi. This extends `ghcopts` and `repl_ghci_args` from the toolchain. Subject to Make variable substitution.,
+      runcompile_flags: Arbitrary extra arguments to pass to runghc. This extends `ghcopts` and `repl_ghci_args` from the toolchain. Subject to Make variable substitution.
       plugins: Compiler plugins to use during compilation.
       tools: Extra tools needed at compile-time, like preprocessors.
       worker: Experimental. Worker binary employed by Bazel's persistent worker mode. See [use-cases documentation](https://rules-haskell.readthedocs.io/en/latest/haskell-use-cases.html#persistent-worker-mode-experimental).
@@ -286,6 +301,7 @@ def haskell_binary(
         deps = deps,
         data = data,
         compiler_flags = compiler_flags,
+        ghcopts = ghcopts,
         repl_ghci_args = repl_ghci_args,
         runcompile_flags = runcompile_flags,
         plugins = plugins,
@@ -325,6 +341,7 @@ def haskell_test(
         deps = [],
         data = [],
         compiler_flags = [],
+        ghcopts = [],
         repl_ghci_args = [],
         runcompile_flags = [],
         plugins = [],
@@ -354,9 +371,10 @@ def haskell_test(
       extra_srcs: Extra (non-Haskell) source files that will be needed at compile time (e.g. by Template Haskell).
       deps: List of other Haskell libraries to be linked to this target.
       data: See [Bazel documentation](https://docs.bazel.build/versions/master/be/common-definitions.html#common.data).,
-      compiler_flags: Flags to pass to Haskell compiler. Subject to Make variable substitution.
-      repl_ghci_args: Arbitrary extra arguments to pass to GHCi. This extends `compiler_flags` and `repl_ghci_args` from the toolchain. Subject to Make variable substitution.,
-      runcompile_flags: Arbitrary extra arguments to pass to runghc. This extends `compiler_flags` and `repl_ghci_args` from the toolchain. Subject to Make variable substitution.
+      compiler_flags: DEPRECATED. Use new name ghcopts.
+      ghcopts: Flags to pass to Haskell compiler. Subject to Make variable substitution.
+      repl_ghci_args: Arbitrary extra arguments to pass to GHCi. This extends `ghcopts` and `repl_ghci_args` from the toolchain. Subject to Make variable substitution.,
+      runcompile_flags: Arbitrary extra arguments to pass to runghc. This extends `ghcopts` and `repl_ghci_args` from the toolchain. Subject to Make variable substitution.
       plugins: Compiler plugins to use during compilation.
       tools: Extra tools needed at compile-time, like preprocessors.
       worker: Experimental. Worker binary employed by Bazel's persistent worker mode. See [use-cases documentation](https://rules-haskell.readthedocs.io/en/latest/haskell-use-cases.html#persistent-worker-mode-experimental).
@@ -387,6 +405,7 @@ def haskell_test(
         deps = deps,
         data = data,
         compiler_flags = compiler_flags,
+        ghcopts = ghcopts,
         repl_ghci_args = repl_ghci_args,
         runcompile_flags = runcompile_flags,
         plugins = plugins,
@@ -433,6 +452,7 @@ def haskell_library(
         deps = [],
         data = [],
         compiler_flags = [],
+        ghcopts = [],
         repl_ghci_args = [],
         runcompile_flags = [],
         plugins = [],
@@ -474,9 +494,10 @@ def haskell_library(
       extra_srcs: Extra (non-Haskell) source files that will be needed at compile time (e.g. by Template Haskell).
       deps: List of other Haskell libraries to be linked to this target.
       data: See [Bazel documentation](https://docs.bazel.build/versions/master/be/common-definitions.html#common.data).,
-      compiler_flags: Flags to pass to Haskell compiler. Subject to Make variable substitution.
-      repl_ghci_args: Arbitrary extra arguments to pass to GHCi. This extends `compiler_flags` and `repl_ghci_args` from the toolchain. Subject to Make variable substitution.,
-      runcompile_flags: Arbitrary extra arguments to pass to runghc. This extends `compiler_flags` and `repl_ghci_args` from the toolchain. Subject to Make variable substitution.
+      compiler_flags: DEPRECATED. Use new name ghcopts.
+      ghcopts: Flags to pass to Haskell compiler. Subject to Make variable substitution.
+      repl_ghci_args: Arbitrary extra arguments to pass to GHCi. This extends `ghcopts` and `repl_ghci_args` from the toolchain. Subject to Make variable substitution.,
+      runcompile_flags: Arbitrary extra arguments to pass to runghc. This extends `ghcopts` and `repl_ghci_args` from the toolchain. Subject to Make variable substitution.
       plugins: Compiler plugins to use during compilation.
       tools: Extra tools needed at compile-time, like preprocessors.
       worker: Experimental. Worker binary employed by Bazel's persistent worker mode. See [use-cases documentation](https://rules-haskell.readthedocs.io/en/latest/haskell-use-cases.html#persistent-worker-mode-experimental).
@@ -500,6 +521,7 @@ def haskell_library(
         deps = deps,
         data = data,
         compiler_flags = compiler_flags,
+        ghcopts = ghcopts,
         repl_ghci_args = repl_ghci_args,
         runcompile_flags = runcompile_flags,
         plugins = plugins,

--- a/haskell/defs.bzl
+++ b/haskell/defs.bzl
@@ -32,7 +32,7 @@ load(
 )
 load(
     ":private/workspace_utils.bzl",
-    "name_change_deprecation",
+    "check_deprecated_attribute_usage",
 )
 
 # NOTE: Documentation needs to be added to the wrapper macros below.
@@ -208,7 +208,14 @@ _haskell_library = rule(
 )
 
 def _haskell_worker_wrapper(rule_type, **kwargs):
-    kwargs = name_change_deprecation("compiler_flags", "ghcopts", kwargs)
+    kwargs["ghcopts"] = check_deprecated_attribute_usage(
+        old_attr_name = "compiler_flags",
+        old_attr_value = kwargs["compiler_flags"],
+        new_attr_name = "ghcopts",
+        new_attr_value = kwargs["ghcopts"],
+    )
+    kwargs.pop("compiler_flags")
+
     defaults = dict(
         worker = select({
             "@rules_haskell//haskell:use_worker": Label("@rules_haskell//tools/worker:bin"),

--- a/haskell/ghc_bindist.bzl
+++ b/haskell/ghc_bindist.bzl
@@ -10,6 +10,7 @@ load(
 )
 load(
     ":private/workspace_utils.bzl",
+    "check_deprecated_attribute_usage",
     "define_rule",
     "execute_or_fail_loudly",
     "find_python",
@@ -415,7 +416,7 @@ DISTDIR="$( dirname "$(resolved="$0"; cd "$(dirname "$resolved")"; while tmp="$(
         version = repr(ctx.attr.version),
         static_runtime = os == "windows",
         fully_static_link = False,  # XXX not yet supported for bindists.
-        compiler_flags = ctx.attr.compiler_flags,
+        ghcopts = ctx.attr.ghcopts,
         haddock_flags = ctx.attr.haddock_flags,
         repl_ghci_args = ctx.attr.repl_ghci_args,
         cabalopts = ctx.attr.cabalopts,
@@ -441,7 +442,7 @@ _ghc_bindist = repository_rule(
             doc = "The desired GHC version",
         ),
         "target": attr.string(),
-        "compiler_flags": attr.string_list(),
+        "ghcopts": attr.string_list(),
         "haddock_flags": attr.string_list(),
         "repl_ghci_args": attr.string_list(),
         "cabalopts": attr.string_list(),
@@ -509,6 +510,7 @@ def ghc_bindist(
         version,
         target,
         compiler_flags = None,
+        ghcopts = None,
         haddock_flags = None,
         repl_ghci_args = None,
         cabalopts = None,
@@ -542,12 +544,19 @@ def ghc_bindist(
       name: A unique name for the repository.
       version: The desired GHC version.
       compiler_flags: [see rules_haskell_toolchains](toolchain.html#rules_haskell_toolchains-compiler_flags)
+      ghcopts: [see rules_haskell_toolchains](toolchain.html#rules_haskell_toolchains-ghcopts)
       haddock_flags: [see rules_haskell_toolchains](toolchain.html#rules_haskell_toolchains-haddock_flags)
       repl_ghci_args: [see rules_haskell_toolchains](toolchain.html#rules_haskell_toolchains-repl_ghci_args)
       cabalopts: [see rules_haskell_toolchains](toolchain.html#rules_haskell_toolchains-cabalopts)
       locale: [see rules_haskell_toolchains](toolchain.html#rules_haskell_toolchains-locale)
 
     """
+    ghcopts = check_deprecated_attribute_usage(
+        old_attr_value = compiler_flags,
+        new_attr_value = ghcopts,
+        message = "compiler_flags attribute is deprecated, use its new name ghcopts instead",
+    )
+
     bindist_name = name
     toolchain_name = "{}-toolchain".format(name)
 
@@ -576,7 +585,7 @@ def ghc_bindist(
     _ghc_bindist(
         name = bindist_name,
         version = version,
-        compiler_flags = compiler_flags,
+        ghcopts = ghcopts,
         haddock_flags = haddock_flags,
         repl_ghci_args = repl_ghci_args,
         cabalopts = cabalopts,
@@ -594,6 +603,7 @@ def ghc_bindist(
 def haskell_register_ghc_bindists(
         version = None,
         compiler_flags = None,
+        ghcopts = None,
         haddock_flags = None,
         repl_ghci_args = None,
         cabalopts = None,
@@ -605,6 +615,7 @@ def haskell_register_ghc_bindists(
     Args:
       version: [see rules_haskell_toolchains](toolchain.html#rules_haskell_toolchains-version)
       compiler_flags: [see rules_haskell_toolchains](toolchain.html#rules_haskell_toolchains-compiler_flags)
+      ghcopts: [see rules_haskell_toolchains](toolchain.html#rules_haskell_toolchains-ghcopts)
       haddock_flags: [see rules_haskell_toolchains](toolchain.html#rules_haskell_toolchains-haddock_flags)
       repl_ghci_args: [see rules_haskell_toolchains](toolchain.html#rules_haskell_toolchains-repl_ghci_args)
       cabalopts: [see rules_haskell_toolchains](toolchain.html#rules_haskell_toolchains-cabalopts)
@@ -619,6 +630,7 @@ def haskell_register_ghc_bindists(
             target = target,
             version = version,
             compiler_flags = compiler_flags,
+            ghcopts = ghcopts,
             haddock_flags = haddock_flags,
             repl_ghci_args = repl_ghci_args,
             cabalopts = cabalopts,

--- a/haskell/ghc_bindist.bzl
+++ b/haskell/ghc_bindist.bzl
@@ -10,12 +10,12 @@ load(
 )
 load(
     ":private/workspace_utils.bzl",
-    "check_deprecated_attribute_usage",
     "define_rule",
     "execute_or_fail_loudly",
     "find_python",
     "resolve_labels",
 )
+load(":private/validate_attrs.bzl", "check_deprecated_attribute_usage")
 
 # If you change this, change stackage's version in the start script
 # (see stackage.org).

--- a/haskell/ghc_bindist.bzl
+++ b/haskell/ghc_bindist.bzl
@@ -552,9 +552,10 @@ def ghc_bindist(
 
     """
     ghcopts = check_deprecated_attribute_usage(
+        old_attr_name = "compiler_flags",
         old_attr_value = compiler_flags,
+        new_attr_name = "ghcopts",
         new_attr_value = ghcopts,
-        message = "compiler_flags attribute is deprecated, use its new name ghcopts instead",
     )
 
     bindist_name = name

--- a/haskell/nixpkgs.bzl
+++ b/haskell/nixpkgs.bzl
@@ -11,6 +11,7 @@ load(
 )
 load(
     ":private/workspace_utils.bzl",
+    "check_deprecated_attribute_usage",
     "define_rule",
     "execute_or_fail_loudly",
     "resolve_labels",
@@ -74,8 +75,8 @@ def _ghc_nixpkgs_haskell_toolchain_impl(repository_ctx):
         version = repr(repository_ctx.attr.version),
         static_runtime = repository_ctx.attr.static_runtime,
         fully_static_link = repository_ctx.attr.fully_static_link,
-        compiler_flags = "{} + {}".format(
-            repository_ctx.attr.compiler_flags,
+        ghcopts = "{} + {}".format(
+            repository_ctx.attr.ghcopts,
             compiler_flags_select,
         ),
         haddock_flags = repository_ctx.attr.haddock_flags,
@@ -118,7 +119,7 @@ _ghc_nixpkgs_haskell_toolchain = repository_rule(
         "version": attr.string(),
         "static_runtime": attr.bool(),
         "fully_static_link": attr.bool(),
-        "compiler_flags": attr.string_list(),
+        "ghcopts": attr.string_list(),
         "compiler_flags_select": attr.string_list_dict(),
         "haddock_flags": attr.string_list(),
         "cabalopts": attr.string_list(),
@@ -193,6 +194,7 @@ def haskell_register_ghc_nixpkgs(
         build_file = None,
         build_file_content = None,
         compiler_flags = None,
+        ghcopts = None,
         compiler_flags_select = None,
         haddock_flags = None,
         repl_ghci_args = None,
@@ -249,6 +251,8 @@ def haskell_register_ghc_nixpkgs(
         required in order to use statically-linked Haskell libraries with GHCi
         and Template Haskell.
       fully_static_link: True if and only if fully-statically-linked binaries are to be built.
+      compiler_flags: DEPRECADED. Use new name ghcopts.
+      ghcopts: A collection of flags that will be passed to GHC
       compiler_flags_select: temporary workaround to pass conditional arguments.
         See https://github.com/bazelbuild/bazel/issues/9199 for details.
       attribute_path: Passed to [nixpkgs_package](https://github.com/tweag/rules_nixpkgs#nixpkgs_package-attribute_path)
@@ -289,12 +293,18 @@ def haskell_register_ghc_nixpkgs(
     )
 
     # haskell_toolchain + haskell_import definitions.
+    ghcopts = check_deprecated_attribute_usage(
+        old_attr_value = compiler_flags,
+        new_attr_value = ghcopts,
+        message = "compiler_flags attribute is deprecated, use its new name ghcopts instead",
+    )
+
     _ghc_nixpkgs_haskell_toolchain(
         name = haskell_toolchain_repo_name,
         version = version,
         static_runtime = static_runtime,
         fully_static_link = fully_static_link,
-        compiler_flags = compiler_flags,
+        ghcopts = ghcopts,
         compiler_flags_select = compiler_flags_select,
         haddock_flags = haddock_flags,
         cabalopts = cabalopts,

--- a/haskell/nixpkgs.bzl
+++ b/haskell/nixpkgs.bzl
@@ -11,11 +11,11 @@ load(
 )
 load(
     ":private/workspace_utils.bzl",
-    "check_deprecated_attribute_usage",
     "define_rule",
     "execute_or_fail_loudly",
     "resolve_labels",
 )
+load(":private/validate_attrs.bzl", "check_deprecated_attribute_usage")
 
 def check_ghc_version(repository_ctx):
     ghc_name = "ghc-{}".format(repository_ctx.attr.version)

--- a/haskell/nixpkgs.bzl
+++ b/haskell/nixpkgs.bzl
@@ -294,9 +294,10 @@ def haskell_register_ghc_nixpkgs(
 
     # haskell_toolchain + haskell_import definitions.
     ghcopts = check_deprecated_attribute_usage(
+        old_attr_name = "compiler_flags",
         old_attr_value = compiler_flags,
+        new_attr_name = "ghcopts",
         new_attr_value = ghcopts,
-        message = "compiler_flags attribute is deprecated, use its new name ghcopts instead",
     )
 
     _ghc_nixpkgs_haskell_toolchain(

--- a/haskell/private/actions/compile.bzl
+++ b/haskell/private/actions/compile.bzl
@@ -164,7 +164,7 @@ def _compilation_defaults(hs, cc, java, posix, dep_info, plugin_dep_info, srcs, 
     )
 
     # Default compiler flags.
-    compile_flags += hs.toolchain.compiler_flags
+    compile_flags += hs.toolchain.ghcopts
     compile_flags += user_compile_flags
 
     package_ids = []

--- a/haskell/private/actions/link.bzl
+++ b/haskell/private/actions/link.bzl
@@ -94,7 +94,7 @@ def link_binary(
     args.add_all(["-optl" + f for f in cc.linker_flags])
     if with_profiling:
         args.add("-prof")
-    args.add_all(hs.toolchain.compiler_flags)
+    args.add_all(hs.toolchain.ghcopts)
     args.add_all(compiler_flags)
 
     # By default, GHC will produce mostly-static binaries, i.e. in which all
@@ -320,7 +320,7 @@ def link_library_dynamic(hs, cc, posix, dep_info, extra_srcs, objects_dir, my_pk
     args = hs.actions.args()
     args.add_all(["-optl" + f for f in cc.linker_flags])
     args.add_all(["-shared", "-dynamic"])
-    args.add_all(hs.toolchain.compiler_flags)
+    args.add_all(hs.toolchain.ghcopts)
     args.add_all(compiler_flags)
 
     (pkg_info_inputs, pkg_info_args) = pkg_info_to_compile_flags(

--- a/haskell/private/actions/runghc.bzl
+++ b/haskell/private/actions/runghc.bzl
@@ -77,7 +77,7 @@ def build_haskell_runghc(
     # negative flag in `extra_args` can disable a positive flag set
     # in `user_compile_flags`, such as `-XNoOverloadedStrings` will disable
     # `-XOverloadedStrings`.
-    args += hs.toolchain.compiler_flags + user_compile_flags + hs.toolchain.repl_ghci_args
+    args += hs.toolchain.ghcopts + user_compile_flags + hs.toolchain.repl_ghci_args
 
     # ghc args need to be wrapped up in "--ghc-arg=" when passing to runghc
     runcompile_flags = ["--ghc-arg=%s" % a for a in args]

--- a/haskell/private/haskell_impl.bzl
+++ b/haskell/private/haskell_impl.bzl
@@ -190,7 +190,7 @@ def _haskell_binary_common_impl(ctx, is_test):
 
     plugins = [_resolve_plugin_tools(ctx, plugin[GhcPluginInfo]) for plugin in plugin_decl]
     preprocessors = _resolve_preprocessors(ctx, ctx.attr.tools)
-    user_compile_flags = _expand_make_variables("compiler_flags", ctx, ctx.attr.compiler_flags)
+    user_compile_flags = _expand_make_variables("ghcopts", ctx, ctx.attr.ghcopts)
     c = hs.toolchain.actions.compile_binary(
         hs,
         cc,
@@ -219,7 +219,7 @@ def _haskell_binary_common_impl(ctx, is_test):
             coverage_data += dep[HaskellCoverageInfo].coverage_data
             coverage_data = list.dedup_on(_get_mix_filepath, coverage_data)
 
-    user_compile_flags = _expand_make_variables("compiler_flags", ctx, ctx.attr.compiler_flags)
+    user_compile_flags = _expand_make_variables("ghcopts", ctx, ctx.attr.ghcopts)
     (binary, solibs) = link_binary(
         hs,
         cc,
@@ -251,7 +251,7 @@ def _haskell_binary_common_impl(ctx, is_test):
 
     target_files = depset([binary])
 
-    user_compile_flags = _expand_make_variables("compiler_flags", ctx, ctx.attr.compiler_flags)
+    user_compile_flags = _expand_make_variables("ghcopts", ctx, ctx.attr.ghcopts)
     extra_args = _expand_make_variables("runcompile_flags", ctx, ctx.attr.runcompile_flags)
     build_haskell_runghc(
         hs,
@@ -376,7 +376,7 @@ def haskell_library_impl(ctx):
 
     plugins = [_resolve_plugin_tools(ctx, plugin[GhcPluginInfo]) for plugin in ctx.attr.plugins]
     preprocessors = _resolve_preprocessors(ctx, ctx.attr.tools)
-    user_compile_flags = _expand_make_variables("compiler_flags", ctx, ctx.attr.compiler_flags)
+    user_compile_flags = _expand_make_variables("ghcopts", ctx, ctx.attr.ghcopts)
     c = hs.toolchain.actions.compile_library(
         hs,
         cc,
@@ -503,7 +503,7 @@ def haskell_library_impl(ctx):
 
     if hasattr(ctx, "outputs"):
         extra_args = _expand_make_variables("runcompile_flags", ctx, ctx.attr.runcompile_flags)
-        user_compile_flags = _expand_make_variables("compiler_flags", ctx, ctx.attr.compiler_flags)
+        user_compile_flags = _expand_make_variables("ghcopts", ctx, ctx.attr.ghcopts)
         build_haskell_runghc(
             hs,
             cc,

--- a/haskell/private/haskell_impl.bzl
+++ b/haskell/private/haskell_impl.bzl
@@ -653,7 +653,7 @@ def _toolchain_library_symlink(dynamic_library):
 def haskell_toolchain_libraries_impl(ctx):
     hs = haskell_context(ctx)
     with_profiling = is_profiling_enabled(hs)
-    with_threaded = "-threaded" in hs.toolchain.compiler_flags
+    with_threaded = "-threaded" in hs.toolchain.ghcopts
 
     cc_toolchain = find_cpp_toolchain(ctx)
     feature_configuration = cc_common.configure_features(

--- a/haskell/private/validate_attrs.bzl
+++ b/haskell/private/validate_attrs.bzl
@@ -15,3 +15,16 @@ def typecheck_stackage_extradeps(extra_deps):
     for extra_deps_value in extra_deps.values():
         if type(extra_deps_value) != "list":
             fail("stack_snapshot extra_deps's dict requires list values, but value \"{}\" has type {}".format(extra_deps_value, type(extra_deps_value)))
+
+def check_deprecated_attribute_usage(
+        old_attr_name,
+        old_attr_value,
+        new_attr_name,
+        new_attr_value):
+    """ Pre: the attributes must have a falsy default value. """
+    if old_attr_value:
+        if new_attr_value:
+            fail("{} is the new name of deprecated attribute {}. They cannot be used at the same time.".format(new_attr_name, old_attr_name))
+        return old_attr_value
+    else:
+        return new_attr_value

--- a/haskell/private/workspace_utils.bzl
+++ b/haskell/private/workspace_utils.bzl
@@ -85,3 +85,20 @@ def define_rule(rule_type, name, **kwargs):
         name = repr(name),
         attrs = "\n    ".join(attrs),
     )
+
+def check_deprecated_attribute_usage(old_attr_value, new_attr_value, message):
+    """ pre: the attributes must have a falsy default value. """
+    if old_attr_value:
+        if new_attr_value:
+            fail(message)
+        print("WARNING: {}".format(message))
+        return old_attr_value
+    else:
+        return new_attr_value
+
+def name_change_deprecation(old_attr_name, new_attr_name, kwargs):
+    """ pre: the attributes must have a falsy default value. """
+    message = "{} is deprecated. Use its new name {} instead.".format(old_attr_name, new_attr_name)
+    kwargs[new_attr_name] = check_deprecated_attribute_usage(kwargs[old_attr_name], kwargs[new_attr_name], message)
+    kwargs.pop(old_attr_name)
+    return kwargs

--- a/haskell/private/workspace_utils.bzl
+++ b/haskell/private/workspace_utils.bzl
@@ -85,16 +85,3 @@ def define_rule(rule_type, name, **kwargs):
         name = repr(name),
         attrs = "\n    ".join(attrs),
     )
-
-def check_deprecated_attribute_usage(
-        old_attr_name,
-        old_attr_value,
-        new_attr_name,
-        new_attr_value):
-    """ pre: the attributes must have a falsy default value. """
-    if old_attr_value:
-        if new_attr_value:
-            fail("{} is the new name of deprecated attribute {}. They cannot be used at the same time.", new_attr_name, old_attr_name)
-        return old_attr_value
-    else:
-        return new_attr_value

--- a/haskell/private/workspace_utils.bzl
+++ b/haskell/private/workspace_utils.bzl
@@ -86,19 +86,15 @@ def define_rule(rule_type, name, **kwargs):
         attrs = "\n    ".join(attrs),
     )
 
-def check_deprecated_attribute_usage(old_attr_value, new_attr_value, message):
+def check_deprecated_attribute_usage(
+        old_attr_name,
+        old_attr_value,
+        new_attr_name,
+        new_attr_value):
     """ pre: the attributes must have a falsy default value. """
     if old_attr_value:
         if new_attr_value:
-            fail(message)
-        print("WARNING: {}".format(message))
+            fail("{} is the new name of deprecated attribute {}. They cannot be used at the same time.", new_attr_name, old_attr_name)
         return old_attr_value
     else:
         return new_attr_value
-
-def name_change_deprecation(old_attr_name, new_attr_name, kwargs):
-    """ pre: the attributes must have a falsy default value. """
-    message = "{} is deprecated. Use its new name {} instead.".format(old_attr_name, new_attr_name)
-    kwargs[new_attr_name] = check_deprecated_attribute_usage(kwargs[old_attr_name], kwargs[new_attr_name], message)
-    kwargs.pop(old_attr_name)
-    return kwargs

--- a/haskell/protobuf.bzl
+++ b/haskell/protobuf.bzl
@@ -163,7 +163,7 @@ def _haskell_proto_aspect_impl(target, ctx):
     )
 
     patched_attrs = {
-        "compiler_flags": [],
+        "ghcopts": [],
         "src_strip_prefix": "",
         "repl_interpreted": True,
         "repl_ghci_args": [],

--- a/haskell/repl.bzl
+++ b/haskell/repl.bzl
@@ -602,7 +602,7 @@ haskell_repl = rule(
             default = [],
         ),
         "repl_ghci_args": attr.string_list(
-            doc = "Arbitrary extra arguments to pass to GHCi. This extends `compiler_flags` and `repl_ghci_args` from the toolchain. Subject to Make variable substitution.",
+            doc = "Arbitrary extra arguments to pass to GHCi. This extends `ghcopts` (previously `compiler_flags`) and `repl_ghci_args` from the toolchain. Subject to Make variable substitution.",
             default = [],
         ),
         "repl_ghci_commands": attr.string_list(

--- a/haskell/repl.bzl
+++ b/haskell/repl.bzl
@@ -420,7 +420,7 @@ def _create_repl(hs, posix, ctx, repl_info, output):
         [ctx.attr.data],
     )
     quote_args = (
-        hs.toolchain.compiler_flags +
+        hs.toolchain.ghcopts +
         repl_info.load_info.compiler_flags +
         hs.toolchain.repl_ghci_args +
         repl_info.load_info.repl_ghci_args +
@@ -489,7 +489,7 @@ def _create_hie_bios(hs, posix, ctx, repl_info):
     """
     args, inputs = _compiler_flags_and_inputs(hs, repl_info, static = True)
     args.extend(ghc_cc_program_args(hs.toolchain.cc_wrapper.executable.path))
-    args.extend(hs.toolchain.compiler_flags)
+    args.extend(hs.toolchain.ghcopts)
     args.extend(repl_info.load_info.compiler_flags)
 
     # Add import directories.

--- a/haskell/toolchain.bzl
+++ b/haskell/toolchain.bzl
@@ -16,10 +16,7 @@ load(
 )
 load(":private/actions/package.bzl", "package")
 load(":cc.bzl", "ghc_cc_program_args")
-load(
-    ":private/workspace_utils.bzl",
-    "check_deprecated_attribute_usage",
-)
+load(":private/validate_attrs.bzl", "check_deprecated_attribute_usage")
 
 _GHC_BINARIES = ["ghc", "ghc-pkg", "hsc2hs", "haddock", "ghci", "runghc", "hpc"]
 

--- a/haskell/toolchain.bzl
+++ b/haskell/toolchain.bzl
@@ -387,6 +387,7 @@ def haskell_toolchain(
 def rules_haskell_toolchains(
         version = None,
         compiler_flags = None,
+        ghcopts = None,
         haddock_flags = None,
         repl_ghci_args = None,
         cabalopts = None,
@@ -405,11 +406,14 @@ def rules_haskell_toolchains(
       version: The desired GHC version
       locale: Locale that will be set during compiler
         invocations. Default: C.UTF-8 (en_US.UTF-8 on MacOS)
+      compiler_flags: DEPRECATED. Use new name ghcopts.
+      ghcopts: A collection of flags that will be passed to GHC on every invocation.
 
     """
     haskell_register_ghc_bindists(
         version = version,
         compiler_flags = compiler_flags,
+        ghcopts = ghcopts,
         haddock_flags = haddock_flags,
         repl_ghci_args = repl_ghci_args,
         cabalopts = cabalopts,

--- a/haskell/toolchain.bzl
+++ b/haskell/toolchain.bzl
@@ -350,9 +350,10 @@ def haskell_toolchain(
     """
     corrected_ghci_args = repl_ghci_args + ["-no-user-package-db"]
     ghcopts = check_deprecated_attribute_usage(
+        old_attr_name = "compiler_flags",
         old_attr_value = compiler_flags,
+        new_attr_name = "ghcopts",
         new_attr_value = ghcopts,
-        message = "compiler_flags attribute is deprecated, use its new name ghcopts instead",
     )
 
     _haskell_toolchain(

--- a/tests/binary-with-link-flags/BUILD.bazel
+++ b/tests/binary-with-link-flags/BUILD.bazel
@@ -11,7 +11,7 @@ package(
 haskell_test(
     name = "binary-with-link-flags",
     srcs = ["Main.hs"],
-    compiler_flags = ["-threaded"],
+    ghcopts = ["-threaded"],
     visibility = ["//visibility:public"],
     deps = ["//tests/hackage:base"],
 )

--- a/tests/extra-source-files/BUILD.bazel
+++ b/tests/extra-source-files/BUILD.bazel
@@ -12,12 +12,12 @@ haskell_library(
         "Foo.hs",
         "FooTH.hs",
     ],
-    # Test that the linker can also see the extra_srcs.
-    compiler_flags = ["-optl-Wl,@tests/extra-source-files/ld-options.txt"],
     extra_srcs = [
         "file.txt",
         "ld-options.txt",
     ],
+    # Test that the linker can also see the extra_srcs.
+    ghcopts = ["-optl-Wl,@tests/extra-source-files/ld-options.txt"],
     tags = [
         # ld on darwin does not support response files.
         "dont_test_on_darwin_with_bindist",

--- a/tests/failing-repros/isystem-issue/BUILD.bazel
+++ b/tests/failing-repros/isystem-issue/BUILD.bazel
@@ -13,7 +13,7 @@ cc_library(
 haskell_binary(
     name = "bin",
     srcs = ["Main.hs"],
-    compiler_flags = ["-Itests/isystem-issue/include"],
+    ghcopts = ["-Itests/isystem-issue/include"],
     deps = [
         ":cbits",
         "//tests/hackage:base",

--- a/tests/hsc/BUILD.bazel
+++ b/tests/hsc/BUILD.bazel
@@ -14,7 +14,7 @@ haskell_library(
         "Flags.hsc",
         "Foo.hsc",
     ],
-    compiler_flags = [
+    ghcopts = [
         "-DTHIS_IS_TRUE",
         "-optP-DTHIS_TOO_IS_TRUE",
     ],

--- a/tests/repl-targets/BUILD.bazel
+++ b/tests/repl-targets/BUILD.bazel
@@ -104,7 +104,7 @@ haskell_test(
 haskell_library(
     name = "rebindable-syntax",
     srcs = ["RebindableSyntax.hs"],
-    compiler_flags = [
+    ghcopts = [
         "-XRebindableSyntax",
         "-Wname-shadowing",
     ],

--- a/tests/textual-hdrs/BUILD.bazel
+++ b/tests/textual-hdrs/BUILD.bazel
@@ -11,7 +11,7 @@ haskell_test(
         "Main.hs",
         "include/main_definition.h",
     ],
-    compiler_flags = ["-Itests/textual-hdrs/include"],
+    ghcopts = ["-Itests/textual-hdrs/include"],
     visibility = ["//visibility:public"],
     deps = ["//tests/hackage:base"],
 )

--- a/tools/runfiles/BUILD.bazel
+++ b/tools/runfiles/BUILD.bazel
@@ -21,7 +21,7 @@ haskell_library(
         "src/Bazel/Arg0.hs",
         "src/Bazel/Runfiles.hs",
     ],
-    compiler_flags = [
+    ghcopts = [
         "-Wall",
         "-Wextra",
         "-Werror",

--- a/tutorial/main/BUILD.bazel
+++ b/tutorial/main/BUILD.bazel
@@ -9,7 +9,7 @@ haskell_toolchain_library(name = "base")
 haskell_test(
     name = "demorgan",
     srcs = ["Main.hs"],
-    compiler_flags = ["-threaded"],
+    ghcopts = ["-threaded"],
     deps = [
         ":base",
         "//lib:booleans",


### PR DESCRIPTION
As mentioned in issue (#1059),
the parameters named `compiler_flags` of various macros and rules have been renamed to `ghcopts`. 

This is to keep naming consistent with the `cabalopts` parameter.

For now the old name still works but a deprecation message is printed,
and the build fails if both new and old named are used at the same time.

I modified some of the tests to use the new name, but not all of them yet
(since both names are supposed to work).