### PR TITLE
Add failure test for haskell_doc with plugin

### DIFF
--- a/tests/RunTests.hs
+++ b/tests/RunTests.hs
@@ -14,7 +14,7 @@ import System.IO.Temp (withSystemTempDirectory)
 
 import qualified System.Process as Process
 import Test.Hspec.Core.Spec (SpecM)
-import Test.Hspec (hspec, it, describe, runIO, shouldSatisfy, expectationFailure)
+import Test.Hspec (context, hspec, it, describe, runIO, shouldSatisfy, expectationFailure)
 
 main :: IO ()
 main = hspec $ do
@@ -115,6 +115,11 @@ main = hspec $ do
     for_ all_failure_tests $ \test -> do
       it test $ do
         assertFailure (bazel ["build", test])
+
+    context "known issues" $
+      it "haskell_doc fails with plugins #1549" $
+        -- https://github.com/tweag/rules_haskell/issues/1549
+        assertFailure (bazel ["build", "//tests/haddock-with-plugin"])
 
   -- Test that the repl still works if we shadow some Prelude functions
   it "repl name shadowing" $ do

--- a/tests/hackage/BUILD.bazel
+++ b/tests/hackage/BUILD.bazel
@@ -24,6 +24,7 @@ load(
         "deepseq",
         "directory",
         "filepath",
+        "ghc",
         "mtl",
         "template-haskell",
         "transformers",

--- a/tests/haddock-with-plugin/BUILD.bazel
+++ b/tests/haddock-with-plugin/BUILD.bazel
@@ -31,5 +31,6 @@ haskell_library(
 
 haskell_doc(
     name = "haddock-with-plugin",
+    tags = ["manual"],
     deps = [":library"],
 )

--- a/tests/haddock-with-plugin/BUILD.bazel
+++ b/tests/haddock-with-plugin/BUILD.bazel
@@ -1,0 +1,35 @@
+load(
+    "@rules_haskell//haskell:defs.bzl",
+    "ghc_plugin",
+    "haskell_doc",
+    "haskell_library",
+)
+
+package(default_testonly = 1)
+
+haskell_library(
+    name = "plugin_library",
+    srcs = ["Plugin.hs"],
+    deps = [
+        "//tests/hackage:base",
+        "//tests/hackage:ghc",
+    ],
+)
+
+ghc_plugin(
+    name = "plugin",
+    module = "Plugin",
+    deps = [":plugin_library"],
+)
+
+haskell_library(
+    name = "library",
+    srcs = ["Lib.hs"],
+    plugins = [":plugin"],
+    deps = ["//tests/hackage:base"],
+)
+
+haskell_doc(
+    name = "haddock-with-plugin",
+    deps = [":library"],
+)

--- a/tests/haddock-with-plugin/Lib.hs
+++ b/tests/haddock-with-plugin/Lib.hs
@@ -1,0 +1,1 @@
+module Lib where

--- a/tests/haddock-with-plugin/Plugin.hs
+++ b/tests/haddock-with-plugin/Plugin.hs
@@ -1,0 +1,6 @@
+module Plugin where
+
+import GhcPlugins
+
+plugin :: Plugin
+plugin = defaultPlugin


### PR DESCRIPTION
Adds a regression test for https://github.com/tweag/rules_haskell/issues/1549.
This does not fix the issue, but adds a test-case that is expected to fail. It is tagged as `manual` and added to the failure tests in `//tests:run-tests` accordingly.