### PR TITLE
Fix for GHC 9.2.1 and GHC 9.0.1

### DIFF
--- a/haskell/assets/ghc_9_0_1_win.patch
+++ b/haskell/assets/ghc_9_0_1_win.patch
@@ -1,0 +1,358 @@
+--- lib/package.conf.d/Cabal-3.4.0.0.conf
++++ lib/package.conf.d/Cabal-3.4.0.0.conf
+@@ -183,5 +183,5 @@ depends:
+     pretty-1.1.3.6 process-1.6.11.0 text-1.2.4.1 time-1.9.3
+     transformers-0.5.6.2
+ 
+-haddock-interfaces:   ${pkgroot}/../../docs/html/libraries/Cabal\Cabal.haddock
+-haddock-html:         ${pkgroot}/../../docs/html/libraries/Cabal
++haddock-interfaces:   ${pkgroot}/../docs/html/libraries/Cabal\Cabal.haddock
++haddock-html:         ${pkgroot}/../docs/html/libraries/Cabal
+--- lib/package.conf.d/Win32-2.10.0.0.conf
++++ lib/package.conf.d/Win32-2.10.0.0.conf
+@@ -61,5 +61,5 @@ includes:
+     alignment.h
+ 
+ depends:              base-4.15.0.0 bytestring-0.10.12.1 filepath-1.4.2.1
+-haddock-interfaces:   ${pkgroot}/../../docs/html/libraries/Win32\Win32.haddock
+-haddock-html:         ${pkgroot}/../../docs/html/libraries/Win32
++haddock-interfaces:   ${pkgroot}/../docs/html/libraries/Win32\Win32.haddock
++haddock-html:         ${pkgroot}/../docs/html/libraries/Win32
+--- lib/package.conf.d/array-0.5.4.0.conf
++++ lib/package.conf.d/array-0.5.4.0.conf
+@@ -29,5 +29,5 @@ dynamic-library-dirs: ${pkgroot}\x86_64-windows-ghc-9.0.1
+ data-dir:             ${pkgroot}\x86_64-windows-ghc-9.0.1\array-0.5.4.0
+ hs-libraries:         HSarray-0.5.4.0
+ depends:              base-4.15.0.0
+-haddock-interfaces:   ${pkgroot}/../../docs/html/libraries/array\array.haddock
+-haddock-html:         ${pkgroot}/../../docs/html/libraries/array
++haddock-interfaces:   ${pkgroot}/../docs/html/libraries/array\array.haddock
++haddock-html:         ${pkgroot}/../docs/html/libraries/array
+--- lib/package.conf.d/base-4.15.0.0.conf
++++ lib/package.conf.d/base-4.15.0.0.conf
+@@ -112,5 +112,5 @@ extra-libraries:
+ include-dirs:         ${pkgroot}\x86_64-windows-ghc-9.0.1\base-4.15.0.0\include
+ includes:             HsBase.h
+ depends:              ghc-bignum-1.0 ghc-prim-0.7.0 rts-1.0
+-haddock-interfaces:   ${pkgroot}/../../docs/html/libraries/base\base.haddock
+-haddock-html:         ${pkgroot}/../../docs/html/libraries/base
++haddock-interfaces:   ${pkgroot}/../docs/html/libraries/base\base.haddock
++haddock-html:         ${pkgroot}/../docs/html/libraries/base
+--- lib/package.conf.d/binary-0.8.8.0.conf
++++ lib/package.conf.d/binary-0.8.8.0.conf
+@@ -40,5 +40,5 @@ hs-libraries:         HSbinary-0.8.8.0
+ depends:
+     array-0.5.4.0 base-4.15.0.0 bytestring-0.10.12.1 containers-0.6.4.1
+ 
+-haddock-interfaces:   ${pkgroot}/../../docs/html/libraries/binary\binary.haddock
+-haddock-html:         ${pkgroot}/../../docs/html/libraries/binary
++haddock-interfaces:   ${pkgroot}/../docs/html/libraries/binary\binary.haddock
++haddock-html:         ${pkgroot}/../docs/html/libraries/binary
+--- lib/package.conf.d/bytestring-0.10.12.1.conf
++++ lib/package.conf.d/bytestring-0.10.12.1.conf
+@@ -94,6 +94,6 @@ depends:
+     base-4.15.0.0 deepseq-1.4.5.0 ghc-bignum-1.0 ghc-prim-0.7.0
+ 
+ haddock-interfaces:
+-    ${pkgroot}/../../docs/html/libraries/bytestring\bytestring.haddock
++    ${pkgroot}/../docs/html/libraries/bytestring\bytestring.haddock
+ 
+-haddock-html:         ${pkgroot}/../../docs/html/libraries/bytestring
++haddock-html:         ${pkgroot}/../docs/html/libraries/bytestring
+--- lib/package.conf.d/containers-0.6.4.1.conf
++++ lib/package.conf.d/containers-0.6.4.1.conf
+@@ -50,6 +50,6 @@ data-dir:             ${pkgroot}\x86_64-windows-ghc-9.0.1\containers-0.6.4.1
+ hs-libraries:         HScontainers-0.6.4.1
+ depends:              array-0.5.4.0 base-4.15.0.0 deepseq-1.4.5.0
+ haddock-interfaces:
+-    ${pkgroot}/../../docs/html/libraries/containers\containers.haddock
++    ${pkgroot}/../docs/html/libraries/containers\containers.haddock
+ 
+-haddock-html:         ${pkgroot}/../../docs/html/libraries/containers
++haddock-html:         ${pkgroot}/../docs/html/libraries/containers
+--- lib/package.conf.d/deepseq-1.4.5.0.conf
++++ lib/package.conf.d/deepseq-1.4.5.0.conf
+@@ -33,6 +33,6 @@ data-dir:             ${pkgroot}\x86_64-windows-ghc-9.0.1\deepseq-1.4.5.0
+ hs-libraries:         HSdeepseq-1.4.5.0
+ depends:              array-0.5.4.0 base-4.15.0.0
+ haddock-interfaces:
+-    ${pkgroot}/../../docs/html/libraries/deepseq\deepseq.haddock
++    ${pkgroot}/../docs/html/libraries/deepseq\deepseq.haddock
+ 
+-haddock-html:         ${pkgroot}/../../docs/html/libraries/deepseq
++haddock-html:         ${pkgroot}/../docs/html/libraries/deepseq
+--- lib/package.conf.d/directory-1.3.6.1.conf
++++ lib/package.conf.d/directory-1.3.6.1.conf
+@@ -31,6 +31,6 @@ depends:
+     Win32-2.10.0.0 base-4.15.0.0 filepath-1.4.2.1 time-1.9.3
+ 
+ haddock-interfaces:
+-    ${pkgroot}/../../docs/html/libraries/directory\directory.haddock
++    ${pkgroot}/../docs/html/libraries/directory\directory.haddock
+ 
+-haddock-html:         ${pkgroot}/../../docs/html/libraries/directory
++haddock-html:         ${pkgroot}/../docs/html/libraries/directory
+--- lib/package.conf.d/exceptions-0.10.4.conf
++++ lib/package.conf.d/exceptions-0.10.4.conf
+@@ -28,6 +28,6 @@ depends:
+     transformers-0.5.6.2
+ 
+ haddock-interfaces:
+-    ${pkgroot}/../../docs/html/libraries/exceptions\exceptions.haddock
++    ${pkgroot}/../docs/html/libraries/exceptions\exceptions.haddock
+ 
+-haddock-html:         ${pkgroot}/../../docs/html/libraries/exceptions
++haddock-html:         ${pkgroot}/../docs/html/libraries/exceptions
+--- lib/package.conf.d/filepath-1.4.2.1.conf
++++ lib/package.conf.d/filepath-1.4.2.1.conf
+@@ -33,6 +33,6 @@ data-dir:             ${pkgroot}\x86_64-windows-ghc-9.0.1\filepath-1.4.2.1
+ hs-libraries:         HSfilepath-1.4.2.1
+ depends:              base-4.15.0.0
+ haddock-interfaces:
+-    ${pkgroot}/../../docs/html/libraries/filepath\filepath.haddock
++    ${pkgroot}/../docs/html/libraries/filepath\filepath.haddock
+ 
+-haddock-html:         ${pkgroot}/../../docs/html/libraries/filepath
++haddock-html:         ${pkgroot}/../docs/html/libraries/filepath
+--- lib/package.conf.d/ghc-9.0.1.conf
++++ lib/package.conf.d/ghc-9.0.1.conf
+@@ -200,5 +200,5 @@ depends:
+     process-1.6.11.0 template-haskell-2.17.0.0 time-1.9.3
+     transformers-0.5.6.2
+ 
+-haddock-interfaces:   ${pkgroot}/../../docs/html/libraries/ghc\ghc.haddock
+-haddock-html:         ${pkgroot}/../../docs/html/libraries/ghc
++haddock-interfaces:   ${pkgroot}/../docs/html/libraries/ghc\ghc.haddock
++haddock-html:         ${pkgroot}/../docs/html/libraries/ghc
+--- lib/package.conf.d/ghc-bignum-1.0.conf
++++ lib/package.conf.d/ghc-bignum-1.0.conf
+@@ -28,6 +28,6 @@ hs-libraries:         HSghc-bignum-1.0
+ include-dirs:         ${pkgroot}\x86_64-windows-ghc-9.0.1\ghc-bignum-1.0\include
+ depends:              ghc-prim-0.7.0
+ haddock-interfaces:
+-    ${pkgroot}/../../docs/html/libraries/ghc-bignum\ghc-bignum.haddock
++    ${pkgroot}/../docs/html/libraries/ghc-bignum\ghc-bignum.haddock
+ 
+-haddock-html:         ${pkgroot}/../../docs/html/libraries/ghc-bignum
++haddock-html:         ${pkgroot}/../docs/html/libraries/ghc-bignum
+--- lib/package.conf.d/ghc-boot-9.0.1.conf
++++ lib/package.conf.d/ghc-boot-9.0.1.conf
+@@ -40,6 +40,6 @@ depends:
+     ghc-boot-th-9.0.1
+ 
+ haddock-interfaces:
+-    ${pkgroot}/../../docs/html/libraries/ghc-boot\ghc-boot.haddock
++    ${pkgroot}/../docs/html/libraries/ghc-boot\ghc-boot.haddock
+ 
+-haddock-html:         ${pkgroot}/../../docs/html/libraries/ghc-boot
++haddock-html:         ${pkgroot}/../docs/html/libraries/ghc-boot
+--- lib/package.conf.d/ghc-boot-th-9.0.1.conf
++++ lib/package.conf.d/ghc-boot-th-9.0.1.conf
+@@ -30,6 +30,6 @@ data-dir:             ${pkgroot}\x86_64-windows-ghc-9.0.1\ghc-boot-th-9.0.1
+ hs-libraries:         HSghc-boot-th-9.0.1
+ depends:              base-4.15.0.0
+ haddock-interfaces:
+-    ${pkgroot}/../../docs/html/libraries/ghc-boot-th\ghc-boot-th.haddock
++    ${pkgroot}/../docs/html/libraries/ghc-boot-th\ghc-boot-th.haddock
+ 
+-haddock-html:         ${pkgroot}/../../docs/html/libraries/ghc-boot-th
++haddock-html:         ${pkgroot}/../docs/html/libraries/ghc-boot-th
+--- lib/package.conf.d/ghc-compact-0.1.0.0.conf
++++ lib/package.conf.d/ghc-compact-0.1.0.0.conf
+@@ -29,6 +29,6 @@ data-dir:             ${pkgroot}\x86_64-windows-ghc-9.0.1\ghc-compact-0.1.0.0
+ hs-libraries:         HSghc-compact-0.1.0.0
+ depends:              base-4.15.0.0 bytestring-0.10.12.1 ghc-prim-0.7.0
+ haddock-interfaces:
+-    ${pkgroot}/../../docs/html/libraries/ghc-compact\ghc-compact.haddock
++    ${pkgroot}/../docs/html/libraries/ghc-compact\ghc-compact.haddock
+ 
+-haddock-html:         ${pkgroot}/../../docs/html/libraries/ghc-compact
++haddock-html:         ${pkgroot}/../docs/html/libraries/ghc-compact
+--- lib/package.conf.d/ghc-heap-9.0.1.conf
++++ lib/package.conf.d/ghc-heap-9.0.1.conf
+@@ -26,6 +26,6 @@ data-dir:             ${pkgroot}\x86_64-windows-ghc-9.0.1\ghc-heap-9.0.1
+ hs-libraries:         HSghc-heap-9.0.1
+ depends:              base-4.15.0.0 ghc-prim-0.7.0 rts-1.0
+ haddock-interfaces:
+-    ${pkgroot}/../../docs/html/libraries/ghc-heap\ghc-heap.haddock
++    ${pkgroot}/../docs/html/libraries/ghc-heap\ghc-heap.haddock
+ 
+-haddock-html:         ${pkgroot}/../../docs/html/libraries/ghc-heap
++haddock-html:         ${pkgroot}/../docs/html/libraries/ghc-heap
+--- lib/package.conf.d/ghc-prim-0.7.0.conf
++++ lib/package.conf.d/ghc-prim-0.7.0.conf
+@@ -25,6 +25,6 @@ hs-libraries:         HSghc-prim-0.7.0
+ extra-libraries:      user32 mingw32 mingwex
+ depends:              rts-1.0
+ haddock-interfaces:
+-    ${pkgroot}/../../docs/html/libraries/ghc-prim\ghc-prim.haddock
++    ${pkgroot}/../docs/html/libraries/ghc-prim\ghc-prim.haddock
+ 
+-haddock-html:         ${pkgroot}/../../docs/html/libraries/ghc-prim
++haddock-html:         ${pkgroot}/../docs/html/libraries/ghc-prim
+--- lib/package.conf.d/ghci-9.0.1.conf
++++ lib/package.conf.d/ghci-9.0.1.conf
+@@ -31,5 +31,5 @@ depends:
+     ghc-boot-th-9.0.1 ghc-heap-9.0.1 template-haskell-2.17.0.0
+     transformers-0.5.6.2
+ 
+-haddock-interfaces:   ${pkgroot}/../../docs/html/libraries/ghci\ghci.haddock
+-haddock-html:         ${pkgroot}/../../docs/html/libraries/ghci
++haddock-interfaces:   ${pkgroot}/../docs/html/libraries/ghci\ghci.haddock
++haddock-html:         ${pkgroot}/../docs/html/libraries/ghci
+--- lib/package.conf.d/haskeline-0.8.1.0.conf
++++ lib/package.conf.d/haskeline-0.8.1.0.conf
+@@ -59,6 +59,6 @@ depends:
+     filepath-1.4.2.1 process-1.6.11.0 stm-2.5.0.0 transformers-0.5.6.2
+ 
+ haddock-interfaces:
+-    ${pkgroot}/../../docs/html/libraries/haskeline\haskeline.haddock
++    ${pkgroot}/../docs/html/libraries/haskeline\haskeline.haddock
+ 
+-haddock-html:         ${pkgroot}/../../docs/html/libraries/haskeline
++haddock-html:         ${pkgroot}/../docs/html/libraries/haskeline
+--- lib/package.conf.d/hpc-0.6.1.0.conf
++++ lib/package.conf.d/hpc-0.6.1.0.conf
+@@ -28,5 +28,5 @@ depends:
+     base-4.15.0.0 containers-0.6.4.1 deepseq-1.4.5.0 directory-1.3.6.1
+     filepath-1.4.2.1 time-1.9.3
+ 
+-haddock-interfaces:   ${pkgroot}/../../docs/html/libraries/hpc\hpc.haddock
+-haddock-html:         ${pkgroot}/../../docs/html/libraries/hpc
++haddock-interfaces:   ${pkgroot}/../docs/html/libraries/hpc\hpc.haddock
++haddock-html:         ${pkgroot}/../docs/html/libraries/hpc
+--- lib/package.conf.d/integer-gmp-1.1.conf
++++ lib/package.conf.d/integer-gmp-1.1.conf
+@@ -28,6 +28,6 @@ data-dir:             ${pkgroot}\x86_64-windows-ghc-9.0.1\integer-gmp-1.1
+ hs-libraries:         HSinteger-gmp-1.1
+ depends:              base-4.15.0.0 ghc-bignum-1.0 ghc-prim-0.7.0
+ haddock-interfaces:
+-    ${pkgroot}/../../docs/html/libraries/integer-gmp\integer-gmp.haddock
++    ${pkgroot}/../docs/html/libraries/integer-gmp\integer-gmp.haddock
+ 
+-haddock-html:         ${pkgroot}/../../docs/html/libraries/integer-gmp
++haddock-html:         ${pkgroot}/../docs/html/libraries/integer-gmp
+--- lib/package.conf.d/libiserv-9.0.1.conf
++++ lib/package.conf.d/libiserv-9.0.1.conf
+@@ -22,6 +22,6 @@ depends:
+     containers-0.6.4.1 deepseq-1.4.5.0 ghci-9.0.1
+ 
+ haddock-interfaces:
+-    ${pkgroot}/../../docs/html/libraries/libiserv\libiserv.haddock
++    ${pkgroot}/../docs/html/libraries/libiserv\libiserv.haddock
+ 
+-haddock-html:         ${pkgroot}/../../docs/html/libraries/libiserv
++haddock-html:         ${pkgroot}/../docs/html/libraries/libiserv
+--- lib/package.conf.d/mtl-2.2.2.conf
++++ lib/package.conf.d/mtl-2.2.2.conf
+@@ -36,5 +36,5 @@ dynamic-library-dirs: ${pkgroot}\x86_64-windows-ghc-9.0.1
+ data-dir:             ${pkgroot}\x86_64-windows-ghc-9.0.1\mtl-2.2.2
+ hs-libraries:         HSmtl-2.2.2
+ depends:              base-4.15.0.0 transformers-0.5.6.2
+-haddock-interfaces:   ${pkgroot}/../../docs/html/libraries/mtl\mtl.haddock
+-haddock-html:         ${pkgroot}/../../docs/html/libraries/mtl
++haddock-interfaces:   ${pkgroot}/../docs/html/libraries/mtl\mtl.haddock
++haddock-html:         ${pkgroot}/../docs/html/libraries/mtl
+--- lib/package.conf.d/parsec-3.1.14.0.conf
++++ lib/package.conf.d/parsec-3.1.14.0.conf
+@@ -52,5 +52,5 @@ hs-libraries:         HSparsec-3.1.14.0
+ depends:
+     base-4.15.0.0 bytestring-0.10.12.1 mtl-2.2.2 text-1.2.4.1
+ 
+-haddock-interfaces:   ${pkgroot}/../../docs/html/libraries/parsec\parsec.haddock
+-haddock-html:         ${pkgroot}/../../docs/html/libraries/parsec
++haddock-interfaces:   ${pkgroot}/../docs/html/libraries/parsec\parsec.haddock
++haddock-html:         ${pkgroot}/../docs/html/libraries/parsec
+--- lib/package.conf.d/pretty-1.1.3.6.conf
++++ lib/package.conf.d/pretty-1.1.3.6.conf
+@@ -32,5 +32,5 @@ dynamic-library-dirs: ${pkgroot}\x86_64-windows-ghc-9.0.1
+ data-dir:             ${pkgroot}\x86_64-windows-ghc-9.0.1\pretty-1.1.3.6
+ hs-libraries:         HSpretty-1.1.3.6
+ depends:              base-4.15.0.0 deepseq-1.4.5.0 ghc-prim-0.7.0
+-haddock-interfaces:   ${pkgroot}/../../docs/html/libraries/pretty\pretty.haddock
+-haddock-html:         ${pkgroot}/../../docs/html/libraries/pretty
++haddock-interfaces:   ${pkgroot}/../docs/html/libraries/pretty\pretty.haddock
++haddock-html:         ${pkgroot}/../docs/html/libraries/pretty
+--- lib/package.conf.d/process-1.6.11.0.conf
++++ lib/package.conf.d/process-1.6.11.0.conf
+@@ -35,6 +35,6 @@ depends:
+     filepath-1.4.2.1
+ 
+ haddock-interfaces:
+-    ${pkgroot}/../../docs/html/libraries/process\process.haddock
++    ${pkgroot}/../docs/html/libraries/process\process.haddock
+ 
+-haddock-html:         ${pkgroot}/../../docs/html/libraries/process
++haddock-html:         ${pkgroot}/../docs/html/libraries/process
+--- lib/package.conf.d/rts-1.0.conf
++++ lib/package.conf.d/rts-1.0.conf
+@@ -78,5 +78,5 @@ ld-options:
+     "-Wl,-u,hs_atomicwrite16" "-Wl,-u,hs_atomicwrite32"
+     "-Wl,-u,base_GHCziEventziWindows_processRemoteCompletion_closure"
+ 
+-haddock-interfaces:   ${pkgroot}/../../docs/html/libraries/rts\rts.haddock
+-haddock-html:         ${pkgroot}/../../docs/html/libraries/rts
++haddock-interfaces:   ${pkgroot}/../docs/html/libraries/rts\rts.haddock
++haddock-html:         ${pkgroot}/../docs/html/libraries/rts
+--- lib/package.conf.d/stm-2.5.0.0.conf
++++ lib/package.conf.d/stm-2.5.0.0.conf
+@@ -34,5 +34,5 @@ dynamic-library-dirs: ${pkgroot}\x86_64-windows-ghc-9.0.1
+ data-dir:             ${pkgroot}\x86_64-windows-ghc-9.0.1\stm-2.5.0.0
+ hs-libraries:         HSstm-2.5.0.0
+ depends:              array-0.5.4.0 base-4.15.0.0
+-haddock-interfaces:   ${pkgroot}/../../docs/html/libraries/stm\stm.haddock
+-haddock-html:         ${pkgroot}/../../docs/html/libraries/stm
++haddock-interfaces:   ${pkgroot}/../docs/html/libraries/stm\stm.haddock
++haddock-html:         ${pkgroot}/../docs/html/libraries/stm
+--- lib/package.conf.d/template-haskell-2.17.0.0.conf
++++ lib/package.conf.d/template-haskell-2.17.0.0.conf
+@@ -39,6 +39,6 @@ depends:
+     base-4.15.0.0 ghc-boot-th-9.0.1 ghc-prim-0.7.0 pretty-1.1.3.6
+ 
+ haddock-interfaces:
+-    ${pkgroot}/../../docs/html/libraries/template-haskell\template-haskell.haddock
++    ${pkgroot}/../docs/html/libraries/template-haskell\template-haskell.haddock
+ 
+-haddock-html:         ${pkgroot}/../../docs/html/libraries/template-haskell
++haddock-html:         ${pkgroot}/../docs/html/libraries/template-haskell
+--- lib/package.conf.d/text-1.2.4.1.conf
++++ lib/package.conf.d/text-1.2.4.1.conf
+@@ -92,5 +92,5 @@ depends:
+     deepseq-1.4.5.0 ghc-bignum-1.0 ghc-prim-0.7.0
+     template-haskell-2.17.0.0
+ 
+-haddock-interfaces:   ${pkgroot}/../../docs/html/libraries/text\text.haddock
+-haddock-html:         ${pkgroot}/../../docs/html/libraries/text
++haddock-interfaces:   ${pkgroot}/../docs/html/libraries/text\text.haddock
++haddock-html:         ${pkgroot}/../docs/html/libraries/text
+--- lib/package.conf.d/time-1.9.3.conf
++++ lib/package.conf.d/time-1.9.3.conf
+@@ -49,5 +49,5 @@ data-dir:             ${pkgroot}\x86_64-windows-ghc-9.0.1\time-1.9.3
+ hs-libraries:         HStime-1.9.3
+ include-dirs:         ${pkgroot}\x86_64-windows-ghc-9.0.1\time-1.9.3\include
+ depends:              Win32-2.10.0.0 base-4.15.0.0 deepseq-1.4.5.0
+-haddock-interfaces:   ${pkgroot}/../../docs/html/libraries/time\time.haddock
+-haddock-html:         ${pkgroot}/../../docs/html/libraries/time
++haddock-interfaces:   ${pkgroot}/../docs/html/libraries/time\time.haddock
++haddock-html:         ${pkgroot}/../docs/html/libraries/time
+--- lib/package.conf.d/transformers-0.5.6.2.conf
++++ lib/package.conf.d/transformers-0.5.6.2.conf
+@@ -56,6 +56,6 @@ data-dir:             ${pkgroot}\x86_64-windows-ghc-9.0.1\transformers-0.5.6.2
+ hs-libraries:         HStransformers-0.5.6.2
+ depends:              base-4.15.0.0
+ haddock-interfaces:
+-    ${pkgroot}/../../docs/html/libraries/transformers\transformers.haddock
++    ${pkgroot}/../docs/html/libraries/transformers\transformers.haddock
+ 
+-haddock-html:         ${pkgroot}/../../docs/html/libraries/transformers
++haddock-html:         ${pkgroot}/../docs/html/libraries/transformers
+--- lib/package.conf.d/xhtml-3000.2.2.1.conf
++++ lib/package.conf.d/xhtml-3000.2.2.1.conf
+@@ -37,5 +37,5 @@ dynamic-library-dirs: ${pkgroot}\x86_64-windows-ghc-9.0.1
+ data-dir:             ${pkgroot}\x86_64-windows-ghc-9.0.1\xhtml-3000.2.2.1
+ hs-libraries:         HSxhtml-3000.2.2.1
+ depends:              base-4.15.0.0
+-haddock-interfaces:   ${pkgroot}/../../docs/html/libraries/xhtml\xhtml.haddock
+-haddock-html:         ${pkgroot}/../../docs/html/libraries/xhtml
++haddock-interfaces:   ${pkgroot}/../docs/html/libraries/xhtml\xhtml.haddock
++haddock-html:         ${pkgroot}/../docs/html/libraries/xhtml

