### PR TITLE
Avoid passing dyn_o files in the command line of ghc

### DIFF
--- a/haskell/experimental/private/module.bzl
+++ b/haskell/experimental/private/module.bzl
@@ -71,6 +71,9 @@ load("//haskell:providers.bzl", "HaskellInfo", "HaskellLibraryInfo")
 # profiling builds use the libraries of narrowed_deps instead of the
 # their object files.
 
+def _drop_dyn_os(f):
+    return None if f.extension == "dyn_o" else f.path
+
 def _build_haskell_module(
         ctx,
         hs,
@@ -240,7 +243,7 @@ def _build_haskell_module(
     ]
     args.add_all(expand_make_variables("ghcopts", ctx, moduleAttr.ghcopts, module_extra_attrs))
     if enable_th:
-        args.add_all(narrowed_objects)
+        args.add_all(narrowed_objects, map_each = _drop_dyn_os)
 
     outputs = [module_outputs.hi]
     if module_outputs.o:

--- a/haskell/experimental/private/module.bzl
+++ b/haskell/experimental/private/module.bzl
@@ -71,9 +71,6 @@ load("//haskell:providers.bzl", "HaskellInfo", "HaskellLibraryInfo")
 # profiling builds use the libraries of narrowed_deps instead of the
 # their object files.
 
-def _drop_dyn_os(f):
-    return None if f.extension == "dyn_o" else f.path
-
 def _build_haskell_module(
         ctx,
         hs,
@@ -243,7 +240,7 @@ def _build_haskell_module(
     ]
     args.add_all(expand_make_variables("ghcopts", ctx, moduleAttr.ghcopts, module_extra_attrs))
     if enable_th:
-        args.add_all(narrowed_objects, map_each = _drop_dyn_os)
+        args.add_all(narrowed_objects)
 
     outputs = [module_outputs.hi]
     if module_outputs.o:

--- a/haskell/experimental/private/module.bzl
+++ b/haskell/experimental/private/module.bzl
@@ -81,6 +81,7 @@ def _build_haskell_module(
         package_name,
         with_profiling,
         with_shared,
+        enable_th,
         hidir,
         odir,
         module_outputs,
@@ -100,6 +101,7 @@ def _build_haskell_module(
       package_name: name of this package, or empty if building a binary
       with_profiling: Whether to build profiling object files
       with_shared: Whether to build dynamic object files
+      enable_th: Whether object files and shared libraries need to be exposed to the build action
       hidir: The directory in which to output interface files
       odir: The directory in which to output object files
       module_outputs: A struct containing the interfaces and object files produced for a haskell_module.
@@ -237,7 +239,7 @@ def _build_haskell_module(
         moduleAttr.tools,
     ]
     args.add_all(expand_make_variables("ghcopts", ctx, moduleAttr.ghcopts, module_extra_attrs))
-    if module[HaskellModuleInfo].attr.enable_th:
+    if enable_th:
         args.add_all(narrowed_objects)
 
     outputs = [module_outputs.hi]
@@ -276,7 +278,7 @@ def _build_haskell_module(
                     object_inputs,
                 ]
                 # libraries and object inputs are only needed if the module uses TH
-                if module[HaskellModuleInfo].attr.enable_th
+                if enable_th
             ],
         ),
         input_manifests = preprocessors_input_manifests + plugin_tool_input_manifests,
@@ -542,6 +544,7 @@ def build_haskell_modules(ctx, hs, cc, posix, package_name, with_profiling, with
             package_name,
             with_profiling,
             with_shared,
+            enable_th,
             hidir,
             odir,
             module_outputs[dep.label],

--- a/haskell/private/haskell_impl.bzl
+++ b/haskell/private/haskell_impl.bzl
@@ -608,6 +608,7 @@ def haskell_library_impl(ctx):
         user_repl_flags = _expand_make_variables("repl_ghci_args", ctx, ctx.attr.repl_ghci_args),
         per_module_transitive_interfaces = module_outputs.per_module_transitive_interfaces,
         per_module_transitive_objects = module_outputs.per_module_transitive_objects,
+        per_module_transitive_dyn_objects = module_outputs.per_module_transitive_dyn_objects,
     )
 
     exports = [

--- a/haskell/providers.bzl
+++ b/haskell/providers.bzl
@@ -20,6 +20,7 @@ HaskellInfo = provider(
         "user_repl_flags": "REPL flags specified by the user, after location expansion.",
         "per_module_transitive_interfaces": "Dict of module labels to depsets of interface files of transitive module dependencies",
         "per_module_transitive_objects": "Dict of module labels to depsets of object files of transitive module dependencies",
+        "per_module_transitive_dyn_objects": "Dict of module labels to depsets of dyn_o object files of transitive module dependencies",
     },
 )
 

--- a/tests/haskell_module/dep-narrowing-th/BUILD.bazel
+++ b/tests/haskell_module/dep-narrowing-th/BUILD.bazel
@@ -59,6 +59,7 @@ haskell_module(
     name = "TestModule",
     src = "TestModule.hs",
     cross_library_deps = [":TestLibModule2"],
+    enable_th = True,
 )
 
 # Modifying TestLibModule2 from TestLib2 doesn't cause a rebuild of

--- a/tests/haskell_module/dep-narrowing-th/TestModule.hs
+++ b/tests/haskell_module/dep-narrowing-th/TestModule.hs
@@ -1,7 +1,10 @@
+{-# LANGUAGE TemplateHaskell #-}
 module TestModule where
 
 import TestLibModule (foo)
 import TestLibModule2 (foo2)
+
+$(return [])
 
 bar :: IO Int
 bar = (+ 2 * foo) <$> foo2


### PR DESCRIPTION
This PR first scraps dyn_o files from the command line, and then undoes that to collect `.dyn_o` files and `.o` files in separate depsets, which is likely the best to maintain (but I'm only going on an intuition here).

Fixes #1683 