### PR TITLE
Update Asterius bundle

### DIFF
--- a/haskell/asterius/repositories.bzl
+++ b/haskell/asterius/repositories.bzl
@@ -31,8 +31,8 @@ AHC_BINDIST = \
     {
         "0.0.1": {
             "linux_amd64": (
-                "https://github.com/ylecornec/test_bundle/releases/download/test/asterius_bundle.tar.gz",
-                "0c50415278e14003541697c99818e96d52ba67b1a140ac0eaf89bfb6b751548f",
+                "https://github.com/tweag/asterius_bundles_for_bazel/releases/download/0.0.1/asterius_bundle.tar.gz",
+                "747cb0d3f0205a5221c4476589374707496e29649f4690de4ff287acdddc1bb4",
             ),
         },
     }

--- a/tests/asterius/lhs/BUILD.bazel
+++ b/tests/asterius/lhs/BUILD.bazel
@@ -1,0 +1,3 @@
+load("//tests:asterius/asterius_tests_utils.bzl", "asterius_test_macro")
+
+asterius_test_macro("//tests/lhs:lhs-bin")


### PR DESCRIPTION
This PR updates the Asterius bundle:

- It is now in a Tweag owned repository (until it is built in the Asterius CI).

- This new bundle supports literate Haskell (the previous one was missing the `unlit` binary provided by Asterius) so there is now a test for this.