### PR TITLE
Add -main-is argument to _build_haskell_module.

### DIFF
--- a/haskell/experimental/private/module.bzl
+++ b/haskell/experimental/private/module.bzl
@@ -183,6 +183,10 @@ def _build_haskell_module(
     # Construct compiler arguments
 
     args = ctx.actions.args()
+
+    if (moduleAttr.src == ctx.attr.main_file):
+        args.add_all(["-main-is", ctx.attr.main_function])
+
     args.add_all([
         "-c",
         "-odir",

--- a/haskell/experimental/private/module.bzl
+++ b/haskell/experimental/private/module.bzl
@@ -190,7 +190,12 @@ def _build_haskell_module(
     if main_function:
         main_file = getattr(ctx.attr, "main_file", None)
         main_function_module = infer_main_module(main_function)
-        if (moduleAttr.src == main_file or main_function_module == moduleAttr.module_name):
+        if moduleAttr.module_name:
+            guess_module_name = moduleAttr.module_name
+        else:
+            guess_module_name = paths.split_extension(get_module_path_from_target(module))[0].replace("/", ".")
+
+        if (moduleAttr.src == main_file or main_function_module == guess_module_name):
             args.add_all(["-main-is", ctx.attr.main_function])
 
     args.add_all([

--- a/haskell/experimental/private/module.bzl
+++ b/haskell/experimental/private/module.bzl
@@ -184,7 +184,8 @@ def _build_haskell_module(
 
     args = ctx.actions.args()
 
-    if (moduleAttr.src == ctx.attr.main_file):
+    if (moduleAttr.src == getattr(ctx.attr, "main_file", None)
+            and getattr(ctx.attr, "main_function", None)):
         args.add_all(["-main-is", ctx.attr.main_function])
 
     args.add_all([

--- a/haskell/experimental/private/module.bzl
+++ b/haskell/experimental/private/module.bzl
@@ -188,13 +188,13 @@ def _build_haskell_module(
     main_function = getattr(ctx.attr, "main_function", None)
 
     if main_function:
-        main_file = getattr(ctx.attr, "main_file", None)
-        main_function_module = infer_main_module(main_function)
         if moduleAttr.module_name:
             guess_module_name = moduleAttr.module_name
         else:
             guess_module_name = paths.split_extension(get_module_path_from_target(module))[0].replace("/", ".")
 
+        main_file = getattr(ctx.attr, "main_file", None)
+        main_function_module = infer_main_module(main_function)
         if (moduleAttr.src == main_file or main_function_module == guess_module_name):
             args.add_all(["-main-is", ctx.attr.main_function])
 

--- a/haskell/experimental/private/module.bzl
+++ b/haskell/experimental/private/module.bzl
@@ -1,4 +1,5 @@
 load("@bazel_skylib//lib:paths.bzl", "paths")
+load("//haskell:private/path_utils.bzl", "infer_main_module")
 load(
     "//haskell:private/dependencies.bzl",
     "gather_dep_info",
@@ -184,9 +185,13 @@ def _build_haskell_module(
 
     args = ctx.actions.args()
 
-    if (moduleAttr.src == getattr(ctx.attr, "main_file", None)
-            and getattr(ctx.attr, "main_function", None)):
-        args.add_all(["-main-is", ctx.attr.main_function])
+    main_function = getattr(ctx.attr, "main_function", None)
+
+    if main_function:
+        main_file = getattr(ctx.attr, "main_file", None)
+        main_function_module = infer_main_module(main_function)
+        if (moduleAttr.src == main_file or main_function_module == moduleAttr.module_name):
+            args.add_all(["-main-is", ctx.attr.main_function])
 
     args.add_all([
         "-c",

--- a/haskell/experimental/private/module.bzl
+++ b/haskell/experimental/private/module.bzl
@@ -191,7 +191,7 @@ def _build_haskell_module(
         if moduleAttr.module_name:
             guess_module_name = moduleAttr.module_name
         else:
-            guess_module_name = paths.split_extension(get_module_path_from_target(module))[0].replace("/", ".")
+            guess_module_name = get_module_path_from_target(module).replace("/", ".")
 
         main_file = getattr(ctx.attr, "main_file", None)
         main_function_module = infer_main_module(main_function)

--- a/tests/haskell_module/BUILD.bazel
+++ b/tests/haskell_module/BUILD.bazel
@@ -5,6 +5,7 @@ filegroup(
         "//tests/haskell_module/attr_merging:all_files",
         "//tests/haskell_module/hs-boot:all_files",
         "//tests/haskell_module/binary:all_files",
+        "//tests/haskell_module/binary-custom-main:all_files",
         "//tests/haskell_module/library:all_files",
         "//tests/haskell_module/library-dep:all_files",
         "//tests/haskell_module/dep-narrowing:all_files",

--- a/tests/haskell_module/binary-custom-main/BUILD.bazel
+++ b/tests/haskell_module/binary-custom-main/BUILD.bazel
@@ -9,19 +9,28 @@ package(default_testonly = 1)
 
 haskell_test(
     name = "Test",
-    main_file = "TestBin.hs",
-    main_function = "custom_main",
+    main_function = "TestBin.custom_main",
     modules = [":TestBinModule"],
     visibility = ["//visibility:public"],
     deps = [
         "//tests/hackage:base",
     ],
+)
+
+haskell_test(
+    name = "TestNoModuleNameCustomMainFunction",
+    main_file = "TestBin.hs",
+    main_function = "TestBin.custom_main",
+    modules = [":TestBinNoModuleName"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//tests/hackage:base",
+    ]
 )
 
 haskell_binary(
     name = "Bin",
-    main_file = "TestBin.hs",
-    main_function = "custom_main",
+    main_function = "TestBin.custom_main",
     modules = [":TestBinModule"],
     visibility = ["//visibility:public"],
     deps = [
@@ -30,9 +39,10 @@ haskell_binary(
 )
 
 haskell_binary(
-    name = "BinNoMainFile",
+    name = "BinNoModuleNameCustomMainFunction",
+    main_file = "TestBin.hs",
     main_function = "TestBin.custom_main",
-    modules = [":TestBinModule"],
+    modules = [":TestBinNoModuleName"],
     visibility = ["//visibility:public"],
     deps = [
         "//tests/hackage:base",
@@ -43,6 +53,11 @@ haskell_module(
     name = "TestBinModule",
     src = "TestBin.hs",
     module_name = "TestBin",
+)
+
+haskell_module(
+    name = "TestBinNoModuleName",
+    src = "TestBin.hs",
 )
 
 filegroup(

--- a/tests/haskell_module/binary-custom-main/BUILD.bazel
+++ b/tests/haskell_module/binary-custom-main/BUILD.bazel
@@ -19,7 +19,6 @@ haskell_test(
 
 haskell_test(
     name = "TestNoModuleNameCustomMainFunction",
-    main_file = "TestBin.hs",
     main_function = "TestBin.custom_main",
     modules = [":TestBinNoModuleName"],
     visibility = ["//visibility:public"],
@@ -40,7 +39,6 @@ haskell_binary(
 
 haskell_binary(
     name = "BinNoModuleNameCustomMainFunction",
-    main_file = "TestBin.hs",
     main_function = "TestBin.custom_main",
     modules = [":TestBinNoModuleName"],
     visibility = ["//visibility:public"],

--- a/tests/haskell_module/binary-custom-main/BUILD.bazel
+++ b/tests/haskell_module/binary-custom-main/BUILD.bazel
@@ -1,0 +1,53 @@
+load(
+    "@rules_haskell//haskell:defs.bzl",
+    "haskell_binary",
+    "haskell_test",
+)
+load("@rules_haskell//haskell/experimental:defs.bzl", "haskell_module")
+
+package(default_testonly = 1)
+
+haskell_test(
+    name = "Test",
+    main_file = "TestBin.hs",
+    main_function = "custom_main",
+    modules = [":TestBinModule"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//tests/hackage:base",
+    ],
+)
+
+haskell_binary(
+    name = "Bin",
+    main_file = "TestBin.hs",
+    main_function = "custom_main",
+    modules = [":TestBinModule"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//tests/hackage:base",
+    ],
+)
+
+haskell_binary(
+    name = "BinNoMainFile",
+    main_function = "TestBin.custom_main",
+    modules = [":TestBinModule"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//tests/hackage:base",
+    ],
+)
+
+haskell_module(
+    name = "TestBinModule",
+    src = "TestBin.hs",
+    module_name = "TestBin",
+)
+
+filegroup(
+    name = "all_files",
+    testonly = True,
+    srcs = glob(["**"]),
+    visibility = ["//visibility:public"],
+)

--- a/tests/haskell_module/binary-custom-main/BUILD.bazel
+++ b/tests/haskell_module/binary-custom-main/BUILD.bazel
@@ -24,7 +24,7 @@ haskell_test(
     visibility = ["//visibility:public"],
     deps = [
         "//tests/hackage:base",
-    ]
+    ],
 )
 
 haskell_binary(

--- a/tests/haskell_module/binary-custom-main/TestBin.hs
+++ b/tests/haskell_module/binary-custom-main/TestBin.hs
@@ -1,0 +1,4 @@
+module TestBin where
+
+custom_main :: IO ()
+custom_main = putStrLn "hello, world!"


### PR DESCRIPTION
when we have `modules` attr in `haskell_binary`, `main_function` is not respected which results in linking error when we try to build