### PR TITLE
Handle Bazel pre-release in version check

### DIFF
--- a/haskell/ghc_bindist.bzl
+++ b/haskell/ghc_bindist.bzl
@@ -1,7 +1,6 @@
 """Workspace rules (GHC binary distributions)"""
 
 load("@bazel_skylib//lib:paths.bzl", "paths")
-load("@bazel_skylib//lib:versions.bzl", "versions")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "patch")
 load("@bazel_tools//tools/cpp:lib_cc_configure.bzl", "get_cpu_value")
 load("@rules_sh//sh:posix.bzl", "sh_posix_configure")
@@ -9,6 +8,7 @@ load(
     ":private/pkgdb_to_bzl.bzl",
     "pkgdb_to_bzl",
 )
+load(":private/versions.bzl", "check_bazel_version")
 load(
     ":private/workspace_utils.bzl",
     "define_rule",
@@ -771,7 +771,7 @@ def haskell_register_ghc_bindists(
 def _configure_python3_toolchain_impl(repository_ctx):
     cpu = get_cpu_value(repository_ctx)
     python3_path = find_python(repository_ctx)
-    if versions.check("4.2.0"):
+    if check_bazel_version("4.2.0")[0]:
         stub_shebang = """stub_shebang = "#!{python3_path}",""".format(
             python3_path = python3_path,
         )

--- a/haskell/ghc_bindist.bzl
+++ b/haskell/ghc_bindist.bzl
@@ -771,7 +771,7 @@ def haskell_register_ghc_bindists(
 def _configure_python3_toolchain_impl(repository_ctx):
     cpu = get_cpu_value(repository_ctx)
     python3_path = find_python(repository_ctx)
-    if versions.is_at_least("4.2.0", versions.get()):
+    if versions.check("4.2.0"):
         stub_shebang = """stub_shebang = "#!{python3_path}",""".format(
             python3_path = python3_path,
         )

--- a/haskell/private/versions.bzl
+++ b/haskell/private/versions.bzl
@@ -1,4 +1,4 @@
-# check_version below cannot be called from anywhere
+# check_bazel_version_compatible below cannot be called from anywhere
 # because native.bazel_version's availability is restricted:
 #   https://github.com/bazelbuild/bazel/issues/8305
 # An alternative hacky way is as follows:
@@ -37,27 +37,6 @@ def _parse_bazel_version(bazel_version):
       The version as a int list such as [2, 0], [0, 29, 1], or [0, 29]
     """
     return [int(_parse_version_chunk(x)) for x in bazel_version.split(".")]
-
-def check_version(actual_version):
-    if type(actual_version) != "string" or len(actual_version) < 5:
-        return  # Unexpected format
-
-    # Please use length 3 tuples, because bazel versions has 3 members;
-    # to avoid surprising behaviors (for example (2,0) >/= (2, 0, 0))
-    min_bazel = (4, 0, 0)  # Change THIS LINE when changing bazel min version
-    max_bazel = (4, 2, 2)  # Change THIS LINE when changing bazel max version
-
-    actual = tuple(_parse_bazel_version(actual_version))
-
-    if (min_bazel <= actual) and (actual <= max_bazel):
-        return  # All good
-
-    min_bazel_string = ".".join([str(x) for x in min_bazel])
-    max_bazel_string = ".".join([str(x) for x in max_bazel])
-
-    adjective = "old" if actual < min_bazel else "recent"
-
-    print("WARNING: bazel version is too {}. Supported versions range from {} to {}, but found: {}".format(adjective, min_bazel_string, max_bazel_string, actual_version))
 
 def _is_at_least(threshold, version):
     """Check that a version is higher or equals to a threshold.
@@ -128,3 +107,12 @@ def check_bazel_version(minimum_bazel_version, maximum_bazel_version = None, baz
             ))
 
     return (True, "")
+
+def check_bazel_version_compatible(actual_version):
+    min_bazel = "4.0.0"  # Change THIS LINE when changing bazel min version
+    max_bazel = "4.2.2"  # Change THIS LINE when changing bazel max version
+
+    (compatible, msg) = check_bazel_version(min_bazel, max_bazel, actual_version)
+
+    if not compatible:
+        print("WARNING:", msg)

--- a/haskell/private/versions.bzl
+++ b/haskell/private/versions.bzl
@@ -46,6 +46,7 @@ def _is_at_least(threshold, version):
     Returns:
       True if version >= threshold.
     """
+
     # Vendored from https://github.com/bazelbuild/bazel-skylib/blob/e30197f3799eb038fbed424e365573f493d52fa5/lib/versions.bzl
     # Needed for check_bazel_version below.
     return _parse_bazel_version(version) >= _parse_bazel_version(threshold)
@@ -58,6 +59,7 @@ def _is_at_most(threshold, version):
     Returns:
       True if version <= threshold.
     """
+
     # Vendored from https://github.com/bazelbuild/bazel-skylib/blob/e30197f3799eb038fbed424e365573f493d52fa5/lib/versions.bzl
     # Needed for check_bazel_version below.
     return _parse_bazel_version(version) <= _parse_bazel_version(threshold)
@@ -73,7 +75,8 @@ def check_bazel_version(minimum_bazel_version, maximum_bazel_version = None, baz
         bool: `True`, if the version meets the criteria, otherwise `False`.
         string: An appropriate message if the version doesn't match.
     """
-    # Vendored from https://github.com/bazelbuild/bazel-skylib/blob/e30197f3799eb038fbed424e365573f493d52fa5/lib/versions.bzl#L82 
+
+    # Vendored from https://github.com/bazelbuild/bazel-skylib/blob/e30197f3799eb038fbed424e365573f493d52fa5/lib/versions.bzl#L82
     # The upstream version `fail`s if the version doesn't match.
     # This version instead returns false.
     if not bazel_version:

--- a/haskell/repositories.bzl
+++ b/haskell/repositories.bzl
@@ -5,13 +5,13 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 load(
     ":private/versions.bzl",
-    "check_version",
+    "check_bazel_version_compatible",
 )
 
 def rules_haskell_dependencies():
     """Provide all repositories that are necessary for `rules_haskell` to function."""
     if "bazel_version" in dir(native):
-        check_version(native.bazel_version)
+        check_bazel_version_compatible(native.bazel_version)
 
     maybe(
         http_archive,

--- a/tests/haskell_cabal_reproducibility/clib/BUILD.bazel
+++ b/tests/haskell_cabal_reproducibility/clib/BUILD.bazel
@@ -10,6 +10,6 @@ cc_library(
     srcs = [":myclib"],
     hdrs = ["myclib.h"],
     includes = ["."],
-    visibility = ["//tests/haskell_cabal_reproducibility:__subpackages__"],
     linkstatic = True,
+    visibility = ["//tests/haskell_cabal_reproducibility:__subpackages__"],
 )

--- a/tests/haskell_cabal_reproducibility/pkg-a/BUILD.bazel
+++ b/tests/haskell_cabal_reproducibility/pkg-a/BUILD.bazel
@@ -7,6 +7,6 @@ haskell_cabal_library(
         "src/LibA.hsc",
     ],
     version = "0.1.0.0",
-    deps = ["//tests/haskell_cabal_reproducibility/clib:libmyclib"],
     visibility = ["//tests/haskell_cabal_reproducibility:__subpackages__"],
+    deps = ["//tests/haskell_cabal_reproducibility/clib:libmyclib"],
 )

--- a/tests/haskell_cabal_reproducibility/pkg-b/BUILD.bazel
+++ b/tests/haskell_cabal_reproducibility/pkg-b/BUILD.bazel
@@ -7,8 +7,8 @@ load("@rules_haskell//haskell:cabal.bzl", "haskell_cabal_binary")
 haskell_cabal_binary(
     name = "pkg-b",
     srcs = [
-        "pkg-b.cabal",
         "exe/Main.hs",
+        "pkg-b.cabal",
     ],
     deps = ["//tests/haskell_cabal_reproducibility/pkg-a"],
 )


### PR DESCRIPTION
Fixes the issue reported in https://github.com/tweag/rules_haskell/pull/1702#issuecomment-1048888698
Second attempt after https://github.com/tweag/rules_haskell/pull/1706

`versions.get` can be empty on pre-release versions which breaks [`versions.is_at_least`](https://github.com/bazelbuild/bazel-skylib/blob/e30197f3799eb038fbed424e365573f493d52fa5/lib/versions.bzl#L69).
This PR adds a variant of [`versions.check_version`](https://github.com/bazelbuild/bazel-skylib/blob/e30197f3799eb038fbed424e365573f493d52fa5/lib/versions.bzl#L82) that doesn't fail on version mismatch, but instead returns a bool indicating whether the version matches or not.

`rules_haskell` already had a very similar function `check_version` to generate a warning if the Bazel version is outside of a known compatibility range. This PR changes that function to re-use the newly introduced `check_bazel_version` based on Skylib to avoid duplication.