### PR TITLE
Use Skylib versions.check

### DIFF
--- a/haskell/ghc_bindist.bzl
+++ b/haskell/ghc_bindist.bzl
@@ -771,7 +771,7 @@ def haskell_register_ghc_bindists(
 def _configure_python3_toolchain_impl(repository_ctx):
     cpu = get_cpu_value(repository_ctx)
     python3_path = find_python(repository_ctx)
-    if versions.is_at_least("4.2.0", versions.get()):
+    if versions.check("4.2.0"):
         stub_shebang = """stub_shebang = "#!{python3_path}",""".format(
             python3_path = python3_path,
         )


### PR DESCRIPTION
`versions.get` can be empty on pre-release versions which breaks `versions.is_at_least`, the Skylib function [`versions.check`](https://github.com/bazelbuild/bazel-skylib/blob/main/lib/versions.bzl#L82) already handles this case.

Fixes the issue reported in https://github.com/tweag/rules_haskell/pull/1702#issuecomment-1048888698

