### PR TITLE
Bzlmod prerequisites

### DIFF
--- a/haskell/asterius/repositories.bzl
+++ b/haskell/asterius/repositories.bzl
@@ -225,8 +225,9 @@ def rules_haskell_asterius_toolchain(
         ghcopts = None,
         repl_ghci_args = None,
         cabalopts = None,
-        locale = None):
-    """ Define and registers asterius related toolchains.
+        locale = None,
+        register = True):
+    """ Define and (optionally) registers asterius related toolchains.
 
     Args:
       name: A unique name for the repository.
@@ -242,6 +243,7 @@ def rules_haskell_asterius_toolchain(
       repl_ghci_args: [see rules_haskell_toolchains](toolchain.html#rules_haskell_toolchains-repl_ghci_args)
       cabalopts: [see rules_haskell_toolchains](toolchain.html#rules_haskell_toolchains-cabalopts)
       locale: [see rules_haskell_toolchains](toolchain.html#rules_haskell_toolchains-locale)
+      register: Whether to register the toolchains (must be set to False if bzlmod is activated)
     """
 
     _ahc(
@@ -266,18 +268,20 @@ def rules_haskell_asterius_toolchain(
         exec_constraints = exec_constraints,
         wasm_cc_toolchain = wasm_cc_toolchain,
     )
-    native.register_toolchains("@{}//:toolchain".format(toolchain_name))
-    native.register_toolchains("@{}//:asterius_toolchain".format(toolchain_name))
-    native.register_toolchains("@{}//:wasm_cc_toolchain".format(toolchain_name))
+    if register:
+        native.register_toolchains("@{}//:toolchain".format(toolchain_name))
+        native.register_toolchains("@{}//:asterius_toolchain".format(toolchain_name))
+        native.register_toolchains("@{}//:wasm_cc_toolchain".format(toolchain_name))
 
 def rules_haskell_asterius_toolchains(
         version = AHC_DEFAULT_VERSION,
         ghcopts = [],
         cabalopts = [],
         repl_ghci_args = [],
-        locale = None):
+        locale = None,
+        register = True):
     """
-    Register Asterius related toolchains for all platforms.
+    Create and (optionally) register Asterius related toolchains for all platforms.
 
     Args:
       version: Asterius version.
@@ -286,6 +290,8 @@ def rules_haskell_asterius_toolchains(
       cabalopts: [see rules_haskell_toolchains](toolchain.html#rules_haskell_toolchains-cabalopts)
       repl_ghci_args: [see rules_haskell_toolchains](toolchain.html#rules_haskell_toolchains-repl_ghci_args)
       locale: [see rules_haskell_toolchains](toolchain.html#rules_haskell_toolchains-locale)
+      register: Whether to register the toolchains (must be set to False if bzlmod is activated)
+
     """
     if not AHC_BINDIST.get(version):
         fail("Binary distribution of Asterius {} not available.".format(version))
@@ -324,6 +330,7 @@ def rules_haskell_asterius_toolchains(
             ghcopts = ghcopts,
             cabalopts = cabalopts,
             locale = locale,
+            register = register,
         )
 
 def asterius_dependencies_bindist(**kwargs):

--- a/haskell/nixpkgs.bzl
+++ b/haskell/nixpkgs.bzl
@@ -214,7 +214,8 @@ def haskell_register_ghc_nixpkgs(
         repository = None,
         nix_file_content = None,
         exec_constraints = None,
-        target_constraints = None):
+        target_constraints = None,
+        register = True):
     """Register a package from Nixpkgs as a toolchain.
 
     Toolchains can be used to compile Haskell code. To have this
@@ -270,6 +271,7 @@ def haskell_register_ghc_nixpkgs(
       repository: Passed to [nixpkgs_package](https://github.com/tweag/rules_nixpkgs#nixpkgs_package-repository)
       sh_posix_attributes: List of attribute paths to extract standard Unix shell tools from.
         Passed to [nixpkgs_sh_posix_configure](https://github.com/tweag/rules_nixpkgs#nixpkgs_sh_posix_configure).
+      register: Whether to register the toolchain (must be set to False if bzlmod is enabled)
     """
     nixpkgs_ghc_repo_name = "{}_ghc_nixpkgs".format(name)
     nixpkgs_sh_posix_repo_name = "{}_sh_posix_nixpkgs".format(name)
@@ -329,7 +331,8 @@ def haskell_register_ghc_nixpkgs(
         target_constraints = target_constraints,
         haskell_toolchain_repo_name = haskell_toolchain_repo_name,
     )
-    native.register_toolchains("@{}//:toolchain".format(toolchain_repo_name))
+    if register:
+        native.register_toolchains("@{}//:toolchain".format(toolchain_repo_name))
 
     # Unix tools toolchain required for Cabal packages
     sh_posix_nixpkgs_kwargs = dict(

--- a/haskell/platforms/list.bzl
+++ b/haskell/platforms/list.bzl
@@ -2,15 +2,15 @@ load("//haskell:private/dict.bzl", "find")
 
 OS = {
     "aix": None,
-    "darwin": "@platforms//os:osx",
+    "darwin": "osx",
     "dragonfly": None,
-    "freebsd": "@platforms//os:freebsd",
+    "freebsd": "freebsd",
     "haiku": None,
     "hpux": None,
-    "ios": "@platforms//os:ios",
-    "linux_android": "@platforms//os:android",
-    "linux": "@platforms//os:linux",
-    "mingw32": "@platforms//os:windows",
+    "ios": "ios",
+    "linux_android": "android",
+    "linux": "linux",
+    "mingw32": "windows",
     "netbsd": None,
     "openbsd": None,
     "solaris2": None,
@@ -19,16 +19,16 @@ OS = {
 ARCH = {
     "aarch64": None,
     "alpha": None,
-    "arm64": "@platforms//cpu:aarch64",
-    "arm": "@platforms//cpu:arm",
-    "i386": "@platforms//cpu:x86_32",
+    "arm64": "aarch64",
+    "arm": "arm",
+    "i386": "x86_32",
     "ia64": None,
     "powerpc64": None,
     "powerpc64le": None,
-    "powerpc": "@platforms//cpu:ppc",
+    "powerpc": "ppc",
     "rs6000": None,
     "sparc": None,
-    "x86_64": "@platforms//cpu:x86_64",
+    "x86_64": "x86_64",
 }
 
 def declare_config_settings():
@@ -36,14 +36,14 @@ def declare_config_settings():
         if constraint_value:
             native.config_setting(
                 name = os,
-                constraint_values = [constraint_value],
+                constraint_values = ["@platforms//os:{}".format(constraint_value)],
                 visibility = ["//visibility:public"],
             )
     for arch, constraint_value in ARCH.items():
         if constraint_value:
             native.config_setting(
                 name = arch,
-                constraint_values = [constraint_value],
+                constraint_values = ["@platforms//cpu:{}".format(constraint_value)],
                 visibility = ["//visibility:public"],
             )
 
@@ -53,7 +53,7 @@ def os_of_constraints(constraints):
     """
     for c in constraints:
         if c.package == "os":
-            return find(OS, str(c))
+            return find(OS, c.name)
 
 def arch_of_constraints(constraints):
     """ Returns the architecture corresponding to the first arch constraint.
@@ -61,7 +61,7 @@ def arch_of_constraints(constraints):
     """
     for c in constraints:
         if c.package == "cpu":
-            return find(ARCH, str(c))
+            return find(ARCH, c.name)
 
 def platform_of_constraints(constraints):
     os = os_of_constraints(constraints)

--- a/haskell/private/pkg_id.bzl
+++ b/haskell/private/pkg_id.bzl
@@ -9,7 +9,7 @@ def _zencode(s):
     Args:
       s: string
     """
-    return s.replace("Z", "ZZ").replace("_", "ZU").replace("/", "ZS")
+    return s.replace("Z", "ZZ").replace("_", "ZU").replace("/", "ZS").replace("~", "z7eU")
 
 def _to_string(my_pkg_id):
     """Get a globally unique package identifier.

--- a/haskell/private/runghc.bzl
+++ b/haskell/private/runghc.bzl
@@ -26,7 +26,7 @@ def _runghc_wrapper_impl(ctx):
 
 import subprocess
 import sys
-from rules_python.python.runfiles import runfiles
+from python.runfiles import runfiles
 
 r = runfiles.Create()
 


### PR DESCRIPTION
This PR contains some changes in preparation for bzlmod support.

### Repository rules
Under `bzlmod` repository rules cannot register toolchains (this has to be done in the `MODULE.bazel` file). So some of them are updated with an extra `register` parameter to optionally disable the registration.


### Workspace names
Under `bzlmod` folders for external repositories have a different (mangled) name. So these changes were needed:

- In the following directive `from rules_python.python.runfiles import runfiles`, the `rules_python` prefix corresponds to the repository folder which can now have a different name. But the `python` module can be accessed directly (See [rules_python example](https://github.com/bazelbuild/rules_python/blob/main/tests/runfiles/runfiles_test.py#L20))

- These mangled repository names includes  tilde symbols so this case was added to the `_zencode` function.

- The `platform_of_constraints` function was comparing stringified labels which contain these non predictable workspace names. So it was modified to only use label names.

