### PR TITLE
Don't pass relocatable flag to cabal_wrapper for libs

### DIFF
--- a/haskell/private/cabal_wrapper.py
+++ b/haskell/private/cabal_wrapper.py
@@ -191,8 +191,9 @@ def distdir_prefix():
 # into the 'flag hash' field of generated interface files. We try to use a
 # reproducible path for the distdir to keep interface files reproducible.
 with mkdtemp(distdir_prefix()) as distdir:
+    is_exe = component.startswith("exe:")
     enable_relocatable_flags = ["--enable-relocatable"] \
-            if not is_windows else []
+            if is_exe and not is_windows else []
 
     # Cabal really wants the current working directory to be directory
     # where the .cabal file is located. So we have no choice but to chance


### PR DESCRIPTION
Two reasons not to do this. First is that Cabal up to 3.6.3.0 doesn't support relocatable libraries. Second is that there is currently a bug in Cabal where if you pass this argument and the library uses the Paths_<pkg> module, Cabal will generate a module that doesn't compile. This currently prevents building several packages with ghc 9.0 or ghc 9.2


I tried adding tests, but the current tests for `haskell_cabal_library` that I based them off of don't pass either. I tried them in the pure nix shell as instructed. I keep getting errors about not being able to load libs from packages.