### PR TITLE
Failure test for transitive re-exports

### DIFF
--- a/tests/RunTests.hs
+++ b/tests/RunTests.hs
@@ -113,10 +113,13 @@ main = hspec $ do
       it test $ do
         assertFailure (bazel ["build", test])
 
-    context "known issues" $
+    context "known issues" $ do
       it "haskell_doc fails with plugins #1549" $
         -- https://github.com/tweag/rules_haskell/issues/1549
         assertFailure (bazel ["build", "//tests/haddock-with-plugin"])
+      it "transitive re-exports do not work #1145" $
+        -- https://github.com/tweag/rules_haskell/issues/1145
+        assertFailure (bazel ["build", "//tests/package-reexport-transitive"])
 
   -- Test that the repl still works if we shadow some Prelude functions
   it "repl name shadowing" $ do

--- a/tests/package-reexport-transitive/BUILD.bazel
+++ b/tests/package-reexport-transitive/BUILD.bazel
@@ -1,0 +1,49 @@
+load(
+    "@rules_haskell//haskell:defs.bzl",
+    "haskell_library",
+    "haskell_test",
+)
+
+package(default_testonly = 1)
+
+haskell_library(
+    name = "root",
+    srcs = ["Root.hs"],
+    deps = ["//tests/hackage:base"],
+)
+
+haskell_library(
+    name = "intermediate",
+    exports = [
+        ":root",
+    ],
+    deps = [
+        ":root",
+    ],
+)
+
+haskell_library(
+    name = "lib",
+    exports = [":intermediate"],
+    deps = [
+        ":intermediate",
+    ],
+)
+
+# Failure test for https://github.com/tweag/rules_haskell/issues/1145
+# TODO Turn into regression test once that issue is resolved.
+haskell_test(
+    name = "final",
+    srcs = ["Main.hs"],
+    tags = ["manual"],
+    deps = [
+        ":lib",
+        "//tests/hackage:base",
+    ],
+)
+
+test_suite(
+    name = "package-reexport-transitive",
+    tags = ["manual"],
+    tests = [":final"],
+)

--- a/tests/package-reexport-transitive/Main.hs
+++ b/tests/package-reexport-transitive/Main.hs
@@ -1,0 +1,6 @@
+module Main where
+
+import Root
+
+main :: IO ()
+main = print root

--- a/tests/package-reexport-transitive/Root.hs
+++ b/tests/package-reexport-transitive/Root.hs
@@ -1,0 +1,4 @@
+module Root where
+
+root :: Int
+root = 42


### PR DESCRIPTION
Adds a test-case to confirm that https://github.com/tweag/rules_haskell/issues/1145 is still an issue.
This test can be turned into a regression test, once the issue is resolved.