### PR TITLE
hopefully a more helpful error for when make is missing

### DIFF
--- a/haskell/ghc_bindist.bzl
+++ b/haskell/ghc_bindist.bzl
@@ -374,6 +374,9 @@ def _ghc_bindist_impl(ctx):
         # tools! This means that sed -i always takes an argument.
         execute_or_fail_loudly(ctx, ["sed", "-e", "s/RelocatableBuild = NO/RelocatableBuild = YES/", "-i.bak", "mk/config.mk.in"], working_directory = unpack_dir)
         execute_or_fail_loudly(ctx, ["./configure", "--prefix", bindist_dir.realpath], working_directory = unpack_dir)
+        make_loc = ctx.which("make")
+        if not make_loc:
+            fail("It looks like the build-essential package might be missing, because there is no make in PATH.  Are the required dependencies installed?  https://rules-haskell.readthedocs.io/en/latest/haskell.html#before-you-begin")
         execute_or_fail_loudly(
             ctx,
             ["make", "install"],


### PR DESCRIPTION
The `build-essential` package is a required dependency, and when it is missing, `make` fails with an error that's not really friendly, as evidenced in #1419.
The new error also links to the other required dependencies, because there's a good chance that some other things are missing too.