### PR TITLE
Disallow non-module dependencies in the deps attribute of haskell_module

### DIFF
--- a/haskell/experimental/defs.bzl
+++ b/haskell/experimental/defs.bzl
@@ -23,7 +23,7 @@ _haskell_module = rule(
         "extra_srcs": attr.label_list(
             allow_files = True,
         ),
-        "modules": attr.label_list(),
+        "deps": attr.label_list(),
         "ghcopts": attr.string_list(),
         "plugins": attr.label_list(
             aspects = [haskell_cc_libraries_aspect],
@@ -55,7 +55,7 @@ def haskell_module(
         src = None,
         extra_srcs = [],
         module_name = "",
-        modules = [],
+        deps = [],
         ghcopts = [],
         plugins = [],
         tools = [],
@@ -75,7 +75,7 @@ def haskell_module(
           name = "Example.Module",
           src = "src/Example/Module.hs",
           src_strip_prefix = "src",
-          modules = [
+          deps = [
               "//:Another.Module",
           ],
       )
@@ -114,7 +114,7 @@ def haskell_module(
                   This is merged with the extra_srcs attribute of rules that depend directly on this haskell_module rule.
       module_name: Use the given module name instead of trying to infer it from src and src_strip_prefix. This is
                    necessary when the src file is not named the same as the Haskell module.
-      modules: List of other Haskell modules needed to compile this module. They need to be included in the `modules`
+      deps: List of other Haskell modules needed to compile this module. They need to be included in the `modules`
                attribute of any library, binary, or test that depends on this module.
                If the module depends on any libraries, they should be listed in the deps attribute of the library,
                binary, or test that depends on this module.
@@ -132,7 +132,7 @@ def haskell_module(
         src = src,
         extra_srcs = extra_srcs,
         module_name = module_name,
-        modules = modules,
+        deps = deps,
         ghcopts = ghcopts,
         plugins = plugins,
         tools = tools,

--- a/haskell/experimental/defs.bzl
+++ b/haskell/experimental/defs.bzl
@@ -1,5 +1,6 @@
 """Experimental Haskell rules"""
 
+load("//haskell/experimental:providers.bzl", "HaskellModuleInfo")
 load(
     "//haskell/experimental/private:module.bzl",
     _haskell_module_impl = "haskell_module_impl",
@@ -23,7 +24,7 @@ _haskell_module = rule(
         "extra_srcs": attr.label_list(
             allow_files = True,
         ),
-        "deps": attr.label_list(),
+        "deps": attr.label_list(providers = [HaskellModuleInfo]),
         "ghcopts": attr.string_list(),
         "plugins": attr.label_list(
             aspects = [haskell_cc_libraries_aspect],

--- a/haskell/experimental/defs.bzl
+++ b/haskell/experimental/defs.bzl
@@ -61,7 +61,7 @@ def haskell_module(
         tools = [],
         worker = None,
         **kwargs):
-    """Declare a dependency between modules.
+    """Declare a module and its dependencies on other modules.
 
     This allows library, binary, and test rules to do incremental builds when only a
     few modules are affected by a change.

--- a/haskell/experimental/private/module.bzl
+++ b/haskell/experimental/private/module.bzl
@@ -391,12 +391,6 @@ def build_haskell_modules(ctx, hs, cc, posix, package_name, with_shared, hidir, 
 
 def haskell_module_impl(ctx):
     module_deps = [dep for dep in ctx.attr.deps if HaskellModuleInfo in dep]
-    if len(module_deps) < len(ctx.attr.deps):
-        fail("""
-{rule_name} contains non-haskell_module labels in the deps attribute: {unexpected_labels}
-Maybe put them in the deps attributes of the corresponding library, binary, or test rule.
-""".format(rule_name = ctx.label, unexpected_labels = ", ".join([str(dep.label) for dep in ctx.attr.deps if not HaskellModuleInfo in dep])))
-
     transitive_module_dep_labels = depset(
         direct = [dep.label for dep in module_deps],
         transitive = [dep[HaskellModuleInfo].transitive_module_dep_labels for dep in module_deps],

--- a/haskell/experimental/private/module.bzl
+++ b/haskell/experimental/private/module.bzl
@@ -390,7 +390,13 @@ def build_haskell_modules(ctx, hs, cc, posix, package_name, with_shared, hidir, 
     )
 
 def haskell_module_impl(ctx):
-    module_deps = [dep for dep in ctx.attr.deps if HaskellModuleInfo in dep]
+    module_deps = [dep for dep in ctx.attr.modules if HaskellModuleInfo in dep]
+    if len(module_deps) < len(ctx.attr.modules):
+        fail("""
+{rule_name} contains non-haskell_module labels in the modules attribute: {unexpected_labels}
+Maybe put them in the deps attributes of the corresponding library, binary, or test rule.
+""".format(rule_name = ctx.label, unexpected_labels = ", ".join([str(dep.label) for dep in ctx.attr.modules if not HaskellModuleInfo in dep])))
+
     transitive_module_dep_labels = depset(
         direct = [dep.label for dep in module_deps],
         transitive = [dep[HaskellModuleInfo].transitive_module_dep_labels for dep in module_deps],

--- a/haskell/experimental/private/module.bzl
+++ b/haskell/experimental/private/module.bzl
@@ -390,12 +390,12 @@ def build_haskell_modules(ctx, hs, cc, posix, package_name, with_shared, hidir, 
     )
 
 def haskell_module_impl(ctx):
-    module_deps = [dep for dep in ctx.attr.modules if HaskellModuleInfo in dep]
-    if len(module_deps) < len(ctx.attr.modules):
+    module_deps = [dep for dep in ctx.attr.deps if HaskellModuleInfo in dep]
+    if len(module_deps) < len(ctx.attr.deps):
         fail("""
-{rule_name} contains non-haskell_module labels in the modules attribute: {unexpected_labels}
+{rule_name} contains non-haskell_module labels in the deps attribute: {unexpected_labels}
 Maybe put them in the deps attributes of the corresponding library, binary, or test rule.
-""".format(rule_name = ctx.label, unexpected_labels = ", ".join([str(dep.label) for dep in ctx.attr.modules if not HaskellModuleInfo in dep])))
+""".format(rule_name = ctx.label, unexpected_labels = ", ".join([str(dep.label) for dep in ctx.attr.deps if not HaskellModuleInfo in dep])))
 
     transitive_module_dep_labels = depset(
         direct = [dep.label for dep in module_deps],

--- a/tests/haskell_module/attr_merging/BUILD.bazel
+++ b/tests/haskell_module/attr_merging/BUILD.bazel
@@ -39,7 +39,6 @@ haskell_module(
     name = "module-with-plugin",
     src = "ModuleWith.hs",
     tags = ["skip_profiling"],
-    deps = [":base"],
 )
 
 haskell_library(

--- a/tests/haskell_module/binary/BUILD.bazel
+++ b/tests/haskell_module/binary/BUILD.bazel
@@ -33,13 +33,11 @@ haskell_module(
     name = "TestBinModule",
     src = "TestBin.hs",
     module_name = "Main",
-    deps = ["//tests/hackage:base"],
 )
 
 haskell_module(
     name = "Main",
     src = "Main.hs",
-    deps = ["//tests/hackage:base"],
 )
 
 filegroup(

--- a/tests/haskell_module/hs-boot/BUILD.bazel
+++ b/tests/haskell_module/hs-boot/BUILD.bazel
@@ -11,29 +11,24 @@ haskell_module(
     name = "lib-A-boot",
     src = "src/A.hs-boot",
     src_strip_prefix = "src",
-    deps = [
-        "//tests/hackage:base",
-    ],
 )
 
 haskell_module(
     name = "lib-B",
     src = "src/B.hs",
-    src_strip_prefix = "src",
-    deps = [
+    modules = [
         ":lib-A-boot",
-        "//tests/hackage:base",
     ],
+    src_strip_prefix = "src",
 )
 
 haskell_module(
     name = "lib-A",
     src = "src/A.hs",
-    src_strip_prefix = "src",
-    deps = [
+    modules = [
         ":lib-B",
-        "//tests/hackage:base",
     ],
+    src_strip_prefix = "src",
 )
 
 haskell_library(

--- a/tests/haskell_module/hs-boot/BUILD.bazel
+++ b/tests/haskell_module/hs-boot/BUILD.bazel
@@ -16,19 +16,19 @@ haskell_module(
 haskell_module(
     name = "lib-B",
     src = "src/B.hs",
-    modules = [
+    src_strip_prefix = "src",
+    deps = [
         ":lib-A-boot",
     ],
-    src_strip_prefix = "src",
 )
 
 haskell_module(
     name = "lib-A",
     src = "src/A.hs",
-    modules = [
+    src_strip_prefix = "src",
+    deps = [
         ":lib-B",
     ],
-    src_strip_prefix = "src",
 )
 
 haskell_library(

--- a/tests/haskell_module/library-dep/BUILD.bazel
+++ b/tests/haskell_module/library-dep/BUILD.bazel
@@ -17,9 +17,6 @@ haskell_library(
 haskell_module(
     name = "TestModule",
     src = "TestModule.hs",
-    deps = [
-        "//tests/hackage:base",
-    ],
 )
 
 haskell_library(

--- a/tests/haskell_module/library/BUILD.bazel
+++ b/tests/haskell_module/library/BUILD.bazel
@@ -24,7 +24,6 @@ haskell_module(
     name = "TestLibModule",
     src = "TestLib.hs",
     extra_srcs = ["extra_src.md"],
-    deps = ["//tests/hackage:base"],
 )
 
 haskell_module(
@@ -32,7 +31,6 @@ haskell_module(
     src = "TestLib2.hs",
     extra_srcs = ["extra_src.md"],
     module_name = "Test.Lib",
-    deps = ["//tests/hackage:base"],
 )
 
 haskell_test(

--- a/tests/haskell_module/multiple/BUILD.bazel
+++ b/tests/haskell_module/multiple/BUILD.bazel
@@ -11,7 +11,7 @@ haskell_module(
 haskell_module(
     name = "branch_left",
     src = "BranchLeft.hs",
-    modules = [
+    deps = [
         ":root",
     ],
 )
@@ -19,7 +19,7 @@ haskell_module(
 haskell_module(
     name = "branch_right",
     src = "BranchRight.hs",
-    modules = [
+    deps = [
         ":root",
     ],
 )
@@ -27,7 +27,7 @@ haskell_module(
 haskell_module(
     name = "leaf",
     src = "Leaf.hs",
-    modules = [
+    deps = [
         ":branch_left",
         ":branch_right",
     ],

--- a/tests/haskell_module/multiple/BUILD.bazel
+++ b/tests/haskell_module/multiple/BUILD.bazel
@@ -6,34 +6,30 @@ load("@rules_haskell//haskell/experimental:defs.bzl", "haskell_module")
 haskell_module(
     name = "root",
     src = "Root.hs",
-    deps = ["//tests/hackage:base"],
 )
 
 haskell_module(
     name = "branch_left",
     src = "BranchLeft.hs",
-    deps = [
+    modules = [
         ":root",
-        "//tests/hackage:base",
     ],
 )
 
 haskell_module(
     name = "branch_right",
     src = "BranchRight.hs",
-    deps = [
+    modules = [
         ":root",
-        "//tests/hackage:base",
     ],
 )
 
 haskell_module(
     name = "leaf",
     src = "Leaf.hs",
-    deps = [
+    modules = [
         ":branch_left",
         ":branch_right",
-        "//tests/hackage:base",
     ],
 )
 

--- a/tests/haskell_module/nested/BUILD.bazel
+++ b/tests/haskell_module/nested/BUILD.bazel
@@ -6,19 +6,17 @@ load("@rules_haskell//haskell/experimental:defs.bzl", "haskell_module")
 haskell_module(
     name = "Branch.Right.Module",
     src = "src/Branch/Right/Module.hs",
-    src_strip_prefix = "src",
-    deps = [
-        "//tests/hackage:base",
+    modules = [
         "//tests/haskell_module/nested/Root:Module",
     ],
+    src_strip_prefix = "src",
 )
 
 haskell_module(
     name = "LeafModule",
     src = "LeafModule.hs",
-    deps = [
+    modules = [
         ":Branch.Right.Module",
-        "//tests/hackage:base",
         "//tests/haskell_module/nested/Branch/Left:Module",
     ],
 )

--- a/tests/haskell_module/nested/BUILD.bazel
+++ b/tests/haskell_module/nested/BUILD.bazel
@@ -6,16 +6,16 @@ load("@rules_haskell//haskell/experimental:defs.bzl", "haskell_module")
 haskell_module(
     name = "Branch.Right.Module",
     src = "src/Branch/Right/Module.hs",
-    modules = [
+    src_strip_prefix = "src",
+    deps = [
         "//tests/haskell_module/nested/Root:Module",
     ],
-    src_strip_prefix = "src",
 )
 
 haskell_module(
     name = "LeafModule",
     src = "LeafModule.hs",
-    modules = [
+    deps = [
         ":Branch.Right.Module",
         "//tests/haskell_module/nested/Branch/Left:Module",
     ],

--- a/tests/haskell_module/nested/Branch/Left/BUILD.bazel
+++ b/tests/haskell_module/nested/Branch/Left/BUILD.bazel
@@ -3,11 +3,11 @@ load("@rules_haskell//haskell/experimental:defs.bzl", "haskell_module")
 haskell_module(
     name = "Module",
     src = "Module.hs",
-    modules = [
-        "//tests/haskell_module/nested/Root:Module",
-    ],
     src_strip_prefix = "/tests/haskell_module/nested",
     visibility = ["//tests/haskell_module/nested:__subpackages__"],
+    deps = [
+        "//tests/haskell_module/nested/Root:Module",
+    ],
 )
 
 filegroup(

--- a/tests/haskell_module/nested/Branch/Left/BUILD.bazel
+++ b/tests/haskell_module/nested/Branch/Left/BUILD.bazel
@@ -3,12 +3,11 @@ load("@rules_haskell//haskell/experimental:defs.bzl", "haskell_module")
 haskell_module(
     name = "Module",
     src = "Module.hs",
-    src_strip_prefix = "/tests/haskell_module/nested",
-    visibility = ["//tests/haskell_module/nested:__subpackages__"],
-    deps = [
-        "//tests/hackage:base",
+    modules = [
         "//tests/haskell_module/nested/Root:Module",
     ],
+    src_strip_prefix = "/tests/haskell_module/nested",
+    visibility = ["//tests/haskell_module/nested:__subpackages__"],
 )
 
 filegroup(

--- a/tests/haskell_module/nested/Root/BUILD.bazel
+++ b/tests/haskell_module/nested/Root/BUILD.bazel
@@ -5,7 +5,6 @@ haskell_module(
     src = "Module.hs",
     src_strip_prefix = "/tests/haskell_module/nested",
     visibility = ["//tests/haskell_module/nested:__subpackages__"],
-    deps = ["//tests/hackage:base"],
 )
 
 filegroup(

--- a/tests/haskell_module/plugin/BUILD.bazel
+++ b/tests/haskell_module/plugin/BUILD.bazel
@@ -45,14 +45,12 @@ haskell_module(
     src = "ModuleWith.hs",
     plugins = [":plugin"],
     tags = ["skip_profiling"],
-    deps = [":base"],
 )
 
 haskell_module(
     name = "module-without-plugin",
     src = "ModuleWithout.hs",
     tags = ["skip_profiling"],
-    deps = [":base"],
 )
 
 haskell_library(

--- a/tests/haskell_module/th/BUILD.bazel
+++ b/tests/haskell_module/th/BUILD.bazel
@@ -11,7 +11,7 @@ haskell_module(
 haskell_module(
     name = "branch_left",
     src = "BranchLeft.hs",
-    modules = [
+    deps = [
         ":root",
     ],
 )
@@ -19,7 +19,7 @@ haskell_module(
 haskell_module(
     name = "branch_right",
     src = "BranchRight.hs",
-    modules = [
+    deps = [
         ":root",
     ],
 )
@@ -27,7 +27,7 @@ haskell_module(
 haskell_module(
     name = "leaf",
     src = "Leaf.hs",
-    modules = [
+    deps = [
         ":branch_left",
         ":branch_right",
     ],

--- a/tests/haskell_module/th/BUILD.bazel
+++ b/tests/haskell_module/th/BUILD.bazel
@@ -6,34 +6,30 @@ load("@rules_haskell//haskell/experimental:defs.bzl", "haskell_module")
 haskell_module(
     name = "root",
     src = "Root.hs",
-    deps = ["//tests/hackage:base"],
 )
 
 haskell_module(
     name = "branch_left",
     src = "BranchLeft.hs",
-    deps = [
+    modules = [
         ":root",
-        "//tests/hackage:base",
     ],
 )
 
 haskell_module(
     name = "branch_right",
     src = "BranchRight.hs",
-    deps = [
+    modules = [
         ":root",
-        "//tests/hackage:base",
     ],
 )
 
 haskell_module(
     name = "leaf",
     src = "Leaf.hs",
-    deps = [
+    modules = [
         ":branch_left",
         ":branch_right",
-        "//tests/hackage:base",
     ],
 )
 

--- a/tests/haskell_module/tools/BUILD.bazel
+++ b/tests/haskell_module/tools/BUILD.bazel
@@ -19,7 +19,6 @@ haskell_module(
     ghcopts = ["-DCAT=$(location :cat)"],
     tools = [":cat"],
     visibility = ["//visibility:public"],
-    deps = ["//tests/hackage:base"],
 )
 
 filegroup(

--- a/tests/library-external-workspace/BUILD.bazel
+++ b/tests/library-external-workspace/BUILD.bazel
@@ -23,7 +23,6 @@ haskell_library(
 haskell_module(
     name = "TestLibModule",
     src = "TestLib2.hs",
-    deps = ["//tests/hackage:base"],
 )
 
 haskell_test(

--- a/tests/library-external-workspace/BUILD.bazel
+++ b/tests/library-external-workspace/BUILD.bazel
@@ -9,8 +9,6 @@ package(default_testonly = 1)
 
 haskell_library(
     name = "TestLib",
-    # TODO: Remove when haskell_module supports dynamic builds
-    linkstatic = True,
     modules = [
         ":TestLibModule",
     ],

--- a/tests/library-external-workspace/repo/BUILD.bazel
+++ b/tests/library-external-workspace/repo/BUILD.bazel
@@ -10,8 +10,6 @@ package(default_testonly = 1)
 
 haskell_library(
     name = "TestLib",
-    # TODO: Remove when haskell_module supports dynamic builds
-    linkstatic = True,
     modules = [
         ":TestLibModule",
     ],

--- a/tests/library-external-workspace/repo/BUILD.bazel
+++ b/tests/library-external-workspace/repo/BUILD.bazel
@@ -26,7 +26,6 @@ haskell_toolchain_library(name = "base")
 haskell_module(
     name = "TestLibModule",
     src = "TestLib.hs",
-    deps = ["base"],
 )
 
 filegroup(


### PR DESCRIPTION
Since non-haskell_module deps are ignored in the deps attribute of `haskell_module`, this PR has bazel produce an error when non-haskell_module dependencies are placed in the modules attribute.