### PR TITLE
Prepare ghc update

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -83,7 +83,7 @@ build:ci-windows-bindist --config=windows-bindist
 #   this rule is missing dependency declarations for the following files included by 'tests/runfiles/main.cc':
 #     '.../execroot/rules_haskell/external/rules_haskell_ghc_windows_amd64/mingw/include/c++/9.2.0/cstdlib'
 #     '.../execroot/rules_haskell/external/rules_haskell_ghc_windows_amd64/mingw/include/c++/9.2.0/x86_64-w64-mingw32/bits/c++config.h'
-build:ci-windows-bindist --remote_default_exec_properties=cache-silo-key=windows-v1
+build:ci-windows-bindist --remote_default_exec_properties=cache-silo-key=windows-v2
 
 # XXX: @com_google_protobuf sets `use_default_shell_env = True`, so we enable
 #   strict action env to avoid changes in `PATH` invalidating the cache.

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -158,10 +158,16 @@ jobs:
           else
               cache_setting="--remote_header=x-buildbuddy-api-key=$BUILDBUDDY_API_KEY"
           fi
+          if [[ ${{ runner.os }} == Windows ]]; then
+              output_root_setting="startup --output_user_root=C:/_bzl"
+          else
+              output_root_setting=""
+          fi
           cat >.bazelrc.local <<EOF
           common --config=ci
           build --config=$BUILD_CONFIG
           build $cache_setting
+          $output_root_setting
           EOF
           cat >~/.netrc <<EOF
           machine api.github.com

--- a/haskell/c2hs.bzl
+++ b/haskell/c2hs.bzl
@@ -83,7 +83,7 @@ def _c2hs_library_impl(ctx):
             inputs,
         ]),
         input_manifests = input_manifests,
-        tools = [hs.tools.ghc, c2hs_exe],
+        tools = [hs.tools.ghc_pkg, c2hs_exe],
         outputs = [hs_file, chi_file],
         command =
             # cpp (called via c2hs) gets very unhappy if the mingw bin dir is
@@ -95,11 +95,13 @@ def _c2hs_library_impl(ctx):
             ) +
             """
         # Include libdir in include path just like hsc2hs does.
-        libdir=$({ghc} --print-libdir)
         # GHC >=9 on Windows stores the includes outside of libdir
-        {c2hs} -C-I$libdir/include -C-I$libdir/../include "$@"
+        # See: https://gitlab.haskell.org/ghc/ghc/-/issues/21609#note_435800
+        include_dirs=($({ghc_pkg} field rts include-dirs  --simple-output))
+        include_dirs_args=( "${{include_dirs[@]/#/-C-I}}" )
+        {c2hs} "${{include_dirs_args[@]}}" "$@"
         """.format(
-                ghc = hs.tools.ghc.path,
+                ghc_pkg = hs.tools.ghc_pkg.path,
                 c2hs = c2hs_exe.path,
             ),
         mnemonic = "HaskellC2Hs",

--- a/haskell/cabal.bzl
+++ b/haskell/cabal.bzl
@@ -339,9 +339,6 @@ def _prepare_cabal_inputs(
         extra_args.append("--ghc-option=-optl-static")
 
     path_args = [
-        "--package-db=" + _dirname(db)
-        for db in package_databases.to_list()
-    ] + [
         "--extra-include-dirs=" + d
         for d in direct_include_dirs.to_list()
     ] + _uniquify(["--extra-lib-dirs=" + d for d in direct_lib_dirs])
@@ -369,6 +366,7 @@ def _prepare_cabal_inputs(
         cabal_basename = cabal.basename,
         cabal_dirname = cabal.dirname,
         extra_ldflags_file = extra_ldflags_file.path if extra_ldflags_file else None,
+        package_databases = [p.path for p in package_databases.to_list()],
     )
 
     ghc_files = hs.toolchain.bindir + hs.toolchain.libdir


### PR DESCRIPTION
This PR contains changes that prepare for the ghc update but should also work with the current version.

- It recovers include directories for `c2hs` via `ghc-pkg field rts include-dirs` instead of relying on `ghc --print-libdir`.
This should be more stable across ghc versions: https://gitlab.haskell.org/ghc/ghc/-/issues/21609#note_435800

Because of the path and command length limits on windows:

- Change the CI `output_user_root` on windows to a shorter path (this requires bumping the `cache-silo-key` value to invalidate the remote cache).

- When compiling a cabal package on windows, create a temporary package database in which we declare all the dependencies before invoking cabal. This generates shorter command lines than passing the databases of dependencies as arguments, both when calling cabal, and then when cabal calls ghc.