### PR TITLE
build doc in CI

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -53,6 +53,8 @@ jobs:
             bazel build //tests:run-tests
             ./bazel-ci-bin/tests/run-tests
             bazel coverage //tests/...
+            bazel build //docs:api_html
+            bazel build //docs:guide_html
             '
 
   test-nixpkgs-cross:

--- a/docs/haskell-use-cases.rst
+++ b/docs/haskell-use-cases.rst
@@ -990,7 +990,7 @@ Similarly, we need to register the native and cross-toolchains for C. ::
 
 Having the toolchains registered, the last remaining bit is telling
 Bazel for which platform to build. Building for ``arm`` requires
-declaring the platform in the `BUILD <https://github.com/tweag/rules_haskell/blob/master/examples/arm/BUILD.bazel>`_ file. ::
+declaring the platform in the `BUILD<https://github.com/tweag/rules_haskell/blob/master/examples/arm/BUILD.bazel>`_ file. ::
 
   platform(
       name = "linux_aarch64",

--- a/docs/haskell-use-cases.rst
+++ b/docs/haskell-use-cases.rst
@@ -990,7 +990,7 @@ Similarly, we need to register the native and cross-toolchains for C. ::
 
 Having the toolchains registered, the last remaining bit is telling
 Bazel for which platform to build. Building for ``arm`` requires
-declaring the platform in the `BUILD<https://github.com/tweag/rules_haskell/blob/master/examples/arm/BUILD.bazel>`_ file. ::
+declaring the platform in the `BUILD <https://github.com/tweag/rules_haskell/blob/master/examples/arm/BUILD.bazel>`_ file. ::
 
   platform(
       name = "linux_aarch64",


### PR DESCRIPTION
The doc is now building in the nix case of the GitHub CI,
to test that it builds without errors as mentioned on issue #1540.