### PR TITLE
cabal sublibraries

### DIFF
--- a/haskell/cabal.bzl
+++ b/haskell/cabal.bzl
@@ -421,9 +421,10 @@ def _haskell_cabal_library_impl(ctx):
     )
     posix = ctx.toolchains["@rules_sh//sh/posix:toolchain_type"]
     package_name = ctx.attr.package_name if ctx.attr.package_name else hs.label.name
-    package_id = "{}-{}".format(
+    package_id = "{}-{}{}".format(
         package_name,
         ctx.attr.version,
+        "-{}".format(ctx.attr.sublibrary_name) if ctx.attr.sublibrary_name else "",
     )
     with_profiling = is_profiling_enabled(hs)
 
@@ -493,9 +494,7 @@ def _haskell_cabal_library_impl(ctx):
         dep_info,
         cc_info,
         direct_cc_info,
-        component = "lib:{}".format(
-            ctx.attr.package_name if ctx.attr.package_name else hs.label.name,
-        ),
+        component = "lib:{}".format(ctx.attr.sublibrary_name or ctx.attr.package_name or hs.label.name),
         package_id = package_id,
         tool_inputs = tool_inputs,
         tool_input_manifests = tool_input_manifests,
@@ -632,6 +631,9 @@ haskell_cabal_library = rule(
         "version": attr.string(
             doc = "Version of the Cabal package.",
             mandatory = True,
+        ),
+        "sublibrary_name": attr.string(
+            doc = "sublibrary of the Cabal package to build",
         ),
         "haddock": attr.bool(
             default = True,

--- a/tests/haskell_cabal_library_sublibrary_name/BUILD
+++ b/tests/haskell_cabal_library_sublibrary_name/BUILD
@@ -1,0 +1,68 @@
+load(
+    "@rules_haskell//haskell:defs.bzl",
+    "haskell_test",
+    "haskell_toolchain_library",
+)
+load(
+    "@rules_haskell//haskell:cabal.bzl",
+    "haskell_cabal_binary",
+    "haskell_cabal_library",
+)
+
+haskell_toolchain_library(name = "base")
+
+haskell_cabal_library(
+    name = "the_main_library",
+    package_name = "package1",
+    srcs = glob([
+        "package1.cabal",
+        "app/**",
+        "lib/**",
+        "sublib/**",
+    ]),
+    version = "0.1.0.0",
+    deps = [
+        ":base",
+        ":the_sublibrary",
+    ],
+)
+
+haskell_cabal_library(
+    name = "the_sublibrary",
+    package_name = "package1",
+    srcs = glob([
+        "package1.cabal",
+        "app/**",
+        "lib/**",
+        "sublib/**",
+    ]),
+    sublibrary_name = "sublib",
+    version = "0.1.0.0",
+    deps = [
+        ":base",
+    ],
+)
+
+haskell_cabal_binary(
+    name = "the_executable",
+    srcs = glob([
+        "package1.cabal",
+        "app/**",
+        "lib/**",
+        "sublib/**",
+    ]),
+    exe_name = "package1_executable",
+    deps = [
+        ":base",
+        ":the_main_library",
+    ],
+)
+
+haskell_test(
+    name = "haskell_cabal_library_sublibrary_name",
+    srcs = ["Main.hs"],
+    deps = [
+        ":base",
+        ":the_sublibrary",
+    ],
+)

--- a/tests/haskell_cabal_library_sublibrary_name/Main.hs
+++ b/tests/haskell_cabal_library_sublibrary_name/Main.hs
@@ -1,0 +1,5 @@
+module Main where
+import SubLib
+
+main :: IO ()
+main = print subLibVal

--- a/tests/haskell_cabal_library_sublibrary_name/app/Main.hs
+++ b/tests/haskell_cabal_library_sublibrary_name/app/Main.hs
@@ -1,0 +1,5 @@
+module Main where
+import Lib
+
+main :: IO ()
+main = print $ "Hello from " ++ libval

--- a/tests/haskell_cabal_library_sublibrary_name/lib/Lib.hs
+++ b/tests/haskell_cabal_library_sublibrary_name/lib/Lib.hs
@@ -1,0 +1,4 @@
+module Lib where
+import SubLib
+
+libval = subLibVal ++ " through Lib"

--- a/tests/haskell_cabal_library_sublibrary_name/package1.cabal
+++ b/tests/haskell_cabal_library_sublibrary_name/package1.cabal
@@ -1,0 +1,31 @@
+cabal-version:      2.4
+name:               package1
+version:            0.1.0.0
+
+executable package1_executable
+    main-is:          Main.hs
+    hs-source-dirs:   app
+    default-language: Haskell2010
+    build-depends:
+        Cabal
+        , base
+        , package1
+
+library
+    exposed-modules:
+        Lib
+    hs-source-dirs:
+        lib
+    build-depends:
+        Cabal
+        , base
+        , sublib
+
+library sublib
+    exposed-modules:
+        SubLib
+    hs-source-dirs:
+        sublib
+    build-depends:
+        Cabal
+        , base

--- a/tests/haskell_cabal_library_sublibrary_name/sublib/SubLib.hs
+++ b/tests/haskell_cabal_library_sublibrary_name/sublib/SubLib.hs
@@ -1,0 +1,7 @@
+{-|
+Module      : SubLib
+Description : Test compilation of cabal sublibrary
+-}
+module SubLib where
+-- |test subLibVal doc
+subLibVal = "SubLib"


### PR DESCRIPTION
This branch adds a way to expose a sub-library of a cabal package by adding an attribute named `sublibrary_name` to the  `haskell_cabal_library` rule.

As mentioned in #1506 something like this is needed to compile a cabal package that depends on its own sub-libraries (such as in #1439).

In this case, it is now possible to make one `haskell_cabal_library` call for each library and make them depend on each other.