--- a/haskell/assets/ghc_9_2_1_mac.patch
+++ b/haskell/assets/ghc_9_2_1_mac.patch
@@ -1,0 +1,11 @@
+--- Makefile	2021-12-14 12:24:30.857292020 +0000
++++ Makefile	2021-12-14 12:24:44.637400564 +0000
+@@ -201,7 +201,7 @@ update_package_db: install_bin install_lib
+ 	@echo "$(PKG_CONFS)"
+ 	@echo "Updating the package DB"
+ 	$(foreach p, $(PKG_CONFS),\
+-		$(call patchpackageconf,$(shell echo $(notdir $p) | sed 's/-\([0-9]*[0-9]\.\)*conf//g'),$(shell echo "$p" | sed 's:xxx:   :g'),$(docdir),$(shell realpath --relative-to="$(ActualLibsDir)" "$(docdir)")))
++		$(call patchpackageconf,$(shell echo $(notdir $p) | sed 's/-\([0-9]*[0-9]\.\)*conf//g'),$(shell echo "$p" | sed 's:xxx:   :g'),$(docdir),$(shell mk/relpath.sh "$(ActualLibsDir)" "$(docdir)")))
+ 	'$(WrapperBinsDir)/ghc-pkg' recache
+ 
+ install_mingw:

