### PR TITLE
Replace (most of) custom set library by Skylib's sets.bzl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 *.swp
 *.swo
 __pycache__
+/.direnv
+/.envrc

--- a/haskell/c2hs.bzl
+++ b/haskell/c2hs.bzl
@@ -18,6 +18,7 @@ load(
     "target_unique_name",
 )
 load(":private/set.bzl", "set")
+load("@bazel_skylib//lib:sets.bzl", "sets")
 load(":private/version_macros.bzl", "version_macro_includes")
 
 def _c2hs_library_impl(ctx):
@@ -62,7 +63,7 @@ def _c2hs_library_impl(ctx):
     ]
     args.add_all(chi_includes)
 
-    version_macro_headers = set.empty()
+    version_macro_headers = sets.make()
     if ctx.attr.version:
         dep_info = gather_dep_info(ctx.attr.name, ctx.attr.deps)
         (version_macro_headers, version_macro_flags) = version_macro_includes(dep_info)

--- a/haskell/cabal.bzl
+++ b/haskell/cabal.bzl
@@ -21,6 +21,7 @@ load(
     "truly_relativize",
 )
 load(":private/set.bzl", "set")
+load("@bazel_skylib//lib:sets.bzl", "sets")
 load(":private/validate_attrs.bzl", "typecheck_stackage_extradeps")
 load(":haddock.bzl", "generate_unified_haddock_info")
 load(
@@ -582,11 +583,11 @@ def _haskell_cabal_library_impl(ctx):
     hs_info = HaskellInfo(
         package_databases = depset([package_database], transitive = [dep_info.package_databases]),
         empty_lib_package_databases = dep_info.empty_lib_package_databases,
-        version_macros = set.empty(),
+        version_macros = sets.make(),
         source_files = depset(),
         boot_files = depset(),
         extra_source_files = depset(),
-        import_dirs = set.empty(),
+        import_dirs = sets.make(),
         hs_libraries = depset(
             direct = [lib for lib in [vanilla_library, dynamic_library, profiling_library] if lib],
             transitive = [dep_info.hs_libraries],
@@ -881,11 +882,11 @@ def _haskell_cabal_binary_impl(ctx):
     hs_info = HaskellInfo(
         package_databases = dep_info.package_databases,
         empty_lib_package_databases = dep_info.empty_lib_package_databases,
-        version_macros = set.empty(),
+        version_macros = sets.make(),
         source_files = depset(),
         boot_files = depset(),
         extra_source_files = depset(),
-        import_dirs = set.empty(),
+        import_dirs = sets.make(),
         hs_libraries = dep_info.hs_libraries,
         deps_hs_libraries = dep_info.deps_hs_libraries,
         empty_hs_libraries = dep_info.empty_hs_libraries,
@@ -1933,7 +1934,7 @@ def _stack_snapshot_impl(repository_ctx):
         else:
             visibility = sorted(
                 # use set to de-duplicate
-                set.to_list(set.from_list([
+                sets.to_list(sets.make([
                     str(vendored_packages[rdep].relative(":__pkg__"))
                     for rdep in reverse_deps[name]
                     if rdep in vendored_packages

--- a/haskell/doctest.bzl
+++ b/haskell/doctest.bzl
@@ -4,6 +4,7 @@ load("@bazel_skylib//lib:dicts.bzl", "dicts")
 load(":cc.bzl", "cc_interop_info", "ghc_cc_program_args")
 load(":private/context.bzl", "haskell_context", "render_env")
 load(":private/set.bzl", "set")
+load("@bazel_skylib//lib:sets.bzl", "sets")
 load(
     "@rules_haskell//haskell:providers.bzl",
     "HaskellCcLibrariesInfo",
@@ -121,7 +122,7 @@ def _haskell_doctest_single(target, ctx):
 
     if ctx.attr.modules:
         inputs = ctx.attr.modules
-        args.add_all(set.to_list(hs_info.import_dirs), format_each = "-i%s")
+        args.add_all(sets.to_list(hs_info.import_dirs), format_each = "-i%s")
     else:
         inputs = [source.path for source in hs_info.source_files.to_list()]
 

--- a/haskell/experimental/private/module.bzl
+++ b/haskell/experimental/private/module.bzl
@@ -1,4 +1,5 @@
 load("@bazel_skylib//lib:paths.bzl", "paths")
+load("@bazel_skylib//lib:sets.bzl", "sets")
 load("//haskell:private/path_utils.bzl", "infer_main_module")
 load(
     "//haskell:private/dependencies.bzl",
@@ -840,7 +841,7 @@ def build_haskell_modules(
         repl_info = struct(
             source_files = depset(source_files),
             boot_files = depset(boot_files),
-            import_dirs = set.from_list(import_dirs),
+            import_dirs = sets.make(import_dirs),
             user_compile_flags = user_compile_flags,
         ),
     )

--- a/haskell/haddock.bzl
+++ b/haskell/haddock.bzl
@@ -17,6 +17,7 @@ load(
 )
 load(":private/context.bzl", "haskell_context", "render_env")
 load(":private/set.bzl", "set")
+load("@bazel_skylib//lib:sets.bzl", "sets")
 
 def generate_unified_haddock_info(this_package_id, this_package_haddock, this_package_html, deps):
     """Collapse dependencies into a single `HaddockInfo`.

--- a/haskell/private/actions/compile.bzl
+++ b/haskell/private/actions/compile.bzl
@@ -25,6 +25,7 @@ load(
     "link_libraries",
 )
 load(":private/set.bzl", "set")
+load("@bazel_skylib//lib:sets.bzl", "sets")
 load("//haskell/experimental:providers.bzl", "HaskellModuleInfo")
 load(
     ":private/actions/process_hsc_file.bzl",
@@ -161,7 +162,7 @@ def _compilation_defaults(
     # the two must both have the same root; i.e., both plain files,
     # both in bin_dir, or both in genfiles_dir.
 
-    import_dirs = set.from_list([
+    import_dirs = sets.make([
         hs.src_root,
         paths.join(hs.bin_dir.path, hs.src_root),
         paths.join(hs.genfiles_dir.path, hs.src_root),
@@ -176,7 +177,7 @@ def _compilation_defaults(
         elif s.extension == "hsc":
             s0, idir = process_hsc_file(hs, cc, hsc_flags, hsc_inputs, s)
             source_files.append(s0)
-            set.mutable_insert(import_dirs, idir)
+            sets.insert(import_dirs, idir)
         elif s.extension in ["hs-boot", "lhs-boot"]:
             boot_files.append(s)
         else:
@@ -184,7 +185,7 @@ def _compilation_defaults(
 
         if s in import_dir_map:
             idir = import_dir_map[s]
-            set.mutable_insert(import_dirs, idir)
+            sets.insert(import_dirs, idir)
 
     # Write the -optP flags to a parameter file because they can be very long on Windows
     # e.g. 27Kb for grpc-haskell

--- a/haskell/private/actions/process_hsc_file.bzl
+++ b/haskell/private/actions/process_hsc_file.bzl
@@ -4,6 +4,7 @@ load("@bazel_skylib//lib:paths.bzl", "paths")
 load(":private/version_macros.bzl", "version_macro_includes")
 load(":private/path_utils.bzl", "declare_compiled")
 load(":private/set.bzl", "set")
+load("@bazel_skylib//lib:sets.bzl", "sets")
 
 def process_hsc_file(hs, cc, hsc_flags, hsc_inputs, hsc_file):
     """Process a single hsc file.
@@ -108,6 +109,6 @@ def preprocess_hsc_flags_and_inputs(dep_info, user_compile_flags, version):
     if version:
         (version_macro_headers, version_macro_flags) = version_macro_includes(dep_info)
         hsc_flags += ["--cflag=" + x for x in version_macro_flags]
-        hsc_inputs += set.to_list(version_macro_headers)
+        hsc_inputs += sets.to_list(version_macro_headers)
 
     return hsc_flags, hsc_inputs

--- a/haskell/private/actions/runghc.bzl
+++ b/haskell/private/actions/runghc.bzl
@@ -17,6 +17,7 @@ load(
     "link_libraries",
 )
 load("@bazel_skylib//lib:shell.bzl", "shell")
+load("@bazel_skylib//lib:sets.bzl", "sets")
 
 def build_haskell_runghc(
         hs,
@@ -56,7 +57,7 @@ def build_haskell_runghc(
     )
 
     if lib_info != None:
-        for idir in set.to_list(hs_info.import_dirs):
+        for idir in sets.to_list(hs_info.import_dirs):
             args += ["-i{0}".format(idir)]
 
     link_libraries(

--- a/haskell/private/dependencies.bzl
+++ b/haskell/private/dependencies.bzl
@@ -4,6 +4,7 @@ load(
     "HaskellLibraryInfo",
 )
 load(":private/set.bzl", "set")
+load("@bazel_skylib//lib:sets.bzl", "sets")
 
 def gather_dep_info(name, deps):
     """Collapse dependencies into a single `HaskellInfo`.
@@ -64,7 +65,7 @@ def gather_dep_info(name, deps):
         if HaskellInfo in dep
     ])
 
-    import_dirs = set.empty()
+    import_dirs = sets.make()
     for dep in deps:
         if HaskellInfo in dep:
             import_dirs = set.mutable_union(import_dirs, dep[HaskellInfo].import_dirs)
@@ -83,7 +84,7 @@ def gather_dep_info(name, deps):
     acc = HaskellInfo(
         package_databases = package_databases,
         empty_lib_package_databases = empty_lib_package_databases,
-        version_macros = set.empty(),
+        version_macros = sets.make(),
         hs_libraries = hs_libraries,
         deps_hs_libraries = deps_hs_libraries,
         empty_hs_libraries = empty_hs_libraries,

--- a/haskell/private/list.bzl
+++ b/haskell/private/list.bzl
@@ -1,6 +1,7 @@
 """Helper functions on lists."""
 
 load(":private/set.bzl", "set")
+load("@bazel_skylib//lib:sets.bzl", "sets")
 
 def _dedup_on(f, list_):
     """deduplicate `list_` by comparing the result of applying
@@ -12,12 +13,12 @@ def _dedup_on(f, list_):
     dedup_on(compare_x, [struct(x=3), struct(x=4), struct(x=3)])
     => [struct(x=3), struct(x=4)]
     """
-    seen = set.empty()
+    seen = sets.make()
     deduped = []
     for el in list_:
         by = f(el)
-        if not set.is_member(seen, by):
-            set.mutable_insert(seen, by)
+        if not sets.contains(seen, by):
+            sets.insert(seen, by)
             deduped.append(el)
     return deduped
 

--- a/haskell/private/path_utils.bzl
+++ b/haskell/private/path_utils.bzl
@@ -1,7 +1,7 @@
 """Utilities for module and path manipulations."""
 
 load("@bazel_skylib//lib:paths.bzl", "paths")
-load(":private/set.bzl", "set")
+load("@bazel_skylib//lib:sets.bzl", "sets")
 
 def is_haskell_extension(extension):
     """Whether the given extension defines a Haskell source file."""

--- a/haskell/private/set.bzl
+++ b/haskell/private/set.bzl
@@ -1,83 +1,14 @@
 """Immutable sets that support efficient merging, traversal, and membership
-check.
+check. 
 """
 
-def _empty():
-    """Create an empty set.
-
-    Returns:
-      set, new empty set.
-    """
-    return struct(_set_items = dict())
-
-def _singleton(e):
-    """Create a set with single element `e` inside.
-
-    Args:
-      e: The element to put in the set.
-
-    Returns:
-      set, new set.
-    """
-    r = dict()
-    r[e] = None
-    return struct(_set_items = r)
-
-def _is_member(s, e):
-    """Return true if `e` is in the set `s`.
-
-    Args:
-      s: The set to inspect.
-      e: The element to search for.
-
-    Result:
-      Bool, true if `e` is in `s`, false otherwise.
-    """
-    return e in s._set_items
-
-def _insert(s, e):
-    """Insert an element into the set.
-
-    Args:
-      s: Set to insert new element into.
-      e: The element to insert.
-
-    Result:
-      A copy of set `s` with `s` element added.
-    """
-    r = dict(s._set_items)
-    r[e] = None
-    return struct(_set_items = r)
-
-def _mutable_insert(s, e):
-    """The same as `set.insert`, but modifies the first argument in place.
-
-    Args:
-      s: Set to insert new element into.
-      e: The element to insert.
-
-    Result:
-      set `s` with `s` element added.
-    """
-    s._set_items[e] = None
-    return s
-
-def _union(s0, s1):
-    """Return union of two sets.
-
-    Args:
-      s0: One set.
-      s1: Another set.
-
-    Result:
-      set, union of the two sets.
-    """
-    r = dict(s0._set_items)
-    r.update(s1._set_items)
-    return struct(_set_items = r)
+load("@bazel_skylib//lib:sets.bzl", "sets")
 
 def _mutable_union(s0, s1):
     """Modify set `s0` adding elements from `s1` to it.
+    This is soon to be upstreamed to Skylib and removed from this file. See
+    <https://github.com/tweag/rules_haskell/pull/1834> and
+    <https://github.com/bazelbuild/bazel-skylib/pull/415> for more information.
 
     Args:
       s0: One set.
@@ -86,27 +17,15 @@ def _mutable_union(s0, s1):
     Result:
       set, union of the two sets.
     """
-    s0._set_items.update(s1._set_items)
+
+    s0._values.update(s1._values)
     return s0
-
-def _difference(s0, s1):
-    """Return the set of elements from s0 not appearing in s1.
-
-    Args:
-      s0: One set.
-      s1: Another set.
-
-    Result:
-      set, difference of the two sets.
-    """
-    s2 = _empty()
-    for item in s0._set_items.keys():
-        if not _is_member(s1, item):
-            _mutable_insert(s2, item)
-    return s2
 
 def _mutable_difference(s0, s1):
     """Modify set `s0` removing elements from `s1` from it.
+    This is soon to be upstreamed to Skylib and removed from this file. See
+    <https://github.com/tweag/rules_haskell/pull/1834> and
+    <https://github.com/bazelbuild/bazel-skylib/pull/415> for more information.
 
     Args:
       s0: One set.
@@ -115,68 +34,22 @@ def _mutable_difference(s0, s1):
     Result:
       set, difference of the two sets.
     """
-    for item in s1._set_items.keys():
-        s0._set_items.pop(item)
+
+    for item in s1._values.keys():
+        s0._values.pop(item)
     return s0
 
-def _map(s, f):
-    """Map elements of given set using a function.
-
-    Args:
-      s: Original set.
-      f: Function to apply to elements of the set.
-
-    Result:
-      set with elements obtained by application of function `f` to the
-      elements of `s`.
-    """
-    return struct(_set_items = {f(x): None for x in s._set_items.keys()})
-
-def _from_list(l):
-    """Create a set containing elements from given list.
-
-    Args:
-      l: List, source of the elements for the new set.
-
-    Result:
-      set containing elements from given list.
-    """
-    return (struct(_set_items = {x: None for x in l}))
-
-def _to_list(s):
-    """Convert set into a list of its elements.
-
-    Args:
-      s: Set to convert.
-
-    Returns:
-      List of elements of the set.
-    """
-    return s._set_items.keys()
-
 def _to_depset(s):
-    """Similar to `set.to_list`, but produces a depset.
-
+    """Similar to `sets.to_list`, but produces a depset.
     Args:
       s: Set to convert.
-
     Returns:
       Depset of elements from the set.
     """
-    return depset(_to_list(s))
+    return depset(sets.to_list(s))
 
 set = struct(
-    empty = _empty,
-    singleton = _singleton,
-    is_member = _is_member,
-    insert = _insert,
-    mutable_insert = _mutable_insert,
-    union = _union,
     mutable_union = _mutable_union,
-    difference = _difference,
     mutable_difference = _mutable_difference,
-    map = _map,
-    from_list = _from_list,
-    to_list = _to_list,
     to_depset = _to_depset,
 )

--- a/haskell/private/version_macros.bzl
+++ b/haskell/private/version_macros.bzl
@@ -1,4 +1,5 @@
 load(":private/set.bzl", "set")
+load("@bazel_skylib//lib:sets.bzl", "sets")
 
 def generate_version_macros(ctx, pkg_name, version):
     """Generate a version macros header file.
@@ -41,7 +42,7 @@ def version_macro_includes(hs_info):
     files = hs_info.version_macros
     flags = [
         f
-        for include in set.to_list(files)
+        for include in sets.to_list(files)
         for f in ["-include", include.path]
     ]
     return (files, flags)

--- a/haskell/repl.bzl
+++ b/haskell/repl.bzl
@@ -34,6 +34,7 @@ load(
 )
 load(":private/java.bzl", "java_interop_info")
 load(":private/set.bzl", "set")
+load("@bazel_skylib//lib:sets.bzl", "sets")
 
 HaskellReplLoadInfo = provider(
     doc = """Haskell REPL target information.


### PR DESCRIPTION
See #1799.

https://github.com/bazelbuild/bazel-skylib/pull/415 tracks the addition of `mutable_{union,difference}` to Skylib, but Skylib's merge process isn't the fastest. For the moment, I've left our implementations in, in the interest of getting this merged quickly. I'll remove those in a future PR, which will allow us to close the issue linked above.