### PR TITLE
add hs-boot support to haskell_module()

### DIFF
--- a/haskell/experimental/defs.bzl
+++ b/haskell/experimental/defs.bzl
@@ -15,10 +15,9 @@ _haskell_module = rule(
         # TODO[AH] Merge with _haskell_common_attrs in //haskell:defs.bzl
         "package_name": attr.string(),
         "src": attr.label(
-            # TODO[AH] How to handle boot files?
             # TODO[AH] How to handle .hsc files?
             # TODO[AH] Do we need .h files in here?
-            allow_single_file = [".hs", ".lhs"],  #, ".hs-boot", ".lhs-boot", ".hsc", ".h"],
+            allow_single_file = [".hs", ".lhs", ".hs-boot"],  #, ".hs-boot", ".lhs-boot", ".hsc", ".h"],
             mandatory = True,
         ),
         "src_strip_prefix": attr.string(),

--- a/haskell/experimental/defs.bzl
+++ b/haskell/experimental/defs.bzl
@@ -17,7 +17,7 @@ _haskell_module = rule(
         "src": attr.label(
             # TODO[AH] How to handle .hsc files?
             # TODO[AH] Do we need .h files in here?
-            allow_single_file = [".hs", ".lhs", ".hs-boot"],  #, ".hs-boot", ".lhs-boot", ".hsc", ".h"],
+            allow_single_file = [".hs", ".lhs", ".hs-boot", ".lhs-boot"],  #, ".hsc", ".h"],
             mandatory = True,
         ),
         "src_strip_prefix": attr.string(),

--- a/haskell/experimental/private/module.bzl
+++ b/haskell/experimental/private/module.bzl
@@ -46,7 +46,7 @@ def haskell_module_impl(ctx):
 
     # Determine outputs
     with_profiling = is_profiling_enabled(hs)
-    hs_boot = paths.split_extension(src.path)[1] == ".hs-boot"
+    hs_boot = paths.split_extension(src.path)[1] in [".hs-boot", ".lhs-boot"]
     extension_template = "%s"
     if hs_boot:
         extension_template = extension_template + "-boot"

--- a/haskell/experimental/private/module.bzl
+++ b/haskell/experimental/private/module.bzl
@@ -46,12 +46,20 @@ def haskell_module_impl(ctx):
 
     # Determine outputs
     with_profiling = is_profiling_enabled(hs)
+    hs_boot = paths.split_extension(src.path)[1] == ".hs-boot"
+    extension_template = "%s"
+    if hs_boot:
+        extension_template = extension_template + "-boot"
+    if with_profiling:
+        extension_template = "p_" + extension_template
+    extension_template = "." + extension_template
+
     obj = ctx.actions.declare_file(
-        paths.replace_extension(src.basename, ".o" if not with_profiling else ".p_o"),
+        paths.replace_extension(src.basename, extension_template % "o"),
         sibling = src,
     )
     interface = ctx.actions.declare_file(
-        paths.replace_extension(src.basename, ".hi" if not with_profiling else ".p_hi"),
+        paths.replace_extension(src.basename, extension_template % "hi"),
         sibling = src,
     )
 

--- a/tests/haskell_module/hs-boot/BUILD.bazel
+++ b/tests/haskell_module/hs-boot/BUILD.bazel
@@ -1,0 +1,56 @@
+load(
+    "@rules_haskell//haskell:defs.bzl",
+    "haskell_library",
+    "haskell_test",
+)
+load("@rules_haskell//haskell/experimental:defs.bzl", "haskell_module")
+
+package(default_testonly = 1)
+
+haskell_module(
+    name = "lib-A-boot",
+    src = "src/A.hs-boot",
+    src_strip_prefix = "src",
+    deps = [
+        "//tests/hackage:base",
+    ],
+)
+
+haskell_module(
+    name = "lib-B",
+    src = "src/B.hs",
+    src_strip_prefix = "src",
+    deps = [
+        ":lib-A-boot",
+        "//tests/hackage:base",
+    ],
+)
+
+haskell_module(
+    name = "lib-A",
+    src = "src/A.hs",
+    src_strip_prefix = "src",
+    deps = [
+        ":lib-B",
+        "//tests/hackage:base",
+    ],
+)
+
+haskell_library(
+    name = "hs-boot-lib",
+    modules = [
+        ":lib-B",
+        ":lib-A",
+    ],
+    deps = ["//tests/hackage:base"],
+)
+
+haskell_test(
+    name = "hs-boot",
+    srcs = ["Main.hs"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":hs-boot-lib",
+        "//tests/hackage:base",
+    ],
+)

--- a/tests/haskell_module/hs-boot/Main.hs
+++ b/tests/haskell_module/hs-boot/Main.hs
@@ -1,0 +1,7 @@
+module Main (main) where
+
+import A ()
+import B ()
+
+main :: IO ()
+main = putStrLn "hsboot"

--- a/tests/haskell_module/hs-boot/src/A.hs
+++ b/tests/haskell_module/hs-boot/src/A.hs
@@ -1,0 +1,8 @@
+module A where
+
+import B (TB (..))
+
+newtype TA = MkTA Int
+
+f :: TB -> TA
+f (MkTB x) = MkTA x

--- a/tests/haskell_module/hs-boot/src/A.hs-boot
+++ b/tests/haskell_module/hs-boot/src/A.hs-boot
@@ -1,0 +1,2 @@
+module A where
+  newtype TA = MkTA Int

--- a/tests/haskell_module/hs-boot/src/B.hs
+++ b/tests/haskell_module/hs-boot/src/B.hs
@@ -1,0 +1,8 @@
+module B where
+
+import {-# SOURCE #-} A (TA (..))
+
+data TB = MkTB !Int
+
+g :: TA -> TB
+g (MkTA x) = MkTB x


### PR DESCRIPTION
depends on: #1564 

I'm not sure if this is the right way to do hs-boot support in haskell_module(). In particular, it would be nice if the `.hs` and `.hs-boot` files could be passed in to the same `haskell_module()` command. To use this, however, would create a cyclic dependency in bazel, which I'm pretty sure it won't be happy about.

Instead the way I've implemented it you have to create a separate module for the `.hs-boot` file by itself.