### PR TITLE
Fix "Update website" CI job

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -13,6 +13,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
+          fetch-depth: 0
           ref: release
       - name: Configure git
         run: |


### PR DESCRIPTION
The job needs access to the origin/master branch and the history of the release branch in order to create a merge commit.

Simply fetching the complete history of all tags and branches makes this work.