### PR TITLE
Skip writing to the remote cache with no API key

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -41,10 +41,15 @@ jobs:
             macOS) BUILD_CONFIG=ci-macos-nixpkgs;;
             Linux) BUILD_CONFIG=ci-linux-nixpkgs;;
           esac
+          if [ -z "$BUILDBUDDY_API_KEY" ]; then
+              cache_setting='--noremote_upload_local_results'
+          else
+              cache_setting="--remote_header=x-buildbuddy-api-key=$BUILDBUDDY_API_KEY"
+          fi
           cat >.bazelrc.local <<EOF
           common --config=ci
           build --config=$BUILD_CONFIG
-          build --remote_header=x-buildbuddy-api-key="$BUILDBUDDY_API_KEY"
+          build $cache_setting
           EOF
           cat >~/.netrc <<EOF
           machine api.github.com


### PR DESCRIPTION
Related to https://github.com/tweag/rules_haskell/pull/1833 -- there was one more use of the empty API key.

For PRs from forks (and also dependabot) access to the repository secrets is not permitted, so the API key for Buildbuddy ends up as empty.

This would lead to an error:
```
WARNING: BES was not properly closed
ERROR: The Build Event Protocol upload failed: Not retrying publishBuildEvents, no more attempts left: status='Status{code=UNAUTHENTICATED, description=failed to parse API key
```