### PR TITLE
Bazel 6.0: Fix config_setting visibility failure on bazel CI

### DIFF
--- a/haskell/platforms/list.bzl
+++ b/haskell/platforms/list.bzl
@@ -37,12 +37,14 @@ def declare_config_settings():
             native.config_setting(
                 name = os,
                 constraint_values = [constraint_value],
+                visibility = ["//visibility:public"],
             )
     for arch, constraint_value in ARCH.items():
         if constraint_value:
             native.config_setting(
                 name = arch,
                 constraint_values = [constraint_value],
+                visibility = ["//visibility:public"],
             )
 
 def os_of_constraints(constraints):


### PR DESCRIPTION
See bazelbuild/bazel#12933.

Repro: `$ USE_BAZEL_VERSION=a05276fea75d47370b363125a074c38cb2badc74 bazelisk build --nobuild --incompatible_config_setting_private_default_visibility //haskell:cc_wrapper.py`

Discovered in failing Bazel CI with `--incompatible_config_setting_private_default_visibility flipped`:

https://buildkite.com/bazel/bazelisk-plus-incompatible-flags/builds/1297#0183cee0-f6d4-4791-99c0-edbe178e4cdf