### PR TITLE
Implement non_default_plugins

### DIFF
--- a/haskell/defs.bzl
+++ b/haskell/defs.bzl
@@ -72,6 +72,9 @@ _haskell_common_attrs = {
     "plugins": attr.label_list(
         aspects = [haskell_cc_libraries_aspect],
     ),
+    "non_default_plugins": attr.label_list(
+        aspects = [haskell_cc_libraries_aspect],
+    ),
     "tools": attr.label_list(
         cfg = "host",
         allow_files = True,
@@ -261,6 +264,7 @@ def haskell_binary(
         repl_ghci_args = [],
         runcompile_flags = [],
         plugins = [],
+        non_default_plugins = [],
         tools = [],
         worker = None,
         linkstatic = True,
@@ -301,7 +305,8 @@ def haskell_binary(
       ghcopts: Flags to pass to Haskell compiler. Subject to Make variable substitution.
       repl_ghci_args: Arbitrary extra arguments to pass to GHCi. This extends `ghcopts` and `repl_ghci_args` from the toolchain. Subject to Make variable substitution.,
       runcompile_flags: Arbitrary extra arguments to pass to runghc. This extends `ghcopts` and `repl_ghci_args` from the toolchain. Subject to Make variable substitution.
-      plugins: Compiler plugins to use during compilation.
+      plugins: Compiler plugins to use during compilation. Every module is compiled with `-fplugin=...`.
+      non_default_plugins: Like `plugins` but doesn't pass `-fplugin=...` to modules by default.
       tools: Extra tools needed at compile-time, like preprocessors.
       worker: Experimental. Worker binary employed by Bazel's persistent worker mode. See [use-cases documentation](https://rules-haskell.readthedocs.io/en/latest/haskell-use-cases.html#persistent-worker-mode-experimental).
       linkstatic: Link dependencies statically wherever possible. Some system libraries may still be linked dynamically, as are libraries for which there is no static library. So the resulting executable will still be dynamically linked, hence only mostly static.
@@ -322,6 +327,7 @@ def haskell_binary(
         repl_ghci_args = repl_ghci_args,
         runcompile_flags = runcompile_flags,
         plugins = plugins,
+        non_default_plugins = non_default_plugins,
         tools = tools,
         worker = worker,
         linkstatic = linkstatic,
@@ -362,6 +368,7 @@ def haskell_test(
         repl_ghci_args = [],
         runcompile_flags = [],
         plugins = [],
+        non_default_plugins = [],
         tools = [],
         worker = None,
         linkstatic = True,
@@ -392,7 +399,8 @@ def haskell_test(
       ghcopts: Flags to pass to Haskell compiler. Subject to Make variable substitution.
       repl_ghci_args: Arbitrary extra arguments to pass to GHCi. This extends `ghcopts` and `repl_ghci_args` from the toolchain. Subject to Make variable substitution.,
       runcompile_flags: Arbitrary extra arguments to pass to runghc. This extends `ghcopts` and `repl_ghci_args` from the toolchain. Subject to Make variable substitution.
-      plugins: Compiler plugins to use during compilation.
+      plugins: Compiler plugins to use during compilation. Every module is compiled with `-fplugin=...`.
+      non_default_plugins: Like `plugins` but doesn't pass `-fplugin=...` to modules by default.
       tools: Extra tools needed at compile-time, like preprocessors.
       worker: Experimental. Worker binary employed by Bazel's persistent worker mode. See [use-cases documentation](https://rules-haskell.readthedocs.io/en/latest/haskell-use-cases.html#persistent-worker-mode-experimental).
       linkstatic: Link dependencies statically wherever possible. Some system libraries may still be linked dynamically, as are libraries for which there is no static library. So the resulting executable will still be dynamically linked, hence only mostly static.
@@ -426,6 +434,7 @@ def haskell_test(
         repl_ghci_args = repl_ghci_args,
         runcompile_flags = runcompile_flags,
         plugins = plugins,
+        non_default_plugins = non_default_plugins,
         tools = tools,
         worker = worker,
         linkstatic = linkstatic,
@@ -474,6 +483,7 @@ def haskell_library(
         repl_ghci_args = [],
         runcompile_flags = [],
         plugins = [],
+        non_default_plugins = [],
         tools = [],
         worker = None,
         hidden_modules = [],
@@ -517,7 +527,8 @@ def haskell_library(
       ghcopts: Flags to pass to Haskell compiler. Subject to Make variable substitution.
       repl_ghci_args: Arbitrary extra arguments to pass to GHCi. This extends `ghcopts` and `repl_ghci_args` from the toolchain. Subject to Make variable substitution.,
       runcompile_flags: Arbitrary extra arguments to pass to runghc. This extends `ghcopts` and `repl_ghci_args` from the toolchain. Subject to Make variable substitution.
-      plugins: Compiler plugins to use during compilation.
+      plugins: Compiler plugins to use during compilation. Every module is compiled with `-fplugin=...`.
+      non_default_plugins: Like `plugins` but doesn't pass `-fplugin=...` to modules by default.
       tools: Extra tools needed at compile-time, like preprocessors.
       worker: Experimental. Worker binary employed by Bazel's persistent worker mode. See [use-cases documentation](https://rules-haskell.readthedocs.io/en/latest/haskell-use-cases.html#persistent-worker-mode-experimental).
       hidden_modules: Modules that should be unavailable for import by dependencies.
@@ -546,6 +557,7 @@ def haskell_library(
         repl_ghci_args = repl_ghci_args,
         runcompile_flags = runcompile_flags,
         plugins = plugins,
+        non_default_plugins = non_default_plugins,
         tools = tools,
         worker = worker,
         hidden_modules = hidden_modules,

--- a/haskell/plugins.bzl
+++ b/haskell/plugins.bzl
@@ -31,7 +31,7 @@ ghc_plugin = rule(
         ),
         "tools": attr.label_list(
             cfg = "host",
-            doc = "Tools needed by the plugin when it used.",
+            doc = "Tools needed by the plugin when enabled.",
         ),
     },
     doc = """\

--- a/haskell/plugins.bzl
+++ b/haskell/plugins.bzl
@@ -19,6 +19,7 @@ ghc_plugin = rule(
     ghc_plugin_impl,
     attrs = {
         "module": attr.string(
+            mandatory = True,
             doc = "Plugin entrypoint.",
         ),
         "deps": attr.label_list(

--- a/haskell/private/actions/compile.bzl
+++ b/haskell/private/actions/compile.bzl
@@ -105,7 +105,7 @@ def _process_hsc_file(hs, cc, hsc_flags, hsc_inputs, hsc_file):
 
     return hs_out, idir
 
-def _compilation_defaults(hs, cc, java, posix, dep_info, plugin_dep_info, srcs, import_dir_map, extra_srcs, user_compile_flags, with_profiling, my_pkg_id, version, plugins, preprocessors):
+def _compilation_defaults(hs, cc, java, posix, dep_info, plugin_dep_info, srcs, import_dir_map, extra_srcs, user_compile_flags, with_profiling, my_pkg_id, version, plugins, non_default_plugins, preprocessors):
     """Compute variables common to all compilation targets (binary and library).
 
     Returns:
@@ -170,7 +170,8 @@ def _compilation_defaults(hs, cc, java, posix, dep_info, plugin_dep_info, srcs, 
     compile_flags += user_compile_flags
 
     package_ids = []
-    for plugin in plugins:
+    all_plugins = plugins + non_default_plugins
+    for plugin in all_plugins:
         package_ids.extend(all_dependencies_package_ids(plugin.deps))
 
     (pkg_info_inputs, pkg_info_args) = pkg_info_to_compile_flags(
@@ -305,13 +306,14 @@ def _compilation_defaults(hs, cc, java, posix, dep_info, plugin_dep_info, srcs, 
     # Plugins
     for plugin in plugins:
         args.add("-fplugin={}".format(plugin.module))
+    for plugin in all_plugins:
         for opt in plugin.args:
             args.add_all(["-fplugin-opt", "{}:{}".format(plugin.module, opt)])
 
-    plugin_tool_inputs = depset(transitive = [plugin.tool_inputs for plugin in plugins])
+    plugin_tool_inputs = depset(transitive = [plugin.tool_inputs for plugin in all_plugins])
     plugin_tool_input_manifests = [
         manifest
-        for plugin in plugins
+        for plugin in all_plugins
         for manifest in plugin.tool_input_manifests
     ]
 
@@ -399,6 +401,7 @@ def compile_binary(
         version,
         inspect_coverage = False,
         plugins = [],
+        non_default_plugins = [],
         preprocessors = []):
     """Compile a Haskell target into object files suitable for linking.
 
@@ -410,7 +413,7 @@ def compile_binary(
         source_files: set of Haskell source files
         boot_files: set of Haskell boot files
     """
-    c = _compilation_defaults(hs, cc, java, posix, dep_info, plugin_dep_info, srcs, import_dir_map, extra_srcs, user_compile_flags, with_profiling, my_pkg_id = None, version = version, plugins = plugins, preprocessors = preprocessors)
+    c = _compilation_defaults(hs, cc, java, posix, dep_info, plugin_dep_info, srcs, import_dir_map, extra_srcs, user_compile_flags, with_profiling, my_pkg_id = None, version = version, plugins = plugins, non_default_plugins = non_default_plugins, preprocessors = preprocessors)
     c.args.add_all(["-main-is", main_function])
     if dynamic:
         # For binaries, GHC creates .o files even for code to be
@@ -464,6 +467,7 @@ def compile_library(
         with_profiling,
         my_pkg_id,
         plugins = [],
+        non_default_plugins = [],
         preprocessors = []):
     """Build arguments for Haskell package build.
 
@@ -479,7 +483,7 @@ def compile_library(
         boot_files: set of Haskell boot files
         import_dirs: import directories that should make all modules visible (for GHCi)
     """
-    c = _compilation_defaults(hs, cc, java, posix, dep_info, plugin_dep_info, srcs, import_dir_map, extra_srcs, user_compile_flags, with_profiling, my_pkg_id = my_pkg_id, version = my_pkg_id.version, plugins = plugins, preprocessors = preprocessors)
+    c = _compilation_defaults(hs, cc, java, posix, dep_info, plugin_dep_info, srcs, import_dir_map, extra_srcs, user_compile_flags, with_profiling, my_pkg_id = my_pkg_id, version = my_pkg_id.version, plugins = plugins, non_default_plugins = non_default_plugins, preprocessors = preprocessors)
     if with_shared:
         c.args.add("-dynamic-too")
 

--- a/haskell/protobuf.bzl
+++ b/haskell/protobuf.bzl
@@ -180,6 +180,7 @@ def _haskell_proto_aspect_impl(target, ctx):
         "deps": ctx.rule.attr.deps +
                 ctx.toolchains["@rules_haskell//protobuf:toolchain"].deps,
         "plugins": [],
+        "non_default_plugins": [],
         "data": [],
         "tools": [],
         "_cc_toolchain": ctx.attr._cc_toolchain,

--- a/tests/binary-with-plugin/BUILD.bazel
+++ b/tests/binary-with-plugin/BUILD.bazel
@@ -19,6 +19,7 @@ haskell_toolchain_library(name = "process")
 haskell_library(
     name = "plugin-lib",
     srcs = ["Plugin.hs"],
+    version = "0",
     deps = [
         ":base",
         ":bytestring",

--- a/tests/binary-with-plugin/BUILD.bazel
+++ b/tests/binary-with-plugin/BUILD.bazel
@@ -36,7 +36,10 @@ haskell_library(
 
 ghc_plugin(
     name = "plugin1",
-    args = ["$(location //tests/binary-simple)", "plugin1"],
+    args = [
+        "$(location //tests/binary-simple)",
+        "plugin1",
+    ],
     module = "Plugin",
     tools = ["//tests/binary-simple"],
     deps = [":plugin-lib"],
@@ -44,7 +47,10 @@ ghc_plugin(
 
 ghc_plugin(
     name = "plugin2",
-    args = ["$(location //tests/binary-simple)", "plugin2"],
+    args = [
+        "$(location //tests/binary-simple)",
+        "plugin2",
+    ],
     module = "Plugin",
     tools = ["//tests/binary-simple"],
     deps = [":plugin-lib"],
@@ -59,9 +65,9 @@ haskell_test(
         ":debug_build": [],
         "//conditions:default": [":plugin1"],
     }),
+    tags = ["skip_profiling"],
     visibility = ["//visibility:public"],
     deps = [":base"],
-    tags = ["skip_profiling"],
 )
 
 haskell_test(
@@ -72,9 +78,9 @@ haskell_test(
         ":debug_build": [],
         "//conditions:default": [":plugin2"],
     }),
+    tags = ["skip_profiling"],
     visibility = ["//visibility:public"],
     deps = [":base"],
-    tags = ["skip_profiling"],
 )
 
 haskell_test(
@@ -84,7 +90,7 @@ haskell_test(
         ":debug_build": [],
         "//conditions:default": [":plugin2"],
     }),
+    tags = ["skip_profiling"],
     visibility = ["//visibility:public"],
     deps = [":base"],
-    tags = ["skip_profiling"],
 )

--- a/tests/binary-with-plugin/BUILD.bazel
+++ b/tests/binary-with-plugin/BUILD.bazel
@@ -8,13 +8,6 @@ load(
 
 package(default_testonly = 1)
 
-config_setting(
-    name = "debug_build",
-    values = {
-        "compilation_mode": "dbg",
-    },
-)
-
 haskell_toolchain_library(name = "base")
 
 haskell_toolchain_library(name = "bytestring")
@@ -59,12 +52,9 @@ ghc_plugin(
 haskell_test(
     name = "binary-with-plugin1",
     srcs = ["Main.hs"],
-    plugins = select({
-        # XXX If profiling is enabled, ignore the plugin because of
-        # https://gitlab.haskell.org/ghc/ghc/issues/14335.
-        ":debug_build": [],
-        "//conditions:default": [":plugin1"],
-    }),
+    plugins = [":plugin1"],
+    # XXX If profiling is enabled, ignore the plugin tests because of
+    # https://gitlab.haskell.org/ghc/ghc/issues/14335.
     tags = ["skip_profiling"],
     visibility = ["//visibility:public"],
     deps = [":base"],
@@ -74,10 +64,7 @@ haskell_test(
     name = "binary-with-plugin2",
     srcs = ["main2.hs"],
     compiler_flags = ["-fplugin=Plugin"],
-    non_default_plugins = select({
-        ":debug_build": [],
-        "//conditions:default": [":plugin2"],
-    }),
+    non_default_plugins = [":plugin2"],
     tags = ["skip_profiling"],
     visibility = ["//visibility:public"],
     deps = [":base"],
@@ -86,10 +73,7 @@ haskell_test(
 haskell_test(
     name = "binary-with-plugin3",
     srcs = ["main3.hs"],
-    non_default_plugins = select({
-        ":debug_build": [],
-        "//conditions:default": [":plugin2"],
-    }),
+    non_default_plugins = [":plugin2"],
     tags = ["skip_profiling"],
     visibility = ["//visibility:public"],
     deps = [":base"],

--- a/tests/binary-with-plugin/BUILD.bazel
+++ b/tests/binary-with-plugin/BUILD.bazel
@@ -61,6 +61,7 @@ haskell_test(
     }),
     visibility = ["//visibility:public"],
     deps = [":base"],
+    tags = ["skip_profiling"],
 )
 
 haskell_test(
@@ -73,6 +74,7 @@ haskell_test(
     }),
     visibility = ["//visibility:public"],
     deps = [":base"],
+    tags = ["skip_profiling"],
 )
 
 haskell_test(
@@ -84,4 +86,5 @@ haskell_test(
     }),
     visibility = ["//visibility:public"],
     deps = [":base"],
+    tags = ["skip_profiling"],
 )

--- a/tests/binary-with-plugin/BUILD.bazel
+++ b/tests/binary-with-plugin/BUILD.bazel
@@ -17,6 +17,8 @@ config_setting(
 
 haskell_toolchain_library(name = "base")
 
+haskell_toolchain_library(name = "bytestring")
+
 haskell_toolchain_library(name = "ghc")
 
 haskell_toolchain_library(name = "process")
@@ -26,27 +28,59 @@ haskell_library(
     srcs = ["Plugin.hs"],
     deps = [
         ":base",
+        ":bytestring",
         ":ghc",
         ":process",
     ],
 )
 
 ghc_plugin(
-    name = "plugin",
-    args = ["$(location //tests/binary-simple)"],
+    name = "plugin1",
+    args = ["$(location //tests/binary-simple)", "plugin1"],
+    module = "Plugin",
+    tools = ["//tests/binary-simple"],
+    deps = [":plugin-lib"],
+)
+
+ghc_plugin(
+    name = "plugin2",
+    args = ["$(location //tests/binary-simple)", "plugin2"],
     module = "Plugin",
     tools = ["//tests/binary-simple"],
     deps = [":plugin-lib"],
 )
 
 haskell_test(
-    name = "binary-with-plugin",
+    name = "binary-with-plugin1",
     srcs = ["Main.hs"],
     plugins = select({
         # XXX If profiling is enabled, ignore the plugin because of
         # https://gitlab.haskell.org/ghc/ghc/issues/14335.
         ":debug_build": [],
-        "//conditions:default": [":plugin"],
+        "//conditions:default": [":plugin1"],
+    }),
+    visibility = ["//visibility:public"],
+    deps = [":base"],
+)
+
+haskell_test(
+    name = "binary-with-plugin2",
+    srcs = ["main2.hs"],
+    compiler_flags = ["-fplugin=Plugin"],
+    non_default_plugins = select({
+        ":debug_build": [],
+        "//conditions:default": [":plugin2"],
+    }),
+    visibility = ["//visibility:public"],
+    deps = [":base"],
+)
+
+haskell_test(
+    name = "binary-with-plugin3",
+    srcs = ["main3.hs"],
+    non_default_plugins = select({
+        ":debug_build": [],
+        "//conditions:default": [":plugin2"],
     }),
     visibility = ["//visibility:public"],
     deps = [":base"],

--- a/tests/binary-with-plugin/Main.hs
+++ b/tests/binary-with-plugin/Main.hs
@@ -1,3 +1,7 @@
 module Main where
 
-main = putStrLn "hello world"
+main =
+  if "plugin" == ['p', 'l', 'u', 'g', 'i', 'n', '1'] then
+    putStrLn "hello world"
+  else
+    error "plugin1 not loaded"

--- a/tests/binary-with-plugin/Plugin.hs
+++ b/tests/binary-with-plugin/Plugin.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE LambdaCase #-}
 module Plugin (plugin) where
 
@@ -6,6 +7,7 @@ import Data.ByteString (ByteString)
 import qualified Data.ByteString.Char8 as Char8
 import GhcPlugins
 import System.Process (readProcess)
+
 
 plugin :: Plugin
 plugin = defaultPlugin { installCoreToDos = install }
@@ -41,5 +43,9 @@ replaceInExpr bs = go
          in (Case (go e0) b t alts')
       Cast e c -> Cast (go e) c
       Tick t e -> Tick t (go e)
-      Lit (LitString _) -> Lit (LitString bs)
+#if __GLASGOW_HASKELL__ >= 808
+      Lit LitString{} -> Lit (LitString bs)
+#else
+      Lit MachStr{} -> Lit (MachStr bs)
+#endif
       e -> e

--- a/tests/binary-with-plugin/Plugin.hs
+++ b/tests/binary-with-plugin/Plugin.hs
@@ -1,15 +1,45 @@
+{-# LANGUAGE LambdaCase #-}
 module Plugin (plugin) where
 
 import Control.Monad (when)
+import Data.ByteString (ByteString)
+import qualified Data.ByteString.Char8 as Char8
 import GhcPlugins
 import System.Process (readProcess)
 
 plugin :: Plugin
 plugin = defaultPlugin { installCoreToDos = install }
 
+-- | @install [arg1, arg2]@ invokes @arg1@ and replaces every string
+-- literal with arg2.
 install :: [CommandLineOption] -> [CoreToDo] -> CoreM [CoreToDo]
-install [arg] todo = do
-  when ('$' `elem` arg) $
+install [arg1, arg2] todo = do
+  when ('$' `elem` arg1) $
     error "Make variable not expanded."
-  _ <- liftIO $ readProcess arg [] ""
-  return todo
+  _ <- liftIO $ readProcess arg1 [] ""
+  return $ CoreDoPluginPass arg2 (pass (Char8.pack arg2)) : todo
+
+pass :: ByteString -> ModGuts -> CoreM ModGuts
+pass bs guts = do
+  let binds = map (replaceString bs) (mg_binds guts)
+  return guts { mg_binds = binds }
+
+replaceString :: ByteString -> CoreBind -> CoreBind
+replaceString bs (NonRec b e) = NonRec b (replaceInExpr bs e)
+replaceString bs (Rec bnds) = Rec $ map (\(b, e) -> (b, replaceInExpr bs e)) bnds
+
+replaceInExpr :: ByteString -> CoreExpr -> CoreExpr
+replaceInExpr bs = go
+  where
+    go = \case
+      App e0 e1 -> App (go e0) (go e1)
+      Lam b e -> Lam b (go e)
+      Let bnd e -> Let bnd (go e)
+      Case e0 b t alts ->
+        let repInAlt (a, bs, e) = (a, bs, go e)
+            alts' = map repInAlt alts
+         in (Case (go e0) b t alts')
+      Cast e c -> Cast (go e) c
+      Tick t e -> Tick t (go e)
+      Lit (LitString _) -> Lit (LitString bs)
+      e -> e

--- a/tests/binary-with-plugin/main2.hs
+++ b/tests/binary-with-plugin/main2.hs
@@ -1,0 +1,7 @@
+module Main where
+
+main =
+  if "plugin" == ['p', 'l', 'u', 'g', 'i', 'n', '2'] then
+    putStrLn "hello world"
+  else
+    error "plugin2 not loaded"

--- a/tests/binary-with-plugin/main3.hs
+++ b/tests/binary-with-plugin/main3.hs
@@ -1,0 +1,7 @@
+module Main where
+
+main =
+  if "plugin" == ['p', 'l', 'u', 'g', 'i', 'n', '2'] then
+    error "unexpected plugin2 loaded"
+  else
+    putStrLn "hello world"


### PR DESCRIPTION
With this new attribute, `haskell_library` and `haskell_binary` can avoid setting `-fplugin` for every module, which is handy if the plugin is slow or fails to process some of the modules.