### PR TITLE
Fix computation of transitive dependencies

### DIFF
--- a/haskell/experimental/private/module.bzl
+++ b/haskell/experimental/private/module.bzl
@@ -431,10 +431,10 @@ def _merge_narrowed_deps_dicts(rule_label, narrowed_deps):
     Returns:
       pair of per_module_transitive_interfaces, per_module_transitive_objects:
         per_module_transitive_interfaces: dict of module labels to their
-		   interfaces and the interfaces of their transitive module dependencies
+           interfaces and the interfaces of their transitive module dependencies
         per_module_transitive_objects: dict of module labels to their
-		   object files and the object file of their transitive module
-		   dependencies
+           object files and the object file of their transitive module
+           dependencies
     """
     per_module_transitive_interfaces = {}
     per_module_transitive_objects = {}

--- a/haskell/experimental/private/module.bzl
+++ b/haskell/experimental/private/module.bzl
@@ -376,14 +376,14 @@ def _collect_module_inputs(module_input_map, directs, dep):
     return all_inputs
 
 def _collect_narrowed_deps_module_files(ctx_label, per_module_transitive_files, dep):
-    direct_cross_library_deps = dep[HaskellModuleInfo].direct_cross_library_deps
+    transitive_cross_library_dep_labels = dep[HaskellModuleInfo].transitive_cross_library_dep_labels.to_list()
     transitives = [
-        per_module_transitive_files[m.label]
-        for m in direct_cross_library_deps
-        if m.label in per_module_transitive_files
+        per_module_transitive_files[m]
+        for m in transitive_cross_library_dep_labels
+        if m in per_module_transitive_files
     ]
-    if len(transitives) < len(direct_cross_library_deps):
-        missing = [str(m.label) for m in direct_cross_library_deps if not m.label in per_module_transitive_files]
+    if len(transitives) < len(transitive_cross_library_dep_labels):
+        missing = [str(m) for m in transitive_cross_library_dep_labels if not m in per_module_transitive_files]
         fail("The following dependencies of {} can't be found in 'narrowed_deps' of {}: {}".format(
             dep.label,
             ctx_label,
@@ -596,12 +596,18 @@ def haskell_module_impl(ctx):
         transitive = [dep[HaskellModuleInfo].transitive_module_dep_labels for dep in ctx.attr.deps],
         order = "postorder",
     )
+
+    transitive_cross_library_dep_labels = depset(
+        direct = [dep.label for dep in ctx.attr.cross_library_deps],
+        transitive = [dep[HaskellModuleInfo].transitive_cross_library_dep_labels for dep in deps],
+    )
+
     return [
         DefaultInfo(),
         HaskellModuleInfo(
             attr = ctx.attr,
             direct_module_deps = ctx.attr.deps,
-            direct_cross_library_deps = ctx.attr.cross_library_deps,
+            transitive_cross_library_dep_labels = transitive_cross_library_dep_labels,
             transitive_module_dep_labels = transitive_module_dep_labels,
         ),
     ]

--- a/haskell/experimental/private/module.bzl
+++ b/haskell/experimental/private/module.bzl
@@ -265,7 +265,6 @@ def _build_haskell_module(
                 plugin_tool_inputs,
                 preprocessors_inputs,
                 interface_inputs,
-                narrowed_objects,
             ] + [
                 files
                 for files in [
@@ -353,11 +352,12 @@ def _collect_module_outputs_of_direct_deps(with_shared, module_outputs, dep):
         ]
     return his, os
 
-def _collect_module_inputs(module_input_map, directs, dep):
+def _collect_module_inputs(module_input_map, extra_inputs, directs, dep):
     """ Put together inputs coming from direct and transitive dependencies.
 
     Args:
       module_input_map: maps labels of dependencies to all the inputs they require
+      extra_inputs: an addition depset of inputs to include
       directs: inputs of direct dependencies
       dep: the target for which to collect inputs
 
