### PR TITLE
Ignore the pycache folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .bazelrc.local
 *.swp
 *.swo
+__pycache__


### PR DESCRIPTION
I noticed this being untracked, and it seems like something that belongs in `.gitignore`