### PR TITLE
haskell_module: Pass cc toolchain linker flags when using the interpreter

### DIFF
--- a/haskell/experimental/private/module.bzl
+++ b/haskell/experimental/private/module.bzl
@@ -188,6 +188,11 @@ def _build_haskell_module(
 
     args.add_all(cc.include_args)
 
+    if plugins or enable_th:
+        # cc toolchain linker flags would be necessary when the interpreter wants to
+        # load any libraries
+        args.add_all(["-optl" + f for f in cc.linker_flags])
+
     # Collect library dependency arguments
     (pkg_info_inputs, pkg_info_args) = pkg_info_to_compile_flags(
         hs,


### PR DESCRIPTION
This gets rid of the "warning: type and size of dynamic symbol ... are not defined"