### PR TITLE
override_toolchain_transition support

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -105,6 +105,10 @@ build:macos-nixpkgs --incompatible_enable_cc_toolchain_resolution
 #build:ci --incompatible_load_proto_rules_from_bzl
 build:ci --incompatible_load_python_rules_from_bzl
 
+# This flag will become the default in bazel 5
+# https://github.com/tweag/rules_haskell/issues/1657
+build: --incompatible_override_toolchain_transition
+
 coverage --build_tag_filters "coverage-compatible" --test_tag_filters "coverage-compatible" --test_output=all
 
 # User Configuration

--- a/haskell/BUILD.bazel
+++ b/haskell/BUILD.bazel
@@ -20,6 +20,13 @@ load(
     "@rules_haskell//haskell:toolchain_info.bzl",
     "haskell_toolchain_info",
 )
+load(
+    "@rules_haskell//haskell:toolchain.bzl",
+    "get_cc_toolchain",
+    "get_haskell_toolchain",
+    "get_nodejs_toolchain",
+    "get_posix_toolchain",
+)
 
 exports_files(
     glob(["*.bzl"]) + [
@@ -171,6 +178,26 @@ config_setting(
 
 haskell_toolchain_info(
     name = "toolchain_info",
+)
+
+get_nodejs_toolchain(
+    name = "current_nodejs_toolchain",
+    visibility = ["//visibility:public"],
+)
+
+get_posix_toolchain(
+    name = "current_posix_toolchain",
+    visibility = ["//visibility:public"],
+)
+
+get_haskell_toolchain(
+    name = "current_haskell_toolchain",
+    visibility = ["//visibility:public"],
+)
+
+get_cc_toolchain(
+    name = "current_cc_toolchain",
+    visibility = ["//visibility:public"],
 )
 
 filegroup(


### PR DESCRIPTION
This PR intends to fix issue #1657 by supporting the `--incompatible_override_toolchain_transition` flag, which becomes enable by default on bazel 5 (I did not however test it on bazel 5).

The asterius haskell toolchain now depends on others toolchains through an attribute with cfg = "exec".
With the exception of rules_sh which declares no target platform constraints, but I now wonder if it would be more consistent to do the same thing for it.

Some new utility targets are declared like `@rules_haskell//haskell:nodejs_toolchain`.
I also tried to declare them in the same external repository as the `haskell_toolchain` but I think this would require adding a parameter to the `haskell_toolchain` rule in order to know the correct workspace name to use [in the default labels](https://github.com/tweag/rules_haskell/compare/ylecornec/override_toolchain_transition?expand=1#diff-f83278238101cead941a012a809724f4fcac6997d0106d70678372f5c533ca84R336-R339).

The second commit adds the `--incompatible_override_toolchain_transition` flag to `.bazelrc` but the ci was also run without it on the first commit. 