--- a/haskell/assets/ghc_9_2_1_win.patch
+++ b/haskell/assets/ghc_9_2_1_win.patch
@@ -1,0 +1,358 @@
+--- lib/package.conf.d/Cabal-3.6.0.0.conf
++++ lib/package.conf.d/Cabal-3.6.0.0.conf
+@@ -185,5 +185,5 @@ depends:
+     pretty-1.1.3.6 process-1.6.13.2 text-1.2.5.0 time-1.11.1.1
+     transformers-0.5.6.2
+ 
+-haddock-interfaces:   ${pkgroot}/../../docs/html/libraries/Cabal\Cabal.haddock
+-haddock-html:         ${pkgroot}/../../docs/html/libraries/Cabal
++haddock-interfaces:   ${pkgroot}/../docs/html/libraries/Cabal\Cabal.haddock
++haddock-html:         ${pkgroot}/../docs/html/libraries/Cabal
+--- lib/package.conf.d/Win32-2.12.0.1.conf
++++ lib/package.conf.d/Win32-2.12.0.1.conf
+@@ -62,5 +62,5 @@ includes:
+     alignment.h
+ 
+ depends:              base-4.16.0.0 filepath-1.4.2.1
+-haddock-interfaces:   ${pkgroot}/../../docs/html/libraries/Win32\Win32.haddock
+-haddock-html:         ${pkgroot}/../../docs/html/libraries/Win32
++haddock-interfaces:   ${pkgroot}/../docs/html/libraries/Win32\Win32.haddock
++haddock-html:         ${pkgroot}/../docs/html/libraries/Win32
+--- lib/package.conf.d/array-0.5.4.0.conf
++++ lib/package.conf.d/array-0.5.4.0.conf
+@@ -29,5 +29,5 @@ dynamic-library-dirs: ${pkgroot}\x86_64-windows-ghc-9.2.1
+ data-dir:             ${pkgroot}\x86_64-windows-ghc-9.2.1\array-0.5.4.0
+ hs-libraries:         HSarray-0.5.4.0
+ depends:              base-4.16.0.0
+-haddock-interfaces:   ${pkgroot}/../../docs/html/libraries/array\array.haddock
+-haddock-html:         ${pkgroot}/../../docs/html/libraries/array
++haddock-interfaces:   ${pkgroot}/../docs/html/libraries/array\array.haddock
++haddock-html:         ${pkgroot}/../docs/html/libraries/array
+--- lib/package.conf.d/base-4.16.0.0.conf
++++ lib/package.conf.d/base-4.16.0.0.conf
+@@ -113,5 +113,5 @@ extra-libraries:
+ include-dirs:         ${pkgroot}\x86_64-windows-ghc-9.2.1\base-4.16.0.0\include
+ includes:             HsBase.h
+ depends:              ghc-bignum-1.2 ghc-prim-0.8.0 rts-1.0.2
+-haddock-interfaces:   ${pkgroot}/../../docs/html/libraries/base\base.haddock
+-haddock-html:         ${pkgroot}/../../docs/html/libraries/base
++haddock-interfaces:   ${pkgroot}/../docs/html/libraries/base\base.haddock
++haddock-html:         ${pkgroot}/../docs/html/libraries/base
+--- lib/package.conf.d/binary-0.8.9.0.conf
++++ lib/package.conf.d/binary-0.8.9.0.conf
+@@ -40,5 +40,5 @@ hs-libraries:         HSbinary-0.8.9.0
+ depends:
+     array-0.5.4.0 base-4.16.0.0 bytestring-0.11.1.0 containers-0.6.5.1
+ 
+-haddock-interfaces:   ${pkgroot}/../../docs/html/libraries/binary\binary.haddock
+-haddock-html:         ${pkgroot}/../../docs/html/libraries/binary
++haddock-interfaces:   ${pkgroot}/../docs/html/libraries/binary\binary.haddock
++haddock-html:         ${pkgroot}/../docs/html/libraries/binary
+--- lib/package.conf.d/bytestring-0.11.1.0.conf
++++ lib/package.conf.d/bytestring-0.11.1.0.conf
+@@ -92,6 +92,6 @@ depends:
+     base-4.16.0.0 deepseq-1.4.6.0 ghc-bignum-1.2 ghc-prim-0.8.0
+ 
+ haddock-interfaces:
+-    ${pkgroot}/../../docs/html/libraries/bytestring\bytestring.haddock
++    ${pkgroot}/../docs/html/libraries/bytestring\bytestring.haddock
+ 
+-haddock-html:         ${pkgroot}/../../docs/html/libraries/bytestring
++haddock-html:         ${pkgroot}/../docs/html/libraries/bytestring
+--- lib/package.conf.d/containers-0.6.5.1.conf
++++ lib/package.conf.d/containers-0.6.5.1.conf
+@@ -50,6 +50,6 @@ data-dir:             ${pkgroot}\x86_64-windows-ghc-9.2.1\containers-0.6.5.1
+ hs-libraries:         HScontainers-0.6.5.1
+ depends:              array-0.5.4.0 base-4.16.0.0 deepseq-1.4.6.0
+ haddock-interfaces:
+-    ${pkgroot}/../../docs/html/libraries/containers\containers.haddock
++    ${pkgroot}/../docs/html/libraries/containers\containers.haddock
+ 
+-haddock-html:         ${pkgroot}/../../docs/html/libraries/containers
++haddock-html:         ${pkgroot}/../docs/html/libraries/containers
+--- lib/package.conf.d/deepseq-1.4.6.0.conf
++++ lib/package.conf.d/deepseq-1.4.6.0.conf
+@@ -33,6 +33,6 @@ data-dir:             ${pkgroot}\x86_64-windows-ghc-9.2.1\deepseq-1.4.6.0
+ hs-libraries:         HSdeepseq-1.4.6.0
+ depends:              array-0.5.4.0 base-4.16.0.0
+ haddock-interfaces:
+-    ${pkgroot}/../../docs/html/libraries/deepseq\deepseq.haddock
++    ${pkgroot}/../docs/html/libraries/deepseq\deepseq.haddock
+ 
+-haddock-html:         ${pkgroot}/../../docs/html/libraries/deepseq
++haddock-html:         ${pkgroot}/../docs/html/libraries/deepseq
+--- lib/package.conf.d/directory-1.3.6.2.conf
++++ lib/package.conf.d/directory-1.3.6.2.conf
+@@ -31,6 +31,6 @@ depends:
+     Win32-2.12.0.1 base-4.16.0.0 filepath-1.4.2.1 time-1.11.1.1
+ 
+ haddock-interfaces:
+-    ${pkgroot}/../../docs/html/libraries/directory\directory.haddock
++    ${pkgroot}/../docs/html/libraries/directory\directory.haddock
+ 
+-haddock-html:         ${pkgroot}/../../docs/html/libraries/directory
++haddock-html:         ${pkgroot}/../docs/html/libraries/directory
+--- lib/package.conf.d/exceptions-0.10.4.conf
++++ lib/package.conf.d/exceptions-0.10.4.conf
+@@ -28,6 +28,6 @@ depends:
+     transformers-0.5.6.2
+ 
+ haddock-interfaces:
+-    ${pkgroot}/../../docs/html/libraries/exceptions\exceptions.haddock
++    ${pkgroot}/../docs/html/libraries/exceptions\exceptions.haddock
+ 
+-haddock-html:         ${pkgroot}/../../docs/html/libraries/exceptions
++haddock-html:         ${pkgroot}/../docs/html/libraries/exceptions
+--- lib/package.conf.d/filepath-1.4.2.1.conf
++++ lib/package.conf.d/filepath-1.4.2.1.conf
+@@ -33,6 +33,6 @@ data-dir:             ${pkgroot}\x86_64-windows-ghc-9.2.1\filepath-1.4.2.1
+ hs-libraries:         HSfilepath-1.4.2.1
+ depends:              base-4.16.0.0
+ haddock-interfaces:
+-    ${pkgroot}/../../docs/html/libraries/filepath\filepath.haddock
++    ${pkgroot}/../docs/html/libraries/filepath\filepath.haddock
+ 
+-haddock-html:         ${pkgroot}/../../docs/html/libraries/filepath
++haddock-html:         ${pkgroot}/../docs/html/libraries/filepath
+--- lib/package.conf.d/ghc-9.2.1.conf
++++ lib/package.conf.d/ghc-9.2.1.conf
+@@ -248,5 +248,5 @@ depends:
+     process-1.6.13.2 template-haskell-2.18.0.0 time-1.11.1.1
+     transformers-0.5.6.2
+ 
+-haddock-interfaces:   ${pkgroot}/../../docs/html/libraries/ghc\ghc.haddock
+-haddock-html:         ${pkgroot}/../../docs/html/libraries/ghc
++haddock-interfaces:   ${pkgroot}/../docs/html/libraries/ghc\ghc.haddock
++haddock-html:         ${pkgroot}/../docs/html/libraries/ghc
+--- lib/package.conf.d/ghc-bignum-1.2.conf
++++ lib/package.conf.d/ghc-bignum-1.2.conf
+@@ -28,6 +28,6 @@ hs-libraries:         HSghc-bignum-1.2
+ include-dirs:         ${pkgroot}\x86_64-windows-ghc-9.2.1\ghc-bignum-1.2\include
+ depends:              ghc-prim-0.8.0
+ haddock-interfaces:
+-    ${pkgroot}/../../docs/html/libraries/ghc-bignum\ghc-bignum.haddock
++    ${pkgroot}/../docs/html/libraries/ghc-bignum\ghc-bignum.haddock
+ 
+-haddock-html:         ${pkgroot}/../../docs/html/libraries/ghc-bignum
++haddock-html:         ${pkgroot}/../docs/html/libraries/ghc-bignum
+--- lib/package.conf.d/ghc-boot-9.2.1.conf
++++ lib/package.conf.d/ghc-boot-9.2.1.conf
+@@ -45,6 +45,6 @@ depends:
+     ghc-boot-th-9.2.1
+ 
+ haddock-interfaces:
+-    ${pkgroot}/../../docs/html/libraries/ghc-boot\ghc-boot.haddock
++    ${pkgroot}/../docs/html/libraries/ghc-boot\ghc-boot.haddock
+ 
+-haddock-html:         ${pkgroot}/../../docs/html/libraries/ghc-boot
++haddock-html:         ${pkgroot}/../docs/html/libraries/ghc-boot
+--- lib/package.conf.d/ghc-boot-th-9.2.1.conf
++++ lib/package.conf.d/ghc-boot-th-9.2.1.conf
+@@ -30,6 +30,6 @@ data-dir:             ${pkgroot}\x86_64-windows-ghc-9.2.1\ghc-boot-th-9.2.1
+ hs-libraries:         HSghc-boot-th-9.2.1
+ depends:              base-4.16.0.0
+ haddock-interfaces:
+-    ${pkgroot}/../../docs/html/libraries/ghc-boot-th\ghc-boot-th.haddock
++    ${pkgroot}/../docs/html/libraries/ghc-boot-th\ghc-boot-th.haddock
+ 
+-haddock-html:         ${pkgroot}/../../docs/html/libraries/ghc-boot-th
++haddock-html:         ${pkgroot}/../docs/html/libraries/ghc-boot-th
+--- lib/package.conf.d/ghc-compact-0.1.0.0.conf
++++ lib/package.conf.d/ghc-compact-0.1.0.0.conf
+@@ -29,6 +29,6 @@ data-dir:             ${pkgroot}\x86_64-windows-ghc-9.2.1\ghc-compact-0.1.0.0
+ hs-libraries:         HSghc-compact-0.1.0.0
+ depends:              base-4.16.0.0 bytestring-0.11.1.0 ghc-prim-0.8.0
+ haddock-interfaces:
+-    ${pkgroot}/../../docs/html/libraries/ghc-compact\ghc-compact.haddock
++    ${pkgroot}/../docs/html/libraries/ghc-compact\ghc-compact.haddock
+ 
+-haddock-html:         ${pkgroot}/../../docs/html/libraries/ghc-compact
++haddock-html:         ${pkgroot}/../docs/html/libraries/ghc-compact
+--- lib/package.conf.d/ghc-heap-9.2.1.conf
++++ lib/package.conf.d/ghc-heap-9.2.1.conf
+@@ -33,6 +33,6 @@ depends:
+     base-4.16.0.0 containers-0.6.5.1 ghc-prim-0.8.0 rts-1.0.2
+ 
+ haddock-interfaces:
+-    ${pkgroot}/../../docs/html/libraries/ghc-heap\ghc-heap.haddock
++    ${pkgroot}/../docs/html/libraries/ghc-heap\ghc-heap.haddock
+ 
+-haddock-html:         ${pkgroot}/../../docs/html/libraries/ghc-heap
++haddock-html:         ${pkgroot}/../docs/html/libraries/ghc-heap
+--- lib/package.conf.d/ghc-prim-0.8.0.conf
++++ lib/package.conf.d/ghc-prim-0.8.0.conf
+@@ -25,6 +25,6 @@ hs-libraries:         HSghc-prim-0.8.0
+ extra-libraries:      user32 mingw32 mingwex
+ depends:              rts-1.0.2
+ haddock-interfaces:
+-    ${pkgroot}/../../docs/html/libraries/ghc-prim\ghc-prim.haddock
++    ${pkgroot}/../docs/html/libraries/ghc-prim\ghc-prim.haddock
+ 
+-haddock-html:         ${pkgroot}/../../docs/html/libraries/ghc-prim
++haddock-html:         ${pkgroot}/../docs/html/libraries/ghc-prim
+--- lib/package.conf.d/ghci-9.2.1.conf
++++ lib/package.conf.d/ghci-9.2.1.conf
+@@ -31,5 +31,5 @@ depends:
+     ghc-heap-9.2.1 ghc-prim-0.8.0 rts-1.0.2 template-haskell-2.18.0.0
+     transformers-0.5.6.2
+ 
+-haddock-interfaces:   ${pkgroot}/../../docs/html/libraries/ghci\ghci.haddock
+-haddock-html:         ${pkgroot}/../../docs/html/libraries/ghci
++haddock-interfaces:   ${pkgroot}/../docs/html/libraries/ghci\ghci.haddock
++haddock-html:         ${pkgroot}/../docs/html/libraries/ghci
+--- lib/package.conf.d/haskeline-0.8.2.conf
++++ lib/package.conf.d/haskeline-0.8.2.conf
+@@ -57,6 +57,6 @@ depends:
+     process-1.6.13.2 stm-2.5.0.0 transformers-0.5.6.2
+ 
+ haddock-interfaces:
+-    ${pkgroot}/../../docs/html/libraries/haskeline\haskeline.haddock
++    ${pkgroot}/../docs/html/libraries/haskeline\haskeline.haddock
+ 
+-haddock-html:         ${pkgroot}/../../docs/html/libraries/haskeline
++haddock-html:         ${pkgroot}/../docs/html/libraries/haskeline
+--- lib/package.conf.d/hpc-0.6.1.0.conf
++++ lib/package.conf.d/hpc-0.6.1.0.conf
+@@ -28,5 +28,5 @@ depends:
+     base-4.16.0.0 containers-0.6.5.1 deepseq-1.4.6.0 directory-1.3.6.2
+     filepath-1.4.2.1 time-1.11.1.1
+ 
+-haddock-interfaces:   ${pkgroot}/../../docs/html/libraries/hpc\hpc.haddock
+-haddock-html:         ${pkgroot}/../../docs/html/libraries/hpc
++haddock-interfaces:   ${pkgroot}/../docs/html/libraries/hpc\hpc.haddock
++haddock-html:         ${pkgroot}/../docs/html/libraries/hpc
+--- lib/package.conf.d/integer-gmp-1.1.conf
++++ lib/package.conf.d/integer-gmp-1.1.conf
+@@ -28,6 +28,6 @@ data-dir:             ${pkgroot}\x86_64-windows-ghc-9.2.1\integer-gmp-1.1
+ hs-libraries:         HSinteger-gmp-1.1
+ depends:              base-4.16.0.0 ghc-bignum-1.2 ghc-prim-0.8.0
+ haddock-interfaces:
+-    ${pkgroot}/../../docs/html/libraries/integer-gmp\integer-gmp.haddock
++    ${pkgroot}/../docs/html/libraries/integer-gmp\integer-gmp.haddock
+ 
+-haddock-html:         ${pkgroot}/../../docs/html/libraries/integer-gmp
++haddock-html:         ${pkgroot}/../docs/html/libraries/integer-gmp
+--- lib/package.conf.d/libiserv-9.2.1.conf
++++ lib/package.conf.d/libiserv-9.2.1.conf
+@@ -27,6 +27,6 @@ depends:
+     deepseq-1.4.6.0 ghci-9.2.1
+ 
+ haddock-interfaces:
+-    ${pkgroot}/../../docs/html/libraries/libiserv\libiserv.haddock
++    ${pkgroot}/../docs/html/libraries/libiserv\libiserv.haddock
+ 
+-haddock-html:         ${pkgroot}/../../docs/html/libraries/libiserv
++haddock-html:         ${pkgroot}/../docs/html/libraries/libiserv
+--- lib/package.conf.d/mtl-2.2.2.conf
++++ lib/package.conf.d/mtl-2.2.2.conf
+@@ -36,5 +36,5 @@ dynamic-library-dirs: ${pkgroot}\x86_64-windows-ghc-9.2.1
+ data-dir:             ${pkgroot}\x86_64-windows-ghc-9.2.1\mtl-2.2.2
+ hs-libraries:         HSmtl-2.2.2
+ depends:              base-4.16.0.0 transformers-0.5.6.2
+-haddock-interfaces:   ${pkgroot}/../../docs/html/libraries/mtl\mtl.haddock
+-haddock-html:         ${pkgroot}/../../docs/html/libraries/mtl
++haddock-interfaces:   ${pkgroot}/../docs/html/libraries/mtl\mtl.haddock
++haddock-html:         ${pkgroot}/../docs/html/libraries/mtl
+--- lib/package.conf.d/parsec-3.1.14.0.conf
++++ lib/package.conf.d/parsec-3.1.14.0.conf
+@@ -52,5 +52,5 @@ hs-libraries:         HSparsec-3.1.14.0
+ depends:
+     base-4.16.0.0 bytestring-0.11.1.0 mtl-2.2.2 text-1.2.5.0
+ 
+-haddock-interfaces:   ${pkgroot}/../../docs/html/libraries/parsec\parsec.haddock
+-haddock-html:         ${pkgroot}/../../docs/html/libraries/parsec
++haddock-interfaces:   ${pkgroot}/../docs/html/libraries/parsec\parsec.haddock
++haddock-html:         ${pkgroot}/../docs/html/libraries/parsec
+--- lib/package.conf.d/pretty-1.1.3.6.conf
++++ lib/package.conf.d/pretty-1.1.3.6.conf
+@@ -32,5 +32,5 @@ dynamic-library-dirs: ${pkgroot}\x86_64-windows-ghc-9.2.1
+ data-dir:             ${pkgroot}\x86_64-windows-ghc-9.2.1\pretty-1.1.3.6
+ hs-libraries:         HSpretty-1.1.3.6
+ depends:              base-4.16.0.0 deepseq-1.4.6.0 ghc-prim-0.8.0
+-haddock-interfaces:   ${pkgroot}/../../docs/html/libraries/pretty\pretty.haddock
+-haddock-html:         ${pkgroot}/../../docs/html/libraries/pretty
++haddock-interfaces:   ${pkgroot}/../docs/html/libraries/pretty\pretty.haddock
++haddock-html:         ${pkgroot}/../docs/html/libraries/pretty
+--- lib/package.conf.d/process-1.6.13.2.conf
++++ lib/package.conf.d/process-1.6.13.2.conf
+@@ -35,6 +35,6 @@ depends:
+     filepath-1.4.2.1
+ 
+ haddock-interfaces:
+-    ${pkgroot}/../../docs/html/libraries/process\process.haddock
++    ${pkgroot}/../docs/html/libraries/process\process.haddock
+ 
+-haddock-html:         ${pkgroot}/../../docs/html/libraries/process
++haddock-html:         ${pkgroot}/../docs/html/libraries/process
+--- lib/package.conf.d/rts-1.0.2.conf
++++ lib/package.conf.d/rts-1.0.2.conf
+@@ -78,5 +78,5 @@ ld-options:
+     "-Wl,-u,hs_atomicwrite16" "-Wl,-u,hs_atomicwrite32"
+     "-Wl,-u,base_GHCziEventziWindows_processRemoteCompletion_closure"
+ 
+-haddock-interfaces:   ${pkgroot}/../../docs/html/libraries/rts\rts.haddock
+-haddock-html:         ${pkgroot}/../../docs/html/libraries/rts
++haddock-interfaces:   ${pkgroot}/../docs/html/libraries/rts\rts.haddock
++haddock-html:         ${pkgroot}/../docs/html/libraries/rts
+--- lib/package.conf.d/stm-2.5.0.0.conf
++++ lib/package.conf.d/stm-2.5.0.0.conf
+@@ -34,5 +34,5 @@ dynamic-library-dirs: ${pkgroot}\x86_64-windows-ghc-9.2.1
+ data-dir:             ${pkgroot}\x86_64-windows-ghc-9.2.1\stm-2.5.0.0
+ hs-libraries:         HSstm-2.5.0.0
+ depends:              array-0.5.4.0 base-4.16.0.0
+-haddock-interfaces:   ${pkgroot}/../../docs/html/libraries/stm\stm.haddock
+-haddock-html:         ${pkgroot}/../../docs/html/libraries/stm
++haddock-interfaces:   ${pkgroot}/../docs/html/libraries/stm\stm.haddock
++haddock-html:         ${pkgroot}/../docs/html/libraries/stm
+--- lib/package.conf.d/template-haskell-2.18.0.0.conf
++++ lib/package.conf.d/template-haskell-2.18.0.0.conf
+@@ -39,6 +39,6 @@ depends:
+     base-4.16.0.0 ghc-boot-th-9.2.1 ghc-prim-0.8.0 pretty-1.1.3.6
+ 
+ haddock-interfaces:
+-    ${pkgroot}/../../docs/html/libraries/template-haskell\template-haskell.haddock
++    ${pkgroot}/../docs/html/libraries/template-haskell\template-haskell.haddock
+ 
+-haddock-html:         ${pkgroot}/../../docs/html/libraries/template-haskell
++haddock-html:         ${pkgroot}/../docs/html/libraries/template-haskell
+--- lib/package.conf.d/text-1.2.5.0.conf
++++ lib/package.conf.d/text-1.2.5.0.conf
+@@ -92,5 +92,5 @@ depends:
+     array-0.5.4.0 base-4.16.0.0 binary-0.8.9.0 bytestring-0.11.1.0
+     deepseq-1.4.6.0 ghc-prim-0.8.0 template-haskell-2.18.0.0
+ 
+-haddock-interfaces:   ${pkgroot}/../../docs/html/libraries/text\text.haddock
+-haddock-html:         ${pkgroot}/../../docs/html/libraries/text
++haddock-interfaces:   ${pkgroot}/../docs/html/libraries/text\text.haddock
++haddock-html:         ${pkgroot}/../docs/html/libraries/text
+--- lib/package.conf.d/time-1.11.1.1.conf
++++ lib/package.conf.d/time-1.11.1.1.conf
+@@ -50,5 +50,5 @@ data-dir:             ${pkgroot}\x86_64-windows-ghc-9.2.1\time-1.11.1.1
+ hs-libraries:         HStime-1.11.1.1
+ include-dirs:         ${pkgroot}\x86_64-windows-ghc-9.2.1\time-1.11.1.1\include
+ depends:              Win32-2.12.0.1 base-4.16.0.0 deepseq-1.4.6.0
+-haddock-interfaces:   ${pkgroot}/../../docs/html/libraries/time\time.haddock
+-haddock-html:         ${pkgroot}/../../docs/html/libraries/time
++haddock-interfaces:   ${pkgroot}/../docs/html/libraries/time\time.haddock
++haddock-html:         ${pkgroot}/../docs/html/libraries/time
+--- lib/package.conf.d/transformers-0.5.6.2.conf
++++ lib/package.conf.d/transformers-0.5.6.2.conf
+@@ -56,6 +56,6 @@ data-dir:             ${pkgroot}\x86_64-windows-ghc-9.2.1\transformers-0.5.6.2
+ hs-libraries:         HStransformers-0.5.6.2
+ depends:              base-4.16.0.0
+ haddock-interfaces:
+-    ${pkgroot}/../../docs/html/libraries/transformers\transformers.haddock
++    ${pkgroot}/../docs/html/libraries/transformers\transformers.haddock
+ 
+-haddock-html:         ${pkgroot}/../../docs/html/libraries/transformers
++haddock-html:         ${pkgroot}/../docs/html/libraries/transformers
+--- lib/package.conf.d/xhtml-3000.2.2.1.conf
++++ lib/package.conf.d/xhtml-3000.2.2.1.conf
+@@ -37,5 +37,5 @@ dynamic-library-dirs: ${pkgroot}\x86_64-windows-ghc-9.2.1
+ data-dir:             ${pkgroot}\x86_64-windows-ghc-9.2.1\xhtml-3000.2.2.1
+ hs-libraries:         HSxhtml-3000.2.2.1
+ depends:              base-4.16.0.0
+-haddock-interfaces:   ${pkgroot}/../../docs/html/libraries/xhtml\xhtml.haddock
+-haddock-html:         ${pkgroot}/../../docs/html/libraries/xhtml
++haddock-interfaces:   ${pkgroot}/../docs/html/libraries/xhtml\xhtml.haddock
++haddock-html:         ${pkgroot}/../docs/html/libraries/xhtml

