### PR TITLE
Relax the hard requirement of the HaskellCcLibrariesInfo provider in haddock_doc_aspect

### DIFF
--- a/haskell/haddock.bzl
+++ b/haskell/haddock.bzl
@@ -134,11 +134,13 @@ def _haskell_doc_aspect_impl(target, ctx):
     )
 
     # C library dependencies for runtime.
-    cc_libraries = get_ghci_library_files(
-        hs,
-        target[HaskellCcLibrariesInfo],
-        [lib for li in target[CcInfo].linking_context.linker_inputs.to_list() for lib in li.libraries],
-    )
+    cc_libraries = []
+    if HaskellCcLibrariesInfo in target:
+        cc_libraries = get_ghci_library_files(
+            hs,
+            target[HaskellCcLibrariesInfo],
+            [lib for li in target[CcInfo].linking_context.linker_inputs.to_list() for lib in li.libraries],
+        )
 
     # TODO(mboes): we should be able to instantiate this template only
     # once per toolchain instance, rather than here.


### PR DESCRIPTION
Defaults `cc_libraries` to `[]` if the aspect target doesn't have the requisite `HaskellCcLibrariesInfo` provider.

Fixes #1603