### PR TITLE
Add a regression test for haskell_doctest

### DIFF
--- a/tests/haskell_doctest/BUILD.bazel
+++ b/tests/haskell_doctest/BUILD.bazel
@@ -23,6 +23,8 @@ haskell_library(
     deps = [
         ":lib-a",
         "//tests/hackage:base",
+        "//tests/hackage:transformers",
+        "@stackage//:data-default-class",
     ],
 )
 

--- a/tests/haskell_doctest/Bar.hs
+++ b/tests/haskell_doctest/Bar.hs
@@ -1,5 +1,9 @@
 module Bar (bar) where
 
+-- Regression test for https://github.com/tweag/rules_haskell/issues/936
+import Data.Default.Class (def)  -- Stackage dependency
+import Data.Functor.Constant  -- GHC package-db dependency
+
 import Foo (foo)
 import Numeric
 
@@ -10,4 +14,4 @@ import Numeric
 -- "9!"
 
 bar :: Int
-bar = 4 + foo
+bar = getConstant $ Constant $ 4 + foo + def


### PR DESCRIPTION
Regression test for https://github.com/tweag/rules_haskell/issues/936.
That issue seems to have been resolved in the meantime. However, that case wasn't covered by the test-suite, yet.