### PR TITLE
Add node to PATH of asterius cabal actions

### DIFF
--- a/haskell/asterius/asterius_config.bzl
+++ b/haskell/asterius/asterius_config.bzl
@@ -24,15 +24,14 @@ ASTERIUS_BINARIES = {
 
 def asterius_tools_config(exec_cc_toolchain, posix_toolchain, node_toolchain, tools_for_ghc_pkg):
     """ Tools, PATH directories and config specific to asterius. """
+    node_paths = [f.dirname for f in node_toolchain.nodeinfo.tool_files]
     return struct(
         # Asterius needs node in the path to evaluate template
         # haskell. And the asterius bundle depends on the posix toolchain
         # because it containts wrapper scripts.
-        path_for_run_ghc = ":".join(
-            posix_toolchain.paths +
-            [f.dirname for f in node_toolchain.nodeinfo.tool_files],
-        ),
-        tools_for_run_ghc = node_toolchain.nodeinfo.tool_files,
+        path_for_run_ghc = posix_toolchain.paths + node_paths,
+        path_for_cabal = node_paths,
+        tools_for_ghc = node_toolchain.nodeinfo.tool_files,
         tools_for_ghc_pkg = tools_for_ghc_pkg,
 
         # Asterius does not behave as other ghc cross compilers yet

--- a/haskell/private/context.bzl
+++ b/haskell/private/context.bzl
@@ -2,15 +2,16 @@
 
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load("//haskell:providers.bzl", "HaskellLibraryInfo", "all_dependencies_package_ids")
+load(":private/path_utils.bzl", "join_path_list")
 
 HaskellContext = provider()
 
-def append_to_path(env, path):
-    if path:
+def append_to_path(env, is_windows, path_list):
+    if path_list:
         if "PATH" in env and env["PATH"]:
-            env["PATH"] = ":".join([env["PATH"], path])
+            env["PATH"] = join_path_list(is_windows, [env["PATH"]] + path_list)
         else:
-            env["PATH"] = path
+            env["PATH"] = join_path_list(is_windows, path_list)
 
 def haskell_context(ctx, attr = None):
     toolchain = ctx.toolchains["@rules_haskell//haskell:toolchain"]

--- a/haskell/private/path_utils.bzl
+++ b/haskell/private/path_utils.bzl
@@ -204,13 +204,13 @@ def declare_compiled(hs, src, ext, directory = None, rel_path = None):
 
     return hs.actions.declare_file(fp_with_dir)
 
-def join_path_list(hs, paths):
+def join_path_list(is_windows, paths):
     """Join the given paths suitable for env vars like PATH.
 
     Joins the list of given paths into a single string separated by ':' on Unix
     or ';' on Windows.
     """
-    sep = ";" if hs.toolchain.is_windows else ":"
+    sep = ";" if is_windows else ":"
     return sep.join(paths)
 
 def mangle_static_library(hs, posix, dynamic_lib, static_lib, outdir):

--- a/haskell/toolchain.bzl
+++ b/haskell/toolchain.bzl
@@ -78,8 +78,8 @@ def _run_ghc(hs, cc, inputs, outputs, mnemonic, arguments, env, params_file = No
     else:
         input_manifests = cc.manifests
 
-    tools.extend(hs.tools_config.tools_for_run_ghc)
-    append_to_path(env, hs.tools_config.path_for_run_ghc)
+    tools.extend(hs.tools_config.tools_for_ghc)
+    append_to_path(env, hs.toolchain.is_windows, hs.tools_config.path_for_run_ghc)
 
     hs.actions.run(
         inputs = inputs,
@@ -97,8 +97,9 @@ def _run_ghc(hs, cc, inputs, outputs, mnemonic, arguments, env, params_file = No
     return args
 
 default_tools_config = struct(
-    path_for_run_ghc = "",
-    tools_for_run_ghc = [],
+    path_for_run_ghc = [],
+    tools_for_ghc = [],
+    path_for_cabal = [],
     tools_for_ghc_pkg = [],
 
     # for cross compiling we will pass ghc a cross compiling cc_toolchain,

--- a/tests/haskell_cabal_binary/Main.hs
+++ b/tests/haskell_cabal_binary/Main.hs
@@ -2,3 +2,5 @@ module Main where
 
 main :: IO ()
 main = return ()
+
+{-# ANN module "Test annotations in cabal package" #-} 


### PR DESCRIPTION
This PR adds `node` to the tools and PATH of asterius cabal actions.

This is necessary to support Template Haskell and annotations such as the one added in example,
but until now it was only done in the `run_ghc` case and not the cabal one.

- There is now a `path_for_cabal` field next to the `path_for_runghc` field in the `tools_config` section of the haskell toolchain.
  `path_for_cabal` does not contain the posix tools, because these are not specific to asterius, and always added to cabal actions.
- These fields are now lists of paths instead of a string, and the `join_path_list` function is used to join them.