### PR TITLE
Test `bazel test //...` in all configurations

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -52,7 +52,7 @@ jobs:
             ./tests/run-start-script.sh --use-nix
             bazel build //tests:run-tests
             ./bazel-ci-bin/tests/run-tests
-            bazel coverage //tests/...
+            bazel coverage //...
             bazel build //docs:api_html
             bazel build //docs:guide_html
             '
@@ -141,7 +141,12 @@ jobs:
           export PATH=$HOME/bazel:$PATH
           [[ ${{ matrix.os }} == macos ]] && export BAZEL_USE_CPP_ONLY_TOOLCHAIN=1
           ./tests/run-start-script.sh --use-bindists
-          bazel test //tests/...
+          if [[ ${{ matrix.os }} == windows ]]; then
+            # On Windows `//...` expands to `/...`.
+            bazel test ///...
+          else
+            bazel test //...
+          fi
           # Test stack_snapshot pinning
           # NOTE keep in sync with tests/RunTests.hs
           bazel run @stackage-pinning-test-unpinned//:pin

--- a/debug/linking_utils/BUILD.bazel
+++ b/debug/linking_utils/BUILD.bazel
@@ -44,6 +44,9 @@ if res != {}:
   pprint.pprint(res)
   exit(1)
 ''',
-    # it only works on linux
-    tags = ["dont_test_on_darwin"],
+    # it only works on linux with nixpkgs
+    tags = [
+        "dont_test_on_darwin",
+        "requires_nix",
+    ],
 )

--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -46,6 +46,7 @@ libraries = [
             input = "//haskell:%s.bzl" % lib,
             provider_template = ":templates/metadata/provider.vm",
             rule_template = ":templates/metadata/rule.vm",
+            tags = ["dont_test_on_windows"],
             deps = ["//haskell"],
         ),
         # Generate markdown API documentation.
@@ -58,6 +59,7 @@ libraries = [
             input = "//haskell:%s.bzl" % lib,
             provider_template = ":templates/markdown/provider.vm",
             rule_template = ":templates/markdown/rule.vm",
+            tags = ["dont_test_on_windows"],
             deps = ["//haskell"],
         ),
         # Convert markdown to html.
@@ -82,6 +84,7 @@ $(execpath //docs/pandoc) \
   -o $(OUTS) \
   $(execpath :{}_md)
 """.format(lib),
+            tags = ["dont_test_on_windows"],
             toolchains = [":set_site_end_location"],
             tools = ["//docs/pandoc"],
         ),
@@ -102,6 +105,7 @@ for file in $(SRCS); do
   cat $$file >>$(OUTS)
 done
 """,
+    tags = ["dont_test_on_windows"],
 )
 
 # Generate top-level API documentation navigation sidebar.
@@ -124,6 +128,7 @@ $(execpath //docs/pandoc) \
   --metadata-file=$(execpath :metadata) \
   <<<""
 """,
+    tags = ["dont_test_on_windows"],
     toolchains = [":set_site_end_location"],
     tools = ["//docs/pandoc"],
 )
@@ -165,6 +170,7 @@ $(execpath //docs/pandoc) \
   --metadata-file=$(execpath :metadata) \
   index_body.html
 """,
+    tags = ["dont_test_on_windows"],
     toolchains = [":set_site_end_location"],
     tools = ["//docs/pandoc"],
 )
@@ -190,6 +196,7 @@ $(location @bazel_tools//tools/zip:zipper) c $@ %s
             ":index_html",
         ] + [":%s_html" % lib for lib in libraries]
     ]),
+    tags = ["dont_test_on_windows"],
     tools = ["@bazel_tools//tools/zip:zipper"],
 )
 
@@ -199,6 +206,7 @@ py_binary(
     srcs = ["serve.py"],
     args = ["$(rootpath :api_html)"],
     data = [":api_html"],
+    tags = ["dont_test_on_windows"],
 )
 
 genrule(
@@ -220,7 +228,10 @@ genrule(
     (cd $$builddir/html && zip -q -r $$CWD/$@ .)
     rm -rf $$builddir
     """,
-    tags = ["requires_nix"],
+    tags = [
+        "dont_test_on_windows",
+        "requires_nix",
+    ],
     tools = [
         "@graphviz//:bin",
         "@sphinx//:bin",

--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -220,6 +220,7 @@ genrule(
     (cd $$builddir/html && zip -q -r $$CWD/$@ .)
     rm -rf $$builddir
     """,
+    tags = ["requires_nix"],
     tools = [
         "@graphviz//:bin",
         "@sphinx//:bin",

--- a/docs/pandoc/BUILD.bazel
+++ b/docs/pandoc/BUILD.bazel
@@ -8,6 +8,7 @@ toolchain_type(
 
 pandoc(
     name = "pandoc",
+    tags = ["dont_test_on_windows"],
     visibility = ["//visibility:public"],
 )
 

--- a/rule_info/BUILD.bazel
+++ b/rule_info/BUILD.bazel
@@ -10,6 +10,7 @@ proto_library(
 
 haskell_proto_library(
     name = "rule_info_haskell_proto",
+    tags = ["requires_dynamic"],
     visibility = ["//visibility:public"],
     deps = [":rule_info_proto"],
 )

--- a/tests/RunTests.hs
+++ b/tests/RunTests.hs
@@ -22,7 +22,7 @@ main = hspec $ do
     assertSuccess (bazel ["run", "//:buildifier"])
 
   it "bazel test" $ do
-    assertSuccess (bazel ["test", "//...", "--build_tests_only"])
+    assertSuccess (bazel ["test", "//..."])
 
   it "bazel test prof" $ do
     -- In .github/workflows/workflow.yaml we specify --test_tag_filters
@@ -31,7 +31,7 @@ main = hspec $ do
     -- we have to duplicate that filter here.
     let tagFilter | os == "darwin" = "-dont_test_on_darwin,-requires_dynamic,-skip_profiling"
                   | otherwise      = "-requires_dynamic,-skip_profiling"
-    assertSuccess (bazel ["test", "-c", "dbg", "//...", "--build_tests_only", "--test_tag_filters", tagFilter])
+    assertSuccess (bazel ["test", "-c", "dbg", "//...", "--build_tag_filters", tagFilter, "--test_tag_filters", tagFilter])
 
   it "bazel build worker" $ do
     assertSuccess (bazel ["build", "//tools/worker:bin"])

--- a/tests/haddock-with-plugin/BUILD.bazel
+++ b/tests/haddock-with-plugin/BUILD.bazel
@@ -26,6 +26,7 @@ haskell_library(
     name = "library",
     srcs = ["Lib.hs"],
     plugins = [":plugin"],
+    tags = ["skip_profiling"],
     deps = ["//tests/hackage:base"],
 )
 

--- a/tests/haddock/BUILD.bazel
+++ b/tests/haddock/BUILD.bazel
@@ -23,6 +23,7 @@ haskell_library(
         "header.h",
     ],
     compiler_flags = ["-I."],
+    tags = ["requires_dynamic"],
     deps = [
         ":haddock-lib-deep",
         "//tests/hackage:base",
@@ -44,6 +45,7 @@ haskell_library(
         # This is missing on darwin with bindist due to
         # https://github.com/tweag/rules_haskell/issues/1317.
         "dont_test_on_darwin_with_bindist",
+        "requires_dynamic",
     ],
     deps = [
         ":haddock-lib-a",
@@ -59,6 +61,7 @@ haskell_doc(
     tags = [
         "dont_test_on_darwin_with_bindist",
         "dont_test_on_windows",
+        "requires_dynamic",
     ],
     deps = [":haddock-lib-b"],
 )
@@ -83,6 +86,7 @@ haskell_doc(
     tags = [
         "dont_test_on_darwin_with_bindist",
         "dont_test_on_windows",
+        "requires_dynamic",
     ],
     deps = [":haddock-lib-b"],
 )

--- a/tests/haddock_protobuf/BUILD.bazel
+++ b/tests/haddock_protobuf/BUILD.bazel
@@ -13,6 +13,7 @@ proto_library(
 
 haskell_proto_library(
     name = "hello_world_haskell_proto",
+    tags = ["requires_dynamic"],
     deps = [
         ":hello_world_proto",
     ],
@@ -21,6 +22,7 @@ haskell_proto_library(
 haskell_library(
     name = "hello_world_haskell",
     srcs = ["HelloWorld.hs"],  # Just imports the proto and does something trivial
+    tags = ["requires_dynamic"],
     deps = [
         ":hello_world_haskell_proto",
         "@stackage//:base",
@@ -30,7 +32,10 @@ haskell_library(
 # Haddocks version A: depend on just the haskell_library
 haskell_doc(
     name = "haddocks_a",
-    tags = ["dont_test_on_windows"],
+    tags = [
+        "dont_test_on_windows",
+        "requires_dynamic",
+    ],
     deps = [
         ":hello_world_haskell",
     ],
@@ -39,7 +44,10 @@ haskell_doc(
 # Haddocks version B: depend on both haskell_library and haskell_proto_library
 haskell_doc(
     name = "haddocks_b",
-    tags = ["dont_test_on_windows"],
+    tags = [
+        "dont_test_on_windows",
+        "requires_dynamic",
+    ],
     deps = [
         ":hello_world_haskell",
         ":hello_world_haskell_proto",

--- a/tests/haskell_doctest/BUILD.bazel
+++ b/tests/haskell_doctest/BUILD.bazel
@@ -36,6 +36,7 @@ haskell_doctest(
 haskell_doctest(
     name = "doctest-lib-all-success",
     doctest_flags = ["-DMAGIC_DOCTEST_THING"],
+    tags = ["requires_dynamic"],
     visibility = ["//visibility:public"],
     deps = [":lib-b"],
 )
@@ -58,6 +59,7 @@ haskell_test(
 
 haskell_doctest(
     name = "doctest-bin",
+    tags = ["requires_dynamic"],
     visibility = ["//visibility:public"],
     deps = [":bin"],
 )

--- a/tests/haskell_proto_library/BUILD.bazel
+++ b/tests/haskell_proto_library/BUILD.bazel
@@ -39,22 +39,26 @@ proto_library(
 
 haskell_proto_library(
     name = "address_haskell_proto",
+    tags = ["requires_dynamic"],
     deps = [":address_proto"],
 )
 
 haskell_proto_library(
     name = "stripped_address_haskell_proto",
+    tags = ["requires_dynamic"],
     deps = [":stripped_address_proto"],
 )
 
 haskell_proto_library(
     name = "person_haskell_proto",
+    tags = ["requires_dynamic"],
     deps = [":person_proto"],
 )
 
 haskell_library(
     name = "hs-lib",
     srcs = ["Bar.hs"],
+    tags = ["requires_dynamic"],
     visibility = ["//visibility:public"],
     deps = [
         ":address_haskell_proto",
@@ -66,6 +70,9 @@ haskell_library(
 
 haskell_doc(
     name = "docs",
-    tags = ["dont_test_on_windows"],
+    tags = [
+        "dont_test_on_windows",
+        "requires_dynamic",
+    ],
     deps = [":hs-lib"],
 )

--- a/tests/haskell_proto_simple/BUILD.bazel
+++ b/tests/haskell_proto_simple/BUILD.bazel
@@ -20,6 +20,7 @@ haskell_proto_library(
     tags = [
         # Requires proto-lens >=0.6.0.0. On Windows we're stuck on 0.5.1.0 until we can update GHC.
         "dont_test_on_windows",
+        "requires_dynamic",
     ],
     deps = [
         ":foo",
@@ -31,6 +32,7 @@ haskell_library(
     srcs = ["Bar.hs"],
     tags = [
         "dont_test_on_windows",
+        "requires_dynamic",
     ],
     visibility = ["//visibility:public"],
     deps = [

--- a/tests/library-deps/BUILD.bazel
+++ b/tests/library-deps/BUILD.bazel
@@ -9,6 +9,7 @@ package(default_testonly = 1)
 haskell_library(
     name = "library-deps",
     srcs = ["TestLib.hs"],
+    tags = ["requires_dynamic"],
     visibility = ["//visibility:public"],
     deps = [
         "//tests/hackage:base",
@@ -20,6 +21,7 @@ haskell_test(
     name = "bin-deps",
     size = "small",
     srcs = ["Bin.hs"],
+    tags = ["requires_dynamic"],
     visibility = ["//visibility:public"],
     deps = [
         "//tests/hackage:base",

--- a/tests/library-with-sysincludes/BUILD.bazel
+++ b/tests/library-with-sysincludes/BUILD.bazel
@@ -49,7 +49,10 @@ haskell_library(
         "Lib.hs",
         "TH.hs",
     ],
-    tags = ["requires_nix"],
+    tags = [
+        "requires_dynamic",
+        "requires_nix",
+    ],
     visibility = ["//visibility:public"],
     deps = [
         ":intermediate-library",

--- a/tools/worker/BUILD.bazel
+++ b/tools/worker/BUILD.bazel
@@ -3,6 +3,8 @@ load("@rules_haskell//haskell:cabal.bzl", "haskell_cabal_binary")
 haskell_cabal_binary(
     name = "bin",
     srcs = glob(["**"]),
+    # Requires more recent GHC version than we use on Windows.
+    tags = ["dont_test_on_windows"],
     visibility = ["//visibility:public"],
     deps = [
         "@rules_haskell_worker_dependencies//:base",


### PR DESCRIPTION
As discussed in https://github.com/tweag/rules_haskell/pull/1553#issuecomment-876459314 and https://github.com/tweag/rules_haskell/pull/1553#issuecomment-879215867 `bazel test //...` was previously not fully tested in all configurations. The nixpkgs pipelines only tested `bazel test //... --build_tests_only` and the bindist configurations only tested `bazel test //tests/...`. This PR changes this so that all configurations and the coverage tests use `bazel test //...`. This required adding exclusion tags to some targets that don't work in all configurations.