### PR TITLE
Fix build problems with GHC 9.x

### DIFF
--- a/haskell/assets/ghc_9_0_2_win.patch
+++ b/haskell/assets/ghc_9_0_2_win.patch
@@ -286,14 +286,13 @@
 +haddock-html:         ${pkgroot}/../docs/html/libraries/process
 --- lib/package.conf.d/rts-1.0.2.conf
 +++ lib/package.conf.d/rts-1.0.2.conf
-@@ -78,5 +78,5 @@ ld-options:
+@@ -77,6 +77,3 @@
+     "-Wl,-u,hs_atomicread32" "-Wl,-u,hs_atomicwrite8"
      "-Wl,-u,hs_atomicwrite16" "-Wl,-u,hs_atomicwrite32"
      "-Wl,-u,base_GHCziEventziWindows_processRemoteCompletion_closure"
-
+-
 -haddock-interfaces:   ${pkgroot}/../../docs/html/libraries/rts\rts.haddock
 -haddock-html:         ${pkgroot}/../../docs/html/libraries/rts
-+haddock-interfaces:   ${pkgroot}/../docs/html/libraries/rts\rts.haddock
-+haddock-html:         ${pkgroot}/../docs/html/libraries/rts
 --- lib/package.conf.d/stm-2.5.0.0.conf
 +++ lib/package.conf.d/stm-2.5.0.0.conf
 @@ -34,5 +34,5 @@ dynamic-library-dirs: ${pkgroot}\x86_64-windows-ghc-9.0.2

--- a/haskell/assets/ghc_9_2_1_win.patch
+++ b/haskell/assets/ghc_9_2_1_win.patch
@@ -286,14 +286,13 @@
 +haddock-html:         ${pkgroot}/../docs/html/libraries/process
 --- lib/package.conf.d/rts-1.0.2.conf
 +++ lib/package.conf.d/rts-1.0.2.conf
-@@ -78,5 +78,5 @@ ld-options:
+@@ -77,6 +77,3 @@
+     "-Wl,-u,hs_atomicread32" "-Wl,-u,hs_atomicwrite8"
      "-Wl,-u,hs_atomicwrite16" "-Wl,-u,hs_atomicwrite32"
      "-Wl,-u,base_GHCziEventziWindows_processRemoteCompletion_closure"
- 
+-
 -haddock-interfaces:   ${pkgroot}/../../docs/html/libraries/rts\rts.haddock
 -haddock-html:         ${pkgroot}/../../docs/html/libraries/rts
-+haddock-interfaces:   ${pkgroot}/../docs/html/libraries/rts\rts.haddock
-+haddock-html:         ${pkgroot}/../docs/html/libraries/rts
 --- lib/package.conf.d/stm-2.5.0.0.conf
 +++ lib/package.conf.d/stm-2.5.0.0.conf
 @@ -34,5 +34,5 @@ dynamic-library-dirs: ${pkgroot}\x86_64-windows-ghc-9.2.1

