### PR TITLE
Do not use File objects in dictionary keys

### DIFF
--- a/haskell/private/cc_libraries.bzl
+++ b/haskell/private/cc_libraries.bzl
@@ -241,13 +241,17 @@ def create_link_config(hs, posix, cc_libraries_info, libraries_to_link, binary, 
 
     return (cache_file, static_libs, dynamic_libs)
 
+def _path_or_none(f):
+    if f != None:
+        return f.path
+
 def cc_library_key(library_to_link):
     """Convert a LibraryToLink into a hashable dictionary key."""
     return struct(
-        dynamic_library = library_to_link.dynamic_library,
-        interface_library = library_to_link.interface_library,
-        static_library = library_to_link.static_library,
-        pic_static_library = library_to_link.pic_static_library,
+        dynamic_library = _path_or_none(library_to_link.dynamic_library),
+        interface_library = _path_or_none(library_to_link.interface_library),
+        static_library = _path_or_none(library_to_link.static_library),
+        pic_static_library = _path_or_none(library_to_link.pic_static_library),
     )
 
 def deps_HaskellCcLibrariesInfo(deps):


### PR DESCRIPTION
The function `cc_library_key` generates the dictionary keys by which `LibLibraryToLink` are mapped to their corresponding `HaskellCcLibraryInfo`. Before this used a `struct` over `None` or `File` objects. This changes uses `None` or `string` instead, where `string` is the `.path` attribute of the `File` object.

Using a `File` object in a dictionary key fails if the `File` object used at lookup time is semantically the same, but has a different identity due to implementation details in Bazel.

Closes https://github.com/tweag/rules_haskell/issues/1536