### PR TITLE
Support using TH and FFI with static C dependencies

### DIFF
--- a/haskell/private/actions/compile.bzl
+++ b/haskell/private/actions/compile.bzl
@@ -334,7 +334,7 @@ def _compilation_defaults(hs, cc, java, posix, dep_info, plugin_dep_info, srcs, 
 
     # Transitive library dependencies for runtime.
     link_libraries(
-        get_ghci_library_files(hs, cc.cc_libraries_info, cc.cc_libraries, for_th_only=True),
+        get_ghci_library_files(hs, cc.cc_libraries_info, cc.cc_libraries, for_th_only = True),
         args,
     )
 

--- a/haskell/private/actions/compile.bzl
+++ b/haskell/private/actions/compile.bzl
@@ -334,7 +334,7 @@ def _compilation_defaults(hs, cc, java, posix, dep_info, plugin_dep_info, srcs, 
 
     # Transitive library dependencies for runtime.
     link_libraries(
-        get_ghci_library_files(hs, cc.cc_libraries_info, cc.cc_libraries),
+        get_ghci_library_files(hs, cc.cc_libraries_info, cc.cc_libraries, for_th_only=True),
         args,
     )
 

--- a/haskell/private/cc_libraries.bzl
+++ b/haskell/private/cc_libraries.bzl
@@ -49,7 +49,7 @@ def get_cc_libraries(cc_libraries_info, libraries_to_link):
         if not cc_libraries_info.libraries[cc_library_key(lib_to_link)].is_haskell
     ]
 
-def get_ghci_library_files(hs, cc_libraries_info, libraries_to_link, *, include_real_paths = False, for_th_only=False):
+def get_ghci_library_files(hs, cc_libraries_info, libraries_to_link, *, include_real_paths = False, for_th_only = False):
     """Get libraries appropriate for loading with GHCi.
 
     See get_library_files for further information.

--- a/haskell/private/cc_libraries.bzl
+++ b/haskell/private/cc_libraries.bzl
@@ -49,7 +49,7 @@ def get_cc_libraries(cc_libraries_info, libraries_to_link):
         if not cc_libraries_info.libraries[cc_library_key(lib_to_link)].is_haskell
     ]
 
-def get_ghci_library_files(hs, cc_libraries_info, libraries_to_link, include_real_paths = False):
+def get_ghci_library_files(hs, cc_libraries_info, libraries_to_link, *, include_real_paths = False, for_th_only=False):
     """Get libraries appropriate for loading with GHCi.
 
     See get_library_files for further information.
@@ -62,6 +62,9 @@ def get_ghci_library_files(hs, cc_libraries_info, libraries_to_link, include_rea
         pic = True,
         include_real_paths = include_real_paths,
     )
+    ghci_can_load_static_libs = hs.toolchain.static_runtime
+    if for_th_only and not ghci_can_load_static_libs:
+        return dynamic_libs
     return static_libs + dynamic_libs
 
 def get_library_files(hs, cc_libraries_info, libraries_to_link, dynamic = False, pic = None, include_real_paths = False):

--- a/tests/library-with-static-cc-dep/BUILD.bazel
+++ b/tests/library-with-static-cc-dep/BUILD.bazel
@@ -1,0 +1,49 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+load("@rules_haskell//haskell:defs.bzl", "haskell_library", "haskell_test")
+
+cc_library(
+    name = "cbits-static",
+    srcs = ["cbits/impl.c"],
+    linkstatic = True,
+)
+
+haskell_library(
+    name = "mypkg",
+    srcs = ["src/MyModule.hs"],
+    src_strip_prefix = "src",
+    ghcopts = ["-XTemplateHaskell"],
+    deps = [
+        ":cbits-static",
+        "//tests/hackage:base",
+    ],
+)
+
+haskell_test(
+    name = "library-with-static-cc-dep-static",
+    srcs = ["test/Main.hs"],
+    linkstatic = True,
+    src_strip_prefix = "test",
+    deps = [
+        ":mypkg",
+        "//tests/hackage:base",
+    ],
+)
+
+haskell_test(
+    name = "library-with-static-cc-dep-dynamic",
+    srcs = ["test/Main.hs"],
+    linkstatic = False,
+    src_strip_prefix = "test",
+    deps = [
+        ":mypkg",
+        "//tests/hackage:base",
+    ],
+)
+
+test_suite(
+    name = "library-with-static-cc-dep",
+    tests = [
+        ":library-with-static-cc-dep-dynamic",
+        ":library-with-static-cc-dep-static",
+    ],
+)

--- a/tests/library-with-static-cc-dep/BUILD.bazel
+++ b/tests/library-with-static-cc-dep/BUILD.bazel
@@ -10,8 +10,8 @@ cc_library(
 haskell_library(
     name = "mypkg",
     srcs = ["src/MyModule.hs"],
-    src_strip_prefix = "src",
     ghcopts = ["-XTemplateHaskell"],
+    src_strip_prefix = "src",
     deps = [
         ":cbits-static",
         "//tests/hackage:base",

--- a/tests/library-with-static-cc-dep/cbits/impl.c
+++ b/tests/library-with-static-cc-dep/cbits/impl.c
@@ -1,0 +1,9 @@
+static int thing;
+
+int get_thing(void) {
+  return thing;
+}
+
+void set_thing(int value) {
+  thing = value;
+}

--- a/tests/library-with-static-cc-dep/src/MyModule.hs
+++ b/tests/library-with-static-cc-dep/src/MyModule.hs
@@ -1,0 +1,11 @@
+module MyModule where
+
+foreign import ccall get_thing :: IO Int
+
+getThing :: IO Int
+getThing = $([| get_thing |])
+
+foreign import ccall set_thing :: Int -> IO ()
+
+setThing :: Int -> IO ()
+setThing = $([| set_thing |])

--- a/tests/library-with-static-cc-dep/test/Main.hs
+++ b/tests/library-with-static-cc-dep/test/Main.hs
@@ -1,0 +1,9 @@
+module Main (main) where
+
+import qualified MyModule
+
+main :: IO ()
+main = do
+  print =<< MyModule.getThing
+  MyModule.setThing 123
+  print =<< MyModule.getThing


### PR DESCRIPTION
Consider the following scenario:

  - Package H1 uses FFI and needs to be linked against a pre-built static library X
  - Package H2 depends on H1 and uses TH (but TH code doesn't depend on X)
  - The ghc in the toolchain doesn't have a static runtime

In this case, as far as I can see, it is not currently possible to build H2 using `haskell_library`: during the compile step, `-lX` is passed to ghc, and the moment TH is used, ghc will try to load `libX.a` and fail. For example, on the added test-case, I currently see:

```
$ bazel build //tests/library-with-static-cc-dep:mypkg
INFO: Analyzed target //tests/library-with-static-cc-dep:mypkg (10 packages loaded, 372 targets configured).
INFO: Found 1 target...
ERROR: /home/daniel/repos/rules_haskell/tests/library-with-static-cc-dep/BUILD.bazel:10:16: HaskellBuildLibrary //tests/library-with-static-cc-dep:mypkg failed: (Exit 1): ghc_wrapper failed: error executing command bazel-out/host/bin/haskell/ghc_wrapper bazel-out/k8-fastbuild/bin/tests/library-with-static-cc-dep/compile_flags_mypkg_HaskellBuildLibrary ... (remaining 1 argument(s) skipped)

Use --sandbox_debug to see verbose messages from the sandbox
<command line>: User-specified static library could not be loaded (bazel-out/k8-fastbuild/bin/tests/library-with-static-cc-dep/libcbits-static.a)
Loading static libraries is not supported in this configuration.
Try using a dynamic library instead.
...
```

Cabal on the other hand doesn't pass `-lX` to ghc in this case, so falling back to `haskell_cabal_library` is the only workaround I see.

To fix this in haskell_library, the proposed solution is to optimistically ignore the static dependencies during the compile
action whenever the ghc runtime will not be able to load them. The only visible difference to the user should be when their TH
code in H2 depends in fact on X (a case that could never work under this scenario anyway): now they will get a symbol-not-found error, instead of a failure to load the static lib.