### PR TITLE
Add missing input_manifests to hsc2hs action

### DIFF
--- a/haskell/private/actions/compile.bzl
+++ b/haskell/private/actions/compile.bzl
@@ -89,6 +89,7 @@ def _process_hsc_file(hs, cc, hsc_flags, hsc_inputs, hsc_file):
             depset(cc.files),
             depset(hsc_inputs),
         ]),
+        input_manifests = cc.manifests,
         outputs = [hs_out],
         mnemonic = "HaskellHsc2hs",
         executable = hs.tools.hsc2hs,


### PR DESCRIPTION
Without this, running hs2chs actions via rbe fails with cc_wrapper-python complaining that it can't find the .runfiles directory