### PR TITLE
Declare cc toolchain for windows

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -25,10 +25,6 @@ test --test_env=LANG=C.UTF-8 --test_env=LOCALE_ARCHIVE
 build:linux-nixpkgs --config=nixpkgs
 build:macos-nixpkgs --config=nixpkgs
 build:nixpkgs --host_platform=@io_tweag_rules_nixpkgs//nixpkgs/platforms:host
-# Use this configuration when targeting Windows. Eventually this will
-# no longer be required:
-# https://bazel.build/roadmaps/platforms.html#replace---cpu-and---host_cpu-flags.
-build:windows-bindist --crosstool_top=@rules_haskell_ghc_windows_amd64//:cc_toolchain
 
 # Build and Test Filters
 # ----------------------
@@ -100,8 +96,8 @@ build:linux-bindist --incompatible_enable_cc_toolchain_resolution
 build:macos-bindist --incompatible_enable_cc_toolchain_resolution
 build:linux-nixpkgs --incompatible_enable_cc_toolchain_resolution
 build:macos-nixpkgs --incompatible_enable_cc_toolchain_resolution
-# Windows still uses --crosstool_top.
-#build:ci-windows-bindist --incompatible_enable_cc_toolchain_resolution
+build:windows-bindist --incompatible_enable_cc_toolchain_resolution
+
 # Blocked by https://github.com/bazelbuild/bazel/issues/11704
 #build:ci --incompatible_load_cc_rules_from_bzl
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 ### Added
 
 * Add support for Bazel 6
+* The provided `cc_toolchain` used for windows can now be used with `--incompatible_enable_cc_toolchain_resolution` so using the `crosstool_top` option is no longer necessary.
 
 ### Removed
 

--- a/start
+++ b/start
@@ -333,7 +333,9 @@ build:ci --jobs=2
 build:ci --verbose_failures
 common:ci --color=no
 test:ci --test_output=errors
-build:ci-windows --crosstool_top=@rules_haskell_ghc_windows_amd64//:cc_toolchain
+
+# Should become the default in bazel 7
+common --incompatible_enable_cc_toolchain_resolution
 
 EOF
 

--- a/tests/integration_testing/IntegrationTesting.hs
+++ b/tests/integration_testing/IntegrationTesting.hs
@@ -76,7 +76,7 @@ generateBazelRc dir = do
 \ build:macos-nixpkgs --incompatible_enable_cc_toolchain_resolution \n\
 \ build:linux-bindist --incompatible_enable_cc_toolchain_resolution \n\
 \ build:macos-bindist --incompatible_enable_cc_toolchain_resolution \n\
-\ build:windows-bindist --crosstool_top=@rules_haskell_ghc_windows_amd64//:cc_toolchain \n\
+\ build:windows-bindist --incompatible_enable_cc_toolchain_resolution \n\
 \ ")
 
 setupWorkspace :: IO (String, String)

--- a/tests/run-start-script.sh
+++ b/tests/run-start-script.sh
@@ -25,17 +25,8 @@ cd $workdir
 # changes, then we need to adapt to those changes in the branch.
 # Which in turn means the start script should pull in those changes too.
 
-case "$OSTYPE" in
-  cygwin|msys)
-    OSCONFIG=("--config=ci-windows")
-    ;;
-  *)
-    OSCONFIG=()
-    ;;
-esac
-
 NIX_PATH=nixpkgs="$pwd/nixpkgs/default.nix" \
   bazel run \
-  --config=ci "${OSCONFIG[@]}" \
+  --config=ci \
   --override_repository=rules_haskell="$pwd" \
   //:example


### PR DESCRIPTION
This PR declares the `cc_toolchain` used for windows, so that it can be found when using the `--incompatible_enable_cc_toolchain_resolution` option.
 As a result using the `crosstool_top` option is not required anymore.