### PR TITLE
Check if haddock paths exists

### DIFF
--- a/haskell/private/pkgdb_to_bzl.py
+++ b/haskell/private/pkgdb_to_bzl.py
@@ -122,11 +122,11 @@ for conf in glob.glob(os.path.join(topdir, "package.conf.d", "*.conf")):
     # first, try to get a path within the package
     haddock_html = None
 
-    # We check if the file exists because cabal will unconditionally
-    # generate the database entry even if no haddock was generated.
-    if pkg.haddock_html and os.path.exists(pkg.haddock_html):
+    if pkg.haddock_html:
         haddock_html = path_to_label(pkg.haddock_html, pkgroot)
-        if not haddock_html:
+        # We check if the file exists because cabal will unconditionally
+        # generate the database entry even if no haddock was generated.
+        if not haddock_html and os.path.exists(pkg.haddock_html):
             haddock_html = os.path.join("haddock", "html", pkg.name)
             output.append("#SYMLINK: {} {}".format(pkg.haddock_html, haddock_html))
 
@@ -138,7 +138,7 @@ for conf in glob.glob(os.path.join(topdir, "package.conf.d", "*.conf")):
 
         # We check if the file exists because cabal will unconditionally
         # generate the database entry even if no haddock was generated.
-        if not os.path.exists(interface_path):
+        if not os.path.exists(interface or interface_path):
             continue
 
         if not interface:

--- a/haskell/private/pkgdb_to_bzl.py
+++ b/haskell/private/pkgdb_to_bzl.py
@@ -120,10 +120,11 @@ for conf in glob.glob(os.path.join(topdir, "package.conf.d", "*.conf")):
     # output a SYMLINK information for the parent process
 
     # first, try to get a path within the package
+    haddock_html = None
+
     # We check if the file exists because cabal will unconditionally
     # generate the database entry even if no haddock was generated.
-    haddock_html = None
-    if pkg.haddock_html:
+    if pkg.haddock_html and os.path.exists(pkg.haddock_html):
         haddock_html = path_to_label(pkg.haddock_html, pkgroot)
         if not haddock_html:
             haddock_html = os.path.join("haddock", "html", pkg.name)
@@ -134,6 +135,12 @@ for conf in glob.glob(os.path.join(topdir, "package.conf.d", "*.conf")):
     haddock_interfaces = []
     for interface_path in pkg.haddock_interfaces:
         interface = path_to_label(interface_path, pkgroot)
+
+        # We check if the file exists because cabal will unconditionally
+        # generate the database entry even if no haddock was generated.
+        if not os.path.exists(interface_path):
+            continue
+
         if not interface:
             interface = os.path.join(
                 "haddock",


### PR DESCRIPTION
Updated version of https://github.com/tweag/rules_haskell/pull/1077 that works with both nixpkgs and bindist mode.
#1077 assumed that the package description always contains valid paths (in `pkg.haddock_html`, `pkg.haddock_interfaces`). However, in the bindist case this is not true, because these paths contain `$topdir` or `${pkgroot}` references. In the Nix case on the other hand they are absolute paths into the Nix store.

Closes https://github.com/tweag/rules_haskell/issues/1075
cc @guibou 