### PR TITLE
Change integration tests implementation to one based on `rules_bazel_integration_test`

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -66,4 +66,5 @@ buildifier_test(
         "@examples//:all_files",
         "@tutorial//:all_files",
     ],
+    tags = ["dont_test_on_windows"],
 )

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -66,5 +66,6 @@ buildifier_test(
         "@examples//:all_files",
         "@tutorial//:all_files",
     ],
+    mode = "diff",
     tags = ["dont_test_on_windows"],
 )

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@com_github_bazelbuild_buildtools//buildifier:def.bzl", "buildifier")
+load("@com_github_bazelbuild_buildtools//buildifier:def.bzl", "buildifier", "buildifier_test")
 
 exports_files(["start"])
 
@@ -47,4 +47,23 @@ buildifier(
     exclude_patterns = buildifier_exclude_patterns,
     mode = "fix",
     verbose = True,
+)
+
+buildifier_test(
+    name = "buildifier_test",
+    srcs = [
+        "BUILD.bazel",
+        "WORKSPACE",
+        "constants.bzl",
+        "//debug/linking_utils:all_files",
+        "//docs:all_files",
+        "//haskell:all_files",
+        "//nixpkgs:all_files",
+        "//rule_info:all_files",
+        "//tests:all_files",
+        "//tools:all_files",
+        "@examples-arm//:all_files",
+        "@examples//:all_files",
+        "@tutorial//:all_files",
+    ],
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -583,3 +583,18 @@ bind(
 load("//tools:repositories.bzl", "rules_haskell_worker_dependencies")
 
 rules_haskell_worker_dependencies()
+
+local_repository(
+    name = "tutorial",
+    path = "tutorial",
+)
+
+local_repository(
+    name = "examples",
+    path = "examples",
+)
+
+local_repository(
+    name = "examples-arm",
+    path = "examples/arm",
+)

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -1,0 +1,14 @@
+filegroup(
+    name = "all_files",
+    testonly = True,
+    srcs = [
+        "BUILD.bazel",
+        "WORKSPACE",
+        "//cat_hs:all_files",
+        "//primitive:all_files",
+        "//rts:all_files",
+        "//transformers:all_files",
+        "//vector:all_files",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/examples/WORKSPACE
+++ b/examples/WORKSPACE
@@ -5,6 +5,11 @@ local_repository(
     path = "..",
 )
 
+local_repository(
+    name = "arm",
+    path = "arm",
+)
+
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@rules_haskell//haskell:repositories.bzl", "rules_haskell_dependencies")
 

--- a/examples/arm/BUILD.bazel
+++ b/examples/arm/BUILD.bazel
@@ -47,3 +47,20 @@ platform(
         "@platforms//cpu:aarch64",
     ],
 )
+
+filegroup(
+    name = "all_files",
+    testonly = True,
+    srcs = [
+        "BUILD.bazel",
+        "BUILD.zlib.bazel",
+        "Example.hs",
+        "Example2.hs",
+        "LibExample.hs",
+        "WORKSPACE",
+        "arm-cross.nix",
+        "qemu-shell.nix",
+        "shell.nix",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/examples/cat_hs/BUILD.bazel
+++ b/examples/cat_hs/BUILD.bazel
@@ -10,3 +10,14 @@ haskell_doc(
         "//cat_hs/lib/cat",
     ],
 )
+
+filegroup(
+    name = "all_files",
+    testonly = True,
+    srcs = glob(["**"]) + [
+        "//cat_hs/exec/cat_hs:all_files",
+        "//cat_hs/lib/args:all_files",
+        "//cat_hs/lib/cat:all_files",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/examples/cat_hs/exec/cat_hs/BUILD.bazel
+++ b/examples/cat_hs/exec/cat_hs/BUILD.bazel
@@ -12,3 +12,10 @@ haskell_binary(
         "@stackage//:base",
     ],
 )
+
+filegroup(
+    name = "all_files",
+    testonly = True,
+    srcs = glob(["**"]),
+    visibility = ["//visibility:public"],
+)

--- a/examples/cat_hs/lib/args/BUILD.bazel
+++ b/examples/cat_hs/lib/args/BUILD.bazel
@@ -24,3 +24,10 @@ haskell_test(
         "@stackage//:optparse-applicative",
     ],
 )
+
+filegroup(
+    name = "all_files",
+    testonly = True,
+    srcs = glob(["**"]),
+    visibility = ["//visibility:public"],
+)

--- a/examples/cat_hs/lib/cat/BUILD.bazel
+++ b/examples/cat_hs/lib/cat/BUILD.bazel
@@ -31,3 +31,10 @@ haskell_test(
         "@stackage//:text",
     ],
 )
+
+filegroup(
+    name = "all_files",
+    testonly = True,
+    srcs = glob(["**"]),
+    visibility = ["//visibility:public"],
+)

--- a/examples/primitive/BUILD.bazel
+++ b/examples/primitive/BUILD.bazel
@@ -33,3 +33,10 @@ haskell_library(
         "//transformers",
     ],
 )
+
+filegroup(
+    name = "all_files",
+    testonly = True,
+    srcs = glob(["**"]),
+    visibility = ["//visibility:public"],
+)

--- a/examples/rts/BUILD.bazel
+++ b/examples/rts/BUILD.bazel
@@ -26,3 +26,10 @@ cc_test(
         ":rts",
     ],
 )
+
+filegroup(
+    name = "all_files",
+    testonly = True,
+    srcs = glob(["**"]),
+    visibility = ["//visibility:public"],
+)

--- a/examples/transformers/BUILD.bazel
+++ b/examples/transformers/BUILD.bazel
@@ -16,3 +16,10 @@ haskell_library(
     visibility = ["//visibility:public"],
     deps = [":base"],
 )
+
+filegroup(
+    name = "all_files",
+    testonly = True,
+    srcs = glob(["**"]),
+    visibility = ["//visibility:public"],
+)

--- a/examples/vector/BUILD.bazel
+++ b/examples/vector/BUILD.bazel
@@ -40,3 +40,10 @@ haskell_library(
         "//primitive",
     ],
 )
