### PR TITLE
Narrowing of dependencies when not using template haskell

### DIFF
--- a/haskell/defs.bzl
+++ b/haskell/defs.bzl
@@ -35,6 +35,10 @@ load(
     "check_deprecated_attribute_usage",
 )
 load(
+    "//haskell:providers.bzl",
+    "HaskellLibraryInfo",
+)
+load(
     "//haskell/experimental:providers.bzl",
     "HaskellModuleInfo",
 )
@@ -53,6 +57,7 @@ _haskell_common_attrs = {
     "deps": attr.label_list(
         aspects = [haskell_cc_libraries_aspect],
     ),
+    "narrowed_deps": attr.label_list(providers = [HaskellLibraryInfo]),
     "modules": attr.label_list(
         providers = [HaskellModuleInfo],
     ),
@@ -248,6 +253,7 @@ def haskell_binary(
         srcs = [],
         extra_srcs = [],
         deps = [],
+        narrowed_deps = [],
         data = [],
         compiler_flags = [],
         ghcopts = [],
@@ -309,6 +315,10 @@ def haskell_binary(
       srcs: Haskell source files. File names must match module names, see above.
       extra_srcs: Extra (non-Haskell) source files that will be needed at compile time (e.g. by Template Haskell).
       deps: List of other Haskell libraries to be linked to this target.
+      narrowed_deps: Like deps, but only for dependencies using the modules
+          attribute. These dependencies are only used if this library uses
+          the modules attribute and the haskell_module rules depend on modules
+          provided by these dependencies.
       modules: List of extra haskell_module() dependencies to be linked into this binary.
       data: See [Bazel documentation](https://docs.bazel.build/versions/master/be/common-definitions.html#common.data).,
       compiler_flags: DEPRECATED. Use new name ghcopts.
@@ -332,6 +342,7 @@ def haskell_binary(
         srcs = srcs,
         extra_srcs = extra_srcs,
         deps = deps,
+        narrowed_deps = narrowed_deps,
         data = data,
         compiler_flags = compiler_flags,
         ghcopts = ghcopts,
@@ -391,6 +402,7 @@ def haskell_test(
         srcs = [],
         extra_srcs = [],
         deps = [],
+        narrowed_deps = [],
         data = [],
         compiler_flags = [],
         ghcopts = [],
@@ -442,6 +454,10 @@ def haskell_test(
       srcs: Haskell source files. File names must match module names, see above.
       extra_srcs: Extra (non-Haskell) source files that will be needed at compile time (e.g. by Template Haskell).
       deps: List of other Haskell libraries to be linked to this target.
+      narrowed_deps: Like deps, but only for dependencies using the modules
+          attribute. These dependencies are only used if this library uses
+          the modules attribute and the haskell_module rules depend on modules
+          provided by these dependencies.
       modules: List of extra haskell_module() dependencies to be linked into this test.
       data: See [Bazel documentation](https://docs.bazel.build/versions/master/be/common-definitions.html#common.data).,
       compiler_flags: DEPRECATED. Use new name ghcopts.
@@ -478,6 +494,7 @@ def haskell_test(
         srcs = srcs,
         extra_srcs = extra_srcs,
         deps = deps,
+        narrowed_deps = narrowed_deps,
         data = data,
         compiler_flags = compiler_flags,
         ghcopts = ghcopts,
@@ -523,6 +540,7 @@ def haskell_library(
         srcs = [],
         extra_srcs = [],
         deps = [],
+        narrowed_deps = [],
         modules = [],
         data = [],
         compiler_flags = [],
@@ -577,6 +595,10 @@ def haskell_library(
       srcs: Haskell source files. File names must match module names, see above.
       extra_srcs: Extra (non-Haskell) source files that will be needed at compile time (e.g. by Template Haskell).
       deps: List of other Haskell libraries to be linked to this target.
+      narrowed_deps: Like deps, but only for dependencies using the modules
+          attribute. These dependencies are only used if this library uses
+          the modules attribute and the haskell_module rules depend on modules
+          provided by these dependencies.
       modules: List of extra haskell_module() dependencies to be linked into this library.
       data: See [Bazel documentation](https://docs.bazel.build/versions/master/be/common-definitions.html#common.data).,
       compiler_flags: DEPRECATED. Use new name ghcopts.
@@ -606,6 +628,7 @@ def haskell_library(
         srcs = srcs,
         extra_srcs = extra_srcs,
         deps = deps,
+        narrowed_deps = narrowed_deps,
         modules = modules,
         data = data,
         compiler_flags = compiler_flags,

--- a/haskell/defs.bzl
+++ b/haskell/defs.bzl
@@ -57,7 +57,7 @@ _haskell_common_attrs = {
     "deps": attr.label_list(
         aspects = [haskell_cc_libraries_aspect],
     ),
-    "narrowed_deps": attr.label_list(providers = [HaskellLibraryInfo]),
+    "narrowed_deps": attr.label_list(),
     "modules": attr.label_list(
         providers = [HaskellModuleInfo],
     ),

--- a/haskell/defs.bzl
+++ b/haskell/defs.bzl
@@ -460,7 +460,9 @@ def haskell_test(
           attribute. These dependencies are only used if this library uses
           the modules attribute and the haskell_module rules depend on modules
           provided by these dependencies.
+          Note: This attribute is experimental and not ready for production, yet.
       modules: List of extra haskell_module() dependencies to be linked into this test.
+          Note: This attribute is experimental and not ready for production, yet.
       data: See [Bazel documentation](https://docs.bazel.build/versions/master/be/common-definitions.html#common.data).,
       compiler_flags: DEPRECATED. Use new name ghcopts.
       ghcopts: Flags to pass to Haskell compiler. Subject to Make variable substitution.
@@ -601,7 +603,9 @@ def haskell_library(
           attribute. These dependencies are only used if this library uses
           the modules attribute and the haskell_module rules depend on modules
           provided by these dependencies.
+          Note: This attribute is experimental and not ready for production, yet.
       modules: List of extra haskell_module() dependencies to be linked into this library.
+          Note: This attribute is experimental and not ready for production, yet.
       data: See [Bazel documentation](https://docs.bazel.build/versions/master/be/common-definitions.html#common.data).,
       compiler_flags: DEPRECATED. Use new name ghcopts.
       ghcopts: Flags to pass to Haskell compiler. Subject to Make variable substitution.

--- a/haskell/defs.bzl
+++ b/haskell/defs.bzl
@@ -319,7 +319,9 @@ def haskell_binary(
           attribute. These dependencies are only used if this library uses
           the modules attribute and the haskell_module rules depend on modules
           provided by these dependencies.
+          Note: This attribute is experimental and not ready for production, yet.
       modules: List of extra haskell_module() dependencies to be linked into this binary.
+          Note: This attribute is experimental and not ready for production, yet.
       data: See [Bazel documentation](https://docs.bazel.build/versions/master/be/common-definitions.html#common.data).,
       compiler_flags: DEPRECATED. Use new name ghcopts.
       ghcopts: Flags to pass to Haskell compiler. Subject to Make variable substitution.

--- a/haskell/experimental/defs.bzl
+++ b/haskell/experimental/defs.bzl
@@ -24,7 +24,8 @@ _haskell_module = rule(
         "extra_srcs": attr.label_list(
             allow_files = True,
         ),
-        "deps": attr.label_list(providers = [HaskellModuleInfo]),
+        "deps": attr.label_list(),
+        "cross_library_deps": attr.label_list(),
         "ghcopts": attr.string_list(),
         "plugins": attr.label_list(
             aspects = [haskell_cc_libraries_aspect],
@@ -57,6 +58,7 @@ def haskell_module(
         extra_srcs = [],
         module_name = "",
         deps = [],
+        cross_library_deps = [],
         ghcopts = [],
         plugins = [],
         tools = [],
@@ -116,11 +118,12 @@ def haskell_module(
       module_name: Use the given module name instead of trying to infer it from src and src_strip_prefix. This is
                    necessary when the src file is not named the same as the Haskell module.
       deps: List of other Haskell modules needed to compile this module. They need to be included in the `modules`
-               attribute of the enclosing library, binary, or test; or they need to be included
-               in the `modules` attribute of any library in the `narrowed_deps` attribute of the enclosing
-               library, binary, or test.
+               attribute of the enclosing library, binary, or test.
                If the module depends on any libraries, they should be listed in the deps attribute of the library,
                binary, or test that depends on this module.
+      cross_library_deps: List of other Haskell modules needed to compile this module that come from other libraries.
+               They need to be included in the `modules` attribute of any library in the `narrowed_deps` attribute
+               of the enclosing library, binary, or test
       ghcopts: Flags to pass to Haskell compiler. Subject to Make variable substitution.
                This is merged with the ghcopts attribute of rules that depend directly on this haskell_module rule.
       plugins: Compiler plugins to use during compilation. (Not implemented, yet)
@@ -136,6 +139,7 @@ def haskell_module(
         extra_srcs = extra_srcs,
         module_name = module_name,
         deps = deps,
+        cross_library_deps = cross_library_deps,
         ghcopts = ghcopts,
         plugins = plugins,
         tools = tools,

--- a/haskell/experimental/defs.bzl
+++ b/haskell/experimental/defs.bzl
@@ -116,7 +116,9 @@ def haskell_module(
       module_name: Use the given module name instead of trying to infer it from src and src_strip_prefix. This is
                    necessary when the src file is not named the same as the Haskell module.
       deps: List of other Haskell modules needed to compile this module. They need to be included in the `modules`
-               attribute of any library, binary, or test that depends on this module.
+               attribute of the enclosing library, binary, or test; or they need to be included
+               in the `modules` attribute of any library in the `narrowed_deps` attribute of the enclosing
+               library, binary, or test.
                If the module depends on any libraries, they should be listed in the deps attribute of the library,
                binary, or test that depends on this module.
       ghcopts: Flags to pass to Haskell compiler. Subject to Make variable substitution.

--- a/haskell/experimental/private/module.bzl
+++ b/haskell/experimental/private/module.bzl
@@ -293,7 +293,7 @@ def _collect_module_inputs(module_input_map, directs, dep):
 
     Args:
       module_input_map: maps labels of dependencies to all the inputs they require
-      directs: inputs of direct depedencies
+      directs: inputs of direct dependencies
       dep: the target for which to collect inputs
 
     Returns:
@@ -314,7 +314,7 @@ def _reorder_module_deps_to_postorder(label, modules):
 
     Args:
       label: The label of the rule with the modules attribute
-      modules: The modules comming from a modules attribute. This list must
+      modules: The modules coming from a modules attribute. This list must
                be the transitive closure of all the module dependencies.
     """
     transitive_module_dep_labels = depset(

--- a/haskell/experimental/private/module.bzl
+++ b/haskell/experimental/private/module.bzl
@@ -377,10 +377,8 @@ def _merge_narrowed_deps_dicts(rule_label, narrowed_deps):
       narrowed_deps: The contents of the narrowed_deps attribute
 
     Returns:
-      struct(per_module_transitive_interfaces):
-        per_module_transitive_interfaces: dict of module labels to their
-            interfaces and the interfaces of their transitive module
-            dependencies
+      dict of module labels to their interfaces and the interfaces of their transitive
+      module dependencies
     """
     per_module_transitive_interfaces = {}
     for dep in narrowed_deps:
@@ -396,7 +394,7 @@ def _merge_narrowed_deps_dicts(rule_label, narrowed_deps):
                 str(dep.label),
             ))
         _merge_depset_dicts(per_module_transitive_interfaces, lib_info.per_module_transitive_interfaces)
-    return struct(per_module_transitive_interfaces = per_module_transitive_interfaces)
+    return per_module_transitive_interfaces
 
 def interfaces_as_list(with_shared, o):
     if with_shared:
@@ -428,7 +426,7 @@ def build_haskell_modules(ctx, hs, cc, posix, package_name, with_shared, hidir, 
             dependencies
     """
 
-    per_module_transitive_interfaces = _merge_narrowed_deps_dicts(ctx.label, ctx.attr.narrowed_deps).per_module_transitive_interfaces
+    per_module_transitive_interfaces = _merge_narrowed_deps_dicts(ctx.label, ctx.attr.narrowed_deps)
 
     dep_info = gather_dep_info(ctx.attr.name, ctx.attr.deps)
     narrowed_deps_info = gather_dep_info(ctx.attr.name, ctx.attr.narrowed_deps)

--- a/haskell/experimental/private/module.bzl
+++ b/haskell/experimental/private/module.bzl
@@ -316,6 +316,9 @@ def _reorder_module_deps_to_postorder(label, modules):
       label: The label of the rule with the modules attribute
       modules: The modules coming from a modules attribute. This list must
                be the transitive closure of all the module dependencies.
+
+    Returns:
+      A list with the targets in modules in postorder
     """
     transitive_module_dep_labels = depset(
         direct = [m.label for m in modules],

--- a/haskell/experimental/private/module.bzl
+++ b/haskell/experimental/private/module.bzl
@@ -320,6 +320,7 @@ def _reorder_module_deps_to_postorder(label, modules):
     transitive_module_dep_labels = depset(
         direct = [m.label for m in modules],
         transitive = [m[HaskellModuleInfo].transitive_module_dep_labels for m in modules],
+        order = "postorder",
     ).to_list()
     module_map = {m.label: m for m in modules}
     if len(module_map) != len(transitive_module_dep_labels):

--- a/haskell/experimental/private/module.bzl
+++ b/haskell/experimental/private/module.bzl
@@ -39,7 +39,6 @@ def _build_haskell_module(
         posix,
         dep_info,
         narrowed_deps_info,
-        package_ids,
         package_name,
         with_shared,
         hidir,
@@ -57,7 +56,6 @@ def _build_haskell_module(
       posix: posix toolchain
       dep_info: info on dependencies in deps
       narrowed_deps_info: info on dependencies in narrowed_deps
-      package_ids: list of package ids to expose when building the module
       package_name: name of this package, or empty if building a binary
       with_shared: Whether to build dynamic object files
       hidir: The directory in which to output interface files
@@ -152,7 +150,7 @@ def _build_haskell_module(
     (pkg_info_inputs, pkg_info_args) = pkg_info_to_compile_flags(
         hs,
         pkg_info = expose_packages(
-            package_ids = package_ids,
+            package_ids = hs.package_ids,
             package_databases = depset(transitive = [dep_info.package_databases, narrowed_deps_info.package_databases]),
             # TODO[AH] Support version macros
             version = None,
@@ -424,7 +422,6 @@ def build_haskell_modules(ctx, hs, cc, posix, package_name, with_shared, hidir, 
     narrowed_deps_info = gather_dep_info(ctx.attr.name, ctx.attr.narrowed_deps)
     transitive_module_deps = _reorder_module_deps_to_postorder(ctx.label, ctx.attr.modules, per_module_transitive_interfaces)
     module_outputs = {dep.label: _declare_module_outputs(hs, with_shared, hidir, odir, dep) for dep in transitive_module_deps}
-    package_ids = hs.package_ids + all_dependencies_package_ids(ctx.attr.narrowed_deps)
 
     module_interfaces = {}
     module_objects = {}
@@ -441,7 +438,6 @@ def build_haskell_modules(ctx, hs, cc, posix, package_name, with_shared, hidir, 
             posix,
             dep_info,
             narrowed_deps_info,
-            package_ids,
             package_name,
             with_shared,
             hidir,

--- a/haskell/experimental/providers.bzl
+++ b/haskell/experimental/providers.bzl
@@ -3,6 +3,7 @@ HaskellModuleInfo = provider(
     fields = {
         "attr": "The attributes of the haskell_module rule",
         "direct_module_deps": "The direct dependency targets of the haskell_module rule",
-        "transitive_module_dep_labels": "List of the labels of transitive module dependencies of the haskell_module rule",
+        "direct_cross_library_deps": "The direct cross-library dependency targets of the haskell_module rule",
+        "transitive_module_dep_labels": "List of the labels of transitive module dependencies of the haskell_module rule in the enclosing library",
     },
 )

--- a/haskell/private/context.bzl
+++ b/haskell/private/context.bzl
@@ -19,7 +19,7 @@ def haskell_context(ctx, attr = None):
     if not attr:
         attr = ctx.attr
 
-    deps = (attr.deps if hasattr(attr, "deps") else []) + (attr.exports if hasattr(attr, "exports") else [])
+    deps = (attr.deps if hasattr(attr, "deps") else []) + (attr.exports if hasattr(attr, "exports") else []) + (attr.narrowed_deps if hasattr(attr, "narrowed_deps") else [])
     package_ids = all_dependencies_package_ids(deps)
 
     if hasattr(attr, "src_strip_prefix"):

--- a/haskell/private/haskell_impl.bzl
+++ b/haskell/private/haskell_impl.bzl
@@ -152,7 +152,9 @@ def is_main_as_haskell_module(modules, main_function):
 
 def _haskell_binary_common_impl(ctx, is_test):
     hs = haskell_context(ctx)
+    deps = ctx.attr.deps + ctx.attr.narrowed_deps
     dep_info = gather_dep_info(ctx.attr.name, ctx.attr.deps)
+    all_deps_info = gather_dep_info(ctx.attr.name, deps)
 
     modules = ctx.attr.modules
     if modules and ctx.files.srcs:
@@ -167,14 +169,14 @@ def _haskell_binary_common_impl(ctx, is_test):
         ctx.attr.name,
         [dep for plugin in all_plugin_decls for dep in plugin[GhcPluginInfo].deps],
     )
-    package_ids = all_dependencies_package_ids(ctx.attr.deps)
+    package_ids = all_dependencies_package_ids(deps)
 
     # Add any interop info for other languages.
     cc = cc_interop_info(
         ctx,
         override_cc_toolchain = hs.tools_config.maybe_exec_cc_toolchain,
     )
-    java = java_interop_info(ctx.attr.deps)
+    java = java_interop_info(deps)
 
     # Make shell tools available.
     posix = ctx.toolchains["@rules_sh//sh/posix:toolchain_type"]
@@ -229,7 +231,7 @@ def _haskell_binary_common_impl(ctx, is_test):
 
     # gather intermediary code coverage instrumentation data
     coverage_data = c.coverage_data
-    for dep in ctx.attr.deps:
+    for dep in deps:
         if HaskellCoverageInfo in dep:
             coverage_data += dep[HaskellCoverageInfo].coverage_data
             coverage_data = list.dedup_on(_get_mix_filepath, coverage_data)
@@ -239,7 +241,7 @@ def _haskell_binary_common_impl(ctx, is_test):
         hs,
         cc,
         posix,
-        dep_info,
+        all_deps_info,
         ctx.files.extra_srcs,
         user_compile_flags,
         c.object_files + c.dyn_object_files,
@@ -250,20 +252,20 @@ def _haskell_binary_common_impl(ctx, is_test):
     )
 
     hs_info = HaskellInfo(
-        package_databases = dep_info.package_databases,
+        package_databases = all_deps_info.package_databases,
         version_macros = set.empty(),
         source_files = c.source_files,
         boot_files = c.boot_files,
         extra_source_files = c.extra_source_files,
         import_dirs = c.import_dirs,
-        hs_libraries = dep_info.hs_libraries,
-        interface_dirs = dep_info.interface_dirs,
+        hs_libraries = all_deps_info.hs_libraries,
+        interface_dirs = all_deps_info.interface_dirs,
         compile_flags = c.compile_flags,
         user_compile_flags = user_compile_flags,
         user_repl_flags = _expand_make_variables("repl_ghci_args", ctx, ctx.attr.repl_ghci_args),
     )
     cc_info = cc_common.merge_cc_infos(
-        cc_infos = [dep[CcInfo] for dep in ctx.attr.deps if CcInfo in dep],
+        cc_infos = [dep[CcInfo] for dep in deps if CcInfo in dep],
     )
 
     target_files = depset([binary])
@@ -278,7 +280,7 @@ def _haskell_binary_common_impl(ctx, is_test):
         extra_args = extra_args,
         user_compile_flags = user_compile_flags,
         output = ctx.outputs.runghc,
-        package_databases = dep_info.package_databases,
+        package_databases = all_deps_info.package_databases,
         version = ctx.attr.version,
         hs_info = hs_info,
     )
@@ -361,8 +363,9 @@ def _haskell_binary_common_impl(ctx, is_test):
 
 def haskell_library_impl(ctx):
     hs = haskell_context(ctx)
-    deps = ctx.attr.deps + ctx.attr.exports
-    dep_info = gather_dep_info(ctx.attr.name, deps)
+    deps = ctx.attr.deps + ctx.attr.exports + ctx.attr.narrowed_deps
+    dep_info = gather_dep_info(ctx.attr.name, ctx.attr.deps + ctx.attr.exports)
+    all_deps_info = gather_dep_info(ctx.attr.name, deps)
     all_plugins = ctx.attr.plugins + ctx.attr.non_default_plugins
     plugin_dep_info = gather_dep_info(
         ctx.attr.name,
@@ -374,12 +377,15 @@ def haskell_library_impl(ctx):
     if modules and ctx.files.srcs:
         fail("""Only one of "srcs" or "modules" attributes must be specified in {}""".format(ctx.label))
 
+    if not modules and ctx.attr.narrowed_deps:
+        fail("""The attribute "narrowed_deps" is enabled only if "modules" is specified in {}""".format(ctx.label))
+
     # Add any interop info for other languages.
     cc = cc_interop_info(
         ctx,
         override_cc_toolchain = hs.tools_config.maybe_exec_cc_toolchain,
     )
-    java = java_interop_info(ctx.attr.deps)
+    java = java_interop_info(ctx.attr.deps + ctx.attr.narrowed_deps)
 
     # Make shell tools available.
     posix = ctx.toolchains["@rules_sh//sh/posix:toolchain_type"]
@@ -447,7 +453,7 @@ def haskell_library_impl(ctx):
             hs,
             cc,
             posix,
-            dep_info,
+            all_deps_info,
             depset(c.object_files, transitive = [module_outputs.os]),
             my_pkg_id,
             with_profiling = with_profiling,
@@ -460,7 +466,7 @@ def haskell_library_impl(ctx):
             hs,
             cc,
             posix,
-            dep_info,
+            all_deps_info,
             depset(ctx.files.extra_srcs),
             depset(c.dyn_object_files, transitive = [module_outputs.dyn_os]),
             my_pkg_id,
@@ -473,7 +479,7 @@ def haskell_library_impl(ctx):
         hs,
         cc,
         posix,
-        dep_info,
+        all_deps_info,
         with_shared,
         exposed_modules,
         other_modules,
@@ -483,7 +489,7 @@ def haskell_library_impl(ctx):
 
     interface_dirs = depset(
         direct = c.interface_files,
-        transitive = [dep_info.interface_dirs, module_outputs.his, module_outputs.dyn_his],
+        transitive = [all_deps_info.interface_dirs, module_outputs.his, module_outputs.dyn_his],
     )
 
     version_macros = set.empty()
@@ -497,7 +503,7 @@ def haskell_library_impl(ctx):
 
     export_infos = gather_dep_info(ctx.attr.name, ctx.attr.exports)
     hs_info = HaskellInfo(
-        package_databases = depset([cache_file], transitive = [dep_info.package_databases, export_infos.package_databases]),
+        package_databases = depset([cache_file], transitive = [all_deps_info.package_databases, export_infos.package_databases]),
         version_macros = version_macros,
         source_files = c.source_files,
         boot_files = c.boot_files,
@@ -505,7 +511,7 @@ def haskell_library_impl(ctx):
         import_dirs = set.mutable_union(c.import_dirs, export_infos.import_dirs),
         hs_libraries = depset(
             direct = [lib for lib in [static_library, dynamic_library] if lib],
-            transitive = [dep_info.hs_libraries, export_infos.hs_libraries],
+            transitive = [all_deps_info.hs_libraries, export_infos.hs_libraries],
         ),
         interface_dirs = depset(transitive = [interface_dirs, export_infos.interface_dirs]),
         compile_flags = c.compile_flags,
@@ -550,7 +556,7 @@ def haskell_library_impl(ctx):
             extra_args = extra_args,
             user_compile_flags = user_compile_flags,
             output = ctx.outputs.runghc,
-            package_databases = dep_info.package_databases,
+            package_databases = all_deps_info.package_databases,
             version = ctx.attr.version,
             hs_info = hs_info,
             lib_info = lib_info,

--- a/haskell/private/haskell_impl.bzl
+++ b/haskell/private/haskell_impl.bzl
@@ -511,6 +511,7 @@ def haskell_library_impl(ctx):
         compile_flags = c.compile_flags,
         user_compile_flags = user_compile_flags,
         user_repl_flags = _expand_make_variables("repl_ghci_args", ctx, ctx.attr.repl_ghci_args),
+        per_module_transitive_interfaces = module_outputs.per_module_transitive_interfaces,
     )
 
     exports = [

--- a/haskell/protobuf.bzl
+++ b/haskell/protobuf.bzl
@@ -179,6 +179,7 @@ def _haskell_proto_aspect_impl(target, ctx):
         "extra_srcs": [],
         "deps": ctx.rule.attr.deps +
                 ctx.toolchains["@rules_haskell//protobuf:toolchain"].deps,
+        "narrowed_deps": [],
         "plugins": [],
         "non_default_plugins": [],
         "data": [],

--- a/haskell/providers.bzl
+++ b/haskell/providers.bzl
@@ -14,6 +14,7 @@ HaskellInfo = provider(
         "compile_flags": "Arguments that were used to compile the code.",
         "user_compile_flags": "Compiler flags specified by the user, after location expansion.",
         "user_repl_flags": "REPL flags specified by the user, after location expansion.",
+        "per_module_transitive_interfaces": "Dict of module labels to interfaces of transitive module dependencies",
     },
 )
 

--- a/tests/haskell_module/BUILD.bazel
+++ b/tests/haskell_module/BUILD.bazel
@@ -7,6 +7,7 @@ filegroup(
         "//tests/haskell_module/binary:all_files",
         "//tests/haskell_module/library:all_files",
         "//tests/haskell_module/library-dep:all_files",
+        "//tests/haskell_module/dep-narrowing:all_files",
         "//tests/haskell_module/multiple:all_files",
         "//tests/haskell_module/nested:all_files",
         "//tests/haskell_module/plugin:all_files",

--- a/tests/haskell_module/dep-narrowing/BUILD.bazel
+++ b/tests/haskell_module/dep-narrowing/BUILD.bazel
@@ -1,6 +1,7 @@
 load(
     "@rules_haskell//haskell:defs.bzl",
     "haskell_library",
+    "haskell_test",
 )
 load("@rules_haskell//haskell/experimental:defs.bzl", "haskell_module")
 
@@ -54,6 +55,23 @@ haskell_library(
         ":TestLib",
         "//tests/hackage:base",
     ],
+)
+
+haskell_module(
+    name = "TestBinModule",
+    src = "TestBinModule.hs",
+    module_name = "Main",
+    deps = [":TestModule"],
+)
+
+haskell_test(
+    name = "Test",
+    modules = [":TestBinModule"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//tests/hackage:base",
+    ],
+    narrowed_deps = [":lib"],
 )
 
 filegroup(

--- a/tests/haskell_module/dep-narrowing/BUILD.bazel
+++ b/tests/haskell_module/dep-narrowing/BUILD.bazel
@@ -1,0 +1,64 @@
+load(
+    "@rules_haskell//haskell:defs.bzl",
+    "haskell_library",
+)
+load("@rules_haskell//haskell/experimental:defs.bzl", "haskell_module")
+
+package(default_testonly = 1)
+
+haskell_library(
+    name = "TestLib",
+    srcs = ["TestLibModule.hs"],
+    deps = [
+        "//tests/hackage:base",
+    ],
+)
+
+haskell_library(
+    name = "TestLib2",
+    modules = [
+        ":TestLibModule2",
+        ":SimpleFoo",
+    ],
+    deps = [
+        "//tests/hackage:base",
+    ],
+)
+
+haskell_module(
+    name = "TestLibModule2",
+    src = "TestLibModule2.hs",
+    deps = [":SimpleFoo"],
+)
+
+haskell_module(
+    name = "SimpleFoo",
+    src = "SimpleFoo.hs",
+)
+
+haskell_module(
+    name = "TestModule",
+    src = "TestModule.hs",
+    deps = [":TestLibModule2"],
+)
+
+haskell_library(
+    name = "lib",
+    modules = [
+        ":TestModule",
+    ],
+    narrowed_deps = [
+        ":TestLib2",
+    ],
+    deps = [
+        ":TestLib",
+        "//tests/hackage:base",
+    ],
+)
+
+filegroup(
+    name = "all_files",
+    testonly = True,
+    srcs = glob(["**"]),
+    visibility = ["//visibility:public"],
+)

--- a/tests/haskell_module/dep-narrowing/BUILD.bazel
+++ b/tests/haskell_module/dep-narrowing/BUILD.bazel
@@ -43,10 +43,21 @@ haskell_module(
     cross_library_deps = [":TestLibModule2"],
 )
 
+# Modifying TestLibModule2 from TestLib2 doesn't cause a rebuild of
+# TestModule2 thanks to narrowing.
+#
+# If cross_library_deps and narrowed_deps weren't used, then a change
+# in TestLib2 would cause all modules in lib to be rebuilt.
+haskell_module(
+    name = "TestModule2",
+    src = "TestModule2.hs",
+)
+
 haskell_library(
     name = "lib",
     modules = [
         ":TestModule",
+        ":TestModule2",
     ],
     narrowed_deps = [
         ":TestLib2",

--- a/tests/haskell_module/dep-narrowing/BUILD.bazel
+++ b/tests/haskell_module/dep-narrowing/BUILD.bazel
@@ -40,7 +40,7 @@ haskell_module(
 haskell_module(
     name = "TestModule",
     src = "TestModule.hs",
-    deps = [":TestLibModule2"],
+    cross_library_deps = [":TestLibModule2"],
 )
 
 haskell_library(
@@ -60,18 +60,18 @@ haskell_library(
 haskell_module(
     name = "TestBinModule",
     src = "TestBinModule.hs",
+    cross_library_deps = [":TestModule"],
     module_name = "Main",
-    deps = [":TestModule"],
 )
 
 haskell_test(
     name = "Test",
     modules = [":TestBinModule"],
+    narrowed_deps = [":lib"],
     visibility = ["//visibility:public"],
     deps = [
         "//tests/hackage:base",
     ],
-    narrowed_deps = [":lib"],
 )
 
 filegroup(

--- a/tests/haskell_module/dep-narrowing/SimpleFoo.hs
+++ b/tests/haskell_module/dep-narrowing/SimpleFoo.hs
@@ -1,0 +1,4 @@
+module SimpleFoo where
+
+foo :: Int
+foo = 23

--- a/tests/haskell_module/dep-narrowing/TestBinModule.hs
+++ b/tests/haskell_module/dep-narrowing/TestBinModule.hs
@@ -1,0 +1,4 @@
+import TestModule
+
+main :: IO ()
+main = print bar

--- a/tests/haskell_module/dep-narrowing/TestLibModule.hs
+++ b/tests/haskell_module/dep-narrowing/TestLibModule.hs
@@ -1,0 +1,4 @@
+module TestLibModule where
+
+foo :: Int
+foo = 21

--- a/tests/haskell_module/dep-narrowing/TestLibModule2.hs
+++ b/tests/haskell_module/dep-narrowing/TestLibModule2.hs
@@ -1,0 +1,6 @@
+module TestLibModule2 where
+
+import SimpleFoo
+
+foo2 :: Int
+foo2 = foo - 1

--- a/tests/haskell_module/dep-narrowing/TestModule.hs
+++ b/tests/haskell_module/dep-narrowing/TestModule.hs
@@ -1,0 +1,7 @@
+module TestModule where
+
+import TestLibModule (foo)
+import TestLibModule2 (foo2)
+
+bar :: Int
+bar = 2 * foo + foo2

--- a/tests/haskell_module/dep-narrowing/TestModule2.hs
+++ b/tests/haskell_module/dep-narrowing/TestModule2.hs
@@ -1,0 +1,4 @@
+module TestModule2 where
+
+f :: IO ()
+f = return ()


### PR DESCRIPTION
Partial implementation of #1631 

This implements the narrowing that supplies the needed interface files from dependencies as inputs to the action of `haskell_module`.