### PR TITLE
Skip integration tests on Bazel CI

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -8,11 +8,11 @@ tasks:
       - "sudo apt -y update && sudo apt -y install libgmp-dev"
     build_flags:
       - "--config=ci-common"
-      - "--build_tag_filters=-requires_nix,-requires_lz4,-requires_shellcheck,-requires_threaded_rts,-dont_test_with_bindist,-dont_test_on_bazelci"
+      - "--build_tag_filters=-requires_nix,-requires_lz4,-requires_shellcheck,-requires_threaded_rts,-dont_test_with_bindist,-dont_test_on_bazelci,-integration"
     build_targets:
       - "//tests/..."
     test_flags:
       - "--config=ci-common"
-      - "--test_tag_filters=-requires_nix,-requires_lz4,-requires_shellcheck,-requires_threaded_rts,-dont_test_with_bindist,-dont_test_on_bazelci"
+      - "--test_tag_filters=-requires_nix,-requires_lz4,-requires_shellcheck,-requires_threaded_rts,-dont_test_with_bindist,-dont_test_on_bazelci,-integration"
     test_targets:
       - "//tests/..."


### PR DESCRIPTION
We have observed that the following tests fail due to the same error on Bazel CI:

```
/tests/haskell_module/repl:haskell_module_repl_cross_library_deps_test_bindist_4_0_0
//tests/haskell_module/repl:haskell_module_repl_cross_library_deps_test_bindist_4_2_2
//tests/haskell_module/repl:haskell_module_repl_test_bindist_4_0_0
//tests/haskell_module/repl:haskell_module_repl_test_bindist_4_2_2
//tests/repl-targets:hs_bin_repl_test_bindist_4_0_0
//tests/repl-targets:hs_bin_repl_test_bindist_4_2_2
//tests/repl-targets:hs_lib_repl_test_bindist_4_0_0
//tests/repl-targets:hs_lib_repl_test_bindist_4_2_2
//tests/stack-snapshot-deps:hs_override_stack_test_bindist_4_0_0
//tests/stack-snapshot-deps:hs_override_stack_test_bindist_4_2_2
```

Note, these are all integration tests that use a specific Bazel bindist release.

```
ERROR: The project you're trying to build requires Bazel /tmp/tmp3n4h0337/bazel (specified in $USE_BAZEL_VERSION),
       but it wasn't found in /var/lib/buildkite-agent/.cache/bazel/_bazel_buildkite-agent/43ded1c95f81ef160feed9e593d6df2e/external/build_bazel_bazel_4_2_2
```

Since the purpose of Bazel's CI is to avoid regressions due to changes to Bazel
itself, there is not much use of running the integration tests against specific
bindist releases on that CI.

Fixes https://github.com/tweag/rules_haskell/issues/1769