### PR TITLE
Fix another config_setting visibility setting.

### DIFF
--- a/haskell/asterius/BUILD.bazel
+++ b/haskell/asterius/BUILD.bazel
@@ -26,6 +26,7 @@ config_setting(
     constraint_values = [
         "@platforms//cpu:wasm32",
     ],
+    visibility = ["//visibility:public"],
 )
 
 # Toolchain type for asterius specific tools such as ahc-dist,


### PR DESCRIPTION
This seems enough to fully pass rules_haskll on Blaze's incompatible flag CI pipeline:
https://buildkite.com/bazel/bazelisk-plus-incompatible-flags/builds/1320#018435e1-7742-44cb-911b-c21b89fb6e95 (I ran that test locally with this patch and the build succeeded).

For https://github.com/bazelbuild/bazel/issues/12933