### PR TITLE
integrate haskell_module() dependencies into haskell_library() rule

### DIFF
--- a/haskell/BUILD.bazel
+++ b/haskell/BUILD.bazel
@@ -70,6 +70,9 @@ bzl_library(
     deps = [
         ":bazel_json",
         ":bazel_tools",
+        "//haskell/experimental:defs.bzl",
+        "//haskell/experimental:providers.bzl",
+        "//haskell/experimental:transitions.bzl",
         "@bazel_skylib//lib:collections",
         "@bazel_skylib//lib:dicts",
         "@bazel_skylib//lib:paths",

--- a/haskell/experimental/BUILD.bazel
+++ b/haskell/experimental/BUILD.bazel
@@ -1,0 +1,14 @@
+load("@bazel_skylib//rules:common_settings.bzl", "string_setting")
+
+string_setting(
+    name = "package_name_setting",
+    build_setting_default = "",
+    visibility = ["//visibility:public"],
+)
+
+# for bzl_library() in //haskell:BUILD.bazel
+exports_files([
+    "providers.bzl",
+    "defs.bzl",
+    "transitions.bzl",
+])

--- a/haskell/experimental/defs.bzl
+++ b/haskell/experimental/defs.bzl
@@ -20,6 +20,7 @@ _haskell_module = rule(
             allow_single_file = [".hs", ".lhs"],  #, ".hs-boot", ".lhs-boot", ".hsc", ".h"],
             mandatory = True,
         ),
+        "src_strip_prefix": attr.string(),
         "extra_srcs": attr.label_list(
             allow_files = True,
         ),

--- a/haskell/experimental/defs.bzl
+++ b/haskell/experimental/defs.bzl
@@ -13,6 +13,7 @@ _haskell_module = rule(
     #   in wrapping macros. See https://github.com/bazelbuild/stardoc/issues/27
     attrs = {
         # TODO[AH] Merge with _haskell_common_attrs in //haskell:defs.bzl
+        "package_name": attr.string(),
         "src": attr.label(
             # TODO[AH] How to handle boot files?
             # TODO[AH] How to handle .hsc files?
@@ -43,6 +44,9 @@ _haskell_module = rule(
             cfg = "host",
             default = Label("@rules_haskell//haskell:ghc_wrapper"),
         ),
+        "_package_name_setting": attr.label(
+            default = Label("@rules_haskell//haskell/experimental:package_name_setting"),
+        ),
         # TODO[AH] Support package name and version for modules that are part of a package.
         # TODO[AH] Suppport worker
     },
@@ -56,6 +60,7 @@ _haskell_module = rule(
 
 def haskell_module(
         name,
+        package_name = None,
         src = None,
         extra_srcs = [],
         deps = [],
@@ -84,6 +89,7 @@ def haskell_module(
 
     Args:
       name: A unique name for this rule.
+      package_name: Override the package name this module will be a part of.
       src_strip_prefix: Prefix before the path matches the module name.
         This is used as an import search for the Haskell compiler.
         Values starting with `/` are relative to the workspace root,
@@ -100,6 +106,7 @@ def haskell_module(
     """
     _haskell_module(
         name = name,
+        package_name = package_name,
         src = src,
         extra_srcs = extra_srcs,
         deps = deps,

--- a/haskell/experimental/defs.bzl
+++ b/haskell/experimental/defs.bzl
@@ -1,0 +1,95 @@
+"""Experimental Haskell rules"""
+
+load(
+    "//haskell/experimental/private:module.bzl",
+    _haskell_module_impl = "haskell_module_impl",
+)
+load("//haskell:private/cc_libraries.bzl", "haskell_cc_libraries_aspect")
+
+_haskell_module = rule(
+    _haskell_module_impl,
+    # NOTE: Documentation needs to be added to the wrapper macros below.
+    #   Currently it is not possible to automatically inherit rule documentation
+    #   in wrapping macros. See https://github.com/bazelbuild/stardoc/issues/27
+    attrs = {
+        # TODO[AH] Merge with _haskell_common_attrs in //haskell:defs.bzl
+        "src": attr.label(
+            # TODO[AH] How to handle boot files?
+            # TODO[AH] How to handle .hsc files?
+            # TODO[AH] Do we need .h files in here?
+            allow_single_file = [".hs", ".lhs"],  #, ".hs-boot", ".lhs-boot", ".hsc", ".h"],
+            mandatory = True,
+        ),
+        "extra_srcs": attr.label_list(
+            allow_files = True,
+        ),
+        "deps": attr.label_list(
+            aspects = [haskell_cc_libraries_aspect],
+        ),
+        "ghcopts": attr.string_list(),
+        #"repl_ghci_args": attr.string_list(),
+        "plugins": attr.label_list(
+            aspects = [haskell_cc_libraries_aspect],
+        ),
+        "tools": attr.label_list(
+            cfg = "host",
+            allow_files = True,
+        ),
+        "_cc_toolchain": attr.label(
+            default = Label("@bazel_tools//tools/cpp:current_cc_toolchain"),
+        ),
+        "_ghc_wrapper": attr.label(
+            executable = True,
+            cfg = "host",
+            default = Label("@rules_haskell//haskell:ghc_wrapper"),
+        ),
+        # TODO[AH] Suppport worker
+    },
+    toolchains = [
+        "@bazel_tools//tools/cpp:toolchain_type",
+        "@rules_haskell//haskell:toolchain",
+        "@rules_sh//sh/posix:toolchain_type",
+    ],
+    fragments = ["cpp"],
+)
+
+def haskell_module(
+        name,
+        src = None,
+        extra_srcs = [],
+        deps = [],
+        ghcopts = [],
+        #repl_ghci_args = [],
+        plugins = [],
+        tools = [],
+        worker = None,
+        **kwargs):
+    """Build a module from Haskell source.
+
+    TODO[AH] Write API docs
+    """
+    _haskell_module(
+        name = name,
+        src = src,
+        extra_srcs = extra_srcs,
+        deps = deps,
+        ghcopts = ghcopts,
+        #repl_ghci_args = repl_ghci_args,
+        plugins = plugins,
+        tools = tools,
+        #worker = worker,
+        **kwargs
+    )
+
+    #repl_kwargs = {
+    #    attr: kwargs[attr]
+    #    for attr in ["testonly", "tags"]
+    #    if attr in kwargs
+    #}
+    #haskell_repl(
+    #    name = "%s@repl" % name,
+    #    deps = [name],
+    #    experimental_from_source = [":%s" % name],
+    #    repl_ghci_args = [],
+    #    **repl_kwargs
+    #)

--- a/haskell/experimental/defs.bzl
+++ b/haskell/experimental/defs.bzl
@@ -28,7 +28,6 @@ _haskell_module = rule(
             aspects = [haskell_cc_libraries_aspect],
         ),
         "ghcopts": attr.string_list(),
-        #"repl_ghci_args": attr.string_list(),
         "plugins": attr.label_list(
             aspects = [haskell_cc_libraries_aspect],
         ),
@@ -61,7 +60,6 @@ def haskell_module(
         extra_srcs = [],
         deps = [],
         ghcopts = [],
-        #repl_ghci_args = [],
         plugins = [],
         tools = [],
         worker = None,
@@ -106,22 +104,8 @@ def haskell_module(
         extra_srcs = extra_srcs,
         deps = deps,
         ghcopts = ghcopts,
-        #repl_ghci_args = repl_ghci_args,
         plugins = plugins,
         tools = tools,
         #worker = worker,
         **kwargs
     )
-
-    #repl_kwargs = {
-    #    attr: kwargs[attr]
-    #    for attr in ["testonly", "tags"]
-    #    if attr in kwargs
-    #}
-    #haskell_repl(
-    #    name = "%s@repl" % name,
-    #    deps = [name],
-    #    experimental_from_source = [":%s" % name],
-    #    repl_ghci_args = [],
-    #    **repl_kwargs
-    #)

--- a/haskell/experimental/defs.bzl
+++ b/haskell/experimental/defs.bzl
@@ -44,6 +44,7 @@ _haskell_module = rule(
             cfg = "host",
             default = Label("@rules_haskell//haskell:ghc_wrapper"),
         ),
+        # TODO[AH] Support package name and version for modules that are part of a package.
         # TODO[AH] Suppport worker
     },
     toolchains = [
@@ -65,9 +66,39 @@ def haskell_module(
         tools = [],
         worker = None,
         **kwargs):
-    """Build a module from Haskell source.
+    """Compile a module from Haskell source.
 
-    TODO[AH] Write API docs
+    Note: This rule is experimental and not ready for production, yet.
+
+    ### Examples
+
+      ```bzl
+      haskell_module(
+          name = "Example.Module",
+          src = "src/Example/Module.hs",
+          src_strip_prefix = "src",
+          deps = [
+              "//:Another.Module",
+              "//:some-library",
+          ],
+      )
+      ```
+
+    Args:
+      name: A unique name for this rule.
+      src_strip_prefix: Prefix before the path matches the module name.
+        This is used as an import search for the Haskell compiler.
+        Values starting with `/` are relative to the workspace root,
+        other paths are relative to the package.
+      src: The Haskell source file.
+      extra_srcs: Extra (non-Haskell) source files that will be needed at compile time (e.g. by Template Haskell).
+      deps: List of other Haskell modules or libraries needed to compile this module.
+      data: See [Bazel documentation](https://docs.bazel.build/versions/master/be/common-definitions.html#common.data).,
+      ghcopts: Flags to pass to Haskell compiler. Subject to Make variable substitution.
+      plugins: Compiler plugins to use during compilation. (Not implemented, yet)
+      tools: Extra tools needed at compile-time, like preprocessors. (Not implemented, yet)
+      worker: Experimental. Worker binary employed by Bazel's persistent worker mode. See [use-cases documentation](https://rules-haskell.readthedocs.io/en/latest/haskell-use-cases.html#persistent-worker-mode-experimental). (Not implemented, yet)
+      **kwargs: Common rule attributes. See [Bazel documentation](https://docs.bazel.build/versions/master/be/common-definitions.html#common-attributes).
     """
     _haskell_module(
         name = name,

--- a/haskell/experimental/private/module.bzl
+++ b/haskell/experimental/private/module.bzl
@@ -131,13 +131,20 @@ def haskell_module_impl(ctx):
         arguments = args,
     )
 
+    workspace_root = paths.join(ctx.bin_dir.path, ctx.label.workspace_root)
+    package_root = paths.join(workspace_root, ctx.label.package)
+    src_strip_prefix = ctx.attr.src_strip_prefix
+    if src_strip_prefix.startswith("/"):
+        interface_dir = paths.join(workspace_root, src_strip_prefix[1:])
+    else:
+        interface_dir = paths.join(package_root, src_strip_prefix)
+
     default_info = DefaultInfo(
         files = depset(direct = [obj, interface]),
     )
     module_info = HaskellModuleInfo(
         object_file = obj,
-        # TODO[AH] Support module hierarchy.
-        interface_dir = interface.dirname,
+        interface_dir = interface_dir,
         interface_file = interface,
     )
 

--- a/haskell/experimental/private/module.bzl
+++ b/haskell/experimental/private/module.bzl
@@ -1,2 +1,120 @@
+load("@bazel_skylib//lib:paths.bzl", "paths")
+load(
+    "//haskell:cc.bzl",
+    "cc_interop_info",
+)
+load(
+    "//haskell:private/context.bzl",
+    "haskell_context",
+)
+load(
+    "//haskell:private/dependencies.bzl",
+    "gather_dep_info",
+)
+load(
+    "//haskell:private/packages.bzl",
+    "expose_packages",
+    "pkg_info_to_compile_flags",
+)
+
 def haskell_module_impl(ctx):
-    pass
+    hs = haskell_context(ctx)
+    cc = cc_interop_info(ctx)
+    posix = ctx.toolchains["@rules_sh//sh/posix:toolchain_type"]
+
+    src = ctx.file.src
+    extra_srcs = ctx.files.extra_srcs
+    dep_info = gather_dep_info(ctx, ctx.attr.deps)
+    # ctx.attr.deps
+    # TODO[AH] Support plugins
+    # ctx.attr.plugins
+    # TODO[AH] Support preprocessors
+    # ctx.attr.tools
+
+    obj = ctx.actions.declare_file(
+        paths.replace_extension(src.basename, ".o"),
+        sibling = src,
+    )
+    interface = ctx.actions.declare_file(
+        paths.replace_extension(src.basename, ".hi"),
+        sibling = src,
+    )
+    # TODO[AH] Support additional outputs such as `.hie`.
+
+    args = ctx.actions.args()
+    args.add_all(["-c", "-o", obj, "-ohi", interface, src])
+    args.add_all([
+        "-v0",
+        "-fPIC",
+        "-hide-all-packages",
+        # Should never trigger in sandboxed builds, but can be useful
+        # to debug issues in non-sandboxed builds.
+        "-Wmissing-home-modules",
+    ])
+    if hs.toolchain.static_runtime and not hs.toolchain.is_windows:
+        # A static GHC RTS requires -fPIC. However, on Unix we also require
+        # -fexternal-dynamic-refs, otherwise GHC still generates R_X86_64_PC32
+        # relocations which prevents loading these static libraries as PIC.
+        args.add("-fexternal-dynamic-refs")
+
+    # GHC expects the CC compiler as the assembler, but segregates the
+    # set of flags to pass to it when used as an assembler. So we have
+    # to set both -optc and -opta.
+    args.add_all(cc.compiler_flags, format_each = "-optc%s")
+    args.add_all(cc.compiler_flags, format_each = "-opta%s")
+
+    # Write the -optP flags to a parameter file because they can be very long on Windows
+    # e.g. 27Kb for grpc-haskell
+    optp_args_file = hs.actions.declare_file("optp_args_%s" % hs.name)
+    optp_args = hs.actions.args()
+    optp_args.add_all(cc.cpp_flags)
+    optp_args.set_param_file_format("multiline")
+    hs.actions.write(optp_args_file, optp_args)
+    args.add(optp_args_file, format = "-optP@%s")
+
+    args.add_all(cc.include_args)
+
+    (pkg_info_inputs, pkg_info_args) = pkg_info_to_compile_flags(
+        hs,
+        pkg_info = expose_packages(
+            package_ids = hs.package_ids,
+            package_databases = dep_info.package_databases,
+            # TODO[AH] Support version macros
+            version = None,
+        ),
+        # TODO[AH] Support plugins
+        plugin_pkg_info = expose_packages(
+            package_ids = [],
+            package_databases = depset(),
+            version = None,
+        ),
+        prefix = "compile-",
+    )
+    args.add_all(pkg_info_args)
+
+    # TODO[AH] Support package id - see `-this-unit-id` flag.
+
+    args.add_all(hs.toolchain.ghcopts)
+    args.add_all(ctx.attr.ghcopts)
+
+    hs.toolchain.actions.run_ghc(
+        hs,
+        cc,
+        inputs = depset(
+            direct = [src] + extra_srcs + [optp_args_file],
+            transitive = [pkg_info_inputs],
+        ),
+        input_manifests = [],
+        outputs = [obj, interface],
+        # TODO[AH] Support profiling
+        mnemonic = "HaskellBuildObject",  # + ("Prof" if with_profiling else ""),
+        progress_message = "HaskellBuildObject {}".format(hs.label),
+        env = hs.env,
+        arguments = args,
+    )
+
+    default_info = DefaultInfo(
+        files = depset(direct = [obj, interface]),
+    )
+
+    return [default_info]

--- a/haskell/experimental/private/module.bzl
+++ b/haskell/experimental/private/module.bzl
@@ -87,7 +87,7 @@ def haskell_module_impl(ctx):
         # TODO[AH] Factor this out
         # TODO[AH] Include object search paths for template Haskell dependencies.
         #   See https://github.com/tweag/rules_haskell/issues/1382
-        dep[HaskellModuleInfo].interface_dir
+        dep[HaskellModuleInfo].import_dir
         for dep in ctx.attr.deps
         if HaskellModuleInfo in dep
     ], format_each = "-i%s")
@@ -144,9 +144,9 @@ def haskell_module_impl(ctx):
     package_root = paths.join(workspace_root, ctx.label.package)
     src_strip_prefix = ctx.attr.src_strip_prefix
     if src_strip_prefix.startswith("/"):
-        interface_dir = paths.join(workspace_root, src_strip_prefix[1:])
+        import_dir = paths.join(workspace_root, src_strip_prefix[1:])
     else:
-        interface_dir = paths.join(package_root, src_strip_prefix)
+        import_dir = paths.join(package_root, src_strip_prefix)
 
     # Construct and return providers
 
@@ -155,7 +155,7 @@ def haskell_module_impl(ctx):
     )
     module_info = HaskellModuleInfo(
         object_file = obj,
-        interface_dir = interface_dir,
+        import_dir = import_dir,
         interface_file = interface,
     )
 

--- a/haskell/experimental/private/module.bzl
+++ b/haskell/experimental/private/module.bzl
@@ -1,0 +1,2 @@
+def haskell_module_impl(ctx):
+    pass

--- a/haskell/experimental/providers.bzl
+++ b/haskell/experimental/providers.bzl
@@ -1,0 +1,8 @@
+HaskellModuleInfo = provider(
+    doc = "Module-specific information.",
+    fields = {
+        "object_file": "",
+        "interface_dir": "",
+        "interface_file": "",
+    },
+)

--- a/haskell/experimental/providers.bzl
+++ b/haskell/experimental/providers.bzl
@@ -1,8 +1,8 @@
 HaskellModuleInfo = provider(
-    doc = "Module-specific information.",
+    doc = "Information about a single compiled Haskell module.",
     fields = {
-        "object_file": "",
-        "interface_dir": "",
-        "interface_file": "",
+        "object_file": "The compiled `.o` file.",
+        "interface_dir": "The import search directory for the interface file.",
+        "interface_file": "The compiled `.hi` file.",
     },
 )

--- a/haskell/experimental/providers.bzl
+++ b/haskell/experimental/providers.bzl
@@ -1,8 +1,8 @@
 HaskellModuleInfo = provider(
     doc = "Information about a single compiled Haskell module.",
     fields = {
-        "object_file": "The compiled `.o` file.",
-        "interface_dir": "The import search directory for the interface file.",
+        "import_dir": "The import search directory for the interface file. For example, if the interface file for `Some.Module` is stored under `bazel-out/k8-opt/bin/pkg/Some/Module.hi`, then `import_dir` should be `bazel-out/k8-opt/bin/pkg`.",
         "interface_file": "The compiled `.hi` file.",
+        "object_file": "The compiled `.o` file.",
     },
 )

--- a/haskell/experimental/transitions.bzl
+++ b/haskell/experimental/transitions.bzl
@@ -1,0 +1,17 @@
+load("//haskell:private/pkg_id.bzl", "pkg_id")
+
+def _package_name_out_transition_impl(settings, attr):
+    package_name = getattr(attr, "package_name", None)
+    version = getattr(attr, "version", None)
+
+    # we don't have direct access to ctx.label here, so we've recreated it in
+    # "attr.label". See //haskell:defs.bzl
+    label = Label(attr.label_string)
+    my_pkg_id = pkg_id.new(label, package_name, version)
+    return {"//haskell/experimental:package_name_setting": pkg_id.to_string(my_pkg_id)}
+
+package_name_out_transition = transition(
+    implementation = _package_name_out_transition_impl,
+    inputs = [],
+    outputs = ["//haskell/experimental:package_name_setting"],
+)

--- a/haskell/private/ls_modules.py
+++ b/haskell/private/ls_modules.py
@@ -19,10 +19,10 @@ import io
 import package_configuration
 
 if len(sys.argv) != 7:
-    sys.exit("Usage: %s <WITH_PROFILING> <DIRECTORY> <GLOBAL_PKG_DB> <HIDDEN_MODS_FILE> <REEXPORTED_MODS_FILE> <RESULT_FILE>" % sys.argv[0])
+    sys.exit("Usage: %s <WITH_PROFILING> <DIRECTORIES> <GLOBAL_PKG_DB> <HIDDEN_MODS_FILE> <REEXPORTED_MODS_FILE> <RESULT_FILE>" % sys.argv[0])
 
 with_profiling = sys.argv[1] == 'True'
-root = sys.argv[2]
+roots = sys.argv[2]
 global_pkg_db_dump = sys.argv[3]
 hidden_modules_file = sys.argv[4]
 reexported_modules_file = sys.argv[5]
@@ -86,19 +86,16 @@ On Windows you may need to enable long file path support:
     """.strip().format(e), file=sys.stderr)
     exit(1)
 
-interface_files = (
-    os.path.join(path, f)
-    for path, dirs, files in os.walk(root, onerror=handle_walk_error)
-    for f in fnmatch.filter(files, '*.p_hi' if with_profiling else '*.hi')
-)
-
 modules = (
     # replace directory separators by . to generate module names
     # / and \ are respectively the separators for unix (linux / darwin) and windows systems
-    os.path.splitext(os.path.relpath(f, start=root))[0]
+    os.path.splitext(os.path.relpath(g, start=root))[0]
         .replace("/",".")
         .replace("\\",".")
-    for f in interface_files
+    for root in roots.split(":")
+    for path, dirs, files in os.walk(root, onerror=handle_walk_error)
+    for f in fnmatch.filter(files, '*.p_hi' if with_profiling else '*.hi')
+    for g in [os.path.join(path, f)]
 )
 
 exposed_modules = (

--- a/haskell/protobuf.bzl
+++ b/haskell/protobuf.bzl
@@ -175,6 +175,7 @@ def _haskell_proto_aspect_impl(target, ctx):
         "reexported_modules": {},
         "name": "proto-autogen-" + ctx.rule.attr.name,
         "srcs": hs_files,
+        "modules": [],
         "extra_srcs": [],
         "deps": ctx.rule.attr.deps +
                 ctx.toolchains["@rules_haskell//protobuf:toolchain"].deps,

--- a/tests/RunTests.hs
+++ b/tests/RunTests.hs
@@ -29,8 +29,8 @@ main = hspec $ do
     -- -dont_test_on_darwin. However, specifiying --test_tag_filters
     -- -requires_dynamic here alone would override that filter. So,
     -- we have to duplicate that filter here.
-    let tagFilter | os == "darwin" = "-dont_test_on_darwin,-requires_dynamic"
-                  | otherwise      = "-requires_dynamic"
+    let tagFilter | os == "darwin" = "-dont_test_on_darwin,-requires_dynamic,-skip_profiling"
+                  | otherwise      = "-requires_dynamic,-skip_profiling"
     assertSuccess (bazel ["test", "-c", "dbg", "//...", "--build_tests_only", "--test_tag_filters", tagFilter])
 
   it "bazel build worker" $ do

--- a/tests/haskell_module/library/BUILD.bazel
+++ b/tests/haskell_module/library/BUILD.bazel
@@ -1,0 +1,37 @@
+load(
+    "@rules_haskell//haskell:defs.bzl",
+    "haskell_library",
+    "haskell_test",
+)
+load("@rules_haskell//haskell/experimental:defs.bzl", "haskell_module")
+
+package(default_testonly = 1)
+
+haskell_library(
+    name = "TestLib",
+    modules = [
+        ":TestLibModule",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//tests/hackage:base",
+    ],
+)
+
+haskell_module(
+    name = "TestLibModule",
+    src = "TestLib.hs",
+    deps = ["//tests/hackage:base"],
+)
+
+haskell_test(
+    name = "bin-deps",
+    size = "small",
+    srcs = ["Bin.hs"],
+    tags = ["skip_profiling"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":TestLib",
+        "//tests/hackage:base",
+    ],
+)

--- a/tests/haskell_module/library/Bin.hs
+++ b/tests/haskell_module/library/Bin.hs
@@ -1,0 +1,6 @@
+module Main (main) where
+
+import TestLib (testMessage)
+
+main :: IO ()
+main = putStrLn testMessage

--- a/tests/haskell_module/library/TestLib.hs
+++ b/tests/haskell_module/library/TestLib.hs
@@ -1,0 +1,4 @@
+module TestLib (testMessage) where
+
+testMessage :: String
+testMessage = "hello, world!"

--- a/tests/haskell_module/multiple/BUILD.bazel
+++ b/tests/haskell_module/multiple/BUILD.bazel
@@ -1,0 +1,35 @@
+load("@rules_haskell//haskell/experimental:defs.bzl", "haskell_module")
+
+haskell_module(
+    name = "root",
+    src = "Root.hs",
+    deps = ["//tests/hackage:base"],
+)
+
+haskell_module(
+    name = "branch_left",
+    src = "BranchLeft.hs",
+    deps = [
+        ":root",
+        "//tests/hackage:base",
+    ],
+)
+
+haskell_module(
+    name = "branch_right",
+    src = "BranchRight.hs",
+    deps = [
+        ":root",
+        "//tests/hackage:base",
+    ],
+)
+
+haskell_module(
+    name = "leaf",
+    src = "Leaf.hs",
+    deps = [
+        ":branch_left",
+        ":branch_right",
+        "//tests/hackage:base",
+    ],
+)

--- a/tests/haskell_module/multiple/BUILD.bazel
+++ b/tests/haskell_module/multiple/BUILD.bazel
@@ -1,3 +1,5 @@
+"""Test compilation of a multiple interdependent Haskell modules with only core-package dependencies."""
+
 load("@rules_haskell//haskell/experimental:defs.bzl", "haskell_module")
 
 haskell_module(

--- a/tests/haskell_module/multiple/BranchLeft.hs
+++ b/tests/haskell_module/multiple/BranchLeft.hs
@@ -1,0 +1,6 @@
+module BranchLeft where
+
+import Root
+
+branch_left :: Int
+branch_left = 3 * root

--- a/tests/haskell_module/multiple/BranchRight.hs
+++ b/tests/haskell_module/multiple/BranchRight.hs
@@ -1,0 +1,6 @@
+module BranchRight where
+
+import Root
+
+branch_right :: Int
+branch_right = 5 * root

--- a/tests/haskell_module/multiple/Leaf.hs
+++ b/tests/haskell_module/multiple/Leaf.hs
@@ -1,0 +1,7 @@
+module Leaf where
+
+import BranchLeft
+import BranchRight
+
+leaf :: Int
+leaf = 7 * branch_left * branch_right

--- a/tests/haskell_module/multiple/Root.hs
+++ b/tests/haskell_module/multiple/Root.hs
@@ -1,0 +1,4 @@
+module Root where
+
+root :: Int
+root = 2

--- a/tests/haskell_module/nested/BUILD.bazel
+++ b/tests/haskell_module/nested/BUILD.bazel
@@ -1,0 +1,21 @@
+load("@rules_haskell//haskell/experimental:defs.bzl", "haskell_module")
+
+haskell_module(
+    name = "Branch.Right.Module",
+    src = "src/Branch/Right/Module.hs",
+    src_strip_prefix = "src",
+    deps = [
+        "//tests/hackage:base",
+        "//tests/haskell_module/nested/Root:Module",
+    ],
+)
+
+haskell_module(
+    name = "LeafModule",
+    src = "LeafModule.hs",
+    deps = [
+        ":Branch.Right.Module",
+        "//tests/hackage:base",
+        "//tests/haskell_module/nested/Branch/Left:Module",
+    ],
+)

--- a/tests/haskell_module/nested/BUILD.bazel
+++ b/tests/haskell_module/nested/BUILD.bazel
@@ -1,3 +1,5 @@
+"""Test compilation of a multiple interdependent Haskell modules in a nested module hierarchy across multiple Bazel packages with only core-package dependencies."""
+
 load("@rules_haskell//haskell/experimental:defs.bzl", "haskell_module")
 
 haskell_module(

--- a/tests/haskell_module/nested/Branch/Left/BUILD.bazel
+++ b/tests/haskell_module/nested/Branch/Left/BUILD.bazel
@@ -1,0 +1,12 @@
+load("@rules_haskell//haskell/experimental:defs.bzl", "haskell_module")
+
+haskell_module(
+    name = "Module",
+    src = "Module.hs",
+    src_strip_prefix = "/tests/haskell_module/nested",
+    visibility = ["//tests/haskell_module/nested:__subpackages__"],
+    deps = [
+        "//tests/hackage:base",
+        "//tests/haskell_module/nested/Root:Module",
+    ],
+)

--- a/tests/haskell_module/nested/Branch/Left/Module.hs
+++ b/tests/haskell_module/nested/Branch/Left/Module.hs
@@ -1,0 +1,6 @@
+module Branch.Left.Module where
+
+import Root.Module
+
+branch_left :: Int
+branch_left = 3 * root

--- a/tests/haskell_module/nested/LeafModule.hs
+++ b/tests/haskell_module/nested/LeafModule.hs
@@ -1,0 +1,7 @@
+module LeafModule where
+
+import Branch.Left.Module
+import Branch.Right.Module
+
+leaf :: Int
+leaf = 7 * branch_left * branch_right

--- a/tests/haskell_module/nested/Root/BUILD.bazel
+++ b/tests/haskell_module/nested/Root/BUILD.bazel
@@ -1,0 +1,9 @@
+load("@rules_haskell//haskell/experimental:defs.bzl", "haskell_module")
+
+haskell_module(
+    name = "Module",
+    src = "Module.hs",
+    src_strip_prefix = "/tests/haskell_module/nested",
+    visibility = ["//tests/haskell_module/nested:__subpackages__"],
+    deps = ["//tests/hackage:base"],
+)

--- a/tests/haskell_module/nested/Root/Module.hs
+++ b/tests/haskell_module/nested/Root/Module.hs
@@ -1,0 +1,4 @@
+module Root.Module where
+
+root :: Int
+root = 2

--- a/tests/haskell_module/nested/src/Branch/Right/Module.hs
+++ b/tests/haskell_module/nested/src/Branch/Right/Module.hs
@@ -1,0 +1,6 @@
+module Branch.Right.Module where
+
+import Root.Module
+
+branch_right :: Int
+branch_right = 5 * root

--- a/tests/haskell_module/single/BUILD.bazel
+++ b/tests/haskell_module/single/BUILD.bazel
@@ -1,7 +1,13 @@
 load("@rules_haskell//haskell/experimental:defs.bzl", "haskell_module")
+load(":test.bzl", "default_info_test")
 
 haskell_module(
     name = "single",
     src = "Single.hs",
     deps = ["//tests/hackage:base"],
+)
+
+default_info_test(
+    name = "default_info_test",
+    target_under_test = ":single",
 )

--- a/tests/haskell_module/single/BUILD.bazel
+++ b/tests/haskell_module/single/BUILD.bazel
@@ -1,3 +1,5 @@
+"""Test compilation of a single Haskell module with only core-package dependencies."""
+
 load("@rules_haskell//haskell/experimental:defs.bzl", "haskell_module")
 load(":test.bzl", "default_info_test")
 
@@ -7,6 +9,7 @@ haskell_module(
     deps = ["//tests/hackage:base"],
 )
 
+# Test that `haskell_module` produces the expected outputs.
 default_info_test(
     name = "default_info_test",
     target_under_test = ":single",

--- a/tests/haskell_module/single/BUILD.bazel
+++ b/tests/haskell_module/single/BUILD.bazel
@@ -1,0 +1,7 @@
+load("@rules_haskell//haskell/experimental:defs.bzl", "haskell_module")
+
+haskell_module(
+    name = "single",
+    src = "Single.hs",
+    deps = ["//tests/hackage:base"],
+)

--- a/tests/haskell_module/single/Single.hs
+++ b/tests/haskell_module/single/Single.hs
@@ -1,0 +1,4 @@
+module Single where
+
+value :: Int
+value = 42

--- a/tests/haskell_module/single/test.bzl
+++ b/tests/haskell_module/single/test.bzl
@@ -1,0 +1,30 @@
+load("@bazel_skylib//lib:paths.bzl", "paths")
+load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
+
+def _default_info_test_impl(ctx):
+    env = analysistest.begin(ctx)
+    target_under_test = analysistest.target_under_test(env)
+
+    default_info = target_under_test[DefaultInfo]
+
+    obj_files = [
+        f
+        for f in default_info.files.to_list()
+        if paths.split_extension(f.path)[1] == ".o"
+    ]
+    asserts.true(env, len(obj_files) == 1, "Expected exactly one object file")
+    [obj_file] = obj_files
+    asserts.equals(env, "Single.o", obj_file.basename)
+
+    hi_files = [
+        f
+        for f in default_info.files.to_list()
+        if paths.split_extension(f.path)[1] == ".hi"
+    ]
+    asserts.true(env, len(hi_files) == 1, "Expected exactly one interface file")
+    [hi_file] = hi_files
+    asserts.equals(env, "Single.hi", hi_file.basename)
+
+    return analysistest.end(env)
+
+default_info_test = analysistest.make(_default_info_test_impl)


### PR DESCRIPTION
Depends on #1553 
^^Not sure if I'm doing this right, since it's still showing all of the changes in the diff, not just mine.

Allows `haskell_library()` rules to depend on `haskell_module()`s through a new `modules` attribute.
