### PR TITLE
Support Bazel 4.2.2

### DIFF
--- a/haskell/private/versions.bzl
+++ b/haskell/private/versions.bzl
@@ -45,7 +45,7 @@ def check_version(actual_version):
     # Please use length 3 tuples, because bazel versions has 3 members;
     # to avoid surprising behaviors (for example (2,0) >/= (2, 0, 0))
     min_bazel = (4, 0, 0)  # Change THIS LINE when changing bazel min version
-    max_bazel = (4, 2, 1)  # Change THIS LINE when changing bazel max version
+    max_bazel = (4, 2, 2)  # Change THIS LINE when changing bazel max version
 
     actual = tuple(_parse_bazel_version(actual_version))
 


### PR DESCRIPTION
Hi,
There has been a fix release for bazel https://github.com/bazelbuild/bazel/releases/tag/4.2.2.
Had to bump this since this is the bazel version in nixpkgs-unstable.