### PR TITLE
Fix Bazel CI

### DIFF
--- a/haskell/BUILD.bazel
+++ b/haskell/BUILD.bazel
@@ -63,6 +63,15 @@ bzl_library(
     ],
 )
 
+# @rules_cc//cc does not define a bzl_library itself, instead we  define our
+# own using the @rules_cc//cc:srcs filegroup.
+bzl_library(
+    name = "rules_cc",
+    srcs = [
+        "@rules_cc//cc:srcs",
+    ],
+)
+
 bzl_library(
     name = "haskell",
     srcs = glob(["**/*.bzl"]),
@@ -70,6 +79,7 @@ bzl_library(
     deps = [
         ":bazel_json",
         ":bazel_tools",
+        ":rules_cc",
         "//haskell/asterius:asterius_bzl",
         "//haskell/experimental:defs.bzl",
         "//haskell/experimental:providers.bzl",

--- a/haskell/asterius/repositories.bzl
+++ b/haskell/asterius/repositories.bzl
@@ -103,7 +103,7 @@ toolchain(
     exec_compatible_with = {exec_constraints},
     target_compatible_with = {target_constraints},
     toolchain = "{wasm_cc_toolchain}",
-    toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
+    toolchain_type = "@rules_cc//cc:toolchain_type",
 )
         """.format(
             bindist_name = ctx.attr.bindist_name,

--- a/haskell/c2hs.bzl
+++ b/haskell/c2hs.bzl
@@ -137,11 +137,11 @@ c2hs_library = rule(
             doc = "Executable version. If this is specified, CPP version macros will be generated for this build.",
         ),
         "_cc_toolchain": attr.label(
-            default = Label("@bazel_tools//tools/cpp:current_cc_toolchain"),
+            default = Label("@rules_cc//cc:current_cc_toolchain"),
         ),
     },
     toolchains = [
-        "@bazel_tools//tools/cpp:toolchain_type",
+        "@rules_cc//cc:toolchain_type",
         "@rules_haskell//haskell:toolchain",
         "@rules_haskell//haskell/c2hs:toolchain",
     ],

--- a/haskell/cabal.bzl
+++ b/haskell/cabal.bzl
@@ -5,7 +5,7 @@ load("@bazel_skylib//lib:paths.bzl", "paths")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe", "read_netrc", "use_netrc")
 load("//vendor/bazel_json/lib:json_parser.bzl", "json_parse")
 load("@bazel_tools//tools/cpp:lib_cc_configure.bzl", "get_cpu_value")
-load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
+load("@rules_cc//cc:find_cc_toolchain.bzl", "find_cc_toolchain")
 load(":cc.bzl", "cc_interop_info", "ghc_cc_program_args")
 load(":private/actions/info.bzl", "library_info_output_groups")
 load(":private/context.bzl", "haskell_context", "render_env")
@@ -598,7 +598,7 @@ def _haskell_cabal_library_impl(ctx):
         )
     else:
         doc_info = None
-    cc_toolchain = find_cpp_toolchain(ctx)
+    cc_toolchain = find_cc_toolchain(ctx)
     feature_configuration = cc_common.configure_features(
         ctx = ctx,
         cc_toolchain = cc_toolchain,
@@ -711,7 +711,7 @@ haskell_cabal_library = rule(
             default = Label("@rules_haskell//haskell:runghc"),
         ),
         "_cc_toolchain": attr.label(
-            default = Label("@bazel_tools//tools/cpp:current_cc_toolchain"),
+            default = Label("@rules_cc//cc:current_cc_toolchain"),
         ),
         "verbose": attr.bool(
             default = True,
@@ -727,7 +727,7 @@ haskell_cabal_library = rule(
         ),
     },
     toolchains = [
-        "@bazel_tools//tools/cpp:toolchain_type",
+        "@rules_cc//cc:toolchain_type",
         "@rules_haskell//haskell:toolchain",
         "@rules_sh//sh/posix:toolchain_type",
     ],
@@ -945,7 +945,7 @@ haskell_cabal_binary = rule(
             default = Label("@rules_haskell//haskell:runghc"),
         ),
         "_cc_toolchain": attr.label(
-            default = Label("@bazel_tools//tools/cpp:current_cc_toolchain"),
+            default = Label("@rules_cc//cc:current_cc_toolchain"),
         ),
         "verbose": attr.bool(
             default = True,
@@ -953,7 +953,7 @@ haskell_cabal_binary = rule(
         ),
     },
     toolchains = [
-        "@bazel_tools//tools/cpp:toolchain_type",
+        "@rules_cc//cc:toolchain_type",
         "@rules_haskell//haskell:toolchain",
         "@rules_sh//sh/posix:toolchain_type",
     ],

--- a/haskell/cc.bzl
+++ b/haskell/cc.bzl
@@ -8,7 +8,7 @@ load(
     "CPP_LINK_EXECUTABLE_ACTION_NAME",
     "C_COMPILE_ACTION_NAME",
 )
-load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
+load("@rules_cc//cc:find_cc_toolchain.bzl", "find_cc_toolchain")
 load(
     "//haskell:providers.bzl",
     "GhcPluginInfo",
@@ -81,7 +81,7 @@ def cc_interop_info(ctx, override_cc_toolchain = None):
 
     # Asterius does not behave as other ghc cross compilers yet and
     # relies on a cc toolchain targeting the exec platform .
-    cc_toolchain = override_cc_toolchain or find_cpp_toolchain(real_ctx)
+    cc_toolchain = override_cc_toolchain or find_cc_toolchain(real_ctx)
 
     feature_configuration = cc_common.configure_features(
         ctx = real_ctx,

--- a/haskell/cc.bzl
+++ b/haskell/cc.bzl
@@ -4,7 +4,7 @@ These rules are deprecated.
 """
 
 load(
-    "@bazel_tools//tools/build_defs/cc:action_names.bzl",
+    "@rules_cc//cc:action_names.bzl",
     "CPP_LINK_EXECUTABLE_ACTION_NAME",
     "C_COMPILE_ACTION_NAME",
 )

--- a/haskell/cc_toolchain_config.bzl
+++ b/haskell/cc_toolchain_config.bzl
@@ -1,9 +1,9 @@
 load(
-    "@bazel_tools//tools/build_defs/cc:action_names.bzl",
+    "@rules_cc//cc:action_names.bzl",
     "ACTION_NAMES",
 )
 load(
-    "@bazel_tools//tools/cpp:cc_toolchain_config_lib.bzl",
+    "@rules_cc//cc:cc_toolchain_config_lib.bzl",
     "artifact_name_pattern",
     "feature",
     "flag_group",

--- a/haskell/defs.bzl
+++ b/haskell/defs.bzl
@@ -88,7 +88,7 @@ _haskell_common_attrs = {
         default = Label("@rules_haskell//haskell:version_macros"),
     ),
     "_cc_toolchain": attr.label(
-        default = Label("@bazel_tools//tools/cpp:current_cc_toolchain"),
+        default = Label("@rules_cc//cc:current_cc_toolchain"),
     ),
     "_ghc_wrapper": attr.label(
         executable = True,
@@ -176,7 +176,7 @@ def _mk_binary_rule(**kwargs):
             "runghc": "%{name}@runghc",
         },
         toolchains = [
-            "@bazel_tools//tools/cpp:toolchain_type",
+            "@rules_cc//cc:toolchain_type",
             "@rules_haskell//haskell:toolchain",
             "@rules_sh//sh/posix:toolchain_type",
         ],
@@ -211,7 +211,7 @@ _haskell_library = rule(
         "runghc": "%{name}@runghc",
     },
     toolchains = [
-        "@bazel_tools//tools/cpp:toolchain_type",
+        "@rules_cc//cc:toolchain_type",
         "@rules_haskell//haskell:toolchain",
         "@rules_sh//sh/posix:toolchain_type",
     ],

--- a/haskell/doctest.bzl
+++ b/haskell/doctest.bzl
@@ -199,12 +199,12 @@ omitted, all exposed modules provided by `deps` will be tested.
 """,
         ),
         "_cc_toolchain": attr.label(
-            default = Label("@bazel_tools//tools/cpp:current_cc_toolchain"),
+            default = Label("@rules_cc//cc:current_cc_toolchain"),
         ),
     },
     fragments = ["cpp"],
     toolchains = [
-        "@bazel_tools//tools/cpp:toolchain_type",
+        "@rules_cc//cc:toolchain_type",
         "@rules_haskell//haskell:toolchain",
         "@rules_haskell//haskell:doctest-toolchain",
         "@rules_sh//sh/posix:toolchain_type",

--- a/haskell/experimental/defs.bzl
+++ b/haskell/experimental/defs.bzl
@@ -34,7 +34,7 @@ _haskell_module = rule(
             allow_files = True,
         ),
         "_cc_toolchain": attr.label(
-            default = Label("@bazel_tools//tools/cpp:current_cc_toolchain"),
+            default = Label("@rules_cc//cc:current_cc_toolchain"),
         ),
         "_ghc_wrapper": attr.label(
             executable = True,
@@ -44,7 +44,7 @@ _haskell_module = rule(
         # TODO[AH] Suppport worker
     },
     toolchains = [
-        "@bazel_tools//tools/cpp:toolchain_type",
+        "@rules_cc//cc:toolchain_type",
         "@rules_haskell//haskell:toolchain",
         "@rules_sh//sh/posix:toolchain_type",
     ],

--- a/haskell/private/cc_wrapper.bzl
+++ b/haskell/private/cc_wrapper.bzl
@@ -1,4 +1,4 @@
-load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
+load("@rules_cc//cc:find_cc_toolchain.bzl", "find_cc_toolchain")
 load("@bazel_tools//tools/build_defs/cc:action_names.bzl", "ACTION_NAMES")
 load("@rules_python//python:defs.bzl", "py_binary")
 
@@ -35,7 +35,7 @@ load("@rules_python//python:defs.bzl", "py_binary")
 #
 
 def _cc_wrapper_impl(ctx):
-    cc_toolchain = find_cpp_toolchain(ctx)
+    cc_toolchain = find_cc_toolchain(ctx)
     feature_configuration = cc_common.configure_features(
         ctx = ctx,
         cc_toolchain = cc_toolchain,
@@ -78,11 +78,11 @@ _cc_wrapper = rule(
         # TODO: Consider using execution groups to transition the toolchain
         # to the target platform.
         "_cc_toolchain": attr.label(
-            default = Label("@bazel_tools//tools/cpp:current_cc_toolchain"),
+            default = Label("@rules_cc//cc:current_cc_toolchain"),
         ),
     },
     fragments = ["cpp"],
-    toolchains = ["@bazel_tools//tools/cpp:toolchain_type"],
+    toolchains = ["@rules_cc//cc:toolchain_type"],
 )
 
 def cc_wrapper(name, **kwargs):

--- a/haskell/private/cc_wrapper.bzl
+++ b/haskell/private/cc_wrapper.bzl
@@ -1,5 +1,5 @@
 load("@rules_cc//cc:find_cc_toolchain.bzl", "find_cc_toolchain")
-load("@bazel_tools//tools/build_defs/cc:action_names.bzl", "ACTION_NAMES")
+load("@rules_cc//cc:action_names.bzl", "ACTION_NAMES")
 load("@rules_python//python:defs.bzl", "py_binary")
 
 # Note [On configuring the cc_wrapper]

--- a/haskell/private/haskell_impl.bzl
+++ b/haskell/private/haskell_impl.bzl
@@ -49,7 +49,7 @@ load(":providers.bzl", "GhcPluginInfo", "HaskellCoverageInfo")
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load("@bazel_skylib//lib:collections.bzl", "collections")
 load("@bazel_skylib//lib:shell.bzl", "shell")
-load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
+load("@rules_cc//cc:find_cc_toolchain.bzl", "find_cc_toolchain")
 load("//haskell/experimental:providers.bzl", "HaskellModuleInfo")
 load("//haskell/experimental/private:module.bzl", "build_haskell_modules", "get_module_path_from_target")
 
@@ -573,7 +573,7 @@ def haskell_library_impl(ctx):
     # XXX: protobuf is passing a "patched ctx"
     # which includes the real ctx as "real_ctx"
     real_ctx = getattr(ctx, "real_ctx", ctx)
-    cc_toolchain = find_cpp_toolchain(real_ctx)
+    cc_toolchain = find_cc_toolchain(real_ctx)
     feature_configuration = cc_common.configure_features(
         ctx = real_ctx,
         cc_toolchain = cc_toolchain,
@@ -692,7 +692,7 @@ def haskell_toolchain_libraries_impl(ctx):
     with_profiling = is_profiling_enabled(hs)
     with_threaded = "-threaded" in hs.toolchain.ghcopts
 
-    cc_toolchain = find_cpp_toolchain(ctx)
+    cc_toolchain = find_cc_toolchain(ctx)
     feature_configuration = cc_common.configure_features(
         ctx = ctx,
         cc_toolchain = cc_toolchain,
@@ -813,11 +813,11 @@ haskell_toolchain_libraries = rule(
     haskell_toolchain_libraries_impl,
     attrs = {
         "_cc_toolchain": attr.label(
-            default = Label("@bazel_tools//tools/cpp:current_cc_toolchain"),
+            default = Label("@rules_cc//cc:current_cc_toolchain"),
         ),
     },
     toolchains = [
-        "@bazel_tools//tools/cpp:toolchain_type",
+        "@rules_cc//cc:toolchain_type",
         "@rules_haskell//haskell:toolchain",
     ],
     fragments = ["cpp"],

--- a/haskell/protobuf.bzl
+++ b/haskell/protobuf.bzl
@@ -13,7 +13,7 @@ load(
     "HaskellLibraryInfo",
     "HaskellProtobufInfo",
 )
-load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
+load("@rules_cc//cc:find_cc_toolchain.bzl", "find_cc_toolchain")
 load(":private/pkg_id.bzl", "pkg_id")
 load(
     ":private/cc_libraries.bzl",
@@ -280,7 +280,7 @@ _haskell_proto_aspect = aspect(
             default = Label("@rules_haskell//haskell:private/ghci_repl_wrapper.sh"),
         ),
         "_cc_toolchain": attr.label(
-            default = Label("@bazel_tools//tools/cpp:current_cc_toolchain"),
+            default = Label("@rules_cc//cc:current_cc_toolchain"),
         ),
         "_ghc_wrapper": attr.label(
             executable = True,
@@ -290,7 +290,7 @@ _haskell_proto_aspect = aspect(
     },
     provides = [HaskellProtobufInfo],
     toolchains = [
-        "@bazel_tools//tools/cpp:toolchain_type",
+        "@rules_cc//cc:toolchain_type",
         "@rules_haskell//haskell:toolchain",
         "@rules_haskell//protobuf:toolchain",
         "@rules_sh//sh/posix:toolchain_type",

--- a/haskell/toolchain.bzl
+++ b/haskell/toolchain.bzl
@@ -1,5 +1,6 @@
 """Rules for defining toolchains"""
 
+load("@rules_cc//cc:find_cc_toolchain.bzl", "find_cc_toolchain")
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load(":ghc_bindist.bzl", "haskell_register_ghc_bindists")
 load(
@@ -211,7 +212,7 @@ def _haskell_toolchain_impl(ctx):
 
     if ctx.attr.asterius_binaries:
         tools_config = asterius_tools_config(
-            exec_cc_toolchain = ctx.toolchains["@rules_cc//cc:toolchain_type"],
+            exec_cc_toolchain = find_cc_toolchain(ctx),
             posix_toolchain = ctx.toolchains["@rules_sh//sh/posix:toolchain_type"],
             node_toolchain = ctx.toolchains["@build_bazel_rules_nodejs//toolchains/node:toolchain_type"],
             tools_for_ghc_pkg = ctx.files.tools,
@@ -334,6 +335,9 @@ _ahc_haskell_toolchain = rule(
     ],
     attrs = dict(
         common_attrs,
+        _cc_toolchain = attr.label(
+            default = Label("@rules_cc//cc:current_cc_toolchain"),
+        ),
     ),
 )
 

--- a/haskell/toolchain.bzl
+++ b/haskell/toolchain.bzl
@@ -211,7 +211,7 @@ def _haskell_toolchain_impl(ctx):
 
     if ctx.attr.asterius_binaries:
         tools_config = asterius_tools_config(
-            exec_cc_toolchain = ctx.toolchains["@bazel_tools//tools/cpp:toolchain_type"],
+            exec_cc_toolchain = ctx.toolchains["@rules_cc//cc:toolchain_type"],
             posix_toolchain = ctx.toolchains["@rules_sh//sh/posix:toolchain_type"],
             node_toolchain = ctx.toolchains["@build_bazel_rules_nodejs//toolchains/node:toolchain_type"],
             tools_for_ghc_pkg = ctx.files.tools,
@@ -329,7 +329,7 @@ _ahc_haskell_toolchain = rule(
     toolchains = [
         "@rules_sh//sh/posix:toolchain_type",
         "@build_bazel_rules_nodejs//toolchains/node:toolchain_type",
-        "@bazel_tools//tools/cpp:toolchain_type",
+        "@rules_cc//cc:toolchain_type",
         "@rules_haskell//haskell:toolchain",
     ],
     attrs = dict(

--- a/tests/solib_dir/solib_test.bzl
+++ b/tests/solib_dir/solib_test.bzl
@@ -1,4 +1,4 @@
-load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
+load("@rules_cc//cc:find_cc_toolchain.bzl", "find_cc_toolchain")
 
 _test_script_template = """#!/usr/bin/env bash
 library_path={library_path}
@@ -21,7 +21,7 @@ def _solib_test_impl(ctx):
         output = dynamic_library,
     )
 
-    cc_toolchain = find_cpp_toolchain(ctx)
+    cc_toolchain = find_cc_toolchain(ctx)
     feature_configuration = cc_common.configure_features(
         ctx = ctx,
         cc_toolchain = cc_toolchain,
@@ -55,12 +55,12 @@ solib_test = rule(
     attrs = {
         "is_windows": attr.bool(),
         "_cc_toolchain": attr.label(
-            default = Label("@bazel_tools//tools/cpp:current_cc_toolchain"),
+            default = Label("@rules_cc//cc:current_cc_toolchain"),
         ),
     },
     executable = True,
     fragments = ["cpp"],
-    toolchains = ["@bazel_tools//tools/cpp:toolchain_type"],
+    toolchains = ["@rules_cc//cc:toolchain_type"],
     test = True,
 )
 """Test that Bazel's solib directory matches our expectations.


### PR DESCRIPTION
Closes #1650

- Fixes [failure due to `CcToolchainType` mismatch](https://buildkite.com/bazel/rules-haskell-haskell/builds/964)
    ```
    (00:15:43) ERROR: /workdir/tests/binary-with-lib-dynamic/BUILD.bazel:13:16: in _haskell_library rule //tests/binary-with-lib-dynamic:lib:
    Traceback (most recent call last):
    	File "/workdir/haskell/private/haskell_impl.bzl", line 378, column 25, in haskell_library_impl
    		cc = cc_interop_info(
    	File "/workdir/haskell/cc.bzl", line 86, column 57, in cc_interop_info
    		feature_configuration = cc_common.configure_features(
    Error in configure_features: in call to configure_features(), parameter 'cc_toolchain' got value of type 'ToolchainInfo', want 'CcToolchainInfo'
    ```
    The issue was that the asterius toolchain setup was not calling `finc_cc_toolchain` but instead directly referencing the cc toolchain. This can cause mismatching result types, either `CcToolchainInfo` or `ToolchainInfo` depending on the Bazel configuration.
- Changes rules_haskell to consistently use `rules_cc` for the CC toolchain.
- ~Fixes [failure due to missing `libgmp`](https://buildkite.com/bazel/rules-haskell-haskell/builds/966#0085fa7a-c25c-4dcf-8862-a26f59d82dde/229-290)~
    ~Adds commands to `presubmit.yml` to install `libgmp-dev` and `libgmp10`.~
    Fixed by https://github.com/tweag/rules_haskell/pull/1655

Tested [successfully on Bazel CI](https://buildkite.com/bazel/rules-haskell-haskell/builds/971#9c534d1f-3d3c-4c71-bbc2-5279d6de3a1d)

cc @meteorcloudy