### PR TITLE
make start script work with sh

### DIFF
--- a/start
+++ b/start
@@ -181,7 +181,7 @@ haskell_register_ghc_nixpkgs(
 EOF
 )
 
-declare -r ZLIB_BUILD_FILE="zlib.BUILD.bazel"
+readonly ZLIB_BUILD_FILE="zlib.BUILD.bazel"
 
 echo "Creating $ZLIB_BUILD_FILE" >&2
 case "$mode" in

--- a/tests/shellcheck/BUILD.bazel
+++ b/tests/shellcheck/BUILD.bazel
@@ -64,7 +64,7 @@ shellcheck(
     name = "start-script",
     args = ["$(location //:start)"],
     data = ["//:start"],
-    sh_flavor = "bash",
+    sh_flavor = "sh",
 )
 
 shellcheck(


### PR DESCRIPTION
This addresses issue #1528 by replacing `declare -r` with `readonly` in the script and updating lint rule to require sh rather than bash.