### PR TITLE
Automatic visibility of stack_snapshot dependencies to vendored packages

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -186,11 +186,6 @@ stack_snapshot(
     local_snapshot = "//:ghcide-stack-snapshot.yaml",
     packages = [
         "ghcide",
-        # Needed by data-default-instances-containers and data-default-instances-old-locale
-        "base",
-        "containers",
-        "data-default-class",
-        "old-locale",
     ],
     stack_snapshot_json = "//:ghcide-snapshot.json" if not is_windows else None,
     vendored_packages = {

--- a/haskell/cabal.bzl
+++ b/haskell/cabal.bzl
@@ -2287,9 +2287,13 @@ def stack_snapshot(
     `@stackage-exe//<package-name>:<executable-name>`, assuming that you
     invoked `stack_snapshot` with `name = "stackage"`.
 
-    In the external repository defined by the rule, all given packages are
-    available as top-level targets named after each package. Additionally, the
-    dependency graph is made available within `packages.bzl` as the `dict`
+    In the external repository defined by the rule, all items of the `packages`
+    attribute and all items of the `vendored_packages` attribute are made
+    available as top-level targets named after each package with public
+    visibility. Other packages that are dependencies of vendored packages are
+    made available with visibility restricted to these vendored packages.
+
+    The dependency graph is made available within `packages.bzl` as the `dict`
     `packages` mapping unversioned package names to structs holding the fields
 
       - name: The unversioned package name.
@@ -2299,6 +2303,7 @@ def stack_snapshot(
       - deps: The list of library dependencies according to stack.
       - tools: The list of tool dependencies according to stack.
       - flags: The list of Cabal flags.
+      - visibility: The visibility of the given package.
 
     **NOTE:** Make sure your GHC version matches the version expected by the
     snapshot. E.g. if you pass `snapshot = "lts-13.15"`, make sure you use

--- a/haskell/cabal.bzl
+++ b/haskell/cabal.bzl
@@ -1884,8 +1884,8 @@ def _stack_snapshot_impl(repository_ctx):
         if name in packages.all or name in vendored_packages:
             visibility = ["//visibility:public"]
         else:
-            # Sort and de-duplicate the list of visibility specifications.
             visibility = sorted({
+                # use dictionary keys to de-duplicate
                 str(vendored_packages[rdep].relative(":__pkg__")): None
                 for rdep in reverse_deps[name]
                 if rdep in vendored_packages

--- a/haskell/cabal.bzl
+++ b/haskell/cabal.bzl
@@ -1884,12 +1884,14 @@ def _stack_snapshot_impl(repository_ctx):
         if name in packages.all or name in vendored_packages:
             visibility = ["//visibility:public"]
         else:
-            visibility = sorted({
-                # use dictionary keys to de-duplicate
-                str(vendored_packages[rdep].relative(":__pkg__")): None
-                for rdep in reverse_deps[name]
-                if rdep in vendored_packages
-            }.keys())
+            visibility = sorted(
+                # use set to de-duplicate
+                set.to_list(set.from_list([
+                    str(vendored_packages[rdep].relative(":__pkg__"))
+                    for rdep in reverse_deps[name]
+                    if rdep in vendored_packages
+                ])),
+            )
             if not visibility:
                 visibility = ["//visibility:private"]
         visibilities[name] = visibility


### PR DESCRIPTION
Closes #1571

If a vendored package depends on an otherwise not public package in the snapshot, then this dependency is made visible to the vendored package.

To handle executable components (tool dependencies) `stack_snapshot` generates a JSON file listing all components and the `-exe` repository reads this file to generate the necessary aliases with the correct visibilities.

