### PR TITLE
Fix empty glob results

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -12,6 +12,7 @@
 startup --host_jvm_args=-Djdk.tls.client.protocols=TLSv1.2
 
 common --incompatible_require_linker_input_cc_api
+common --incompatible_disallow_empty_glob
 
 # test environment does not propagate locales by default some tests reads files
 # written in UTF8, we need to propagate the correct environment variables, such

--- a/.bazelrc
+++ b/.bazelrc
@@ -12,7 +12,9 @@
 startup --host_jvm_args=-Djdk.tls.client.protocols=TLSv1.2
 
 common --incompatible_require_linker_input_cc_api
-common --incompatible_disallow_empty_glob
+
+# TODO enable when using Bazel >= 5, see https://github.com/tweag/rules_haskell/pull/1828
+common --incompatible_disallow_empty_glob=false
 
 # test environment does not propagate locales by default some tests reads files
 # written in UTF8, we need to propagate the correct environment variables, such

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -341,14 +341,14 @@ nixpkgs_package(
 
 nixpkgs_package(
     name = "nixpkgs_lz4",
-    attribute_path = "lz4",
+    attribute_path = "lz4.out",
     build_file_content = """
 package(default_visibility = ["//visibility:public"])
 load("@rules_cc//cc:defs.bzl", "cc_library")
 
 cc_library(
   name = "nixpkgs_lz4",
-  srcs = glob(["lib/liblz4.dylib", "lib/liblz4.so*"]),
+  srcs = glob(["lib/liblz4.dylib", "lib/liblz4.so*"], allow_empty = True),
   includes = ["include"],
 )
     """,

--- a/tests/stackage_zlib_runpath/BUILD.bazel
+++ b/tests/stackage_zlib_runpath/BUILD.bazel
@@ -39,7 +39,7 @@ haskell_cabal_binary(
 filegroup(
     name = "all_files",
     testonly = True,
-    srcs = glob(["**"]) + glob(["cabal_binary/**"]),
+    srcs = glob(["**"]),
     visibility = ["//visibility:public"],
 )
 


### PR DESCRIPTION
Fixes #1827 

I did enable the `--incompatible_disallow_empty_glob` flag and found a few problems with `glob` calls by it.

Unfortunately, we cannot yet flip the switch to disallow empty glob results, since the embedded bazel_tools repository of the Bazel version we are using is not yet ready:

https://github.com/bazelbuild/bazel/blob/f64b7553607e1d3572611cc5011c498e3cd4505c/tools/jdk/jdk.BUILD#L165-L169

That is the reason the bindist checks fail with an error:
```
ERROR: Traceback (most recent call last):
	File "/private/var/tmp/_bazel_runner/d1e3bdaa0c37ce8d00ecff62b05849c3/external/local_jdk/BUILD.bazel", line 168, column 16, in <toplevel>
		srcs = glob(["conf/**"]),
Error in glob: glob pattern 'conf/**' didn't match anything, but allow_empty is set to False (the default value of allow_empty can be set with --incompatible_disallow_empty_glob).
ERROR: /private/var/tmp/_bazel_runner/d1e3bdaa0c37ce8d00ecff62b05849c3/external/bazel_tools/tools/jdk/BUILD:336:6: Target '@local_jdk//:jdk' contains an error and its package is in error and referenced by '@bazel_tools//tools/jdk:jdk'
```

After review, I'll remove the flag again so CI will pass.