### PR TITLE
Revert "remove asterius tests using haskell_modules"

### DIFF
--- a/tests/asterius/haskell_module/hs-boot/BUILD.bazel
+++ b/tests/asterius/haskell_module/hs-boot/BUILD.bazel
@@ -1,0 +1,3 @@
+load("//tests:asterius/asterius_tests_utils.bzl", "asterius_test_macro")
+
+asterius_test_macro("//tests/haskell_module/hs-boot")

--- a/tests/asterius/haskell_module/library/BUILD.bazel
+++ b/tests/asterius/haskell_module/library/BUILD.bazel
@@ -1,0 +1,7 @@
+load("//tests:asterius/asterius_tests_utils.bzl", "asterius_test_macro")
+
+asterius_test_macro(
+    "//tests/haskell_module/library:bin-deps",
+    test_entry_point = "test_entry_point.mjs",
+    test_subfolder_name = "test_subfolder_name",
+)


### PR DESCRIPTION
Depends on #1621

This PR contains Asterius tests making use of the `haskell_modules` feature.

These do not work at the moment, most likely because of a temporary difference in the way `ahc` and `ghc` handle the `-odir` option.

See: https://github.com/ylecornec/asterius_odir_repro