### PR TITLE
Mark fetch_stack as configure and dependent on PATH

### DIFF
--- a/haskell/cabal.bzl
+++ b/haskell/cabal.bzl
@@ -2343,6 +2343,8 @@ def _fetch_stack_impl(repository_ctx):
 
 _fetch_stack = repository_rule(
     _fetch_stack_impl,
+    configure = True,
+    environ = ["PATH"],
 )
 """Find a suitably recent local Stack or download it."""
 


### PR DESCRIPTION
To ensure that Bazel re-runs the rule if PATH changes or a reconfiguration is requested.

Closes https://github.com/tweag/rules_haskell/issues/1079