### PR TITLE
Reproducible interface files for Cabal packages with C dependencies

### DIFF
--- a/haskell/private/cabal_wrapper.py
+++ b/haskell/private/cabal_wrapper.py
@@ -107,7 +107,8 @@ execroot = os.getcwd()
 setup = os.path.join(execroot, json_args["setup_path"])
 srcdir = os.path.join(execroot, json_args["pkg_dir"])
 # By definition (see ghc-pkg source code).
-pkgroot = os.path.realpath(os.path.join(execroot, os.path.dirname(json_args["package_db_path"])))
+rel_pkgroot = os.path.dirname(json_args["package_db_path"])
+pkgroot = os.path.realpath(os.path.join(execroot, rel_pkgroot))
 libdir = os.path.join(pkgroot, "{}_iface".format(name))
 dynlibdir = os.path.join(pkgroot, "lib")
 bindir = os.path.join(pkgroot, "bin")
@@ -205,6 +206,10 @@ with mkdtemp(distdir_prefix()) as distdir:
     os.putenv("TEMP", os.path.join(distdir, "tmp"))
     os.makedirs(os.path.join(distdir, "tmp"))
 
+    rel_execroot = os.path.relpath(execroot)
+    cfg_execroot = rel_execroot if not is_windows else execroot
+    cfg_pkgroot = os.path.join(cfg_execroot, rel_pkgroot)
+
 
     # Create a Paths module that will be used instead of the cabal generated one.
     # https://cabal.readthedocs.io/en/3.4/cabal-package.html#accessing-data-files-from-package-code
@@ -283,13 +288,20 @@ with mkdtemp(distdir_prefix()) as distdir:
         "--package-db=global", \
         ] + \
         extra_args + \
-        [ arg.replace("=", "=" + execroot + "/") for arg in path_args ] + \
+        [ arg.replace("=", "=" + cfg_execroot + "/") for arg in path_args ] + \
         [ "--package-db=" + package_database ], # This arg must come last.
         )
     run([runghc] + runghc_args + [setup, "build", "--verbose=0", "--builddir=" + distdir])
     if haddock:
         run([runghc] + runghc_args + [setup, "haddock", "--verbose=0", "--builddir=" + distdir])
-    run([runghc] + runghc_args + [setup, "install", "--verbose=0", "--builddir=" + distdir])
+    # Setup.hs install fails if the configuration uses relative C header or
+    # library search paths. Instead, we use Setup.hs copy to install the
+    # package files and then manually register the package configuration in the
+    # package-db.
+    # See https://github.com/haskell/cabal/issues/1317#issuecomment-1025942396
+    run([runghc] + runghc_args + [setup, "copy", "--verbose=0", "--builddir=" + distdir])
+    if component.startswith("lib"):
+        run([runghc] + runghc_args + [setup, "register", "--gen-pkg-config=" + os.path.join(package_database, name + ".conf"), "--verbose=0", "--builddir=" + distdir])
     # Bazel builds are not sandboxed on Windows and can be non-sandboxed on
     # other OSs. Operations like executing `configure` scripts can modify the
     # source tree. If the `srcs` attribute uses a glob like `glob(["**"])`,
@@ -315,12 +327,18 @@ def make_relocatable_paths(line):
     line = re.sub("library-dirs:.*", "library-dirs: ${pkgroot}/lib", line)
 
     def make_relative_to_pkgroot(matchobj):
-        abspath=matchobj.group(0)
-        return os.path.join("${pkgroot}", os.path.relpath(abspath, start=pkgroot))
+        oldpath=matchobj.group(0)
+        rel_to_pkgroot = os.path.relpath(oldpath, start=cfg_pkgroot)
+        return os.path.join("${pkgroot}", rel_to_pkgroot)
 
-    # The $execroot is an absolute path and should not leak into the output.
-    # Replace each ocurrence of execroot by a path relative to ${pkgroot}.
-    line = re.sub(re.escape(execroot) + '\S*', make_relative_to_pkgroot, line)
+    # On Windows paths may contain the absolute path to the execroot.
+    # This path is non-reproducible and should not leak into build outputs.
+    #
+    # On other systems paths may be relative to the distdir.
+    # These paths are invalid in the package configuration.
+    #
+    # Replace each ocurrence of either kind of path by one relative to ${pkgroot}.
+    line = re.sub(re.escape(cfg_execroot) + '\S*', make_relative_to_pkgroot, line)
     return line
 
 if libraries != [] and os.path.isfile(package_conf_file):

--- a/tests/haskell_cabal_reproducibility/clib/BUILD.bazel
+++ b/tests/haskell_cabal_reproducibility/clib/BUILD.bazel
@@ -1,0 +1,15 @@
+cc_library(
+    name = "myclib",
+    srcs = ["add.c"],
+    hdrs = ["myclib.h"],
+    includes = ["."],
+)
+
+cc_library(
+    name = "libmyclib",
+    srcs = [":myclib"],
+    hdrs = ["myclib.h"],
+    includes = ["."],
+    visibility = ["//tests/haskell_cabal_reproducibility:__subpackages__"],
+    linkstatic = True,
+)

--- a/tests/haskell_cabal_reproducibility/clib/add.c
+++ b/tests/haskell_cabal_reproducibility/clib/add.c
@@ -1,0 +1,3 @@
+#include "myclib.h"
+
+int add(int a, int b) { return a + b; }

