### PR TITLE
Bazel 6 support

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -107,7 +107,7 @@ build:macos-nixpkgs --incompatible_enable_cc_toolchain_resolution
 # Blocked by https://github.com/bazelbuild/buildtools/issues/757
 #build:ci --incompatible_load_proto_rules_from_bzl
 
-# This flag will become the default in bazel 5
+# This flag will become the default in bazel 6
 # https://github.com/tweag/rules_haskell/issues/1657
 build: --incompatible_override_toolchain_transition
 

--- a/.bazelrc
+++ b/.bazelrc
@@ -106,7 +106,6 @@ build:macos-nixpkgs --incompatible_enable_cc_toolchain_resolution
 #build:ci --incompatible_load_cc_rules_from_bzl
 # Blocked by https://github.com/bazelbuild/buildtools/issues/757
 #build:ci --incompatible_load_proto_rules_from_bzl
-build:ci --incompatible_load_python_rules_from_bzl
 
 # This flag will become the default in bazel 5
 # https://github.com/tweag/rules_haskell/issues/1657

--- a/.bazelrc
+++ b/.bazelrc
@@ -104,8 +104,10 @@ build:macos-nixpkgs --incompatible_enable_cc_toolchain_resolution
 #build:ci-windows-bindist --incompatible_enable_cc_toolchain_resolution
 # Blocked by https://github.com/bazelbuild/bazel/issues/11704
 #build:ci --incompatible_load_cc_rules_from_bzl
-# Blocked by https://github.com/bazelbuild/buildtools/issues/757
-#build:ci --incompatible_load_proto_rules_from_bzl
+
+# This flag will become the default in a later version of bazel
+# See https://github.com/bazelbuild/bazel/issues/8922
+build:ci --incompatible_load_proto_rules_from_bzl
 
 # This flag will become the default in bazel 6
 # https://github.com/tweag/rules_haskell/issues/1657

--- a/.bazelrc
+++ b/.bazelrc
@@ -13,8 +13,7 @@ startup --host_jvm_args=-Djdk.tls.client.protocols=TLSv1.2
 
 common --incompatible_require_linker_input_cc_api
 
-# TODO enable when using Bazel >= 5, see https://github.com/tweag/rules_haskell/pull/1828
-common --incompatible_disallow_empty_glob=false
+common --incompatible_disallow_empty_glob=true
 
 # test environment does not propagate locales by default some tests reads files
 # written in UTF8, we need to propagate the correct environment variables, such

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [Unreleased]
+
+### Added
+
+* Add support for Bazel 6
+
+### Removed
+
+* Remove support for Bazel 4
+
+
 ## [0.16] 2022-12-06
 
 [0.16]: https://github.com/tweag/rules_haskell/compare/v0.15...v0.16

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The full reference documentation for rules is at https://haskell.build.
 
 ## Setup
 
-You'll need [Bazel >= 4.0][bazel-getting-started] installed.
+You'll need [Bazel >= 5.0][bazel-getting-started] installed.
 
 If you are on NixOS, skip to the [Nixpkgs](#Nixpkgs) section.
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -491,10 +491,10 @@ haskell_package_repository_dummy(
 
 http_archive(
     name = "io_bazel_stardoc",
-    sha256 = "c9794dcc8026a30ff67cf7cf91ebe245ca294b20b071845d12c192afe243ad72",
+    sha256 = "3fd8fec4ddec3c670bd810904e2e33170bedfe12f90adf943508184be458c8bb",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/stardoc/releases/download/0.5.0/stardoc-0.5.0.tar.gz",
-        "https://github.com/bazelbuild/stardoc/releases/download/0.5.0/stardoc-0.5.0.tar.gz",
+        "https://mirror.bazel.build/github.com/bazelbuild/stardoc/releases/download/0.5.3/stardoc-0.5.3.tar.gz",
+        "https://github.com/bazelbuild/stardoc/releases/download/0.5.3/stardoc-0.5.3.tar.gz",
     ],
 )
 

--- a/haskell/cabal_wrapper.bzl
+++ b/haskell/cabal_wrapper.bzl
@@ -9,6 +9,7 @@ def cabal_wrapper(name, **kwargs):
         ],
         srcs_version = "PY3",
         python_version = "PY3",
+        imports = ["private"],
         deps = [
             "@bazel_tools//tools/python/runfiles",
         ],

--- a/haskell/private/versions.bzl
+++ b/haskell/private/versions.bzl
@@ -14,14 +14,14 @@
 # because every bazel version tested requires a lot of space on CI
 # See https://github.com/tweag/rules_haskell/pull/1781#issuecomment-1187640454
 SUPPORTED_BAZEL_VERSIONS = [
-    "4.0.0",
-    "4.2.2",
     "5.0.0",
     "5.2.0",
+    "6.0.0",
 ]
 
 SUPPORTED_NIXPKGS_BAZEL_PACKAGES = [
-    "bazel_4",
+    "bazel_5",
+    "bazel_6",
 ]
 
 def _parse_version_chunk(version_chunk):

--- a/haskell/repositories.bzl
+++ b/haskell/repositories.bzl
@@ -49,8 +49,9 @@ def rules_haskell_dependencies():
     maybe(
         http_archive,
         name = "rules_python",
-        url = "https://github.com/bazelbuild/rules_python/releases/download/0.5.0/rules_python-0.5.0.tar.gz",
-        sha256 = "cd6730ed53a002c56ce4e2f396ba3b3be262fd7cb68339f0377a45e8227fe332",
+        sha256 = "48a838a6e1983e4884b26812b2c748a35ad284fd339eb8e2a6f3adf95307fbcd",
+        strip_prefix = "rules_python-0.16.2",
+        url = "https://github.com/bazelbuild/rules_python/archive/refs/tags/0.16.2.tar.gz",
     )
 
     maybe(

--- a/start
+++ b/start
@@ -9,11 +9,11 @@ set -eu
 # we use the default version (currently "8.10.7").
 GHC_VERSION=${GHC_VERSION:="8.10.7"}
 
-readonly MIN_BAZEL_MAJOR=4
+readonly MIN_BAZEL_MAJOR=5
 readonly MIN_BAZEL_MINOR=0
 
-readonly MAX_BAZEL_MAJOR=5
-readonly MAX_BAZEL_MINOR=2
+readonly MAX_BAZEL_MAJOR=6
+readonly MAX_BAZEL_MINOR=0
 
 stderr () {
   >&2 echo "$*"


### PR DESCRIPTION
This PR addresses the remaining items of issue #1855
- Stardoc is updated because of issue #1853
- Commit https://github.com/tweag/rules_haskell/pull/1860/commits/3be8027a8b7cc517b0ee725347c0d9b7ba84420e  adds a missing import to the `cabal_wrapper` python rule. It seems that things were working fine before due to [this issue](https://github.com/bazelbuild/rules_python/issues/382) which is fixed when using bazel6 + python 3.11
 
I did not try to replace the `crosstool_top` option yet as it seems to works fine with bazel 6, so replacing it can be done in another PR.


