### PR TITLE
added hie_bios_path_prefix attribute to haskell_repl

### DIFF
--- a/haskell/repl.bzl
+++ b/haskell/repl.bzl
@@ -510,7 +510,7 @@ def _create_hie_bios(hs, posix, ctx, repl_info, path_prefix):
 
     args_file = ctx.actions.declare_file(".%s.hie-bios" % ctx.label.name)
     args_link = ctx.actions.declare_file("%s@hie-bios" % ctx.label.name)
-    ctx.actions.write(args_file, "\n".join(args))
+    ctx.actions.write(args_file, "\n".join(args) + "\n")
     ln(hs, posix, args_file, args_link, extra_inputs = inputs)
     return [OutputGroupInfo(hie_bios = [args_link])]
 

--- a/tests/hie-bios/BUILD.bazel
+++ b/tests/hie-bios/BUILD.bazel
@@ -1,0 +1,54 @@
+load(
+    "@rules_haskell//haskell:defs.bzl",
+    "haskell_repl",
+    "haskell_test",
+)
+
+haskell_test(
+    name = "binary-hie-bios-test",
+    srcs = ["Main.hs"],
+    deps = ["//tests/hackage:base"],
+)
+
+haskell_repl(
+    name = "hie-bios",
+    testonly = 1,
+    collect_data = True,
+    hie_bios_path_prefix = ["$magic_string"],
+    deps = [":binary-hie-bios-test"],
+)
+
+haskell_repl(
+    name = "hie-bios-no-prefix",
+    testonly = 1,
+    collect_data = True,
+    deps = [":binary-hie-bios-test"],
+)
+
+filegroup(
+    name = "hie-bios-file",
+    testonly = 1,
+    srcs = [":hie-bios"],
+    output_group = "hie_bios",
+)
+
+filegroup(
+    name = "hie-bios-file-no-prefix",
+    testonly = 1,
+    srcs = [":hie-bios-no-prefix"],
+    output_group = "hie_bios",
+)
+
+sh_test(
+    name = "test-hie-bios",
+    size = "small",
+    srcs = ["test_hie_bios.sh"],
+    args = [
+        "$(location :hie-bios-file)",
+        "$(location :hie-bios-file-no-prefix)",
+    ],
+    data = [
+        ":hie-bios-file",
+        ":hie-bios-file-no-prefix",
+    ],
+)

--- a/tests/hie-bios/BUILD.bazel
+++ b/tests/hie-bios/BUILD.bazel
@@ -51,4 +51,5 @@ sh_test(
         ":hie-bios-file",
         ":hie-bios-file-no-prefix",
     ],
+    tags = ["dont_test_on_windows"],
 )

--- a/tests/hie-bios/BUILD.bazel
+++ b/tests/hie-bios/BUILD.bazel
@@ -51,5 +51,5 @@ sh_test(
         ":hie-bios-file",
         ":hie-bios-file-no-prefix",
     ],
-    tags = ["dont_test_on_windows"],
+    deps = ["@bazel_tools//tools/bash/runfiles"],
 )

