### PR TITLE
Fix protobuf url

### DIFF
--- a/haskell/repositories.bzl
+++ b/haskell/repositories.bzl
@@ -66,7 +66,7 @@ def rules_haskell_dependencies():
         sha256 = "f18a40816260a9a3190a94efb0fc26270b244a2436681602f0a944739095d632",
         strip_prefix = "protobuf-3.15.1",
         urls = [
-            "https://github.com/google/protobuf/archive/v3.15.1.tar.gz",
+            "https://github.com/protocolbuffers/protobuf/archive/v3.15.1.tar.gz",
         ],
     )
 


### PR DESCRIPTION
It looks like google/protobuf got moved to protocolbuffers/protobuf
and then they renamed google/protobuf-dart to google/protobuf so now
the url returns a 404.

changelog_begin
changelog_end