### PR TITLE
Fix "missing libgmp.so" error

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -4,6 +4,8 @@ tasks:
     environment:
       # haskell base uses the environment locale to decode sockets
       LANG: "C.UTF-8"
+    shell_commands:
+      - "sudo apt -y update && sudo apt -y install libgmp-dev"
     build_flags:
       - "--build_tag_filters=-requires_nix,-requires_lz4,-requires_shellcheck,-requires_threaded_rts,-dont_test_with_bindist,-dont_test_on_bazelci"
     build_targets:


### PR DESCRIPTION
Bazel CI's base image no longer contains a lot of potential dependencies used by projects, but instead now it's possible to install dependencies using `sudo apt install` easily. This should probably fix the reported error.