### PR TITLE
Suppress bogus warnings when using plugins

### DIFF
--- a/haskell/experimental/private/module.bzl
+++ b/haskell/experimental/private/module.bzl
@@ -225,8 +225,6 @@ def _build_haskell_module(
         for manifest in plugin.tool_input_manifests
     ]
 
-    # TODO[AH] Support package id - see `-this-unit-id` flag.
-
     args.add_all(hs.toolchain.ghcopts)
 
     args.add_all(expand_make_variables("ghcopts", ctx, ctx.attr.ghcopts, haskell_library_extra_label_attrs(ctx.attr)))

--- a/haskell/experimental/private/module.bzl
+++ b/haskell/experimental/private/module.bzl
@@ -81,6 +81,7 @@ def _build_haskell_module(
         package_name,
         with_profiling,
         with_shared,
+        enable_th,
         hidir,
         odir,
         module_outputs,
@@ -100,6 +101,7 @@ def _build_haskell_module(
       package_name: name of this package, or empty if building a binary
       with_profiling: Whether to build profiling object files
       with_shared: Whether to build dynamic object files
+      enable_th: Whether object files and shared libraries need to be exposed to the build action
       hidir: The directory in which to output interface files
       odir: The directory in which to output object files
       module_outputs: A struct containing the interfaces and object files produced for a haskell_module.
@@ -235,7 +237,7 @@ def _build_haskell_module(
         moduleAttr.tools,
     ]
     args.add_all(expand_make_variables("ghcopts", ctx, moduleAttr.ghcopts, module_extra_attrs))
-    if module[HaskellModuleInfo].attr.enable_th:
+    if enable_th:
         args.add_all(narrowed_objects)
 
     outputs = [module_outputs.hi]
@@ -274,7 +276,7 @@ def _build_haskell_module(
                     object_inputs,
                 ]
                 # libraries and object inputs are only needed if the module uses TH
-                if module[HaskellModuleInfo].attr.enable_th
+                if enable_th
             ],
         ),
         input_manifests = preprocessors_input_manifests + plugin_tool_input_manifests,
@@ -540,6 +542,7 @@ def build_haskell_modules(ctx, hs, cc, posix, package_name, with_profiling, with
             package_name,
             with_profiling,
             with_shared,
+            enable_th,
             hidir,
             odir,
             module_outputs[dep.label],

--- a/haskell/experimental/private/module.bzl
+++ b/haskell/experimental/private/module.bzl
@@ -236,6 +236,10 @@ def _build_haskell_module(
         moduleAttr.plugins,
         moduleAttr.tools,
     ]
+    if plugins and not enable_th:
+        # For #1681. These suppresses bogus warnings about missing libraries which
+        # aren't really needed.
+        args.add("-Wno-missed-extra-shared-lib")
     args.add_all(expand_make_variables("ghcopts", ctx, moduleAttr.ghcopts, module_extra_attrs))
     if enable_th:
         args.add_all(narrowed_objects)

--- a/tests/haskell_module/plugin/BUILD.bazel
+++ b/tests/haskell_module/plugin/BUILD.bazel
@@ -60,7 +60,10 @@ haskell_library(
         ":module-without-plugin",
     ],
     tags = ["skip_profiling"],
-    deps = [":base"],
+    deps = [
+        ":base",
+        "@stackage//:temporary",
+    ],
 )
 
 haskell_test(


### PR DESCRIPTION
When a `haskell_module` rule doesn't enable TH, but uses plugins, we pass `-Wno-missed-extra-shared-lib` to the build action in order to suppress bogus warnings.

Fixes #1681