### PR TITLE
Refine Continuous Integration workflow

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -83,10 +83,15 @@ jobs:
           # Avoid failures of the form `deadline exceeded after 14999958197ns DEADLINE_EXCEEDED`.
           # See https://github.com/tweag/rules_haskell/issues/1498 and https://github.com/tweag/rules_haskell/pull/1692.
           sudo sysctl -w net.ipv4.tcp_keepalive_time=60
+          if [ -z "$BUILDBUDDY_API_KEY" ]; then
+              cache_setting='--noremote_upload_local_results'
+          else
+              cache_setting="--remote_header=x-buildbuddy-api-key=$BUILDBUDDY_API_KEY"
+          fi
           cat >.bazelrc.local <<EOF
           common --config=ci
           build --config=linux-nixpkgs
-          build --remote_header=x-buildbuddy-api-key="$BUILDBUDDY_API_KEY"
+          build $cache_setting
           EOF
           ln -sr .bazelrc.local examples/arm/.bazelrc.local
           cat >~/.netrc <<EOF
@@ -141,10 +146,15 @@ jobs:
             Linux) BUILD_CONFIG=ci-linux-bindist;;
             Windows) BUILD_CONFIG=ci-windows-bindist;;
           esac
+          if [ -z "$BUILDBUDDY_API_KEY" ]; then
+              cache_setting='--noremote_upload_local_results'
+          else
+              cache_setting="--remote_header=x-buildbuddy-api-key=$BUILDBUDDY_API_KEY"
+          fi
           cat >.bazelrc.local <<EOF
           common --config=ci
           build --config=$BUILD_CONFIG
-          build --remote_header=x-buildbuddy-api-key="$BUILDBUDDY_API_KEY"
+          build $cache_setting
           EOF
           cat >~/.netrc <<EOF
           machine api.github.com

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -1,5 +1,10 @@
 name: Continuous integration
-on: [push]
+on:
+  push:
+    branches: master
+  pull_request:
+    branches: master
+  workflow_dispatch: # allows manual triggering
 env:
   # Bump this number to invalidate the GH actions cache
   cache-version: 0


### PR DESCRIPTION
- skip writes to Buildbuddy without API key
- run workflow on push requests and on manual dispatch