--- a/haskell/assets/relpath.sh
+++ b/haskell/assets/relpath.sh
@@ -1,0 +1,53 @@
+#!/bin/sh
+
+# POSIX shell implementation of `realpath --relative-to=$1 $2.
+# This is an adaptation of the implementation from
+# <https://github.com/Offirmo/offirmo-shell-lib>.
+
+# returns relative path to $2=$target from $1=$source
+## NOTE : path are compared in text only. They don’t have to exist
+##        and they WONT be normalized/escaped
+## Result in "$return_value"# both $1 and $2 are absolute paths beginning with /
+
+src="$1"
+target="$2"
+
+common_part="$src"
+result=""
+
+while test "${target#$common_part}" = "${target}" ; do
+    #echo "common_part is now : \"$common_part\""
+    #echo "result is now      : \"$result\""
+    #echo "target#common_part : \"${target#$common_part}\""
+    # no match, means that candidate common part is not correct
+    # go up one level (reduce common part)
+    common_part="$(dirname "$common_part")"
+    # and record that we went back
+    if test -z "$result" ; then
+        result=".."
+    else
+        result="../$result"
+    fi
+done
+
+#echo "common_part is     : \"$common_part\""
+
+if test "$common_part" = "/" ; then
+    # special case for root (no common path)
+    result="$result/"
+fi
+
+# since we now have identified the common part,
+# compute the non-common part
+forward_part="${target#$common_part}"
+#echo "forward_part = \"$forward_part\""
+
+if test -n "$result" && test -n "$forward_part" ; then
+    #echo "(simple concat)"
+    result="$result$forward_part"
+elif test -n "$forward_part" ; then
+    #echo "(concat with slash removal)"
+    result="$(printf "%s" "$forward_part" | cut -c 1-)"
+fi
+
+printf "%s" "$result"