@@ -366,7 +366,7 @@ def _collect_module_inputs(module_input_map, directs, dep):
     """
     all_inputs = depset(
         direct = directs,
-        transitive = [
+        transitive = [extra_inputs] + [
             module_input_map[m.label]  # Will be set by a previous iteration, since all deps were visited before.
             for m in dep[HaskellModuleInfo].direct_module_deps
             if m.label in module_input_map
@@ -527,8 +527,8 @@ def build_haskell_modules(ctx, hs, cc, posix, package_name, with_shared, hidir, 
             narrowed_objects = _collect_narrowed_deps_module_files(ctx.label, per_module_transitive_objects, dep) if enable_th else depset()
 
         his, os = _collect_module_outputs_of_direct_deps(with_shared, module_outputs, dep)
-        interface_inputs = _collect_module_inputs(module_interfaces, his, dep)
-        object_inputs = _collect_module_inputs(module_objects, os, dep)
+        interface_inputs = _collect_module_inputs(module_interfaces, narrowed_interfaces, his, dep)
+        object_inputs = _collect_module_inputs(module_objects, narrowed_objects, os, dep)
 
         _build_haskell_module(
             ctx,
@@ -542,7 +542,7 @@ def build_haskell_modules(ctx, hs, cc, posix, package_name, with_shared, hidir, 
             hidir,
             odir,
             module_outputs[dep.label],
-            depset(transitive = [interface_inputs, narrowed_interfaces]),
+            interface_inputs,
             object_inputs,
             narrowed_objects,
             dep,

--- a/haskell/experimental/private/module.bzl
+++ b/haskell/experimental/private/module.bzl
@@ -402,7 +402,7 @@ def _reorder_module_deps_to_postorder(label, modules):
                in the enclosing library/binary/test.
 
     Returns:
-      A list with the targets in modules in postorder
+      A list with the modules in postorder
     """
     transitive_module_dep_labels = depset(
         direct = [m.label for m in modules],

--- a/haskell/experimental/private/module.bzl
+++ b/haskell/experimental/private/module.bzl
@@ -257,7 +257,6 @@ def _build_haskell_module(
             transitive = [
                 dep_info.package_databases,
                 dep_info.interface_dirs,
-                narrowed_deps_info.empty_hs_libraries,
                 narrowed_deps_info.empty_lib_package_databases,
                 pkg_info_inputs,
                 plugin_dep_info.package_databases,
@@ -269,7 +268,11 @@ def _build_haskell_module(
                 narrowed_objects,
             ] + [
                 files
-                for files in [dep_info.hs_libraries, object_inputs]
+                for files in [
+                    dep_info.hs_libraries,
+                    narrowed_deps_info.empty_hs_libraries,
+                    object_inputs,
+                ]
                 # libraries and object inputs are only needed if the module uses TH
                 if module[HaskellModuleInfo].attr.enable_th
             ],

--- a/haskell/experimental/providers.bzl
+++ b/haskell/experimental/providers.bzl
@@ -3,7 +3,7 @@ HaskellModuleInfo = provider(
     fields = {
         "attr": "The attributes of the haskell_module rule",
         "direct_module_deps": "The direct dependency targets of the haskell_module rule",
-        "transitive_cross_library_dep_labels": "The labels of transitive cross-library dependencies of the module",
+        "direct_cross_library_deps": "The direct cross-library dependency targets of the haskell_module rule",
         "transitive_module_dep_labels": "List of the labels of transitive module dependencies of the haskell_module rule in the enclosing library",
     },
 )

--- a/haskell/experimental/providers.bzl
+++ b/haskell/experimental/providers.bzl
@@ -3,7 +3,7 @@ HaskellModuleInfo = provider(
     fields = {
         "attr": "The attributes of the haskell_module rule",
         "direct_module_deps": "The direct dependency targets of the haskell_module rule",
-        "direct_cross_library_deps": "The direct cross-library dependency targets of the haskell_module rule",
+        "transitive_cross_library_dep_labels": "The labels of transitive cross-library dependencies of the module",
         "transitive_module_dep_labels": "List of the labels of transitive module dependencies of the haskell_module rule in the enclosing library",
     },
 )

--- a/haskell/private/haskell_impl.bzl
+++ b/haskell/private/haskell_impl.bzl
@@ -178,7 +178,7 @@ def _haskell_binary_common_impl(ctx, is_test):
         fail("""Only one of "srcs" or "modules" attributes must be specified in {}""".format(ctx.label))
 
     if not modules and ctx.attr.narrowed_deps:
-        fail("""The attribute "narrowed_deps" is enabled only if "modules" is specified in {}""".format(ctx.label))
+        fail("""The attribute "narrowed_deps" can only be used if "modules" is specified in {}""".format(ctx.label))
 
     # Note [Plugin order]
     plugin_decl = reversed(ctx.attr.plugins)

--- a/haskell/private/haskell_impl.bzl
+++ b/haskell/private/haskell_impl.bzl
@@ -177,6 +177,9 @@ def _haskell_binary_common_impl(ctx, is_test):
     if modules and ctx.files.srcs:
         fail("""Only one of "srcs" or "modules" attributes must be specified in {}""".format(ctx.label))
 
+    if not modules and ctx.attr.narrowed_deps:
+        fail("""The attribute "narrowed_deps" is enabled only if "modules" is specified in {}""".format(ctx.label))
+
     # Note [Plugin order]
     plugin_decl = reversed(ctx.attr.plugins)
     non_default_plugin_decl = reversed(ctx.attr.non_default_plugins)

--- a/tests/haskell_module/dep-narrowing/BUILD.bazel
+++ b/tests/haskell_module/dep-narrowing/BUILD.bazel
@@ -43,6 +43,12 @@ haskell_module(
     cross_library_deps = [":TestLibModule2"],
 )
 
+haskell_module(
+    name = "LibTop",
+    src = "LibTop.hs",
+    deps = [":TestModule"],
+)
+
 # Modifying TestLibModule2 from TestLib2 doesn't cause a rebuild of
 # TestModule2 thanks to narrowing.
 #
@@ -56,6 +62,7 @@ haskell_module(
 haskell_library(
     name = "lib",
     modules = [
+        ":LibTop",
         ":TestModule",
         ":TestModule2",
     ],
@@ -71,7 +78,7 @@ haskell_library(
 haskell_module(
     name = "TestBinModule",
     src = "TestBinModule.hs",
-    cross_library_deps = [":TestModule"],
+    cross_library_deps = [":LibTop"],
     module_name = "Main",
 )
 

--- a/tests/haskell_module/dep-narrowing/LibTop.hs
+++ b/tests/haskell_module/dep-narrowing/LibTop.hs
@@ -1,0 +1,8 @@
+module LibTop(bar, bar2, foo2) where
+
+import TestModule
+
+-- Requiring foo2 tests that the interface file for the cross-library
+-- dep TestLibModule2.foo2 is exposed when building this module.
+bar2 :: Int
+bar2 = foo2

--- a/tests/haskell_module/dep-narrowing/TestBinModule.hs
+++ b/tests/haskell_module/dep-narrowing/TestBinModule.hs
@@ -1,4 +1,7 @@
-import TestModule
+import LibTop
 
+-- Requiring both bar and foo2 tests that the interface file
+-- for the cross-library dep TestLibModule2.foo2 is exposed
+-- when building this module.
 main :: IO ()
-main = print bar
+main = print (bar + foo2)

--- a/tests/haskell_module/dep-narrowing/TestModule.hs
+++ b/tests/haskell_module/dep-narrowing/TestModule.hs
@@ -1,4 +1,4 @@
-module TestModule where
+module TestModule(bar, foo2) where
 
 import TestLibModule (foo)
 import TestLibModule2 (foo2)


### PR DESCRIPTION
The most important fix here is exposing interface files coming from transitive cross-library dependencies. Otherwise, the strengthened tests would fail.

