### PR TITLE
Add th_deps attribute for compile-time dependencies

### DIFF
--- a/haskell/BUILD.bazel
+++ b/haskell/BUILD.bazel
@@ -176,6 +176,13 @@ config_setting(
     },
 )
 
+config_setting(
+    name = "use_deps_on_empty_th_deps",
+    flag_values = {
+        "@rules_haskell//flags:incompatible_use_deps_on_empty_th_deps": "true"
+    },
+)
+
 haskell_toolchain_info(
     name = "toolchain_info",
 )

--- a/haskell/defs.bzl
+++ b/haskell/defs.bzl
@@ -61,6 +61,9 @@ _haskell_common_attrs = {
     "modules": attr.label_list(
         providers = [HaskellModuleInfo],
     ),
+    "th_deps": attr.label_list(
+        aspects = [haskell_cc_libraries_aspect],
+    ),
     # a proxy for ctx.label so that the transition can access it
     "label_string": attr.string(),
     "data": attr.label_list(
@@ -99,6 +102,10 @@ _haskell_common_attrs = {
         executable = True,
         cfg = "host",
         default = Label("@rules_haskell//haskell:ghc_wrapper"),
+    ),
+    "use_deps_on_empty_th_deps": attr.bool(
+        # Should be provided by the wrappers, not the user
+        mandatory=True,
     ),
     "worker": attr.label(
         default = None,
@@ -233,6 +240,10 @@ def _haskell_worker_wrapper(rule_type, **kwargs):
     kwargs.pop("compiler_flags")
 
     defaults = dict(
+        use_deps_on_empty_th_deps = select({
+            "@rules_haskell//haskell:use_deps_on_empty_th_deps": True,
+            "//conditions:default": False,
+        }),
         worker = select({
             "@rules_haskell//haskell:use_worker": Label("@rules_haskell//tools/worker:bin"),
             "//conditions:default": None,
@@ -254,6 +265,7 @@ def haskell_binary(
         extra_srcs = [],
         deps = [],
         narrowed_deps = [],
+        th_deps = [],
         data = [],
         compiler_flags = [],
         ghcopts = [],
@@ -322,6 +334,8 @@ def haskell_binary(
           Note: This attribute is experimental and not ready for production, yet.
       modules: List of extra haskell_module() dependencies to be linked into this binary.
           Note: This attribute is experimental and not ready for production, yet.
+      th_deps: List of libraries needed to run TemplateHaskell code. These are needed
+          only at compile time.
       data: See [Bazel documentation](https://docs.bazel.build/versions/master/be/common-definitions.html#common.data).,
       compiler_flags: DEPRECATED. Use new name ghcopts.
       ghcopts: Flags to pass to Haskell compiler. Subject to Make variable substitution.
@@ -345,6 +359,7 @@ def haskell_binary(
         extra_srcs = extra_srcs,
         deps = deps,
         narrowed_deps = narrowed_deps,
+        th_deps = th_deps,
         data = data,
         compiler_flags = compiler_flags,
         ghcopts = ghcopts,
@@ -405,6 +420,7 @@ def haskell_test(
         extra_srcs = [],
         deps = [],
         narrowed_deps = [],
+        th_deps = [],
         data = [],
         compiler_flags = [],
         ghcopts = [],
@@ -463,6 +479,8 @@ def haskell_test(
           Note: This attribute is experimental and not ready for production, yet.
       modules: List of extra haskell_module() dependencies to be linked into this test.
           Note: This attribute is experimental and not ready for production, yet.
+      th_deps: List of libraries needed to run TemplateHaskell code. These are needed
+          only at compile time.
       data: See [Bazel documentation](https://docs.bazel.build/versions/master/be/common-definitions.html#common.data).,
       compiler_flags: DEPRECATED. Use new name ghcopts.
       ghcopts: Flags to pass to Haskell compiler. Subject to Make variable substitution.
@@ -499,6 +517,7 @@ def haskell_test(
         extra_srcs = extra_srcs,
         deps = deps,
         narrowed_deps = narrowed_deps,
+        th_deps = th_deps,
         data = data,
         compiler_flags = compiler_flags,
         ghcopts = ghcopts,
@@ -546,6 +565,7 @@ def haskell_library(
         deps = [],
         narrowed_deps = [],
         modules = [],
+        th_deps = [],
         data = [],
         compiler_flags = [],
         ghcopts = [],
@@ -606,6 +626,8 @@ def haskell_library(
           Note: This attribute is experimental and not ready for production, yet.
       modules: List of extra haskell_module() dependencies to be linked into this library.
           Note: This attribute is experimental and not ready for production, yet.
+      th_deps: List of libraries needed to run TemplateHaskell code. These are needed
+          only at compile time.
       data: See [Bazel documentation](https://docs.bazel.build/versions/master/be/common-definitions.html#common.data).,
       compiler_flags: DEPRECATED. Use new name ghcopts.
       ghcopts: Flags to pass to Haskell compiler. Subject to Make variable substitution.
@@ -636,6 +658,7 @@ def haskell_library(
         deps = deps,
         narrowed_deps = narrowed_deps,
         modules = modules,
+        th_deps = th_deps,
         data = data,
         compiler_flags = compiler_flags,
         ghcopts = ghcopts,

--- a/haskell/private/context.bzl
+++ b/haskell/private/context.bzl
@@ -19,8 +19,21 @@ def haskell_context(ctx, attr = None):
     if not attr:
         attr = ctx.attr
 
-    deps = (attr.deps if hasattr(attr, "deps") else []) + (attr.exports if hasattr(attr, "exports") else []) + (attr.narrowed_deps if hasattr(attr, "narrowed_deps") else [])
-    package_ids = all_dependencies_package_ids(deps)
+    deps = getattr(attr, "deps", [])
+
+    if hasattr(attr, "th_deps"):
+        th_deps = attr.th_deps
+        if not th_deps and attr.use_deps_on_empty_th_deps:
+            th_deps = deps
+    else:
+        th_deps = deps
+
+    package_ids = all_dependencies_package_ids(
+        deps +
+        getattr(attr, "exports", []) +
+        getattr(attr, "narrowed_deps", [])
+    )
+    th_package_ids = all_dependencies_package_ids(th_deps)
 
     if hasattr(attr, "src_strip_prefix"):
         src_strip_prefix = attr.src_strip_prefix
@@ -63,6 +76,7 @@ def haskell_context(ctx, attr = None):
         ghc_wrapper = ghc_wrapper,
         worker = worker,
         package_ids = package_ids,
+        th_package_ids = th_package_ids,
         src_root = src_root,
         package_root = paths.join(ctx.label.workspace_root, ctx.label.package),
         env = env,

--- a/haskell/private/haskell_impl.bzl
+++ b/haskell/private/haskell_impl.bzl
@@ -173,6 +173,12 @@ def _haskell_binary_common_impl(ctx, is_test):
     dep_info = gather_dep_info(ctx.attr.name, ctx.attr.deps)
     all_deps_info = gather_dep_info(ctx.attr.name, deps)
 
+    th_deps = getattr(ctx.attr, "th_deps", [])
+    if not th_deps and ctx.attr.use_deps_on_empty_th_deps:
+        th_deps = deps
+
+    th_dep_info = gather_dep_info(ctx.attr.name, th_deps)
+
     modules = ctx.attr.modules
     if modules and ctx.files.srcs:
         fail("""Only one of "srcs" or "modules" attributes must be specified in {}""".format(ctx.label))
@@ -231,6 +237,7 @@ def _haskell_binary_common_impl(ctx, is_test):
         java,
         posix,
         dep_info,
+        th_dep_info,
         plugin_dep_info,
         srcs = srcs_files,
         module_map = module_map,
@@ -423,6 +430,12 @@ def haskell_library_impl(ctx):
     dep_info = gather_dep_info(ctx.attr.name, ctx.attr.deps + ctx.attr.exports)
     narrowed_deps_info = gather_dep_info(ctx.attr.name, ctx.attr.narrowed_deps)
     all_deps_info = gather_dep_info(ctx.attr.name, deps)
+
+    th_deps = getattr(ctx.attr, "th_deps", [])
+    if not th_deps and ctx.attr.use_deps_on_empty_th_deps:
+        th_deps = deps
+    th_dep_info = gather_dep_info(ctx.attr.name, th_deps)
+
     all_plugins = ctx.attr.plugins + ctx.attr.non_default_plugins
     plugin_dep_info = gather_dep_info(
         ctx.attr.name,
@@ -482,6 +495,7 @@ def haskell_library_impl(ctx):
         java,
         posix,
         dep_info,
+        th_dep_info,
         plugin_dep_info,
         srcs = srcs_files,
         module_map = module_map,

--- a/tests/th_deps/BUILD.bazel
+++ b/tests/th_deps/BUILD.bazel
@@ -1,0 +1,55 @@
+load(
+    "@rules_haskell//haskell:defs.bzl",
+    "haskell_library",
+    "haskell_test",
+)
+
+package(default_testonly = 1)
+
+test_suite(
+    name = "th_deps",
+    tests = [
+        ":use-lib-b"
+    ],
+   )
+
+
+haskell_library(
+    name = "lib-a",
+    srcs = [ "LibA.hs" ],
+    deps = [
+        "//tests/hackage:base",
+    ],
+)
+
+haskell_library(
+    name = "lib-b",
+    srcs = [ "LibB.hs", "TH.hs" ],
+    hidden_modules = ["TH"],
+    th_deps = [
+        ":lib-a",
+        "//tests/data:ourclibrary",
+        "//tests/hackage:template-haskell",
+    ],
+    deps = [
+        "//tests/hackage:base",
+    ],
+)
+
+haskell_test(
+    name = "use-lib-b",
+    srcs = [
+        "Main.hs",
+    ],
+    deps = [
+        ":lib-b",
+        "//tests/hackage:base",
+    ],
+)
+
+filegroup(
+    name = "all_files",
+    testonly = True,
+    srcs = glob(["**"]),
+    visibility = ["//visibility:public"],
+)

--- a/tests/th_deps/LibA.hs
+++ b/tests/th_deps/LibA.hs
@@ -1,0 +1,4 @@
+module LibA(hype) where
+
+hype :: String -> String
+hype x = x ++ "!"

--- a/tests/th_deps/LibB.hs
+++ b/tests/th_deps/LibB.hs
@@ -1,0 +1,8 @@
+{-# LANGUAGE TemplateHaskell #-}
+module LibB(value) where
+
+import Language.Haskell.TH
+import TH(valueQ)
+
+value :: String
+value = $valueQ

--- a/tests/th_deps/Main.hs
+++ b/tests/th_deps/Main.hs
@@ -1,0 +1,12 @@
+module Main where
+
+import Control.Monad (unless)
+import System.Exit (exitFailure)
+import System.IO (hPutStrLn, stderr)
+import LibB(value)
+
+main :: IO ()
+main =
+  unless (value == "42!") $ do
+    hPutStrLn stderr "Expected 42!"
+    exitFailure

--- a/tests/th_deps/TH.hs
+++ b/tests/th_deps/TH.hs
@@ -1,0 +1,10 @@
+{-# LANGUAGE TemplateHaskell #-}
+module TH(valueQ) where
+
+import Language.Haskell.TH
+import LibA(hype)
+
+foreign import ccall "c_add_one" c_add_one' :: Int -> Int
+
+valueQ :: Q Exp
+valueQ = [| hype (show (c_add_one' 41)) |]


### PR DESCRIPTION
Implements the proposal in #1382. 

A new `th_deps` attribute is added to `haskell_(library|binary|test)` that is similar to `deps` but makes only the libraries in the formaer available at compile-time. Dependencies in `th_deps` are also made available during linking: FFI declarations also need to be resolved at link time, even if they were used only for the sake of TH.

As discussed in the issue, this reduces the number of dependencies for the build action, creating more opportunities for parallel work.

In addition, adding all cc deps at compile time was preventing some configurations from working: ghc's dynamic linker
apparently tries to load the .so files in the order in which they are specified so if a.so declares symbols referenced by b.so,
a.so needs to be given first. We don't seem to control the order in which these are passed from the rules, though. E.g., without `th_deps` defaulting to `[]` I'm unable to package llvm-hs to use a bazel-built llvm, since the former uses TH and FFI (but no FFI during TH) and the latter splits things in several several packages.