### PR TITLE
Don't set -fplugin by default if plugin.module is empty

### DIFF
--- a/haskell/plugins.bzl
+++ b/haskell/plugins.bzl
@@ -19,7 +19,7 @@ ghc_plugin = rule(
     ghc_plugin_impl,
     attrs = {
         "module": attr.string(
-            doc = "Plugin entrypoint.",
+            doc = "Plugin entrypoint. Omit it to prevent -fplugin= from being set by default.",
         ),
         "deps": attr.label_list(
             doc = "Plugin dependencies. These are compile-time dependencies only.",

--- a/haskell/private/actions/compile.bzl
+++ b/haskell/private/actions/compile.bzl
@@ -303,9 +303,10 @@ def _compilation_defaults(hs, cc, java, posix, dep_info, plugin_dep_info, srcs, 
 
     # Plugins
     for plugin in plugins:
-        args.add("-fplugin={}".format(plugin.module))
-        for opt in plugin.args:
-            args.add_all(["-fplugin-opt", "{}:{}".format(plugin.module, opt)])
+        if plugin.module != "":
+            args.add("-fplugin={}".format(plugin.module))
+            for opt in plugin.args:
+                args.add_all(["-fplugin-opt", "{}:{}".format(plugin.module, opt)])
 
     plugin_tool_inputs = depset(transitive = [plugin.tool_inputs for plugin in plugins])
     plugin_tool_input_manifests = [


### PR DESCRIPTION
This is necessary when the plugin fails if run on some modules of a package.