### PR TITLE
Integration testing: create separate directories for every bazel version to improve caching

### DIFF
--- a/tests/integration_testing/IntegrationTesting.hs
+++ b/tests/integration_testing/IntegrationTesting.hs
@@ -82,11 +82,12 @@ generateBazelRc dir = do
 setupWorkspace :: IO (String, String)
 setupWorkspace = do
     workspaceDir <- getEnv "BIT_WORKSPACE_DIR"
+    bazelBinId <- getEnv "BIT_BAZEL_BIN_ID"
     outputBase <- outputBaseDir
     runfilesDir <- getEnv "RUNFILES_DIR"
     let execDir = outputBase </> "bazel_testing"
     createDirIfNotExist execDir
-    let newWorkspaceDir = execDir </> "main"
+    let newWorkspaceDir = execDir </> bazelBinId
     let outputUserRoot = outputBase
     removeDirIfExist newWorkspaceDir
     copyDirectoryRecursive workspaceDir newWorkspaceDir

--- a/tests/integration_testing/haskell_bazel_integration_test.bzl
+++ b/tests/integration_testing/haskell_bazel_integration_test.bzl
@@ -20,6 +20,7 @@ def haskell_bazel_integration_test(
         bazel_binaries,
         workspace_path,
         args = [],
+        env = {},
         deps = [],
         rule_files = [],
         **kwargs):
@@ -40,12 +41,13 @@ def haskell_bazel_integration_test(
         arguments = args,
     )
 
-    for bazel_name, bazel_binary in bazel_binaries.items():
+    for bazel_id, bazel_binary in bazel_binaries.items():
         bazel_integration_test(
-            name = "%s_%s" % (name, bazel_name),
+            name = "%s_%s" % (name, bazel_id),
             test_runner = runner_name,
             bazel_binary = bazel_binary,
             workspace_files = integration_test_utils.glob_workspace_files(workspace_path) + rule_files,
             workspace_path = workspace_path,
+            env = dict(env, **{"BIT_BAZEL_BIN_ID": bazel_id}),
             **kwargs
         )

--- a/tests/integration_testing/rules_haskell_integration_test.bzl
+++ b/tests/integration_testing/rules_haskell_integration_test.bzl
@@ -20,11 +20,11 @@ def rules_haskell_integration_test(
         nixpkgs_bazel_packages = SUPPORTED_NIXPKGS_BAZEL_PACKAGES,
         **kwargs):
     bindist_bazel_binaries = {
-        version: integration_test_utils.bazel_binary_label(version)
+        version.replace(".", "_"): integration_test_utils.bazel_binary_label(version)
         for version in bindist_bazel_versions
     }
     nixpkgs_bazel_binaries = {
-        package: nixpkgs_bazel_label(package)
+        package.replace(".", "_"): nixpkgs_bazel_label(package)
         for package in nixpkgs_bazel_packages
     }
 


### PR DESCRIPTION
First version of new integration testing mechanism is executing every test in same workspace directory in order to keep workspace absolute path and reuse build cache between test workspaces. The problem is when multiple Bazel version get tested, every new Bazel version destroys cache of previous one. With arbitrary test order it makes caching almost useless. This PR proposes creating separate directory for every Bazel version to keep absolute path between every test workspaces tested with specific Bazel version