### PR TITLE
CI: Install libtinfo5 which is required by GHC bindists

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -65,6 +65,7 @@ build:ci-common --experimental_repository_cache_hardlinks
 # Use a remote cache during CI
 build:ci-common --bes_results_url=https://app.buildbuddy.io/invocation/
 build:ci-common --bes_backend=grpcs://remote.buildbuddy.io
+build:ci-windows-bindist --bes_upload_mode=wait_for_upload_complete --bes_timeout=60s
 build:remote-cache --remote_cache=grpcs://remote.buildbuddy.io
 build:ci-common --remote_timeout=3600
 # Avoid failures of the form `deadline exceeded after 14999958197ns DEADLINE_EXCEEDED`.

--- a/.github/workflows/patch-test.yaml
+++ b/.github/workflows/patch-test.yaml
@@ -30,6 +30,12 @@ jobs:
         ghc-version: ${{ fromJSON(needs.find-ghc-version.outputs.ghc-matrix) }}
     runs-on: ${{ matrix.os }}
     steps:
+      - name: Install required packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install --no-install-recommends -yy libtinfo5
+          sudo apt-get clean
+        if: ${{ matrix.os == 'ubuntu-latest' }}
       - uses: actions/checkout@v3
       - name: Mount Bazel cache
         uses: actions/cache@v3

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -125,6 +125,8 @@ jobs:
         run: |-
           sudo swapoff -a
           sudo rm -rf /swapfile /usr/share/dotnet /usr/local/lib/android /opt/ghc
+          sudo apt-get update
+          sudo apt-get install --no-install-recommends -yy libtinfo5
           sudo apt clean
           docker rmi $(docker images -q) -f
       - uses: actions/checkout@v3


### PR DESCRIPTION
```
external/rules_haskell_ghc_linux_amd64/lib/bin/ghc-pkg: error while loading shared libraries: libtinfo.so.5: cannot open shared object file: No such file or directory
```