### PR TITLE
Enable test error output on Bazel CI

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -7,10 +7,12 @@ tasks:
     shell_commands:
       - "sudo apt -y update && sudo apt -y install libgmp-dev"
     build_flags:
+      - "--config=ci-common"
       - "--build_tag_filters=-requires_nix,-requires_lz4,-requires_shellcheck,-requires_threaded_rts,-dont_test_with_bindist,-dont_test_on_bazelci"
     build_targets:
       - "//tests/..."
     test_flags:
+      - "--config=ci-common"
       - "--test_tag_filters=-requires_nix,-requires_lz4,-requires_shellcheck,-requires_threaded_rts,-dont_test_with_bindist,-dont_test_on_bazelci"
     test_targets:
       - "//tests/..."

--- a/.bazelrc
+++ b/.bazelrc
@@ -68,7 +68,7 @@ build:ci-common --remote_timeout=3600
 # See https://github.com/tweag/rules_haskell/issues/1498.
 build:ci-common --keep_backend_build_event_connections_alive=false
 
-test:ci --test_output=errors
+test:ci-common --test_output=errors
 
 build:ci-linux-bindist --config=linux-bindist
 build:ci-linux-nixpkgs --config=linux-nixpkgs

--- a/.bazelrc
+++ b/.bazelrc
@@ -61,8 +61,8 @@ build:ci-common --experimental_repository_cache_hardlinks
 
 # Use a remote cache during CI
 build:ci-common --bes_results_url=https://app.buildbuddy.io/invocation/
-build:ci-common --bes_backend=grpcs://cloud.buildbuddy.io
-build:remote-cache --remote_cache=grpcs://cloud.buildbuddy.io
+build:ci-common --bes_backend=grpcs://remote.buildbuddy.io
+build:remote-cache --remote_cache=grpcs://remote.buildbuddy.io
 build:ci-common --remote_timeout=3600
 # Avoid failures of the form `deadline exceeded after 14999958197ns DEADLINE_EXCEEDED`.
 # See https://github.com/tweag/rules_haskell/issues/1498.


### PR DESCRIPTION
Having error output is tremendously useful after the fact when tests failed on CI where you cannot simply inspect the log files.
