### PR TITLE
feat: use pgml-supports-no-pie with GHC 9.4

### DIFF
--- a/haskell/cc.bzl
+++ b/haskell/cc.bzl
@@ -219,7 +219,9 @@ def ghc_cc_program_args(hs, cc, ld):
         cc + " -E -undef -traditional",
         "-optc-fno-stack-protector",
     ]
-    if hs.toolchain.numeric_version >= [8, 10, 3]:
+    if hs.toolchain.numeric_version >= [9, 4, 1]:
+        args.append("-pgml-supports-no-pie")
+    elif hs.toolchain.numeric_version >= [8, 10, 3]:
         args.append("-pgmc-supports-no-pie")
     if hs.toolchain.numeric_version >= [9, 0, 1]:
         args.extend([


### PR DESCRIPTION
Instead of `pgmc-supports-no-pie` which is deprecated.

Close #1803.