### PR TITLE
Add template haskell support to haskell_module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /bazel-*
 .bazelrc.local
+*.swp
+*.swo

--- a/haskell/experimental/private/module.bzl
+++ b/haskell/experimental/private/module.bzl
@@ -31,7 +31,20 @@ load(
     "HaskellModuleInfo",
 )
 
-def _build_haskell_module(ctx, hs, cc, posix, dep_info, package_name, with_shared, hidir, odir, module_outputs, interface_inputs, object_inputs, module):
+def _build_haskell_module(
+        ctx,
+        hs,
+        cc,
+        posix,
+        dep_info,
+        package_name,
+        with_shared,
+        hidir,
+        odir,
+        module_outputs,
+        interface_inputs,
+        object_inputs,
+        module):
     """Build a module
 
     Args:
@@ -337,7 +350,21 @@ def build_haskell_modules(ctx, hs, cc, posix, package_name, with_shared, hidir, 
         interface_inputs = _collect_module_inputs(module_interfaces, his, dep)
         object_inputs = _collect_module_inputs(module_objects, os, dep)
 
-        _build_haskell_module(ctx, hs, cc, posix, dep_info, package_name, with_shared, hidir, odir, module_outputs[dep.label], interface_inputs, object_inputs, dep)
+        _build_haskell_module(
+            ctx,
+            hs,
+            cc,
+            posix,
+            dep_info,
+            package_name,
+            with_shared,
+            hidir,
+            odir,
+            module_outputs[dep.label],
+            interface_inputs,
+            object_inputs,
+            dep,
+        )
 
     module_outputs_list = module_outputs.values()
     hi_set = depset([outputs.hi for outputs in module_outputs_list])

--- a/haskell/experimental/private/module.bzl
+++ b/haskell/experimental/private/module.bzl
@@ -198,9 +198,8 @@ def _build_haskell_module(ctx, hs, cc, posix, dep_info, package_name, with_share
                 plugin_dep_info.hs_libraries,
                 plugin_tool_inputs,
                 preprocessors_inputs,
-                # TODO[AH] Factor this out
-                # TODO[AH] Include object files for template Haskell dependencies.
                 interface_inputs,
+                object_inputs,
             ],
         ),
         input_manifests = preprocessors_input_manifests + plugin_tool_input_manifests,
@@ -258,20 +257,17 @@ def _collect_module_outputs_of_direct_deps(with_shared, module_outputs, dep):
         if o  # boot module files produce no useful object files
     ]
     if with_shared:
-        dyn_his = [
+        his += [
             module_outputs[m.label].dyn_hi
             for m in dep[HaskellModuleInfo].direct_module_deps
         ]
-        dyn_os = [
+        os += [
             dyn_o
             for m in dep[HaskellModuleInfo].direct_module_deps
             for dyn_o in [module_outputs[m.label].dyn_o]
             if dyn_o  # boot module files produce no useful object files
         ]
-    else:
-        dyn_his = []
-        dyn_os = []
-    return his + dyn_his, os, dyn_os
+    return his, os
 
 def _collect_module_inputs(module_input_map, directs, dep):
     """ Put together inputs coming from direct and transitive dependencies.
@@ -335,14 +331,11 @@ def build_haskell_modules(ctx, hs, cc, posix, package_name, with_shared, hidir, 
     module_outputs = {dep.label: _declare_module_outputs(hs, with_shared, hidir, odir, dep) for dep in transitive_module_deps}
 
     module_interfaces = {}
-    module_dyn_interfaces = {}
     module_objects = {}
-    module_dyn_objects = {}
     for dep in transitive_module_deps:
-        his, os, dyn_os = _collect_module_outputs_of_direct_deps(with_shared, module_outputs, dep)
+        his, os = _collect_module_outputs_of_direct_deps(with_shared, module_outputs, dep)
         interface_inputs = _collect_module_inputs(module_interfaces, his, dep)
         object_inputs = _collect_module_inputs(module_objects, os, dep)
-        dyn_object_inputs = _collect_module_inputs(module_dyn_objects, dyn_os, dep)
 
         _build_haskell_module(ctx, hs, cc, posix, dep_info, package_name, with_shared, hidir, odir, module_outputs[dep.label], interface_inputs, object_inputs, dep)
 

--- a/tests/haskell_module/BUILD.bazel
+++ b/tests/haskell_module/BUILD.bazel
@@ -10,6 +10,7 @@ filegroup(
         "//tests/haskell_module/multiple:all_files",
         "//tests/haskell_module/nested:all_files",
         "//tests/haskell_module/plugin:all_files",
+        "//tests/haskell_module/th:all_files",
         "//tests/haskell_module/tools:all_files",
     ],
     visibility = ["//visibility:public"],

--- a/tests/haskell_module/th/BUILD.bazel
+++ b/tests/haskell_module/th/BUILD.bazel
@@ -1,0 +1,59 @@
+"""Test compilation of a multiple interdependent Haskell modules with only core-package dependencies."""
+
+load("@rules_haskell//haskell:defs.bzl", "haskell_library")
+load("@rules_haskell//haskell/experimental:defs.bzl", "haskell_module")
+
+haskell_module(
+    name = "root",
+    src = "Root.hs",
+    deps = ["//tests/hackage:base"],
+)
+
+haskell_module(
+    name = "branch_left",
+    src = "BranchLeft.hs",
+    deps = [
+        ":root",
+        "//tests/hackage:base",
+    ],
+)
+
+haskell_module(
+    name = "branch_right",
+    src = "BranchRight.hs",
+    deps = [
+        ":root",
+        "//tests/hackage:base",
+    ],
+)
+
+haskell_module(
+    name = "leaf",
+    src = "Leaf.hs",
+    deps = [
+        ":branch_left",
+        ":branch_right",
+        "//tests/hackage:base",
+    ],
+)
+
+haskell_library(
+    name = "lib",
+    modules = [
+        ":root",
+        ":branch_left",
+        ":branch_right",
+        ":leaf",
+    ],
+    deps = [
+        "//tests/hackage:base",
+        "//tests/hackage:template-haskell",
+    ],
+)
+
+filegroup(
+    name = "all_files",
+    testonly = True,
+    srcs = glob(["**"]),
+    visibility = ["//visibility:public"],
+)

--- a/tests/haskell_module/th/BranchLeft.hs
+++ b/tests/haskell_module/th/BranchLeft.hs
@@ -1,0 +1,6 @@
+module BranchLeft where
+
+import Root
+
+branch_left :: Int
+branch_left = 3 * root

--- a/tests/haskell_module/th/BranchRight.hs
+++ b/tests/haskell_module/th/BranchRight.hs
@@ -1,0 +1,6 @@
+module BranchRight(root, branch_right) where
+
+import Root
+
+branch_right :: Int
+branch_right = 5 * root

--- a/tests/haskell_module/th/Leaf.hs
+++ b/tests/haskell_module/th/Leaf.hs
@@ -1,0 +1,12 @@
+{-# LANGUAGE TemplateHaskell #-}
+module Leaf where
+
+import BranchLeft
+import BranchRight
+import Control.Monad (replicateM)
+import Language.Haskell.TH (runIO)
+
+runIO (replicateM root (return ())) >> return []
+
+leaf :: Int
+leaf = 7 * branch_left * branch_right

--- a/tests/haskell_module/th/Root.hs
+++ b/tests/haskell_module/th/Root.hs
@@ -1,0 +1,4 @@
+module Root where
+
+root :: Int
+root = 2


### PR DESCRIPTION
This PR exposes object and .dyn_o files to the build action of haskell_module.

It also adds a test of building a module which uses Template Haskell.