### PR TITLE
Fix incorrect sha256 hash for release 0.16

### DIFF
--- a/.github/workflows/workspace_snippet.sh
+++ b/.github/workflows/workspace_snippet.sh
@@ -7,7 +7,7 @@ set -o errexit -o nounset -o pipefail
 TAG=${GITHUB_REF_NAME}
 REPO_NAME=${GITHUB_REPOSITORY#*/}
 PREFIX="${REPO_NAME}-${TAG:1}"
-SHA=$(git archive --format=tar.gz --prefix=${PREFIX}/ ${TAG} | shasum -a 256 | awk '{print $1}')
+SHA=$(git archive --format=tar --prefix=${PREFIX}/ ${TAG} | gzip | shasum -a 256 | awk '{print $1}')
 
 cat << EOF
 WORKSPACE snippet:

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -59,7 +59,7 @@ The Git archive checksum can be calculated with:
 
 ```bash
 REV=0.x
-git archive --format=tar.gz --prefix=rules_haskell-${REV}/ v${REV} | sha256sum
+git archive --format=tar --prefix=rules_haskell-${REV}/ v${REV} | gzip | sha256sum
 ```
 
 **Note** The trailing slash on the prefix is important; don't forget it.

--- a/start
+++ b/start
@@ -205,7 +205,7 @@ load(
 # Download rules_haskell and make it accessible as "@rules_haskell".
 http_archive(
     name = "rules_haskell",
-    sha256 = "f7a228ef21c7976e42f0949b927f40d3381305d65e19585625eb6ce2c59116e9",
+    sha256 = "2a07b55c30e526c07138c717b0343a07649e27008a873f2508ffab3074f3d4f3",
     strip_prefix = "rules_haskell-0.16",
     url = "https://github.com/tweag/rules_haskell/archive/refs/tags/v0.16.tar.gz",
 )


### PR DESCRIPTION
I just observed that the sha256 hash in the workspace snippet and the `start` script for the aforementioned release does not match the hash from the archive downloaded from Github.

The reason is a change in git.

```console
$ git --version
git version 2.36.2
$ git archive --format=tar.gz --prefix=rules_haskell-0.16/ v0.16 | sha256sum
2a07b55c30e526c07138c717b0343a07649e27008a873f2508ffab3074f3d4f3  -

# versus

$ git --version
git version 2.38.1
$ git archive --format=tar.gz  --prefix=rules_haskell-0.16/ v0.16 | sha256sum
f7a228ef21c7976e42f0949b927f40d3381305d65e19585625eb6ce2c59116e9  -

$ curl -sL https://github.com/tweag/rules_haskell/archive/refs/tags/v0.16.tar.gz | sha256sum
2a07b55c30e526c07138c717b0343a07649e27008a873f2508ffab3074f3d4f3  -
```

Since version 2.38 git handles compression with gzip internally which only guarantees reproducible
output for the same git and zlib versions.

Before 2.38, running this command was actually equivalent to `git archive --format=tar ... | gzip -cn`.

Note, I already updated the hash on the release page.

Depends on #1848 