### PR TITLE
regexp for platform matching in mergify config

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,11 +1,11 @@
 pull_request_rules:
   - name: automatic merge
     conditions:
-      - 'status-success~=Build & Test - Nixpkgs \(ubuntu\).*'
-      - 'status-success~=Build & Test - Nixpkgs \(macos\).*'
-      - 'status-success~=Build & Test - bindist \(ubuntu\).*'
-      - 'status-success~=Build & Test - bindist \(macos\).*'
-      - 'status-success~=Build & Test - bindist \(windows\).*'
+      - 'status-success~=Build & Test - Nixpkgs \(ubuntu-.*\).*'
+      - 'status-success~=Build & Test - Nixpkgs \(macos-.*\).*'
+      - 'status-success~=Build & Test - bindist \(ubuntu-.*\).*'
+      - 'status-success~=Build & Test - bindist \(macos-.*\).*'
+      - 'status-success~=Build & Test - bindist \(windows-.*\).*'
       - 'status-success~=Build & Test - Cross.*'
       - "status-success=deploy/netlify"
       - "#approved-reviews-by>=1"


### PR DESCRIPTION
The platform names for the ci changed in #1606 and mergify it is still looking for the [old ones](https://github.com/tweag/rules_haskell/pull/1614/checks?check_run_id=3947881608).

This PR intends to fix that.