### PR TITLE
Fix locale setting in GHC bindist on Linux

### DIFF
--- a/haskell/ghc_bindist.bzl
+++ b/haskell/ghc_bindist.bzl
@@ -416,7 +416,7 @@ rm -f
         execute_or_fail_loudly(ctx, ["./bin/ghc-pkg", "recache"])
 
     toolchain_libraries = pkgdb_to_bzl(ctx, filepaths, "lib")
-    locale = ctx.attr.locale or "en_US.UTF-8" if os == "darwin" else "C.UTF-8"
+    locale = ctx.attr.locale or ("en_US.UTF-8" if os == "darwin" else "C.UTF-8")
     toolchain = define_rule(
         "haskell_toolchain",
         name = "toolchain-impl",


### PR DESCRIPTION
The if expression was not parenthesized leading to the locale always being set to `C.UTF-8` on Linux.