### PR TITLE
Use more deterministic distdir path in haskell_cabal_*

### DIFF
--- a/haskell/private/cabal_wrapper.py
+++ b/haskell/private/cabal_wrapper.py
@@ -37,7 +37,9 @@ from __future__ import print_function
 
 from contextlib import contextmanager
 from glob import glob
+import itertools
 import json
+import hashlib
 import os
 import os.path
 import re
@@ -134,32 +136,57 @@ def recache_db():
 recache_db()
 
 @contextmanager
-def tmpdir():
-    """This is a reimplementation of `tempfile.TemporaryDirectory` because
-    the latter isn't available in python2
+def mkdtemp(prefix):
+    """Create a temporary directory.
+
+    This is a context manager that will create the directory on entry and
+    delete it on exit.
+
+    The directory will be created under the given `prefix` path with an
+    optional suffix to avoid conflict with already existing directories.
     """
+    candidates = itertools.chain([prefix], ("{}_{}".format(prefix, i) for i in itertools.count(1)))
+    for candidate in candidates:
+        dirname = os.path.abspath(candidate)
+        try:
+            os.makedirs(dirname, mode=0o700, exist_ok=False)
+            break
+        except FileExistsError:
+            pass
+    try:
+        yield dirname
+    finally:
+        shutil.rmtree(dirname, ignore_errors = True)
+
+def distdir_prefix():
     # Build into a sibling path of the final binary output location.
     # This is to ensure that relative `RUNPATH`s are valid in the intermediate
     # output in the `--builddir` as well as in the final output in `--bindir`.
     # Executables are placed into `<distdir>/build/<package-name>/<binary>`.
     # Libraries are placed into `<distdir>/build/<library>`. I.e. there is an
     # extra subdirectory for libraries.
-    #
-    # On Windows we don't do dynamic linking and prefer shorter paths to avoid
-    # exceeding `MAX_PATH`.
     if is_windows:
-        distdir = tempfile.mkdtemp()
+        # On Windows we don't do dynamic linking and prefer shorter paths to
+        # avoid exceeding `MAX_PATH`.
+        distdir_root = tempfile.gettempdir()
     else:
         if component.startswith("exe:"):
-            distdir = tempfile.mkdtemp(dir=os.path.dirname(os.path.dirname(pkgroot)))
+            distdir_root = os.path.dirname(os.path.dirname(pkgroot))
         else:
-            distdir = tempfile.mkdtemp(dir=os.path.dirname(pkgroot))
-    try:
-        yield distdir
-    finally:
-        shutil.rmtree(distdir, ignore_errors = True)
+            distdir_root = os.path.dirname(pkgroot)
+    if is_windows:
+        # On Windows we use a fixed length directory name to avoid exceeding
+        # `MAX_PATH` on targets with long names.
+        distdir_name = hashlib.md5(name.encode("utf-8")).hexdigest()
+    else:
+        distdir_name = name
+    return os.path.join(distdir_root, name)
 
-with tmpdir() as distdir:
+# Build into a temporary distdir that will be cleaned up after the build. The
+# path to this distdir enters into flags that are passed to GHC and thereby
+# into the 'flag hash' field of generated interface files. We try to use a
+# reproducible path for the distdir to keep interface files reproducible.
+with mkdtemp(distdir_prefix()) as distdir:
     enable_relocatable_flags = ["--enable-relocatable"] \
             if not is_windows else []
 


### PR DESCRIPTION
Addresses indeterministic interface generation as reported in #1600.

Use a path for distdir in the `haskell_cabal_*` rules that is based on the package name and deterministic unless there is a collision with an already existing file or directory.

The distdir path enters flags that are passed to GHC and thereby enters the 'flag hash' field of the generated interface files. If the distdir path is indeterministic, then the interface file will also be indeterministic.

With this PR a build of the `hspec` Cabal library and its dependencies has been found to be bit-reproducible by building it twice without caching and comparing the outputs.

Notably, there is still an issue with non-deterministic builds if a `haskell_cabal_*` target has a C library dependency that was built by Bazel. In that case the absolute path to the sandbox execroot, which can change between builds, enters the [include and library search path flags](https://github.com/tweag/rules_haskell/blob/a7241fa64c7cd36462a1f6ac4c660d1247d5e07b/haskell/cabal.bzl#L343-L345). Cabal forces us to provide these paths as absolute paths, see https://github.com/haskell/cabal/issues/1317 and https://github.com/haskell/cabal/issues/694. Meaning, the generated interface files of `haskell_cabal_library` targets with Bazel built C library dependencies remain indeterministic.
