### PR TITLE
Sort exposed-modules in package conf

### DIFF
--- a/haskell/private/ls_modules.py
+++ b/haskell/private/ls_modules.py
@@ -107,8 +107,8 @@ exposed_modules = (
 extra_modules = [x for x in extra_modules_str.split(",") if x != ""]
 
 with io.open(results_file, "w", encoding='utf8') as f:
-    f.write(", ".join(itertools.chain(
+    f.write(", ".join(sorted(itertools.chain(
         exposed_modules,
         reexported_modules,
         extra_modules,
-    )))
+    ))))


### PR DESCRIPTION
The order of the `exposed-modules` in the generated package conf was non-deterministic, making builds non-reproducible.

This would happen since python's `os.walk()` will return files in arbitrary order. So now we sort them before writing to the file.