### PR TITLE
separate ahc.BUILD.tpl file for asterius.

### DIFF
--- a/haskell/ahc.BUILD.tpl
+++ b/haskell/ahc.BUILD.tpl
@@ -1,0 +1,18 @@
+load(
+    "@rules_haskell//haskell:defs.bzl",
+    "haskell_import",
+    "haskell_toolchain",
+)
+
+load(
+    "@rules_haskell//haskell/asterius:defs.bzl",
+    "asterius_toolchain",
+)
+
+package(default_visibility = ["//visibility:public"])
+
+%{toolchain_libraries}
+
+%{toolchain}
+
+%{asterius_toolchain}

--- a/haskell/asterius/repositories.bzl
+++ b/haskell/asterius/repositories.bzl
@@ -130,7 +130,7 @@ _ahc_toolchain = repository_rule(
 
 def _ahc_impl(ctx):
     filepaths = resolve_labels(ctx, [
-        "@rules_haskell//haskell:ghc.BUILD.tpl",
+        "@rules_haskell//haskell:ahc.BUILD.tpl",
         "@rules_haskell//haskell:private/pkgdb_to_bzl.py",
     ])
     lib_path = str(ctx.path(ctx.attr.asterius_lib_setting_file).dirname)
@@ -169,7 +169,7 @@ def _ahc_impl(ctx):
 
     ctx.template(
         "BUILD",
-        filepaths["@rules_haskell//haskell:ghc.BUILD.tpl"],
+        filepaths["@rules_haskell//haskell:ahc.BUILD.tpl"],
         substitutions = {
             "%{toolchain_libraries}": toolchain_libraries,
             "%{toolchain}": toolchain,

--- a/haskell/ghc.BUILD.tpl
+++ b/haskell/ghc.BUILD.tpl
@@ -12,18 +12,12 @@ load(
     "haskell_import",
     "haskell_toolchain",
 )
-load(
-    "@rules_haskell//haskell/asterius:defs.bzl",
-    "asterius_toolchain",
-)
 
 package(default_visibility = ["//visibility:public"])
 
 %{toolchain_libraries}
 
 %{toolchain}
-
-%{asterius_toolchain}
 
 filegroup(
     name = "bin",

--- a/haskell/ghc_bindist.bzl
+++ b/haskell/ghc_bindist.bzl
@@ -468,7 +468,6 @@ rm -f
         substitutions = {
             "%{toolchain_libraries}": toolchain_libraries,
             "%{toolchain}": toolchain,
-            "%{asterius_toolchain}": "",
         },
         executable = False,
     )


### PR DESCRIPTION
Before this PR, the same `ghc.BUILD.tpl` file was used for both asterius and regular haskell toolchain, but now the asterius one uses a new `ahc.BUILD.tpl` file.

Most notably, this prevents loading the `@rules_haskell//haskell/asterius:defs.bzl` file when it is not needed, which is what seems to be happening in issue #1635.
