### PR TITLE
Expose object files of transitive dependencies when using TH

### DIFF
--- a/haskell/experimental/private/module.bzl
+++ b/haskell/experimental/private/module.bzl
@@ -237,7 +237,8 @@ def _build_haskell_module(
         moduleAttr.tools,
     ]
     args.add_all(expand_make_variables("ghcopts", ctx, moduleAttr.ghcopts, module_extra_attrs))
-    args.add_all(narrowed_objects)
+    if module[HaskellModuleInfo].attr.enable_th:
+        args.add_all(narrowed_objects)
 
     outputs = [module_outputs.hi]
     if module_outputs.o:
@@ -523,8 +524,9 @@ def build_haskell_modules(ctx, hs, cc, posix, package_name, with_profiling, with
             dep_info_i = dep_info
             narrowed_deps_info_i = narrowed_deps_info
 
-            # objects are only needed if the module uses TH
-            narrowed_objects = _collect_narrowed_deps_module_files(ctx.label, per_module_transitive_objects, dep) if enable_th else depset()
+            # even if TH is not enabled, we collect the narrowed_objects for building
+            # other modules that import this one and that might use TH
+            narrowed_objects = _collect_narrowed_deps_module_files(ctx.label, per_module_transitive_objects, dep)
 
         his, os = _collect_module_outputs_of_direct_deps(with_shared, module_outputs, dep)
         interface_inputs = _collect_module_inputs(module_interfaces, narrowed_interfaces, his, dep)

--- a/tests/haskell_module/dep-narrowing-th/BUILD.bazel
+++ b/tests/haskell_module/dep-narrowing-th/BUILD.bazel
@@ -16,11 +16,27 @@ haskell_library(
 )
 
 haskell_library(
+    name = "TestLib1",
+    modules = [
+        ":TestLibModule1",
+    ],
+    deps = [
+        "//tests/hackage:base",
+    ],
+)
+
+haskell_module(
+    name = "TestLibModule1",
+    src = "TestLibModule1.hs",
+)
+
+haskell_library(
     name = "TestLib2",
     modules = [
         ":TestLibModule2",
         ":SimpleFoo",
     ],
+    narrowed_deps = [":TestLib1"],
     deps = [
         "//tests/hackage:base",
         "@stackage//:temporary",
@@ -36,6 +52,7 @@ haskell_module(
 haskell_module(
     name = "SimpleFoo",
     src = "SimpleFoo.hs",
+    cross_library_deps = [":TestLibModule1"],
 )
 
 haskell_module(

--- a/tests/haskell_module/dep-narrowing-th/SimpleFoo.hs
+++ b/tests/haskell_module/dep-narrowing-th/SimpleFoo.hs
@@ -1,6 +1,7 @@
 module SimpleFoo where
 
+import TestLibModule1 (foo1)
 import System.IO.Temp
 
 foo :: IO Int
-foo = withSystemTempDirectory "test" $ \_ -> return 23
+foo = withSystemTempDirectory "test" $ \_ -> return foo1

--- a/tests/haskell_module/dep-narrowing-th/TestLibModule1.hs
+++ b/tests/haskell_module/dep-narrowing-th/TestLibModule1.hs
@@ -1,0 +1,4 @@
+module TestLibModule1 where
+
+foo1 :: Int
+foo1 = 2


### PR DESCRIPTION
Turns out that we only collected object files of cross-library dependencies if TH was enabled for a given module.

Unfortunately, if a module M doesn't use TH, those dependencies might still be necessary if some other module using TH imports module M.

This PR adds a test to rehearse this case and a fix.