### PR TITLE
Fix coverage

### DIFF
--- a/haskell/private/haskell_impl.bzl
+++ b/haskell/private/haskell_impl.bzl
@@ -316,6 +316,13 @@ def _haskell_binary_common_impl(ctx, is_test):
             binary,
         ] + mix_runfiles + srcs_runfiles + java.inputs.to_list()
 
+        # This provider will trigger the coverage generation for .lcov files
+        instrumented_files_info = [coverage_common.instrumented_files_info(
+            ctx,
+        )]
+    else:
+        instrumented_files_info = []
+
     return [
         hs_info,
         cc_info,
@@ -336,7 +343,7 @@ def _haskell_binary_common_impl(ctx, is_test):
             posix = posix,
             runfiles = ctx.runfiles(collect_data = True).files,
         )),
-    ]
+    ] + instrumented_files_info
 
 def haskell_library_impl(ctx):
     hs = haskell_context(ctx)

--- a/haskell/private/path_utils.bzl
+++ b/haskell/private/path_utils.bzl
@@ -24,7 +24,17 @@ def module_name(hs, f, rel_path = None):
     rpath = rel_path
 
     if not rpath:
-        rpath = _rel_path_to_module(hs, f)
+        # .hs files generated from .chs files are generated in an "unique" subdirectory based on the name of the .chs file.
+        # For example, the .chs file: A/B/C.chs will generate the A/B/C.chs/A/B/C.hs.
+        # In #1592 we see that it breaks module name detection.
+
+        c2hs_components = f.path.split(".chs/")
+
+        # if there is a `.chs/`
+        if len(c2hs_components) == 2:
+            rpath = c2hs_components[1]
+        else:
+            rpath = _rel_path_to_module(hs, f)
 
     (hsmod, _) = paths.split_extension(rpath.replace("/", "."))
     return hsmod
@@ -382,6 +392,7 @@ def _rel_path_to_module(hs, f):
 
     # If it's a generated file, strip off the bin or genfiles prefix.
     path = f.path
+
     if path.startswith(hs.bin_dir.path):
         path = paths.relativize(path, hs.bin_dir.path)
     elif path.startswith(hs.genfiles_dir.path):


### PR DESCRIPTION
This branch fix a few coverage gotchas:

- Close #1436, coverage information were not provided to bazel
- Close #1592, coverage fails when `chs` files are involved
- Close #1593, coverage fails when "Main" files are not named `Main.hs`