--- a/tests/haskell_cabal_reproducibility/clib/myclib.h
+++ b/tests/haskell_cabal_reproducibility/clib/myclib.h
@@ -1,0 +1,6 @@
+#ifndef GUARD_MYCLIB_H_INCLUDED
+#define GUARD_MYCLIB_H_INCLUDED
+
+int add(int, int);
+
+#endif  // GUARD_MYCLIB_H_INCLUDED

--- a/tests/haskell_cabal_reproducibility/pkg-a/BUILD.bazel
+++ b/tests/haskell_cabal_reproducibility/pkg-a/BUILD.bazel
@@ -1,0 +1,12 @@
+load("@rules_haskell//haskell:cabal.bzl", "haskell_cabal_library")
+
+haskell_cabal_library(
+    name = "pkg-a",
+    srcs = [
+        "pkg-a.cabal",
+        "src/LibA.hsc",
+    ],
+    version = "0.1.0.0",
+    deps = ["//tests/haskell_cabal_reproducibility/clib:libmyclib"],
+    visibility = ["//tests/haskell_cabal_reproducibility:__subpackages__"],
+)

--- a/tests/haskell_cabal_reproducibility/pkg-a/pkg-a.cabal
+++ b/tests/haskell_cabal_reproducibility/pkg-a/pkg-a.cabal
@@ -1,0 +1,11 @@
+cabal-version:      2.4
+name:               pkg-a
+version:            0.1.0.0
+
+library
+    exposed-modules:  LibA
+    build-depends:    base ^>=4.14.1.0
+    includes:         myclib.h
+    extra-libraries:  myclib
+    hs-source-dirs:   src
+    default-language: Haskell2010

--- a/tests/haskell_cabal_reproducibility/pkg-a/src/LibA.hsc
+++ b/tests/haskell_cabal_reproducibility/pkg-a/src/LibA.hsc
@@ -1,0 +1,8 @@
+module LibA (double) where
+
+#include "myclib.h"
+
+foreign import ccall "myclib.h add" c_add :: Int -> Int -> Int
+
+double :: Int -> Int
+double a = c_add a a

--- a/tests/haskell_cabal_reproducibility/pkg-b/BUILD.bazel
+++ b/tests/haskell_cabal_reproducibility/pkg-b/BUILD.bazel
@@ -1,0 +1,14 @@
+load("@rules_haskell//haskell:cabal.bzl", "haskell_cabal_binary")
+
+# TODO Define an integration test to confirm that the build of pkg-a is
+# deterministic, i.e. that the generated artifacts are bit-reproducible.
+# Pending on https://github.com/tweag/rules_haskell/pull/1645
+
+haskell_cabal_binary(
+    name = "pkg-b",
+    srcs = [
+        "pkg-b.cabal",
+        "exe/Main.hs",
+    ],
+    deps = ["//tests/haskell_cabal_reproducibility/pkg-a"],
+)

--- a/tests/haskell_cabal_reproducibility/pkg-b/exe/Main.hs
+++ b/tests/haskell_cabal_reproducibility/pkg-b/exe/Main.hs
@@ -1,0 +1,7 @@
+module Main where
+
+import LibA (double)
+
+main :: IO ()
+main = do
+  putStrLn $ show (double 21)

--- a/tests/haskell_cabal_reproducibility/pkg-b/pkg-b.cabal
+++ b/tests/haskell_cabal_reproducibility/pkg-b/pkg-b.cabal
@@ -1,0 +1,9 @@
+cabal-version:      2.4
+name:               pkg-b
+version:            0.1.0.0
+
+executable pkg-b
+    main-is:          Main.hs
+    build-depends:    base, pkg-a
+    hs-source-dirs:   exe
+    default-language: Haskell2010


### PR DESCRIPTION
This is the continuation of https://github.com/tweag/rules_haskell/pull/1648 addressing the case where a Cabal target has C dependencies.

Addresses the non-reproducible interface files aspect of https://github.com/tweag/rules_haskell/issues/1600.

As described in https://github.com/haskell/cabal/issues/1317#issuecomment-1025942396 we can avoid passing absolute C header and library search paths to Cabal builds if we do not call `Setup.hs install`. [`Setup.hs install` fails](https://github.com/haskell/cabal/issues/1317#issuecomment-985537653) if the configuration contains relative paths. Instead, we call `Setup.hs copy` to copy the generated files and then generate a package configuration file with `Setup.hs register --gen-pkg-config`, patch it to replace relative paths by paths starting with `${pkgroot}`, and then invoke `ghc-pkg` directly to cache the package-db.

This adds a test-case that be used to confirm that the build is now reproducible.
```
$ n=1; bazel clean; bazel build //tests/haskell_cabal_reproducibility/pkg-b --execution_log_json_file=execlog$n.json; rsync -aL bazel-bin output$n
$ n=2; bazel clean; bazel build //tests/haskell_cabal_reproducibility/pkg-b --execution_log_json_file=execlog$n.json; rsync -aL bazel-bin output$n
$ diff -u execlog1.json execlog2.json
$ diff -ur output1 output2
$ diff -u <(ghc --show-iface output1/bazel-bin/tests/haskell_cabal_reproducibility/pkg-a/_install/pkg-a-0.1.0.0_iface/LibA.dyn_hi) <(ghc --show-iface output2/bazel-bin/tests/haskell_cabal_reproducibility/pkg-a/_install/pkg-a-0.1.0.0_iface/LibA.dyn_hi)
```

When https://github.com/tweag/rules_haskell/pull/1645 is merged this could be turned into an integration test.