### PR TITLE
Add missing prefixes for GHC 9 on darwin_arm64

### DIFF
--- a/haskell/ghc_bindist.bzl
+++ b/haskell/ghc_bindist.bzl
@@ -31,15 +31,18 @@ GHC_BINDIST_STRIP_PREFIX = \
         },
         "9.2.3": {
             "darwin_amd64": "ghc-9.2.3-x86_64-apple-darwin",
+            "darwin_arm64": "ghc-9.2.3-aarch64-apple-darwin",
             "windows_amd64": "ghc-9.2.3-x86_64-unknown-mingw32",
         },
         "9.2.1": {
             "darwin_amd64": "ghc-9.2.1-x86_64-apple-darwin",
+            "darwin_arm64": "ghc-9.2.1-aarch64-apple-darwin",
             "windows_amd64": "ghc-9.2.1-x86_64-unknown-mingw32",
         },
         "9.0.2": {
             "windows_amd64": "ghc-9.0.2-x86_64-unknown-mingw32",
             "darwin_amd64": "ghc-9.0.2-x86_64-apple-darwin",
+            "darwin_arm64": "ghc-9.0.2-aarch64-apple-darwin",
         },
         "9.0.1": {
             "windows_amd64": "ghc-9.0.1-x86_64-unknown-mingw32",


### PR DESCRIPTION
This fixes an error that occurs while unpacking the bindist when compiling with GHC 9 on arm64 macOS:

```
ERROR:
  /Users/<USER>/git/bazel-rules-haskell/tutorial/main/BUILD.bazel:7:26: //main:base
depends on
  @rules_haskell_ghc_darwin_arm64//:toolchain-impl
in repository
  @rules_haskell_ghc_darwin_arm64
which failed to fetch. no such package '@rules_haskell_ghc_darwin_arm64//':

java.io.IOException: Error extracting
  /private/var/tmp/_bazel_<USER>/0a9dd77dcbc0f8a38889048f5c926ef3/external/rules_haskell_ghc_darwin_arm64/bindist_unpacked/temp9224205716600269016/ghc-9.2.1-aarch64-apple-darwin.tar.xz
to
  /private/var/tmp/_bazel_<USER>/0a9dd77dcbc0f8a38889048f5c926ef3/external/rules_haskell_ghc_darwin_arm64/bindist_unpacked/temp9224205716600269016:

Prefix "ghc-9.2.1" was given, but not found in the archive.
Here are possible prefixes for this archive: "ghc-9.2.1-aarch64-apple-darwin".
```

(formatted for better readability)

Note that the different naming of the architecture (`darwin_arm64` and `darwin_aarch64`) is intentional, since the bindists use this slightly different naming convention.

There seem to be further issues with GHC 9.2 on arm64 macOS, e.g. the toolchain's `base` library apparently cannot be found, but that's for another PR...