--- a/haskell/ghc.BUILD.tpl
+++ b/haskell/ghc.BUILD.tpl
@@ -30,8 +30,8 @@ filegroup(
 )
 
 filegroup(
-    name = "doc",
-    srcs = glob(["doc/**"]),
+    name = "%{docdir}",
+    srcs = glob(["%{docdir}/**"]),
 )
 
 # Expose embedded MinGW toolchain when on Windows.

--- a/haskell/ghc_bindist.bzl
+++ b/haskell/ghc_bindist.bzl
@@ -666,6 +666,7 @@ def ghc_bindist(
             "8.8.2": ["@rules_haskell//haskell:assets/ghc_8_8_2_win_base.patch"],
             "8.8.3": ["@rules_haskell//haskell:assets/ghc_8_8_3_win_base.patch"],
             "8.8.4": ["@rules_haskell//haskell:assets/ghc_8_8_4_win_base.patch"],
+            "9.0.1": ["@rules_haskell//haskell:assets/ghc_9_0_1_win.patch"],
             "9.2.1": ["@rules_haskell//haskell:assets/ghc_9_2_1_win.patch"],
         }.get(version)
 

--- a/haskell/ghc_bindist.bzl
+++ b/haskell/ghc_bindist.bzl
@@ -344,6 +344,9 @@ GHC_BINDIST_STRIP_PREFIX = \
             "darwin_amd64": "ghc-9.2.1-x86_64-apple-darwin",
             "windows_amd64": "ghc-9.2.1-x86_64-unknown-mingw32",
         },
