### PR TITLE
Fix haskell_module when dependencies appear both as narrowed and not-narrowed

### DIFF
--- a/haskell/cabal.bzl
+++ b/haskell/cabal.bzl
@@ -573,7 +573,7 @@ def _haskell_cabal_library_impl(ctx):
     )
     hs_info = HaskellInfo(
         package_databases = depset([package_database], transitive = [dep_info.package_databases]),
-        empty_lib_package_databases = depset(transitive = [dep_info.empty_lib_package_databases]),
+        empty_lib_package_databases = dep_info.empty_lib_package_databases,
         version_macros = set.empty(),
         source_files = depset(),
         boot_files = depset(),

--- a/haskell/experimental/private/module.bzl
+++ b/haskell/experimental/private/module.bzl
@@ -71,6 +71,20 @@ load("//haskell:providers.bzl", "HaskellInfo", "HaskellLibraryInfo")
 # profiling builds use the libraries of narrowed_deps instead of the
 # their object files.
 
+# Note [Deps as both narrowed and not narrowed]
+#
+# Package databases are searched in reversed order with respect to
+# how they appear in the command line of GHC or in environment files.
+#
+# If a package appears both in narrowed_deps and in normal deps, different
+# versions of the package will appear in different package databases.
+# One of the versions points to an empty shared library, and the other
+# version points to the real shared library.
+#
+# When both versions are needed, we want package database pointing
+# to the real shared library to take precedence. Thus it should appear
+# last in the command line or the environment files.
+
 def _build_haskell_module(
         ctx,
         hs,
@@ -200,9 +214,12 @@ def _build_haskell_module(
             package_ids = hs.package_ids,
             package_databases = depset(
                 transitive = [
-                    dep_info.package_databases,
+                    # Mind the order in which databases are specified here.
+                    # See Note [Deps as both narrowed and not narrowed].
                     narrowed_deps_info.empty_lib_package_databases,
+                    dep_info.package_databases,
                 ],
+                order = "preorder",
             ),
             # TODO[AH] Support version macros
             version = None,

--- a/haskell/private/haskell_impl.bzl
+++ b/haskell/private/haskell_impl.bzl
@@ -580,10 +580,13 @@ def haskell_library_impl(ctx):
         empty_lib_package_databases = depset(
             direct = [cache_file_empty],
             transitive = [
-                dep_info.package_databases,
+                # Mind the order in which databases are specified here.
+                # See Note [Deps as both narrowed and not narrowed].
                 narrowed_deps_info.empty_lib_package_databases,
                 export_infos.empty_lib_package_databases,
+                dep_info.package_databases,
             ],
+            order = "preorder",
         ),
         version_macros = version_macros,
         source_files = c.source_files,

--- a/tests/haskell_module/dep-narrowing-th/BUILD.bazel
+++ b/tests/haskell_module/dep-narrowing-th/BUILD.bazel
@@ -31,6 +31,17 @@ haskell_module(
 )
 
 haskell_library(
+    name = "NonModulesTestLib",
+    srcs = [
+        "NonModulesTestLib.hs",
+    ],
+    deps = [
+        ":TestLib1",
+        "//tests/hackage:base",
+    ],
+)
+
+haskell_library(
     name = "TestLib2",
     modules = [
         ":TestLibModule2",
@@ -84,6 +95,7 @@ haskell_library(
         ":TestLib2",
     ],
     deps = [
+        ":NonModulesTestLib",
         ":TestLib",
         "//tests/hackage:base",
         "//tests/hackage:template-haskell",

--- a/tests/haskell_module/dep-narrowing-th/NonModulesTestLib.hs
+++ b/tests/haskell_module/dep-narrowing-th/NonModulesTestLib.hs
@@ -1,0 +1,6 @@
+module NonModulesTestLib where
+
+import TestLibModule1 (foo1)
+
+fooNonModules :: Int
+fooNonModules = foo1

--- a/tests/haskell_module/dep-narrowing-th/TestModule.hs
+++ b/tests/haskell_module/dep-narrowing-th/TestModule.hs
@@ -1,10 +1,11 @@
 {-# LANGUAGE TemplateHaskell #-}
 module TestModule where
 
+import NonModulesTestLib (fooNonModules)
 import TestLibModule (foo)
 import TestLibModule2 (foo2)
 
 $(return [])
 
 bar :: IO Int
-bar = (+ 2 * foo) <$> foo2
+bar = (+ fooNonModules * foo) <$> foo2


### PR DESCRIPTION
Without this fix, when a module uses TH, ghc would find missing symbols when loading normal dependencies.
This would happen when this dependencies need in turn dependencies that are listed as narrowed. Narrowed dependencies point to empty shared libraries that don't provide the necessary symbols to regular deps. However they had precedence over packages pointing to the real libraries which also appear in the environment file.

This PR changes the order of packages so those with a real library take precedence over those with an empty library.