### PR TITLE
Add hs libraries to the inputs of HaskellBuildObject

### DIFF
--- a/haskell/experimental/private/module.bzl
+++ b/haskell/experimental/private/module.bzl
@@ -205,6 +205,7 @@ def _build_haskell_module(
             transitive = [
                 dep_info.package_databases,
                 dep_info.interface_dirs,
+                dep_info.hs_libraries,
                 pkg_info_inputs,
                 plugin_dep_info.package_databases,
                 plugin_dep_info.interface_dirs,

--- a/tests/haskell_module/th/BUILD.bazel
+++ b/tests/haskell_module/th/BUILD.bazel
@@ -48,6 +48,7 @@ haskell_library(
     deps = [
         "//tests/hackage:base",
         "//tests/hackage:template-haskell",
+        "@stackage//:vector",
     ],
 )
 

--- a/tests/haskell_module/th/Leaf.hs
+++ b/tests/haskell_module/th/Leaf.hs
@@ -4,9 +4,10 @@ module Leaf where
 import BranchLeft
 import BranchRight
 import Control.Monad (replicateM)
+import qualified Data.Vector as Vector
 import Language.Haskell.TH (runIO)
 
-runIO (replicateM root (return ())) >> return []
+runIO (replicateM root (return Vector.empty)) >> return []
 
 leaf :: Int
 leaf = 7 * branch_left * branch_right


### PR DESCRIPTION
`haskell_module` was tested so far with boot libraries only. But it turned out that if we tried to make it depend on other libraries it would complain that the libraries can't be found.

This PR strengthens the tests and adds the missing inputs.