--- a/haskell/c2hs.bzl
+++ b/haskell/c2hs.bzl
@@ -95,7 +95,8 @@ def _c2hs_library_impl(ctx):
             """
         # Include libdir in include path just like hsc2hs does.
         libdir=$({ghc} --print-libdir)
-        {c2hs} -C-I$libdir/include "$@"
+        # GHC >=9 on Windows stores the includes outside of libdir
+        {c2hs} -C-I$libdir/include -C-I$libdir/../include "$@"
         """.format(
                 ghc = hs.tools.ghc.path,
                 c2hs = c2hs_exe.path,

--- a/haskell/ghc_bindist.bzl
+++ b/haskell/ghc_bindist.bzl
@@ -31,6 +31,7 @@ GHC_BINDIST_STRIP_PREFIX = \
         },
         "9.0.2": {
             "windows_amd64": "ghc-9.0.2-x86_64-unknown-mingw32",
+            "darwin_amd64": "ghc-9.0.2-x86_64-apple-darwin",
         },
         "9.0.1": {
             "windows_amd64": "ghc-9.0.1-x86_64-unknown-mingw32",
@@ -40,6 +41,9 @@ GHC_BINDIST_STRIP_PREFIX = \
 GHC_BINDIST_LIBDIR = \
     {
         "9.2.1": {
+            "darwin_amd64": "lib/lib",
+        },
+        "9.0.2": {
             "darwin_amd64": "lib/lib",
         },
     }

--- a/haskell/private/actions/process_hsc_file.bzl
+++ b/haskell/private/actions/process_hsc_file.bzl
@@ -60,17 +60,32 @@ def process_hsc_file(hs, cc, hsc_flags, hsc_inputs, hsc_file):
     if hs.env.get("PATH") == None and hs.toolchain.is_windows:
         hs.env["PATH"] = ""
 
-    hs.actions.run(
+    hs.actions.run_shell(
         inputs = depset(transitive = [
             depset(cc.hdrs),
             depset([hsc_file]),
             depset(cc.files),
             depset(hsc_inputs),
+            depset(hs.toolchain.bindir),
         ]),
         input_manifests = cc.manifests,
         outputs = [hs_out],
         mnemonic = "HaskellHsc2hs",
-        executable = hs.tools.hsc2hs,
+        command =
+            # cpp (called via c2hs) gets very unhappy if the mingw bin dir is
+            # not in PATH so we add it to PATH explicitly.
+            """
+            export PATH=$PATH:{mingw_bin}
+
+            # Include libdir in include path just like hsc2hs does.
+            libdir=$({ghc} --print-libdir)
+            # GHC >=9 on Windows stores the includes outside of libdir
+            {hsc2hs} -C-I$libdir/include -C-I$libdir/../include "$@"
+            """.format(
+                mingw_bin = paths.dirname(cc.tools.cc) if hs.toolchain.is_windows else "",
+                ghc = hs.tools.ghc.path,
+                hsc2hs = hs.tools.hsc2hs.path,
+            ),
         arguments = [args],
         env = hs.env,
     )

--- a/haskell/private/cabal_wrapper.py
+++ b/haskell/private/cabal_wrapper.py
@@ -191,10 +191,8 @@ def distdir_prefix():
 # into the 'flag hash' field of generated interface files. We try to use a
 # reproducible path for the distdir to keep interface files reproducible.
 with mkdtemp(distdir_prefix()) as distdir:
-    enable_relocatable_flags = []
-    if not is_windows and json_args["ghc_version"] != None and json_args["ghc_version"] < [9,2,1]:
-        # ToDo: not work relocatable from Cabal-3.6.0.0 buildin GHC 9.2.1
-        enable_relocatable_flags = ["--enable-relocatable"]
+    enable_relocatable_flags = ["--enable-relocatable"] \
+            if not is_windows else []
 
     # Cabal really wants the current working directory to be directory
     # where the .cabal file is located. So we have no choice but to chance


### PR DESCRIPTION
This PR integrates changes from the daml project which where deemed necessary when upgrading GHC to 9.0.2, see https://github.com/digital-asset/daml/pull/12300

1. handle include dir for GHC 9.x on Windows https://github.com/digital-asset/daml/blob/main/bazel_tools/haskell-ghc-includes.patch
2. remove non-existent haddock settings for the `rts` package https://github.com/digital-asset/daml/blob/main/bazel_tools/haskell-rts-docs.patch

Note, I did not want to change the default GHC version to 9.x yet, but I did run checks for 9.0.2 and 9.2.1 in branches https://github.com/tweag/rules_haskell/tree/fix-bindist-issues-9.2.1 and https://github.com/tweag/rules_haskell/tree/fix-bindist-issues-9.0.2:

* https://github.com/tweag/rules_haskell/actions/runs/2420231685
* https://github.com/tweag/rules_haskell/actions/runs/2419656854

Furthermore, this PR reverts commit 20085b2af090645d1daae15dd910964dad255611 because building the example with GHC 9.2.1 failed (https://github.com/tweag/rules_haskell/actions/runs/2414717193), and reverting the commit fixed the problem.  :exclamation: cc @matsubara0507 