+        "9.0.1": {
+            "windows_amd64": "ghc-9.0.1-x86_64-unknown-mingw32",
+        },
     }
 
 GHC_BINDIST_LIBDIR = \

--- a/haskell/ghc_bindist.bzl
+++ b/haskell/ghc_bindist.bzl
@@ -346,6 +346,13 @@ GHC_BINDIST_STRIP_PREFIX = \
         },
     }
 
+GHC_BINDIST_LIBDIR = \
+    {
+        "9.2.1": {
+            "darwin_amd64": "lib/lib",
+        },
+    }
+
 def _ghc_bindist_impl(ctx):
     filepaths = resolve_labels(ctx, [
         "@rules_haskell//haskell:ghc.BUILD.tpl",
@@ -455,7 +462,11 @@ rm -f
     if len(ctx.attr.patches) > 0:
         execute_or_fail_loudly(ctx, ["./bin/ghc-pkg", "recache"])
 
-    toolchain_libraries = pkgdb_to_bzl(ctx, filepaths, "lib")
+    libdir = "lib"
+    if GHC_BINDIST_LIBDIR.get(version) != None and GHC_BINDIST_LIBDIR[version].get(target) != None:
+        libdir = GHC_BINDIST_LIBDIR[version][target]
+
+    toolchain_libraries = pkgdb_to_bzl(ctx, filepaths, libdir)
     locale = ctx.attr.locale or ("en_US.UTF-8" if os == "darwin" else "C.UTF-8")
     toolchain = define_rule(
         "haskell_toolchain",

--- a/haskell/ghc_bindist.bzl
+++ b/haskell/ghc_bindist.bzl
@@ -338,6 +338,14 @@ GHC_BINDIST = \
         },
     }
 
+GHC_BINDIST_STRIP_PREFIX = \
+    {
+        "9.2.1": {
+            "darwin_amd64": "ghc-9.2.1-x86_64-apple-darwin",
+            "windows_amd64": "ghc-9.2.1-x86_64-unknown-mingw32",
+        },
+    }
+
 def _ghc_bindist_impl(ctx):
     filepaths = resolve_labels(ctx, [
         "@rules_haskell//haskell:ghc.BUILD.tpl",
@@ -362,12 +370,16 @@ def _ghc_bindist_impl(ctx):
     # the raw distribution.
     unpack_dir = "bindist_unpacked" if os != "windows" else ""
 
+    stripPrefix = "ghc-" + version
+    if GHC_BINDIST_STRIP_PREFIX.get(version) != None and GHC_BINDIST_STRIP_PREFIX[version].get(target) != None:
+        stripPrefix = GHC_BINDIST_STRIP_PREFIX[version][target]
+
     ctx.download_and_extract(
         url = url,
         output = unpack_dir,
         sha256 = sha256,
         type = "tar.xz",
-        stripPrefix = "ghc-" + version,
+        stripPrefix = stripPrefix,
     )
 
     if os == "windows":

--- a/haskell/ghc_bindist.bzl
+++ b/haskell/ghc_bindist.bzl
@@ -648,6 +648,7 @@ def ghc_bindist(
             "8.8.2": ["@rules_haskell//haskell:assets/ghc_8_8_2_win_base.patch"],
             "8.8.3": ["@rules_haskell//haskell:assets/ghc_8_8_3_win_base.patch"],
             "8.8.4": ["@rules_haskell//haskell:assets/ghc_8_8_4_win_base.patch"],
+            "9.2.1": ["@rules_haskell//haskell:assets/ghc_9_2_1_win.patch"],
         }.get(version)
 
     if target == "darwin_amd64":

--- a/haskell/ghc_bindist.bzl
+++ b/haskell/ghc_bindist.bzl
@@ -360,7 +360,10 @@ GHC_BINDIST_DOCDIR = \
     {
         "9.2.1": {
             "windows_amd64": "docs",
-        }
+        },
+        "9.0.1": {
+            "windows_amd64": "docs",
+        },
     }
 
 def _ghc_bindist_impl(ctx):

--- a/haskell/ghc_bindist.bzl
+++ b/haskell/ghc_bindist.bzl
@@ -353,6 +353,13 @@ GHC_BINDIST_LIBDIR = \
         },
     }
 
