### PR TITLE
test for a cabal_library that depends on a haskell_library

### DIFF
--- a/tests/haskell_cabal_library_depends_on_haskell_library/BUILD.bazel
+++ b/tests/haskell_cabal_library_depends_on_haskell_library/BUILD.bazel
@@ -1,0 +1,30 @@
+# This is a test where a haskell_cabal_library depends on a regular haskell_library
+
+load("@rules_haskell//haskell:cabal.bzl", "haskell_cabal_library")
+load(
+    "@rules_haskell//haskell:defs.bzl",
+    "haskell_library",
+    "haskell_toolchain_library",
+)
+
+package(default_testonly = 1)
+
+haskell_toolchain_library(name = "base")
+
+haskell_cabal_library(
+    name = "lib",
+    package_name = "lib",
+    srcs = [
+        "Lib.hs",
+        "lib.cabal",
+    ],
+    tags = ["skip_profiling"],  # This test fails with profiling at the moment as cabal seems to be looking for a non profiling version of :other_lib.
+    version = "0.1.0.0",
+    deps = [":other_lib"],
+)
+
+haskell_library(
+    name = "other_lib",
+    srcs = ["Otherlib.hs"],
+    deps = [":base"],
+)

--- a/tests/haskell_cabal_library_depends_on_haskell_library/Lib.hs
+++ b/tests/haskell_cabal_library_depends_on_haskell_library/Lib.hs
@@ -1,0 +1,9 @@
+module Lib where
+
+import OtherLib
+
+x :: Int
+x = 0
+
+z :: String
+z = y

--- a/tests/haskell_cabal_library_depends_on_haskell_library/Otherlib.hs
+++ b/tests/haskell_cabal_library_depends_on_haskell_library/Otherlib.hs
@@ -1,0 +1,4 @@
+module OtherLib where
+
+y :: String
+y = "other lib"

--- a/tests/haskell_cabal_library_depends_on_haskell_library/lib.cabal
+++ b/tests/haskell_cabal_library_depends_on_haskell_library/lib.cabal
@@ -1,0 +1,9 @@
+cabal-version: >=1.10
+name: lib
+version: 0.1.0.0
+build-type: Simple
+
+library
+  build-depends: base, other-lib
+  default-language: Haskell2010
+  exposed-modules: Lib


### PR DESCRIPTION
This adds a test where a `haskell_cabal_library` target depends on a regular `haskell_library`.

This target fails to build in the profiling case as described in issue (#1573).