### PR TITLE
Upgrade macOS image and replace set-output command

### DIFF
--- a/.github/workflows/patch-test.yaml
+++ b/.github/workflows/patch-test.yaml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-10.15, windows-latest]
+        os: [ubuntu-latest, macos-11, windows-latest]
         ghc-version: ${{ fromJSON(needs.find-ghc-version.outputs.ghc-matrix) }}
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-10.15]
+        os: [ubuntu-latest, macos-11]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
@@ -108,7 +108,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-10.15, windows-latest]
+        os: [ubuntu-latest, macos-11, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - if: ${{ matrix.os == 'ubuntu-latest' }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 * Add support for GHC 9.2.4 (see [#1814])
 
 [#1791]: https://github.com/tweag/rules_haskell/pull/1791
-[#1791]: https://github.com/tweag/rules_haskell/pull/1814
+[#1814]: https://github.com/tweag/rules_haskell/pull/1814
 
 ### Removed
 

--- a/tests/extract_from_ghc_bindist.py
+++ b/tests/extract_from_ghc_bindist.py
@@ -17,4 +17,6 @@ version_numbers = [x['version'] for x in gen_ghc_bindist.VERSIONS]
 
 unexpected(["8.10.1", "8.10.2"], version_numbers, "GHC 8.10.1 and 8.10.2 not supported. Upgrade to 8.10.3 or later.")
 
-print("::set-output name=ghc-matrix::{}".format(version_numbers))
+with open(os.environ['GITHUB_OUTPUT'], mode='a', encoding='utf-8') as output:
+  output.write("ghc-matrix={}\n".format(version_numbers))
+


### PR DESCRIPTION
Both are deprecated and will not work after the deprecation period.