+GHC_BINDIST_DOCDIR = \
+    {
+        "9.2.1": {
+            "windows_amd64": "docs",
+        }
+    }
+
 def _ghc_bindist_impl(ctx):
     filepaths = resolve_labels(ctx, [
         "@rules_haskell//haskell:ghc.BUILD.tpl",
@@ -473,6 +480,10 @@ rm -f
     if GHC_BINDIST_LIBDIR.get(version) != None and GHC_BINDIST_LIBDIR[version].get(target) != None:
         libdir = GHC_BINDIST_LIBDIR[version][target]
 
+    docdir = "doc"
+    if GHC_BINDIST_DOCDIR.get(version) != None and GHC_BINDIST_DOCDIR[version].get(target) != None:
+        docdir = GHC_BINDIST_DOCDIR[version][target]
+
     toolchain_libraries = pkgdb_to_bzl(ctx, filepaths, libdir)
     locale = ctx.attr.locale or ("en_US.UTF-8" if os == "darwin" else "C.UTF-8")
     toolchain = define_rule(
@@ -482,7 +493,7 @@ rm -f
         libraries = "toolchain_libraries",
         # See Note [GHC toolchain files]
         libdir = [":lib"],
-        docdir = [":doc"],
+        docdir = [":{}".format(docdir)],
         version = repr(ctx.attr.version),
         static_runtime = os == "windows",
         fully_static_link = False,  # XXX not yet supported for bindists.
@@ -498,6 +509,7 @@ rm -f
         substitutions = {
             "%{toolchain_libraries}": toolchain_libraries,
             "%{toolchain}": toolchain,
+            "%{docdir}": docdir,
         },
         executable = False,
     )

--- a/haskell/private/cabal_wrapper.py
+++ b/haskell/private/cabal_wrapper.py
@@ -187,8 +187,10 @@ def distdir_prefix():
 # into the 'flag hash' field of generated interface files. We try to use a
 # reproducible path for the distdir to keep interface files reproducible.
 with mkdtemp(distdir_prefix()) as distdir:
-    enable_relocatable_flags = ["--enable-relocatable"] \
-            if not is_windows else []
+    enable_relocatable_flags = []
+    if not is_windows and json_args["ghc_version"] != None and json_args["ghc_version"] < [9,2,1]:
+        # ToDo: not work relocatable from Cabal-3.6.0.0 buildin GHC 9.2.1
+        enable_relocatable_flags = ["--enable-relocatable"]
 
     # Cabal really wants the current working directory to be directory
     # where the .cabal file is located. So we have no choice but to chance

--- a/haskell/private/pkgdb_to_bzl.py
+++ b/haskell/private/pkgdb_to_bzl.py
@@ -43,6 +43,9 @@ def unfold_fields(content):
 
 def path_to_label(path, pkgroot):
     """Substitute one pkgroot for another relative one to obtain a label."""
+    if path.find("${pkgroot}") != -1:
+        return os.path.normpath(path.replace("${pkgroot}", topdir)).replace('\\', '/')
+
     topdir_relative_path = path.replace(pkgroot, "$topdir")
     if topdir_relative_path.find("$topdir") != -1:
         return os.path.normpath(topdir_relative_path.replace("$topdir", topdir)).replace('\\', '/')

--- a/haskell/private/pkgdb_to_bzl.py
+++ b/haskell/private/pkgdb_to_bzl.py
@@ -44,7 +44,7 @@ def unfold_fields(content):
 def path_to_label(path, pkgroot):
     """Substitute one pkgroot for another relative one to obtain a label."""
     if path.find("${pkgroot}") != -1:
-        return os.path.normpath(path.replace("${pkgroot}", topdir)).replace('\\', '/')
+        return os.path.normpath(path.strip("\"").replace("${pkgroot}", topdir)).replace('\\', '/')
 
     topdir_relative_path = path.replace(pkgroot, "$topdir")
     if topdir_relative_path.find("$topdir") != -1:

--- a/haskell/toolchain.bzl
+++ b/haskell/toolchain.bzl
@@ -167,6 +167,8 @@ def _haskell_toolchain_impl(ctx):
     if ctx.attr.docdir_path:
         docdir_path = ctx.attr.docdir_path
     elif docdir:
+        docdir_path = None
+
         # Find a file matching `html/libraries/base-*.*.*.*/*` and infer `docdir` from its path.
         # `GHC.Paths.docdir` reports paths such as `.../doc/html/libraries/base-4.13.0.0`.
         for f in docdir:

--- a/haskell/toolchain.bzl
+++ b/haskell/toolchain.bzl
@@ -172,9 +172,9 @@ def _haskell_toolchain_impl(ctx):
         # Find a file matching `html/libraries/base-*.*.*.*/*` and infer `docdir` from its path.
         # `GHC.Paths.docdir` reports paths such as `.../doc/html/libraries/base-4.13.0.0`.
         for f in docdir:
-            html_start = f.path.find("html/libraries/base-")
+            html_start = f.path.find("html/libraries/base")
             if html_start != -1:
-                base_end = f.path.find("/", html_start + len("html/libraries/base-"))
+                base_end = f.path.find("/", html_start + len("html/libraries/base"))
                 if base_end != -1:
                     docdir_path = f.path[:base_end]
                     break


### PR DESCRIPTION
Occur various errors when build project using GHC 9.2.1 or GHC 9.0.1.

So, fix rules_haskell.

FYI: check by sample project https://github.com/matsubara0507/example-haskell-with-bazel/actions/runs/1593848398

### 1. invalid `stripPrefix`

Use GHC 9.0.1 in Windows: 

```
ERROR: An error occurred during the fetch of repository 'rules_haskell_ghc_windows_amd64':
   Traceback (most recent call last):
	File "C:/users/runneradmin/_bazel_runneradmin/ugsis23d/external/rules_haskell/haskell/ghc_bindist.bzl", line 391, column 29, in _ghc_bindist_impl
		ctx.download_and_extract(
Error in download_and_extract: java.io.IOException: Error extracting C:/users/runneradmin/_bazel_runneradmin/ugsis23d/external/rules_haskell_ghc_windows_amd64/temp656765299240579188/ghc-9.0.1-x86_64-unknown-mingw32.tar.xz to C:/users/runneradmin/_bazel_runneradmin/ugsis23d/external/rules_haskell_ghc_windows_amd64/temp656765299240579188: Prefix "ghc-9.0.1" was given, but not found in the archive. Here are possible prefixes for this archive: "ghc-9.0.1-x86_64-unknown-mingw32".
```

`ghc-9.0.1-x86_64-unknown-mingw32.tar.xz` is extracted to `ghc-9.0.1-x86_64-unknown-mingw32` not to `ghc-9.0.1` directory. So, fix `stripPrefix` 4531a7f6442dca44b9c4edfdad1ee3c1ce53568f

And, GHC 9.2.1 in macOS and GHC 9.2.1 in Windows is occur same error too 341a03a32fd920d13338e9041c9c946c57cf71db

### 2. Change path `html/libraries/base-4.14.0.0` to `html/libraries/base` with GHC 9.0.1 and GHC 9.2.1

```
ERROR: /path/to/external/rules_haskell_ghc_darwin_amd64/BUILD:23:18: in _haskell_toolchain rule @rules_haskell_ghc_darwin_amd64//:toolchain-impl: 
Traceback (most recent call last):
	File "/path/to/external/rules_haskell/haskell/toolchain.bzl", line 180, column 17, in _haskell_toolchain_impl
		fail("Could not infer `docdir_path` from provided `docdir` attribute. Missing `lib/settings` file.", "docdir")
Error in fail: Could not infer `docdir_path` from provided `docdir` attribute. Missing `lib/settings` file. docdir
```

fix it fde80bd6d1c7126b6df331bab470a9972088b92f

### 3. Change path `lib/package.conf.d` to `lib/lib/package.conf.d` with GHC 9.2.1 in macOS

fix it dc9e0b18278bf6d46c6b7e67f7579d044af655d7

### 4. Change `$topdir` to `${pkgroot}` in pkgdb file with GHC 9.0.1 and GHC 9.2.1

fix it f4c84c423b92f8eb849ad5677d0f1b86e7998055

### 5. `realpath` is not found with GHC 9.2.1 in macOS

See https://gitlab.haskell.org/ghc/ghc/-/issues/19963
So, patch [this commit](https://gitlab.haskell.org/ghc/ghc/-/commit/fab2579e63bb317d4c266d7b949cf96ad6e5d17b).

### 6. `--enable-relocatable` is not work from Cabal 3.6.0

So, disable `--enable-relocatable` when GHC 9.2.1 (Cabal 3.6.0) 20085b2af090645d1daae15dd910964dad255611
I think ideally disable `--enable-relocatable` only when use Cabal 3.6.0. But I don't have idea method get Cabal package version.

### 7.  Invalid `haddock-html` path in pkgdb with GHC 9.2.1 and GHC 9.0.1 in Windows

fix it using patch e22e9d286247ce6b2f6fbc199448c57f57b4c5ff 1b70303402fe372464a9c69cce70ac30ac8d4253

### 8. Change `doc` to `docs` with GHC 9.2.1 and GHC 9.0.1 in Windows

fix it 4ce551ca5e99b5b579cc317c401498f08b48f299 cf3082ad863597ae19075bb779881eae4202cc8e