### PR TITLE
Update nixpkgs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,7 +11,7 @@ extensions = [
 
 master_doc = 'index'
 
-language = None
+language = "en"
 
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 

--- a/haskell/asterius/asterius_webpack_config.js.tpl
+++ b/haskell/asterius/asterius_webpack_config.js.tpl
@@ -5,6 +5,7 @@ module.exports = {
   context: path.resolve(__dirname, '.'),
   output: {
     path: path.resolve(__dirname, "."),
+    hashFunction: "xxhash64",
   },
   mode : 'production',
   stats: 'errors-only',

--- a/haskell/private/coverage_wrapper.sh.tpl
+++ b/haskell/private/coverage_wrapper.sh.tpl
@@ -56,7 +56,7 @@ hpc_dir_args=()
 mix_file_paths={mix_file_paths}
 for m in "${mix_file_paths[@]}"
 do
-  absolute_mix_file_path=$(rlocation $m)
+  absolute_mix_file_path=$(rlocation "$m")
   hpc_parent_dir=$(dirname "$absolute_mix_file_path")
   trimmed_hpc_parent_dir="${hpc_parent_dir%%_.hpc*}"
   hpc_dir_args+=("--hpcdir=${trimmed_hpc_parent_dir}_.hpc")

--- a/nixpkgs/default.nix
+++ b/nixpkgs/default.nix
@@ -1,8 +1,8 @@
 { ... }@args:
 let
-  # 2022-10-25
-  sha256 = "1n3r4s53q2clynvd6v2css054kf0icyfhxgs79brqvmrsxa7d0db";
-  rev = "6107f97012a0c134c5848125b5aa1b149b76d2c9";
+  # 2023-01-03
+  sha256 = "1213j2gvsmzmhpyi2jyn729s9d0gbn56k3d873iknd5ilb2rvpcr";
+  rev = "73247c5ab2bc2037d7dd0d310f1fb43ed191edad";
 in
 import (fetchTarball {
   inherit sha256;


### PR DESCRIPTION
This PR updates the version of nixpks in the repository (to a version that contains bazel 6).
And fixes some issues due to the new versions of node, sphynx and shellcheck.