+
+filegroup(
+    name = "all_files",
+    testonly = True,
+    srcs = glob(["**"]),
+    visibility = ["//visibility:public"],
+)

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -1,5 +1,6 @@
 load(":inline_tests.bzl", "sh_inline_test")
 load("@bazel_tools//tools/build_rules:test_rules.bzl", "rule_test")
+load("@com_github_bazelbuild_buildtools//buildifier:def.bzl", "buildifier_test")
 load("@os_info//:os_info.bzl", "is_windows")
 load("//tests:rule_test_exe.bzl", "rule_test_exe")
 load(
@@ -514,4 +515,9 @@ filegroup(
         "//tests/version-macros:all_files",
     ],
     visibility = ["//visibility:public"],
+)
+
+buildifier_test(
+    name = "buildifier_test",
+    srcs = ["//:all_files"],
 )

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -1,6 +1,5 @@
 load(":inline_tests.bzl", "sh_inline_test")
 load("@bazel_tools//tools/build_rules:test_rules.bzl", "rule_test")
-load("@com_github_bazelbuild_buildtools//buildifier:def.bzl", "buildifier_test")
 load("@os_info//:os_info.bzl", "is_windows")
 load("//tests:rule_test_exe.bzl", "rule_test_exe")
 load(
@@ -515,9 +514,4 @@ filegroup(
         "//tests/version-macros:all_files",
     ],
     visibility = ["//visibility:public"],
-)
-
-buildifier_test(
-    name = "buildifier_test",
-    srcs = ["//:all_files"],
 )

--- a/tests/RunTests.hs
+++ b/tests/RunTests.hs
@@ -18,9 +18,6 @@ import Test.Hspec (context, hspec, it, describe, runIO, shouldSatisfy, expectati
 
 main :: IO ()
 main = hspec $ do
-  it "bazel lint" $ do
-    assertSuccess (bazel ["run", "//:buildifier"])
-
   it "bazel test" $ do
     assertSuccess (bazel ["test", "//..."])
 

--- a/tutorial/BUILD.bazel
+++ b/tutorial/BUILD.bazel
@@ -1,0 +1,10 @@
+filegroup(
+    name = "all_files",
+    testonly = True,
+    srcs = glob(["**"]) + [
+        "//lib:all_files",
+        "//main:all_files",
+        "//tools/build_rules:all_files",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/tutorial/lib/BUILD.bazel
+++ b/tutorial/lib/BUILD.bazel
@@ -8,3 +8,10 @@ haskell_library(
     srcs = ["Bool.hs"],
     visibility = ["//main:__pkg__"],
 )
+
+filegroup(
+    name = "all_files",
+    testonly = True,
+    srcs = glob(["**"]),
+    visibility = ["//visibility:public"],
+)

--- a/tutorial/main/BUILD.bazel
+++ b/tutorial/main/BUILD.bazel
@@ -15,3 +15,10 @@ haskell_test(
         "//lib:booleans",
     ],
 )
+
+filegroup(
+    name = "all_files",
+    testonly = True,
+    srcs = glob(["**"]),
+    visibility = ["//visibility:public"],
+)

--- a/tutorial/tools/build_rules/BUILD.bazel
+++ b/tutorial/tools/build_rules/BUILD.bazel
@@ -1,0 +1,6 @@
+filegroup(
+    name = "all_files",
+    testonly = True,
+    srcs = glob(["**"]),
+    visibility = ["//visibility:public"],
+)


### PR DESCRIPTION
This PR suggests alternative approach to integration testing, based on rules_bazel_integration_test ruleset. Unfortunately I could not come up with anything less radical than put all required changes in one PR, cause otherwise both implementation would stay for a while in repo which could be very unclear and misleading 

So here is a list of changes I've put here:

1. Create haskell_bazel_integration_test rule for integration test
      with test scenario written in haskell and similar to go_bazel_test setup procedure
2. Create rules_haskell_integration_test macro for integration test running
      haskell scenario with all bazel versions supported in rules_haskell
3. Remove rules_go-based integration_test implementation
4. Remove rules_go patching for the sake of this implementation
5. Create IntegrationTesting library with helper functions formerly
      located in RunTests.hs
6. Reimplement existing integration_test implementations with
      rules_haskell_integration_test