### PR TITLE
generate_paths_module attribute to haskell_cabal_library rule.

### DIFF
--- a/haskell/cabal.bzl
+++ b/haskell/cabal.bzl
@@ -213,7 +213,7 @@ def _prepare_cabal_inputs(
     # haskell_cabal_library depends on a normal haskell_library.
     # Which is the case with the generate_paths_module
     if with_profiling and generate_paths_module:
-        fail("The generate_paths_module option of haskell_cabal_library is not compatible with the profiling mode yet.")
+        fail("The generate_paths_module options of haskell_cabal_library/haskell_cabal_binary are not compatible with the profiling mode yet.")
 
     # Haskell library dependencies or indirect C library dependencies are
     # already covered by their corresponding package-db entries. We only need

--- a/haskell/cabal.bzl
+++ b/haskell/cabal.bzl
@@ -282,11 +282,11 @@ def _prepare_cabal_inputs(
     ]
     extra_args = ["--flags=" + " ".join(flags)]
 
-    version = [int(x) for x in hs.toolchain.version.split(".")]
+    ghc_version = [int(x) for x in hs.toolchain.version.split(".")]
     if dynamic_file:
         # See Note [No PIE when linking] in haskell/private/actions/link.bzl
         if not (hs.toolchain.is_darwin or hs.toolchain.is_windows):
-            if version < [8, 10] or not is_library:
+            if ghc_version < [8, 10] or not is_library:
                 extra_args.append("--ghc-option=-optl-no-pie")
     extra_args.extend(hs.toolchain.cabalopts + cabalopts)
     if dynamic_file:
@@ -357,7 +357,7 @@ def _prepare_cabal_inputs(
         path_args = path_args,
         toolchain_info = _cabal_toolchain_info(hs, cc, workspace_name, runghc),
         generate_paths_module = generate_paths_module,
-        ghc_version = version,
+        ghc_version = ghc_version,
         cabal_basename = cabal.basename,
         cabal_dirname = cabal.dirname,
     )

--- a/haskell/cabal.bzl
+++ b/haskell/cabal.bzl
@@ -684,9 +684,9 @@ haskell_cabal_library = rule(
             the tools are executed as part of the build.""",
         ),
         "generate_paths_module": attr.bool(
-            doc = """ If true the rule will generate a Paths_pkgname based on the haskell_runfiles library.
-            WARNING: not supported yet in profiling mode.
-            https://cabal.readthedocs.io/en/3.4/cabal-package.html#accessing-data-files-from-package-code
+            doc = """ If True the rule will generate a [Paths_{pkgname}](https://cabal.readthedocs.io/en/3.4/cabal-package.html#accessing-data-files-from-package-code) module based on the haskell_runfiles library.
+            In that case, the `@rules_haskell//tools/runfiles` target should also be added to the deps attribute.  
+            WARNING: this is not supported in profiling mode yet.
             """,
             default = False,
         ),

--- a/haskell/cabal.bzl
+++ b/haskell/cabal.bzl
@@ -208,6 +208,13 @@ def _prepare_cabal_inputs(
     """Compute Cabal wrapper, arguments, inputs."""
     with_profiling = is_profiling_enabled(hs)
 
+    # Fail if generate_paths_module and profiling are active at the
+    # same time. For now, the build fails in profiling mode if a
+    # haskell_cabal_library depends on a normal haskell_library.
+    # Which is the case with the generate_paths_module
+    if with_profiling and generate_paths_module:
+        fail("The generate_paths_module option of haskell_cabal_library is not compatible with the profiling mode yet.")
+
     # Haskell library dependencies or indirect C library dependencies are
     # already covered by their corresponding package-db entries. We only need
     # to add libraries and headers for direct C library dependencies to the
@@ -678,6 +685,7 @@ haskell_cabal_library = rule(
         ),
         "generate_paths_module": attr.bool(
             doc = """ If true the rule will generate a Paths_pkgname based on the haskell_runfiles library.
+            WARNING: not supported yet in profiling mode.
             https://cabal.readthedocs.io/en/3.4/cabal-package.html#accessing-data-files-from-package-code
             """,
             default = False,

--- a/haskell/cabal.bzl
+++ b/haskell/cabal.bzl
@@ -829,7 +829,7 @@ def _haskell_cabal_binary_impl(ctx):
         runghc = ctx.executable._runghc,
         package_database = package_database,
         verbose = ctx.attr.verbose,
-        generate_paths_module = False,
+        generate_paths_module = ctx.attr.generate_paths_module,
         dynamic_file = binary,
         transitive_haddocks = _gather_transitive_haddocks(ctx.attr.deps),
     )
@@ -913,6 +913,13 @@ haskell_cabal_binary = rule(
             allow_files = True,
             doc = """Tool dependencies. They are built using the host configuration, since
             the tools are executed as part of the build.""",
+        ),
+        "generate_paths_module": attr.bool(
+            doc = """ If True the rule will generate a [Paths_{pkgname}](https://cabal.readthedocs.io/en/3.4/cabal-package.html#accessing-data-files-from-package-code) module based on the haskell_runfiles library.
+            In that case, the `@rules_haskell//tools/runfiles` target should also be added to the deps attribute.  
+            WARNING: this is not supported in profiling mode yet.
+            """,
+            default = False,
         ),
         "flags": attr.string_list(
             doc = "List of Cabal flags, will be passed to `Setup.hs configure --flags=...`.",

--- a/haskell/cabal_wrapper.bzl
+++ b/haskell/cabal_wrapper.bzl
@@ -9,5 +9,8 @@ def cabal_wrapper(name, **kwargs):
         deps = [
             "@bazel_tools//tools/python/runfiles",
         ],
+        data = [
+            "@rules_haskell//haskell:private/generate_cabal_paths_module.py",
+        ],
         **kwargs
     )

--- a/haskell/cabal_wrapper.bzl
+++ b/haskell/cabal_wrapper.bzl
@@ -3,14 +3,14 @@ load("@rules_python//python:defs.bzl", "py_binary")
 def cabal_wrapper(name, **kwargs):
     py_binary(
         name = name,
-        srcs = ["@rules_haskell//haskell:private/cabal_wrapper.py"],
+        srcs = [
+            "@rules_haskell//haskell:private/cabal_wrapper.py",
+            "@rules_haskell//haskell:private/generate_cabal_paths_module.py",
+        ],
         srcs_version = "PY3",
         python_version = "PY3",
         deps = [
             "@bazel_tools//tools/python/runfiles",
-        ],
-        data = [
-            "@rules_haskell//haskell:private/generate_cabal_paths_module.py",
         ],
         **kwargs
     )

--- a/haskell/private/cabal_wrapper.py
+++ b/haskell/private/cabal_wrapper.py
@@ -180,10 +180,8 @@ with tmpdir() as distdir:
     generated_paths_file = None
     if json_args["generate_paths_module"]:
         component_name = component.split(':')[1]
-        mangled_component_name = component_name.replace("-", "_")
-        cabal_paths_file_content = generate_cabal_paths_module(
+        (paths_file, cabal_paths_file_content) = generate_cabal_paths_module(
             component_name = component_name,
-            mangled_component_name = mangled_component_name,
             ghc_version = json_args["ghc_version"],
             is_windows = is_windows,
             cabal_basename = json_args["cabal_basename"],
@@ -196,7 +194,6 @@ with tmpdir() as distdir:
             pkgroot = pkgroot,
             workspace = toolchain_info["workspace"],
         )
-        paths_file = f"Paths_{mangled_component_name}.hs"
         if not os.path.exists(paths_file):
             with open(paths_file, 'w') as f:
                 f.write(cabal_paths_file_content)

--- a/haskell/private/generate_cabal_paths_module.py
+++ b/haskell/private/generate_cabal_paths_module.py
@@ -4,6 +4,13 @@ We modify the getDataFileName and getDataDir functions to use bazel's runfile li
 And we try to keep the same behavior as before for the others functions
 (getBinDir getLibDir getDynLibDir getLibexecDir getSysconfDir).
 
+These functions are defined by cabal through the following files:
+https://github.com/haskell/cabal/blob/master/Cabal/src/Distribution/Simple/Build/PathsModule.hs
+https://github.com/haskell/cabal/blob/master/templates/Paths_pkg.template.hs
+
+For windows we need to implement the "absolute" case of the template.
+Otherwise we want the "relocatable" case since we called configure with "--enable-relocatable".
+
 """
 import re
 import os
@@ -38,6 +45,7 @@ def generate_cabal_paths_module(component_name, mangled_component_name, ghc_vers
                                 ghc, libdir, dynlibdir, bindir, datadir, pkgroot, workspace):
 
     # cabal calls ghc --info to recover the target arch and os, and uses these in path names.
+    # https://github.com/haskell/cabal/blob/496d6fcc26779e754523a6cc7576aea49ef8056e/Cabal/src/Distribution/Simple/GHC/Internal.hs#L87
     # So we do the same.
     p = Popen(f"{ghc} --info", shell=True, stdout=PIPE)
     ghc_info_string = p.stdout.read().decode("utf-8")

--- a/haskell/private/generate_cabal_paths_module.py
+++ b/haskell/private/generate_cabal_paths_module.py
@@ -1,0 +1,243 @@
+""" Generates a Paths_libname module instead of cabal.
+
+We modify the getDataFileName and getDataDir functions to use bazel's runfile library.
+And we try to keep the same behavior as before for the others functions
+(getBinDir getLibDir getDynLibDir getLibexecDir getSysconfDir).
+
+"""
+import re
+import os
+import json
+import ast
+from subprocess import (Popen, PIPE)
+
+def normalise_os(os):
+    """ recognise os name using aliases known to cabal """
+    os = os.lower()
+    if os in ["mingw32", "win32", "cygwin32"]: return "windows"
+    if os == "darwin": return "osx"
+    if os == "gnu": return "hurd"
+    if os == "kfreebsdgnu": return "freebsd"
+    if os == "solaris2": return "solaris"
+    if os in ["linux-android", "linux-androideabi", "linux-androideabihf"]:
+        return "android"
+    return os
+
+def normalise_arch(arch):
+    """ recognise architecture name using aliases known to cabal """
+    arch = arch.lower()
+    if arch == "powerpc": return "ppc"
+    if arch in ["powerpc64", "powerpc64le"]: return "ppc64"
+    if arch in ["sparc64", "sun4"]: return "sparc"
+    if arch in ["mipsel", "mipseb"]: return "mips"
+    if arch in ["armeb", "armel"]: return "arm"
+    if arch == "arm64": return "aarch64"
+    return arch
+ 
+def generate_cabal_paths_module(component_name, mangled_component_name, ghc_version, is_windows, cabal_basename, cabal_dirname,
+                                ghc, libdir, dynlibdir, bindir, datadir, pkgroot, workspace):
+
+    # cabal calls ghc --info to recover the target arch and os, and uses these in path names.
+    # So we do the same.
+    p = Popen(f"{ghc} --info", shell=True, stdout=PIPE)
+    ghc_info_string = p.stdout.read().decode("utf-8")
+    ghc_info = ast.literal_eval("("+ghc_info_string+")")
+    for (k, v) in ghc_info:
+        if k == "Target platform":
+            m = re.match("([^-]*)-[^-]*-([^-]*)", v, re.IGNORECASE)
+            if m:
+                target_arch = normalise_arch(m.group(1))
+                target_os = normalise_os(m.group(2))
+                ghc_version_string = ".".join((str(n) for n in ghc_version))
+                config = f"{target_arch}-{target_os}-ghc-{ghc_version_string}"
+
+    # Recover the package version from the cabal file
+    with open(cabal_basename) as cabal_file:
+        cabal_file_content = cabal_file.readlines()
+    package_version = None
+    for line in cabal_file_content:
+        m = re.match("version:\s*([\d.]+)", line, re.IGNORECASE)
+        if m:
+            package_version = m.group(1)
+    if not package_version:
+        print("could not find a package version inside cabal file")
+        exit(1)
+
+    supports_cpp = ghc_version >= [6,6,1]
+    supports_rebindable_syntax = ghc_version >= [7,0,1]
+    package_version_numbers = [int(c) for c in package_version.split('.')]
+    version_definition = """version = Version {} []""".format(package_version_numbers)
+
+    if is_windows:
+        cabal_dirname = cabal_dirname.replace("/", r"\\")
+        path_separator = r'\\'
+        is_path_separator_definition = r"""isPathSeparator c = c == '/' || c == '\\'"""
+        other_functions = r"""
+prefix :: FilePath
+prefix = "{pkgroot}"
+
+getBinDir     = return $ prefix `joinFileName` bindir
+getLibDir     = return $ prefix `joinFileName` libdir
+getDynLibDir  = return $ prefix `joinFileName` dynlibdir
+getLibexecDir = return $ prefix `joinFileName` ("{component_name}-{package_version}" ++ libexecCommonSuffix)
+getSysconfDir = return $ prefix `joinFileName` sysconfdir
+""".format(
+    pkgroot = pkgroot.replace("\\", r"\\"),
+    component_name = component_name,
+    package_version = package_version,
+           )
+    else:
+        path_separator = '/'
+        is_path_separator_definition = """isPathSeparator c = c == '/'"""
+        other_functions = """
+getPrefixDirReloc :: FilePath -> IO FilePath
+getPrefixDirReloc dirRel = do
+    exePath <- getExecutablePath
+    let (dir,_) = splitFileName exePath
+    return ((dir `minusFileName` bindir) `joinFileName` dirRel)
+
+getExePath = getExecutablePath
+getBinDir     = catchIO (getEnv $ packageName++"_bindir")     (\_ -> getPrefixDirReloc bindir)
+getLibDir     = catchIO (getEnv $ packageName++"_libdir")     (\_ -> getPrefixDirReloc libdir)
+getDynLibDir  = catchIO (getEnv $ packageName++"_dynlibdir")  (\_ -> getPrefixDirReloc dynlibdir)
+getLibexecDir = catchIO (getEnv $ packageName++"_libexecdir") (\_ -> getPrefixDirReloc libexecdir)
+getSysconfDir = catchIO (getEnv $ packageName++"_sysconfdir") (\_ -> getPrefixDirReloc sysconfdir)
+
+"""
+
+    rebindable_syntax_pragma = ("{-# LANGUAGE NoRebindableSyntax #-}"
+                                if supports_rebindable_syntax else "")
+    if supports_cpp:
+        cpp_pragma = "{-# LANGUAGE CPP #-}"
+        catch_io_type = """
+#if defined(VERSION_base)
+
+#if MIN_VERSION_base(4,0,0)
+catchIO :: IO a -> (Exception.IOException -> IO a) -> IO a
+#else
+catchIO :: IO a -> (Exception.Exception -> IO a) -> IO a
+#endif
+
+#else
+catchIO :: IO a -> (Exception.IOException -> IO a) -> IO a
+#endif
+    """
+    else:
+        cpp_pragma = ""
+        catch_io_type = """
+catchIO :: IO a -> (Exception.IOException -> IO a) -> IO a
+    """
+
+    cabal_paths_file_content = """
+-- Based on the Paths_pkg.template.hs file from cabal.
+-- We are only interested in the relocatable case.
+{cpp_pragma}
+{rebindable_syntax_pragma}
+
+{{-# LANGUAGE ForeignFunctionInterface #-}}
+{{-# OPTIONS_GHC -fno-warn-missing-import-lists #-}}
+{{-# OPTIONS_GHC -w #-}}
+
+module Paths_{mangled_component_name} (
+    version,
+    getBinDir, getLibDir, getDynLibDir, getDataDir, getLibexecDir,
+    getDataFileName, getSysconfDir
+  ) where
+
+import qualified Bazel.Runfiles as Runfiles
+import System.Environment (getEnv, getExecutablePath)
+import qualified Control.Exception as Exception
+import Data.Version (Version(..))
+import Prelude
+
+{catch_io_type}
+catchIO = Exception.catch
+
+version :: Version
+{version_definition}
+
+s = [pathSeparator]
+dataDirWorkspacePath = "{workspace}"++s++"{cabal_dirname}"++s++"_install"++s++"{datadir}"
+packageName = "{component_name}"
+
+libdir = "{libdir}"
+bindir = "{bindir}"
+dynlibdir = "{dynlibdir}"
+libexecCommonSuffix = s ++ "{config}" ++ s ++ "{component_name}-{package_version}"
+libexecdir = "libexec" ++ libexecCommonSuffix
+sysconfdir = "etc"
+
+getDataDirFromBazel :: IO FilePath
+getDataDirFromBazel = do
+    r <- Runfiles.create
+    let path = Runfiles.rlocation r $ dataDirWorkspacePath
+    return path
+
+getDataFileName :: FilePath -> IO FilePath
+getDataFileName name = do
+    datadir <- getDataDir
+    return $ datadir++s++name
+
+getDataDir = catchIO
+    (getEnv (packageName++"_datadir"))
+    (\_ -> getDataDirFromBazel) 
+
+getBinDir, getLibDir, getDynLibDir, getDataDir, getLibexecDir, getSysconfDir :: IO FilePath
+{other_functions}
+
+-- Utility functions 
+minusFileName :: FilePath -> String -> FilePath
+minusFileName dir ""     = dir
+minusFileName dir "."    = dir
+minusFileName dir suffix =
+    minusFileName (fst (splitFileName dir)) (fst (splitFileName suffix))
+
+splitFileName :: FilePath -> (String, String)
+splitFileName p = (reverse (path2++drive), reverse fname)
+  where
+    (path,drive) = case p of
+      (c:':':p') -> (reverse p',[':',c])
+      _          -> (reverse p ,"")
+    (fname,path1) = break isPathSeparator path
+    path2 = case path1 of
+      []                           -> "."
+      [_]                          -> path1   -- don't remove the trailing slash if
+                                            -- there is only one character
+      (c:path') | isPathSeparator c -> path'
+      _                             -> path1
+
+
+joinFileName :: String -> String -> FilePath
+joinFileName ""  fname = fname
+joinFileName "." fname = fname
+joinFileName dir ""    = dir
+joinFileName dir fname
+  | isPathSeparator (last dir) = dir ++ fname
+  | otherwise                  = dir ++ pathSeparator : fname
+
+pathSeparator :: Char
+pathSeparator = '{path_separator}'
+
+isPathSeparator :: Char -> Bool
+{is_path_separator_definition}
+    
+    """.format(
+        cpp_pragma = cpp_pragma,
+        component_name = component_name,
+        mangled_component_name = mangled_component_name,
+        catch_io_type = catch_io_type,
+        version_definition = version_definition,
+        path_separator = path_separator,
+        is_path_separator_definition = is_path_separator_definition,
+        package_version = package_version,
+        rebindable_syntax_pragma = rebindable_syntax_pragma,
+        config = config,
+        libdir = libdir,
+        dynlibdir = dynlibdir,
+        bindir = bindir,
+        datadir = datadir,
+        cabal_dirname = cabal_dirname,
+        workspace = workspace,
+        other_functions = other_functions,
+    )
+    return cabal_paths_file_content

--- a/haskell/private/generate_cabal_paths_module.py
+++ b/haskell/private/generate_cabal_paths_module.py
@@ -65,10 +65,12 @@ def generate_cabal_paths_module(component_name, ghc_version, is_windows, cabal_b
     package_version = None
     cabal_package_name = None
     for line in cabal_file_content:
-        if m := re.match("version:\s*([\d.]+)", line, re.IGNORECASE):
+        m = re.match("version:\s*([\d.]+)", line, re.IGNORECASE)
+        if m :
             package_version = m.group(1)
             continue
-        if m := re.match("name:\s*([a-zA-Z0-9\-]+)", line, re.IGNORECASE):
+        m = re.match("name:\s*([a-zA-Z0-9\-]+)", line, re.IGNORECASE)
+        if m :
             cabal_package_name = m.group(1)
 
     if not package_version:

--- a/tests/haskell_cabal_datafiles/compare_other_cabal_functions/BUILD.bazel
+++ b/tests/haskell_cabal_datafiles/compare_other_cabal_functions/BUILD.bazel
@@ -1,0 +1,34 @@
+# The generate_paths_module option generates a Paths_libname file instead of cabal
+# so we can override getDataFileName and getDataDir functions and use bazel's runfile library.
+#
+# We test here that the other functions of the module (that we had to reimplement)
+# have the same behavior as cabal's one.
+#
+
+load(
+    "@rules_haskell//haskell:cabal.bzl",
+    "haskell_cabal_binary",
+    "haskell_cabal_library",
+)
+load(
+    "@rules_haskell//haskell:defs.bzl",
+    "haskell_binary",
+    "haskell_test",
+    "haskell_toolchain_library",
+)
+load("@os_info//:os_info.bzl", "is_windows")
+
+sh_test(
+    name = "same_other_functions{}".format(".exe" if is_windows else ""),
+    size = "small",
+    srcs = ["compare_files.sh"],
+    args = [
+        "$(rootpath //tests/haskell_cabal_datafiles/compare_other_cabal_functions/with_generate_paths_module:write_values)",
+        "$(rootpath //tests/haskell_cabal_datafiles/compare_other_cabal_functions/without_generate_paths_module:write_values)",
+    ],
+    data = [
+        "//tests/haskell_cabal_datafiles/compare_other_cabal_functions/with_generate_paths_module:write_values",
+        "//tests/haskell_cabal_datafiles/compare_other_cabal_functions/without_generate_paths_module:write_values",
+    ],
+    deps = ["@bazel_tools//tools/bash/runfiles"],
+)

--- a/tests/haskell_cabal_datafiles/compare_other_cabal_functions/BUILD.bazel
+++ b/tests/haskell_cabal_datafiles/compare_other_cabal_functions/BUILD.bazel
@@ -30,5 +30,6 @@ sh_test(
         "//tests/haskell_cabal_datafiles/compare_other_cabal_functions/with_generate_paths_module:write_values",
         "//tests/haskell_cabal_datafiles/compare_other_cabal_functions/without_generate_paths_module:write_values",
     ],
+    tags = ["skip_profiling"],
     deps = ["@bazel_tools//tools/bash/runfiles"],
 )

--- a/tests/haskell_cabal_datafiles/compare_other_cabal_functions/compare_files.sh
+++ b/tests/haskell_cabal_datafiles/compare_other_cabal_functions/compare_files.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# --- begin runfiles.bash initialization v2 ---
+# Copy-pasted from the Bazel Bash runfiles library v2.
+set -uo pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
+# --- end runfiles.bash initialization v2 ---
+set -e
+$(rlocation "$TEST_WORKSPACE/$1") out1
+$(rlocation "$TEST_WORKSPACE/$2") out2
+
+diff out1 out2

--- a/tests/haskell_cabal_datafiles/compare_other_cabal_functions/with_generate_paths_module/BUILD.bazel
+++ b/tests/haskell_cabal_datafiles/compare_other_cabal_functions/with_generate_paths_module/BUILD.bazel
@@ -1,0 +1,33 @@
+load(
+    "@rules_haskell//haskell:cabal.bzl",
+    "haskell_cabal_library",
+)
+load(
+    "@rules_haskell//haskell:defs.bzl",
+    "haskell_binary",
+    "haskell_toolchain_library",
+)
+
+haskell_toolchain_library(name = "base")
+
+haskell_cabal_library(
+    name = "lib",
+    package_name = "lib",
+    srcs = [
+        "Lib.hs",
+        "lib.cabal",
+    ],
+    generate_paths_module = True,
+    version = "0.1.0.0",
+    deps = ["//tools/runfiles"],
+)
+
+haskell_binary(
+    name = "write_values",
+    srcs = ["Write.hs"],
+    visibility = ["//tests/haskell_cabal_datafiles/compare_other_cabal_functions:__pkg__"],
+    deps = [
+        ":base",
+        ":lib",
+    ],
+)

--- a/tests/haskell_cabal_datafiles/compare_other_cabal_functions/with_generate_paths_module/BUILD.bazel
+++ b/tests/haskell_cabal_datafiles/compare_other_cabal_functions/with_generate_paths_module/BUILD.bazel
@@ -8,6 +8,8 @@ load(
     "haskell_toolchain_library",
 )
 
+package(default_testonly = 1)
+
 haskell_toolchain_library(name = "base")
 
 haskell_cabal_library(
@@ -18,6 +20,7 @@ haskell_cabal_library(
         "lib.cabal",
     ],
     generate_paths_module = True,
+    tags = ["skip_profiling"],
     version = "0.1.0.0",
     deps = ["//tools/runfiles"],
 )
@@ -25,6 +28,7 @@ haskell_cabal_library(
 haskell_binary(
     name = "write_values",
     srcs = ["Write.hs"],
+    tags = ["skip_profiling"],
     visibility = ["//tests/haskell_cabal_datafiles/compare_other_cabal_functions:__pkg__"],
     deps = [
         ":base",

--- a/tests/haskell_cabal_datafiles/compare_other_cabal_functions/with_generate_paths_module/Lib.hs
+++ b/tests/haskell_cabal_datafiles/compare_other_cabal_functions/with_generate_paths_module/Lib.hs
@@ -1,0 +1,20 @@
+module Lib where
+import Paths_lib
+import System.Environment
+import Data.List
+import System.FilePath
+
+writeCabalPathsValues :: String -> IO ()
+writeCabalPathsValues outputFileName = do
+  bindir <- getBinDir   
+  libdir <- getLibDir     
+  dynlibdir <- getDynLibDir  
+  libexecdir <- getLibexecDir 
+  sysconfdir <- getSysconfDir 
+  exePath <- getExecutablePath
+  let (dir,_) = splitFileName exePath
+  let paths = map (makeRelative dir) [bindir, libdir, dynlibdir, libexecdir, sysconfdir]
+  let v = version
+  writeFile outputFileName $ intercalate "\n"
+      (paths ++ [show v, ""])
+

--- a/tests/haskell_cabal_datafiles/compare_other_cabal_functions/with_generate_paths_module/Write.hs
+++ b/tests/haskell_cabal_datafiles/compare_other_cabal_functions/with_generate_paths_module/Write.hs
@@ -1,0 +1,9 @@
+module Main where
+
+import Lib
+import System.Environment
+
+main = do
+  [outputFileName] <- getArgs
+  writeCabalPathsValues outputFileName
+

--- a/tests/haskell_cabal_datafiles/compare_other_cabal_functions/with_generate_paths_module/lib.cabal
+++ b/tests/haskell_cabal_datafiles/compare_other_cabal_functions/with_generate_paths_module/lib.cabal
@@ -1,0 +1,11 @@
+cabal-version: >=1.10
+name: lib
+version: 0.1.0.0
+build-type: Simple
+
+library
+  build-depends: base, process, runfiles, filepath
+  default-language: Haskell2010
+  exposed-modules: Lib
+  other-modules: Paths_lib
+

--- a/tests/haskell_cabal_datafiles/compare_other_cabal_functions/without_generate_paths_module/BUILD.bazel
+++ b/tests/haskell_cabal_datafiles/compare_other_cabal_functions/without_generate_paths_module/BUILD.bazel
@@ -8,6 +8,8 @@ load(
     "haskell_toolchain_library",
 )
 
+package(default_testonly = 1)
+
 haskell_toolchain_library(name = "base")
 
 haskell_cabal_library(
@@ -18,6 +20,7 @@ haskell_cabal_library(
         "lib.cabal",
     ],
     generate_paths_module = False,
+    tags = ["skip_profiling"],
     version = "0.1.0.0",
     visibility = ["//visibility:public"],
     deps = ["//tools/runfiles"],
@@ -26,6 +29,7 @@ haskell_cabal_library(
 haskell_binary(
     name = "write_values",
     srcs = ["Write.hs"],
+    tags = ["skip_profiling"],
     visibility = ["//tests/haskell_cabal_datafiles/compare_other_cabal_functions:__pkg__"],
     deps = [
         ":base",

--- a/tests/haskell_cabal_datafiles/compare_other_cabal_functions/without_generate_paths_module/BUILD.bazel
+++ b/tests/haskell_cabal_datafiles/compare_other_cabal_functions/without_generate_paths_module/BUILD.bazel
@@ -1,0 +1,34 @@
+load(
+    "@rules_haskell//haskell:cabal.bzl",
+    "haskell_cabal_library",
+)
+load(
+    "@rules_haskell//haskell:defs.bzl",
+    "haskell_binary",
+    "haskell_toolchain_library",
+)
+
+haskell_toolchain_library(name = "base")
+
+haskell_cabal_library(
+    name = "lib",
+    package_name = "lib",
+    srcs = [
+        "Lib.hs",
+        "lib.cabal",
+    ],
+    generate_paths_module = False,
+    version = "0.1.0.0",
+    visibility = ["//visibility:public"],
+    deps = ["//tools/runfiles"],
+)
+
+haskell_binary(
+    name = "write_values",
+    srcs = ["Write.hs"],
+    visibility = ["//tests/haskell_cabal_datafiles/compare_other_cabal_functions:__pkg__"],
+    deps = [
+        ":base",
+        ":lib",
+    ],
+)

--- a/tests/haskell_cabal_datafiles/compare_other_cabal_functions/without_generate_paths_module/Lib.hs
+++ b/tests/haskell_cabal_datafiles/compare_other_cabal_functions/without_generate_paths_module/Lib.hs
@@ -1,0 +1,20 @@
+module Lib where
+import Paths_lib
+import System.Environment
+import Data.List
+import System.FilePath
+
+writeCabalPathsValues :: String -> IO ()
+writeCabalPathsValues outputFileName = do
+  bindir <- getBinDir   
+  libdir <- getLibDir     
+  dynlibdir <- getDynLibDir  
+  libexecdir <- getLibexecDir 
+  sysconfdir <- getSysconfDir 
+  exePath <- getExecutablePath
+  let (dir,_) = splitFileName exePath
+  let paths = map (makeRelative dir) [bindir, libdir, dynlibdir, libexecdir, sysconfdir]
+  let v = version
+  writeFile outputFileName $ intercalate "\n"
+      (paths ++ [show v, ""])
+

--- a/tests/haskell_cabal_datafiles/compare_other_cabal_functions/without_generate_paths_module/Write.hs
+++ b/tests/haskell_cabal_datafiles/compare_other_cabal_functions/without_generate_paths_module/Write.hs
@@ -1,0 +1,9 @@
+module Main where
+
+import Lib
+import System.Environment
+
+main = do
+  [outputFileName] <- getArgs
+  writeCabalPathsValues outputFileName
+

--- a/tests/haskell_cabal_datafiles/compare_other_cabal_functions/without_generate_paths_module/lib.cabal
+++ b/tests/haskell_cabal_datafiles/compare_other_cabal_functions/without_generate_paths_module/lib.cabal
@@ -1,0 +1,11 @@
+cabal-version: >=1.10
+name: lib
+version: 0.1.0.0
+build-type: Simple
+
+library
+  build-depends: base, process, runfiles, filepath
+  default-language: Haskell2010
+  exposed-modules: Lib
+  other-modules: Paths_lib
+

--- a/tests/haskell_cabal_datafiles/haskell_cabal_binary_with_datafiles/BUILD.bazel
+++ b/tests/haskell_cabal_datafiles/haskell_cabal_binary_with_datafiles/BUILD.bazel
@@ -1,0 +1,39 @@
+# Check that we manage to access the runfile while using the generate_paths_module attribute of haskell_cabal_binary
+
+load("@bazel_skylib//rules:diff_test.bzl", "diff_test")
+load("@rules_cc//cc:defs.bzl", "cc_library")
+load(
+    "@rules_haskell//haskell:cabal.bzl",
+    "haskell_cabal_binary",
+    "haskell_cabal_library",
+)
+load(
+    "@rules_haskell//haskell:defs.bzl",
+    "haskell_binary",
+    "haskell_test",
+    "haskell_toolchain_library",
+)
+load("@os_info//:os_info.bzl", "is_windows")
+
+haskell_toolchain_library(name = "base")
+
+haskell_cabal_binary(
+    name = "inside",
+    srcs = [
+        "Main.hs",
+        "datafile",
+        "generate-paths-module-binary.cabal",
+    ],
+    generate_paths_module = True,
+    visibility = ["//tests/haskell_cabal_datafiles/other_script/src:__pkg__"],
+    deps = [
+        ":base",
+        "//tools/runfiles",
+    ],
+)
+
+sh_test(
+    name = "direct_test_inside{}".format(".exe" if is_windows else ""),
+    srcs = [":inside"],
+    tags = ["skip_profiling"],
+)

--- a/tests/haskell_cabal_datafiles/haskell_cabal_binary_with_datafiles/BUILD.bazel
+++ b/tests/haskell_cabal_datafiles/haskell_cabal_binary_with_datafiles/BUILD.bazel
@@ -15,6 +15,8 @@ load(
 )
 load("@os_info//:os_info.bzl", "is_windows")
 
+package(default_testonly = 1)
+
 haskell_toolchain_library(name = "base")
 
 haskell_cabal_binary(
@@ -25,6 +27,7 @@ haskell_cabal_binary(
         "generate-paths-module-binary.cabal",
     ],
     generate_paths_module = True,
+    tags = ["skip_profiling"],
     visibility = ["//tests/haskell_cabal_datafiles/other_script/src:__pkg__"],
     deps = [
         ":base",

--- a/tests/haskell_cabal_datafiles/haskell_cabal_binary_with_datafiles/Main.hs
+++ b/tests/haskell_cabal_datafiles/haskell_cabal_binary_with_datafiles/Main.hs
@@ -1,0 +1,14 @@
+module Main where
+
+import Paths_generate_paths_module_binary
+import Control.Exception
+import System.Exit
+
+readDataFile :: IO ()
+readDataFile = do
+  p <- getDataFileName "datafile"
+  handle ((\e -> print p >> (exitWith $ ExitFailure 1)):: IOException -> IO ()) $ do
+      s <- readFile p
+      return ()
+
+main = readDataFile

--- a/tests/haskell_cabal_datafiles/haskell_cabal_binary_with_datafiles/datafile
+++ b/tests/haskell_cabal_datafiles/haskell_cabal_binary_with_datafiles/datafile
@@ -1,0 +1,1 @@
+datafile_content

--- a/tests/haskell_cabal_datafiles/haskell_cabal_binary_with_datafiles/generate-paths-module-binary.cabal
+++ b/tests/haskell_cabal_datafiles/haskell_cabal_binary_with_datafiles/generate-paths-module-binary.cabal
@@ -1,0 +1,14 @@
+cabal-version: >=1.10
+name: generate-paths-module-binary
+version: 0.1.0.0
+build-type: Simple
+
+data-files:
+  datafile
+
+executable inside
+  build-depends: base, runfiles
+  default-language: Haskell2010
+  main-is: Main.hs
+  other-modules: Paths_generate_paths_module_binary
+  autogen-modules: Paths_generate_paths_module_binary

--- a/tests/haskell_cabal_datafiles/haskell_cabal_library_with_datafiles/BUILD.bazel
+++ b/tests/haskell_cabal_datafiles/haskell_cabal_library_with_datafiles/BUILD.bazel
@@ -34,6 +34,7 @@ haskell_cabal_library(
 haskell_test(
     name = "test_paths_module",
     srcs = ["Main.hs"],
+    tags = ["skip_profiling"],
     deps = [
         ":base",
         ":lib",
@@ -57,4 +58,5 @@ haskell_cabal_binary(
 sh_test(
     name = "direct_test_inside{}".format(".exe" if is_windows else ""),
     srcs = [":inside"],
+    tags = ["skip_profiling"],
 )

--- a/tests/haskell_cabal_datafiles/haskell_cabal_library_with_datafiles/BUILD.bazel
+++ b/tests/haskell_cabal_datafiles/haskell_cabal_library_with_datafiles/BUILD.bazel
@@ -19,13 +19,14 @@ haskell_toolchain_library(name = "base")
 
 haskell_cabal_library(
     name = "lib",
-    package_name = "lib",
+    package_name = "lib-pkg",
     srcs = [
         "Lib.hs",
         "datafile",
         "lib.cabal",
     ],
     generate_paths_module = True,
+    sublibrary_name = "sublib",
     version = "0.1.0.0",
     visibility = ["//visibility:public"],
     deps = ["//tools/runfiles"],

--- a/tests/haskell_cabal_datafiles/haskell_cabal_library_with_datafiles/BUILD.bazel
+++ b/tests/haskell_cabal_datafiles/haskell_cabal_library_with_datafiles/BUILD.bazel
@@ -1,0 +1,60 @@
+# Check that we manage to access the runfile while using the generate_paths_module attribute of haskell_cabal_library
+
+load("@bazel_skylib//rules:diff_test.bzl", "diff_test")
+load("@rules_cc//cc:defs.bzl", "cc_library")
+load(
+    "@rules_haskell//haskell:cabal.bzl",
+    "haskell_cabal_binary",
+    "haskell_cabal_library",
+)
+load(
+    "@rules_haskell//haskell:defs.bzl",
+    "haskell_binary",
+    "haskell_test",
+    "haskell_toolchain_library",
+)
+load("@os_info//:os_info.bzl", "is_windows")
+
+haskell_toolchain_library(name = "base")
+
+haskell_cabal_library(
+    name = "lib",
+    package_name = "lib",
+    srcs = [
+        "Lib.hs",
+        "datafile",
+        "lib.cabal",
+    ],
+    generate_paths_module = True,
+    version = "0.1.0.0",
+    visibility = ["//visibility:public"],
+    deps = ["//tools/runfiles"],
+)
+
+haskell_test(
+    name = "test_paths_module",
+    srcs = ["Main.hs"],
+    deps = [
+        ":base",
+        ":lib",
+    ],
+)
+
+haskell_cabal_binary(
+    name = "inside",
+    srcs = [
+        "Main.hs",
+        "datafile",
+        "lib.cabal",
+    ],
+    flags = [
+        "use-base",
+        "expose-lib",
+    ],
+    deps = [":lib"],
+)
+
+sh_test(
+    name = "direct_test_inside{}".format(".exe" if is_windows else ""),
+    srcs = [":inside"],
+)

--- a/tests/haskell_cabal_datafiles/haskell_cabal_library_with_datafiles/BUILD.bazel
+++ b/tests/haskell_cabal_datafiles/haskell_cabal_library_with_datafiles/BUILD.bazel
@@ -15,6 +15,8 @@ load(
 )
 load("@os_info//:os_info.bzl", "is_windows")
 
+package(default_testonly = 1)
+
 haskell_toolchain_library(name = "base")
 
 haskell_cabal_library(
@@ -27,6 +29,7 @@ haskell_cabal_library(
     ],
     generate_paths_module = True,
     sublibrary_name = "sublib",
+    tags = ["skip_profiling"],
     version = "0.1.0.0",
     visibility = ["//visibility:public"],
     deps = ["//tools/runfiles"],
@@ -53,6 +56,7 @@ haskell_cabal_binary(
         "use-base",
         "expose-lib",
     ],
+    tags = ["skip_profiling"],
     deps = [":lib"],
 )
 

--- a/tests/haskell_cabal_datafiles/haskell_cabal_library_with_datafiles/Lib.hs
+++ b/tests/haskell_cabal_datafiles/haskell_cabal_library_with_datafiles/Lib.hs
@@ -1,5 +1,5 @@
 module Lib where
-import Paths_lib
+import Paths_lib_pkg
 import Control.Exception
 import System.Exit
 import Data.List

--- a/tests/haskell_cabal_datafiles/haskell_cabal_library_with_datafiles/Lib.hs
+++ b/tests/haskell_cabal_datafiles/haskell_cabal_library_with_datafiles/Lib.hs
@@ -1,0 +1,13 @@
+module Lib where
+import Paths_lib
+import Control.Exception
+import System.Exit
+import Data.List
+
+readDataFile :: IO ()
+readDataFile = do
+  p <- getDataFileName "datafile"
+  handle ((\e -> print p >> (exitWith $ ExitFailure 1)):: IOException -> IO ()) $ do
+      s <- readFile p
+      return ()
+

--- a/tests/haskell_cabal_datafiles/haskell_cabal_library_with_datafiles/Main.hs
+++ b/tests/haskell_cabal_datafiles/haskell_cabal_library_with_datafiles/Main.hs
@@ -1,0 +1,5 @@
+module Main where
+
+import Lib
+
+main = readDataFile

--- a/tests/haskell_cabal_datafiles/haskell_cabal_library_with_datafiles/datafile
+++ b/tests/haskell_cabal_datafiles/haskell_cabal_library_with_datafiles/datafile
@@ -1,0 +1,1 @@
+datafile_content

--- a/tests/haskell_cabal_datafiles/haskell_cabal_library_with_datafiles/lib.cabal
+++ b/tests/haskell_cabal_datafiles/haskell_cabal_library_with_datafiles/lib.cabal
@@ -1,0 +1,18 @@
+cabal-version: >=1.10
+name: lib
+version: 0.1.0.0
+build-type: Simple
+
+data-files:
+  datafile
+
+library
+  build-depends: base, runfiles
+  default-language: Haskell2010
+  exposed-modules: Lib
+  other-modules: Paths_lib
+
+executable inside
+  build-depends: base, lib
+  default-language: Haskell2010
+  main-is: Main.hs

--- a/tests/haskell_cabal_datafiles/haskell_cabal_library_with_datafiles/lib.cabal
+++ b/tests/haskell_cabal_datafiles/haskell_cabal_library_with_datafiles/lib.cabal
@@ -1,5 +1,5 @@
 cabal-version: >=1.10
-name: lib
+name: lib-pkg
 version: 0.1.0.0
 build-type: Simple
 
@@ -9,10 +9,15 @@ data-files:
 library
   build-depends: base, runfiles
   default-language: Haskell2010
-  exposed-modules: Lib
-  other-modules: Paths_lib
 
 executable inside
-  build-depends: base, lib
+  build-depends: base, sublib
   default-language: Haskell2010
   main-is: Main.hs
+
+library sublib
+  visibility: public
+  build-depends: base, runfiles
+  default-language: Haskell2010
+  exposed-modules: Lib
+  other-modules: Paths_lib_pkg

--- a/tests/haskell_cabal_datafiles/other_binary/haskell_cabal_library_datafiles_2/BUILD.bazel
+++ b/tests/haskell_cabal_datafiles/other_binary/haskell_cabal_library_datafiles_2/BUILD.bazel
@@ -14,11 +14,14 @@ load(
     "haskell_toolchain_library",
 )
 
+package(default_testonly = 1)
+
 haskell_toolchain_library(name = "base")
 
 haskell_binary(
     name = "bin",
     srcs = ["Main.hs"],
+    tags = ["skip_profiling"],
     deps = [
         ":base",
         "//tests/haskell_cabal_datafiles/haskell_cabal_library_with_datafiles:lib",

--- a/tests/haskell_cabal_datafiles/other_binary/haskell_cabal_library_datafiles_2/BUILD.bazel
+++ b/tests/haskell_cabal_datafiles/other_binary/haskell_cabal_library_datafiles_2/BUILD.bazel
@@ -28,6 +28,7 @@ haskell_binary(
 haskell_test(
     name = "binary_other_pkg",
     srcs = ["Main.hs"],
+    tags = ["skip_profiling"],
     deps = [
         ":base",
         "//tests/haskell_cabal_datafiles/haskell_cabal_library_with_datafiles:lib",

--- a/tests/haskell_cabal_datafiles/other_binary/haskell_cabal_library_datafiles_2/BUILD.bazel
+++ b/tests/haskell_cabal_datafiles/other_binary/haskell_cabal_library_datafiles_2/BUILD.bazel
@@ -1,0 +1,35 @@
+# tests that a haskell binary from another package can access
+# datafiles of it's cabal_library dependencY
+
+load("@rules_cc//cc:defs.bzl", "cc_library")
+load(
+    "@rules_haskell//haskell:cabal.bzl",
+    "haskell_cabal_binary",
+    "haskell_cabal_library",
+)
+load(
+    "@rules_haskell//haskell:defs.bzl",
+    "haskell_binary",
+    "haskell_test",
+    "haskell_toolchain_library",
+)
+
+haskell_toolchain_library(name = "base")
+
+haskell_binary(
+    name = "bin",
+    srcs = ["Main.hs"],
+    deps = [
+        ":base",
+        "//tests/haskell_cabal_datafiles/haskell_cabal_library_with_datafiles:lib",
+    ],
+)
+
+haskell_test(
+    name = "binary_other_pkg",
+    srcs = ["Main.hs"],
+    deps = [
+        ":base",
+        "//tests/haskell_cabal_datafiles/haskell_cabal_library_with_datafiles:lib",
+    ],
+)

--- a/tests/haskell_cabal_datafiles/other_binary/haskell_cabal_library_datafiles_2/Main.hs
+++ b/tests/haskell_cabal_datafiles/other_binary/haskell_cabal_library_datafiles_2/Main.hs
@@ -1,0 +1,5 @@
+module Main where
+
+import Lib
+
+main = readDataFile

--- a/tests/haskell_cabal_datafiles/other_script/src/BUILD.bazel
+++ b/tests/haskell_cabal_datafiles/other_script/src/BUILD.bazel
@@ -1,0 +1,18 @@
+# Test that datafiles of a haskell_cabal_binary with generate_paths_module are accessible.
+
+load("@os_info//:os_info.bzl", "is_windows")
+
+package(default_testonly = 1)
+
+exe = ".exe" if is_windows else ""
+
+sh_test(
+    name = "test_cabal_binary_dep_datafiles".format(exe),
+    srcs = ["test_cabal_binary_dep_datafiles.sh"],
+    args = [
+        "$(rootpath //tests/haskell_cabal_datafiles/haskell_cabal_binary_with_datafiles:inside)",
+    ],
+    data = ["//tests/haskell_cabal_datafiles/haskell_cabal_binary_with_datafiles:inside"],
+    tags = ["skip_profiling"],
+    deps = ["@bazel_tools//tools/bash/runfiles"],
+)

--- a/tests/haskell_cabal_datafiles/other_script/src/test_cabal_binary_dep_datafiles.sh
+++ b/tests/haskell_cabal_datafiles/other_script/src/test_cabal_binary_dep_datafiles.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# --- begin runfiles.bash initialization v2 ---
+# Copy-pasted from the Bazel Bash runfiles library v2.
+set -uo pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
+# --- end runfiles.bash initialization v2 ---
+set -euo pipefail
+
+$(rlocation "$TEST_WORKSPACE/$1")


### PR DESCRIPTION
This PR adds the ability to override the `getDatadir` and `getDataFileName` functions [provided by cabal](https://cabal.readthedocs.io/en/3.4/cabal-package.html#accessing-data-files-from-package-code) to access runfiles, in order to use Bazel's [runfile library](https://hackage.haskell.org/package/bazel-runfiles-0.12/docs/Bazel-Runfiles.html).

This makes the data-files of `haskell_cabal_libraries` rules accessible to `haskell_binary` rules, which has been a problem before (#1247).

This works by generating a `Paths_{libname}.hs` file, which provides the functions of interest, before cabal can do so.

This option is off by default  and activated by setting the `generates_paths_module` attribute of `haskell_cabal_library` to `True`.

Some other functions are defined by this module (`getBinDir`, `getLibDir`, `getDynLibDir`, `getLibexecDir` and `getSysconfDir`):
for these we imitate the previous behavior of cabal.

## Tests

 - Three of the tests check that the datafiles are accessible from binaries in various locations.
 - `//tests/haskell_cabal_datafiles/compare_other_cabal_functions:same_other_functions`  compiles two copies of a library (with and without the option) and  checks that the functions we do not intend to change yield the same result.

## Profiling

Profiling is not compatible with this `generate_paths_module` option for now as it runs into the following issue: #1573.