### PR TITLE
Fix com_google_protobuf URL

### DIFF
--- a/haskell/repositories.bzl
+++ b/haskell/repositories.bzl
@@ -66,7 +66,7 @@ def rules_haskell_dependencies():
         sha256 = "f18a40816260a9a3190a94efb0fc26270b244a2436681602f0a944739095d632",
         strip_prefix = "protobuf-3.15.1",
         urls = [
-            "https://github.com/google/protobuf/archive/v3.15.1.tar.gz",
+            "https://github.com/protocolbuffers/protobuf/archive/refs/tags/v3.15.1.tar.gz",
         ],
     )
 


### PR DESCRIPTION
The previous URL now produces 404. Perhaps the tag was removed. Note that the sha256 remains the same with this change.
https://developers.google.com/ also links to https://github.com/protocolbuffers/protobuf/releases. 

Thanks @lunaris for finding the replacement URL.