### PR TITLE
explicitly pass hsc2hs binary to cabal_wrapper.py.

### DIFF
--- a/haskell/cabal.bzl
+++ b/haskell/cabal.bzl
@@ -168,6 +168,7 @@ def _cabal_toolchain_info(hs, cc, workspace_name, runghc):
     return struct(
         ghc = hs.tools.ghc.path,
         ghc_pkg = hs.tools.ghc_pkg.path,
+        hsc2hs = hs.tools.hsc2hs.path,
         runghc = runghc.path,
         ar = ar,
         cc = cc.tools.cc,

--- a/haskell/private/cabal_wrapper.py
+++ b/haskell/private/cabal_wrapper.py
@@ -17,6 +17,7 @@
 # , "path_args": list of string   # Additional args to Setup.hs configure where paths need to be prefixed with execroot.
 # , "toolchain_info" :
 #     { "ghc": string                  # path to ghc
+#     , "hsc2hs": string               # path to hsc2hs
 #     , "ghc_pkg": string              # path to ghc_pkg
 #     , "runghc": string               # path to runghc
 #     , "ar": string                   # path to ar
@@ -116,6 +117,7 @@ runghc_args = json_args["runghc_args"]
 
 runghc = find_exe(toolchain_info["runghc"])
 ghc = find_exe(toolchain_info["ghc"])
+hsc2hs = find_exe(toolchain_info["hsc2hs"])
 ghc_pkg = find_exe(toolchain_info["ghc_pkg"])
 
 extra_args = json_args["extra_args"]
@@ -222,6 +224,7 @@ with tmpdir() as distdir:
         "--user", \
         "--with-compiler=" + ghc,
         "--with-hc-pkg=" + ghc_pkg,
+        "--with-hsc2hs=" + hsc2hs,
         "--with-ar=" + ar,
         "--with-gcc=" + cc,
         "--with-strip=" + strip,

--- a/tests/asterius/stackage_zlib_runpath/BUILD
+++ b/tests/asterius/stackage_zlib_runpath/BUILD
@@ -1,0 +1,3 @@
+load("//tests:asterius/asterius_tests_utils.bzl", "asterius_test_macro")
+
+asterius_test_macro("//tests/stackage_zlib_runpath:cabal-binary")

--- a/tests/stackage_zlib_runpath/BUILD.bazel
+++ b/tests/stackage_zlib_runpath/BUILD.bazel
@@ -28,6 +28,7 @@ haskell_cabal_binary(
     name = "cabal-binary",
     srcs = glob(["cabal-binary/**"]),
     tags = ["requires_nix"],
+    visibility = ["//tests/asterius/stackage_zlib_runpath:__pkg__"],
     deps = [
         "//tests/hackage:base",
         # Depend transitively on libz.


### PR DESCRIPTION
This PR explicitly pass the `hsc2hs` binary from the haskell toolchain to cabal, which is needed for asterius to build the `@stackage-zlib//:zlib` target, and make the new test pass.