--- a/tests/hie-bios/BUILD.bazel
+++ b/tests/hie-bios/BUILD.bazel
@@ -44,8 +44,8 @@ sh_test(
     size = "small",
     srcs = ["test_hie_bios.sh"],
     args = [
-        "$(location :hie-bios-file)",
-        "$(location :hie-bios-file-no-prefix)",
+        "$(rootpath :hie-bios-file)",
+        "$(rootpath :hie-bios-file-no-prefix)",
     ],
     data = [
         ":hie-bios-file",

--- a/tests/hie-bios/Main.hs
+++ b/tests/hie-bios/Main.hs
@@ -1,0 +1,3 @@
+module Main where
+
+main = putStrLn "hello world"

--- a/tests/hie-bios/test_hie_bios.sh
+++ b/tests/hie-bios/test_hie_bios.sh
@@ -11,7 +11,7 @@ if grep -q '$magic_string' "$1"; then
     od -c "$1"
     echo "$1 (sed output) ="
     sed 's#$magic_string/##' "$1" | od -c
-    sed 's#$magic_string/##' "$1" | diff -B "$2" -
+    sed 's#$magic_string/##' "$1" | diff "$2" -
 else
     echo "\$magic_string should be in file: $1"
     exit 1

--- a/tests/hie-bios/test_hie_bios.sh
+++ b/tests/hie-bios/test_hie_bios.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+# To test the hie_bios_path_prefix argument of haskell_repl rule.
+# we check that the prefix $magic_string is added to some paths of file $1
+# and that if we remove them, we get back file $2
+
+if grep -q '$magic_string' "$1"; then
+    sed -i 's#$magic_string/##' "$1"
+    cmp "$1" "$2"
+else
+    echo "\$magic_string should be in file: $1"
+    exit 1
+fi

--- a/tests/hie-bios/test_hie_bios.sh
+++ b/tests/hie-bios/test_hie_bios.sh
@@ -5,8 +5,7 @@
 # and that if we remove them, we get back file $2
 
 if grep -q '$magic_string' "$1"; then
-    sed -i 's#$magic_string/##' "$1"
-    cmp "$1" "$2"
+    sed 's#$magic_string/##' "$1" | cmp "$2"
 else
     echo "\$magic_string should be in file: $1"
     exit 1

--- a/tests/hie-bios/test_hie_bios.sh
+++ b/tests/hie-bios/test_hie_bios.sh
@@ -1,18 +1,37 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 # To test the hie_bios_path_prefix argument of haskell_repl rule.
 # we check that the prefix $magic_string is added to some paths of file $1
 # and that if we remove them, we get back file $2
 
-if grep -q '$magic_string' "$1"; then
-    echo "$2 ="
-    od -c "$2"
-    echo "$1 ="
-    od -c "$1"
-    echo "$1 (sed output) ="
-    sed 's#$magic_string/##' "$1" | od -c
-    sed 's#$magic_string/##' "$1" | diff "$2" -
+# --- begin runfiles.bash initialization v2 ---
+# Copy-pasted from the Bazel Bash runfiles library v2.
+set -uo pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+source "$0.runfiles/$f" 2>/dev/null || \
+source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
+# --- end runfiles.bash initialization v2 ---
+
+FILE1="$(rlocation "$TEST_WORKSPACE/$1")"
+FILE2="$(rlocation "$TEST_WORKSPACE/$2")"
+if grep -q '$magic_string' "$FILE1"; then
+    if sed 's#$magic_string/##' "$FILE1" | diff "$FILE2" -; then
+	exit 0
+    else
+	echo "$2 ="
+	od -c "$FILE2"
+	echo "$1 ="
+	od -c "$FILE1"
+	echo "$1 (sed output) ="
+	sed 's#$magic_string/##' "$FILE1" | od -c
+	exit 1
+    fi
 else
     echo "\$magic_string should be in file: $1"
+    echo "$1 ="
+    od -c "$FILE1"
     exit 1
 fi

--- a/tests/hie-bios/test_hie_bios.sh
+++ b/tests/hie-bios/test_hie_bios.sh
@@ -6,12 +6,12 @@
 
 if grep -q '$magic_string' "$1"; then
     echo "$2 ="
-    od "$2"
+    od -c "$2"
     echo "$1 ="
-    od "$1"
+    od -c "$1"
     echo "$1 (sed output) ="
-    sed 's#$magic_string/##' "$1" | od
-    sed 's#$magic_string/##' "$1" | cmp "$2"
+    sed 's#$magic_string/##' "$1" | od -c
+    sed 's#$magic_string/##' "$1" | diff -B "$2" -
 else
     echo "\$magic_string should be in file: $1"
     exit 1

--- a/tests/hie-bios/test_hie_bios.sh
+++ b/tests/hie-bios/test_hie_bios.sh
@@ -5,6 +5,12 @@
 # and that if we remove them, we get back file $2
 
 if grep -q '$magic_string' "$1"; then
+    echo "$2 ="
+    od "$2"
+    echo "$1 ="
+    od "$1"
+    echo "$1 (sed output) ="
+    sed 's#$magic_string/##' "$1" | od
     sed 's#$magic_string/##' "$1" | cmp "$2"
 else
     echo "\$magic_string should be in file: $1"


### PR DESCRIPTION
I added an attribute named `hie_bios_path_prefix` to the `haskell_repl` rule to address issue #1432.

This makes it possible for hie-bios to output paths relative to a different folder than the workspace root.

In order to use absolute paths, it is possible to use a placeholder in the prefix,
and then replace it with a call to `pwd` in the user defined [.hie-bios script](https://rules-haskell.readthedocs.io/en/latest/haskell-use-cases.html#configuring-ide-integration-with-ghcide).