### PR TITLE
Add repro for #1551

### DIFF
--- a/tests/cabal_binary_th/BUILD.bazel
+++ b/tests/cabal_binary_th/BUILD.bazel
@@ -1,0 +1,25 @@
+# repro for https://github.com/tweag/rules_haskell/issues/1551
+
+package(default_testonly = 1)
+
+load("@rules_haskell//haskell:cabal.bzl", "haskell_cabal_binary", "haskell_cabal_library")
+
+haskell_cabal_library(
+    name = "cabal-test-th",
+    srcs = [
+        "Main.hs",
+        "QQ.hs",
+        "cabal_test_th.cabal",
+    ],
+    version = "0.0.1",
+)
+
+haskell_cabal_binary(
+    name = "anexe",
+    srcs = [
+        "Main.hs",
+        "QQ.hs",
+        "cabal_test_th.cabal",
+    ],
+    tags = ["skip_profiling"],  # this fails in the nix cases when profiling is enable.
+)

--- a/tests/cabal_binary_th/Main.hs
+++ b/tests/cabal_binary_th/Main.hs
@@ -1,0 +1,6 @@
+{-# LANGUAGE QuasiQuotes #-}
+module Main where
+
+import QQ
+
+main = print [qq| 1 + 1 |]

--- a/tests/cabal_binary_th/QQ.hs
+++ b/tests/cabal_binary_th/QQ.hs
@@ -1,0 +1,9 @@
+{-# OPTIONS_GHC -Wno-missing-fields #-}
+
+module QQ where
+
+import Language.Haskell.TH
+import Language.Haskell.TH.Quote
+
+qq :: QuasiQuoter
+qq = QuasiQuoter { quoteExp = stringE }

--- a/tests/cabal_binary_th/cabal_test_th.cabal
+++ b/tests/cabal_binary_th/cabal_test_th.cabal
@@ -1,0 +1,24 @@
+cabal-version: 1.12
+
+name:           cabal-test-th
+version:        0.0.1
+license:        AllRightsReserved
+build-type:     Simple
+
+library
+  other-modules:
+     Main
+     QQ
+  build-depends:
+     base
+    , template-haskell
+  default-language: Haskell2010
+
+executable anexe
+  main-is: Main.hs
+  other-modules:
+      QQ
+  build-depends:
+     base
+    , template-haskell
+  default-language: Haskell2010


### PR DESCRIPTION
This PR adds the repro for issue #1551 to the tests.

The original error does not seem to happen anymore but there is now the following issue when compiling in profiling mode in the nix setups:
```
Main.hs:6:14: fatal:
       cannot find object file ‘../../bazel-out/k8-dbg/bin/tests/anexe/build/anexe/anexe-tmp/QQ.dyn_o’
       while linking an interpreted expression
```

See this [CI run](https://github.com/tweag/rules_haskell/runs/5332087625?check_suite_focus=true#step:7:406).
