### PR TITLE
Correct checksum instructions and update hash

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -114,7 +114,8 @@ this to "unlimited"; adjust as necessary.
 The Git archive checksum can be calculated with:
 
 ```bash
-git archive --format=tar.gz --prefix=rules-haskell-${REV}/ ${REV} | sha256sum
+REV=0.x
+git archive --format=tar.gz --prefix=rules_haskell-${REV}/ v${REV} | sha256sum
 ```
 
 **Note** The trailing slash on the prefix is important; don't forget it.

--- a/docs/haskell-use-cases.rst
+++ b/docs/haskell-use-cases.rst
@@ -30,7 +30,7 @@ rules_haskell. To use a released version, do the following::
       name = "rules_haskell",
       strip_prefix = "rules_haskell-0.15",
       urls = ["https://github.com/tweag/rules_haskell/archive/v0.15.tar.gz"],
-      sha256 = "1424cd5a798f75971568f8cda3c2d94f2a6faf647487cc9c94f6b4ba6a8f3712",
+      sha256 = "aba3c16015a2363b16e2f867bdc5c792fa71c68cb97d8fe95fddc41e409d6ba8",
   )
 
 Picking a compiler

--- a/start
+++ b/start
@@ -203,7 +203,7 @@ http_archive(
     name = "rules_haskell",
     strip_prefix = "rules_haskell-0.15",
     urls = ["https://github.com/tweag/rules_haskell/archive/v0.15.tar.gz"],
-    sha256 = "1424cd5a798f75971568f8cda3c2d94f2a6faf647487cc9c94f6b4ba6a8f3712",
+    sha256 = "aba3c16015a2363b16e2f867bdc5c792fa71c68cb97d8fe95fddc41e409d6ba8",
 )
 
 load(

--- a/start
+++ b/start
@@ -8,7 +8,7 @@ set -eu
 readonly MIN_BAZEL_MAJOR=4
 readonly MIN_BAZEL_MINOR=0
 
-readonly MAX_BAZEL_MAJOR=4
+readonly MAX_BAZEL_MAJOR=5
 readonly MAX_BAZEL_MINOR=2
 
 stderr () {


### PR DESCRIPTION
After the release, I noticed that the checksum for the tag was apparently not correct.

Also, the max Bazel version was not yet adapted in the `start` script after #1781 .