### PR TITLE
Use https://cache.iog.io as substituter

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -29,7 +29,7 @@ jobs:
           nix_path: nixpkgs=./nixpkgs/default.nix
           extra_nix_config: |
             trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=
-            extra-substituters = https://hydra.iohk.io
+            extra-substituters = https://cache.iog.io
       - name: Configure
         env:
           BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
@@ -80,7 +80,7 @@ jobs:
           nix_path: nixpkgs=./nixpkgs/default.nix
           extra_nix_config: |
             trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=
-            extra-substituters = https://hydra.iohk.io
+            extra-substituters = https://cache.iog.io
       - name: Configure
         env:
           BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}


### PR DESCRIPTION
Using the old substituter URL failed on CI and caused a rebuild of GHC 8.4.4:
```
warning: error: unable to download https://hydra.iohk.io/nix-cache-info: Timeout was reached (28); retrying in 1205 ms
warning: error: unable to download https://hydra.iohk.io/nix-cache-info: Timeout was reached (28); retrying in 2664 ms
...
building '/nix/store/nx5waliy6ks7blssp5czccr0anfkqlcy-ghc-8.4.4.drv'...
```