### PR TITLE
Add GHC bindist version 9.4.5 and 9.6.1

### DIFF
--- a/.github/workflows/patch-test.yaml
+++ b/.github/workflows/patch-test.yaml
@@ -29,6 +29,10 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-11, windows-latest]
         ghc-version: ${{ fromJSON(needs.find-ghc-version.outputs.ghc-matrix) }}
+        exclude:
+          # skip GHC 9.4.5 on windows, see https://github.com/tweag/rules_haskell/issues/1892
+          - os: windows-latest
+            ghc-version: '9.4.5'
     runs-on: ${{ matrix.os }}
     steps:
       - name: Install required packages

--- a/.github/workflows/patch-test.yaml
+++ b/.github/workflows/patch-test.yaml
@@ -3,6 +3,7 @@ on:
   push:
     paths:
     - 'haskell/ghc_bindist.bzl'
+    - 'haskell/private/ghc_bindist_generated.bzl'
     - 'haskell/assets/**'
   workflow_dispatch:
 env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 * Add support for Bazel 6
 * The provided `cc_toolchain` used for windows can now be used with `--incompatible_enable_cc_toolchain_resolution` so using the `crosstool_top` option is no longer necessary.
 * Add support for GHC 9.2.5 (see [#1869])
+* Add support for GHC 9.4.5 (linux, macOS) and GHC 9.6.1 (see [#1890])
+
+[#1890]: https://github.com/tweag/rules_haskell/pull/1890
 
 ### Removed
 

--- a/haskell/assets/ghc_9_4_5_win.patch
+++ b/haskell/assets/ghc_9_4_5_win.patch
@@ -1,0 +1,379 @@
+--- lib/package.conf.d/Cabal-3.8.1.0.conf
++++ lib/package.conf.d/Cabal-3.8.1.0.conf
+@@ -252,6 +252,6 @@ depends:
+     transformers-0.5.6.2
+ 
+ haddock-interfaces:
+-    ${pkgroot}/../../doc/html/libraries/Cabal-3.8.1.0\Cabal.haddock
++    ${pkgroot}/../doc/html/libraries/Cabal-3.8.1.0\Cabal.haddock
+ 
+-haddock-html:         ${pkgroot}/../../doc/html/libraries/Cabal-3.8.1.0
++haddock-html:         ${pkgroot}/../doc/html/libraries/Cabal-3.8.1.0
+--- lib/package.conf.d/Cabal-syntax-3.8.1.0.conf
++++ lib/package.conf.d/Cabal-syntax-3.8.1.0.conf
+@@ -116,6 +116,6 @@ depends:
+     pretty-1.1.3.6 text-2.0.2 time-1.12.2 transformers-0.5.6.2
+ 
+ haddock-interfaces:
+-    ${pkgroot}/../../doc/html/libraries/Cabal-syntax-3.8.1.0\Cabal-syntax.haddock
++    ${pkgroot}/../doc/html/libraries/Cabal-syntax-3.8.1.0\Cabal-syntax.haddock
+ 
+-haddock-html:         ${pkgroot}/../../doc/html/libraries/Cabal-syntax-3.8.1.0
++haddock-html:         ${pkgroot}/../doc/html/libraries/Cabal-syntax-3.8.1.0
+--- lib/package.conf.d/Win32-2.12.0.1.conf
++++ lib/package.conf.d/Win32-2.12.0.1.conf
+@@ -63,6 +63,6 @@ includes:
+ 
+ depends:              base-4.17.1.0 filepath-1.4.2.2
+ haddock-interfaces:
+-    ${pkgroot}/../../doc/html/libraries/Win32-2.12.0.1\Win32.haddock
++    ${pkgroot}/../doc/html/libraries/Win32-2.12.0.1\Win32.haddock
+ 
+-haddock-html:         ${pkgroot}/../../doc/html/libraries/Win32-2.12.0.1
++haddock-html:         ${pkgroot}/../doc/html/libraries/Win32-2.12.0.1
+--- lib/package.conf.d/array-0.5.4.0.conf
++++ lib/package.conf.d/array-0.5.4.0.conf
+@@ -30,6 +30,6 @@ data-dir:             ${pkgroot}\x86_64-windows-ghc-9.4.5\array-0.5.4.0
+ hs-libraries:         HSarray-0.5.4.0
+ depends:              base-4.17.1.0
+ haddock-interfaces:
+-    ${pkgroot}/../../doc/html/libraries/array-0.5.4.0\array.haddock
++    ${pkgroot}/../doc/html/libraries/array-0.5.4.0\array.haddock
+ 
+-haddock-html:         ${pkgroot}/../../doc/html/libraries/array-0.5.4.0
++haddock-html:         ${pkgroot}/../doc/html/libraries/array-0.5.4.0
+--- lib/package.conf.d/base-4.17.1.0.conf
++++ lib/package.conf.d/base-4.17.1.0.conf
+@@ -116,6 +116,6 @@ include-dirs:         ${pkgroot}\x86_64-windows-ghc-9.4.5\base-4.17.1.0\include
+ includes:             HsBase.h
+ depends:              ghc-bignum-1.3 ghc-prim-0.9.0 rts-1.0.2
+ haddock-interfaces:
+-    ${pkgroot}/../../doc/html/libraries/base-4.17.1.0\base.haddock
++    ${pkgroot}/../doc/html/libraries/base-4.17.1.0\base.haddock
+ 
+-haddock-html:         ${pkgroot}/../../doc/html/libraries/base-4.17.1.0
++haddock-html:         ${pkgroot}/../doc/html/libraries/base-4.17.1.0
+--- lib/package.conf.d/binary-0.8.9.1.conf
++++ lib/package.conf.d/binary-0.8.9.1.conf
+@@ -41,6 +41,6 @@ depends:
+     array-0.5.4.0 base-4.17.1.0 bytestring-0.11.4.0 containers-0.6.7
+ 
+ haddock-interfaces:
+-    ${pkgroot}/../../doc/html/libraries/binary-0.8.9.1\binary.haddock
++    ${pkgroot}/../doc/html/libraries/binary-0.8.9.1\binary.haddock
+ 
+-haddock-html:         ${pkgroot}/../../doc/html/libraries/binary-0.8.9.1
++haddock-html:         ${pkgroot}/../doc/html/libraries/binary-0.8.9.1
+--- lib/package.conf.d/bytestring-0.11.4.0.conf
++++ lib/package.conf.d/bytestring-0.11.4.0.conf
+@@ -99,6 +99,6 @@ depends:
+     template-haskell-2.19.0.0
+ 
+ haddock-interfaces:
+-    ${pkgroot}/../../doc/html/libraries/bytestring-0.11.4.0\bytestring.haddock
++    ${pkgroot}/../doc/html/libraries/bytestring-0.11.4.0\bytestring.haddock
+ 
+-haddock-html:         ${pkgroot}/../../doc/html/libraries/bytestring-0.11.4.0
++haddock-html:         ${pkgroot}/../doc/html/libraries/bytestring-0.11.4.0
+--- lib/package.conf.d/containers-0.6.7.conf
++++ lib/package.conf.d/containers-0.6.7.conf
+@@ -53,6 +53,6 @@ depends:
+     template-haskell-2.19.0.0
+ 
+ haddock-interfaces:
+-    ${pkgroot}/../../doc/html/libraries/containers-0.6.7\containers.haddock
++    ${pkgroot}/../doc/html/libraries/containers-0.6.7\containers.haddock
+ 
+-haddock-html:         ${pkgroot}/../../doc/html/libraries/containers-0.6.7
++haddock-html:         ${pkgroot}/../doc/html/libraries/containers-0.6.7
+--- lib/package.conf.d/deepseq-1.4.8.0.conf
++++ lib/package.conf.d/deepseq-1.4.8.0.conf
+@@ -33,6 +33,6 @@ data-dir:             ${pkgroot}\x86_64-windows-ghc-9.4.5\deepseq-1.4.8.0
+ hs-libraries:         HSdeepseq-1.4.8.0
+ depends:              array-0.5.4.0 base-4.17.1.0 ghc-prim-0.9.0
+ haddock-interfaces:
+-    ${pkgroot}/../../doc/html/libraries/deepseq-1.4.8.0\deepseq.haddock
++    ${pkgroot}/../doc/html/libraries/deepseq-1.4.8.0\deepseq.haddock
+ 
+-haddock-html:         ${pkgroot}/../../doc/html/libraries/deepseq-1.4.8.0
++haddock-html:         ${pkgroot}/../doc/html/libraries/deepseq-1.4.8.0
+--- lib/package.conf.d/directory-1.3.7.1.conf
++++ lib/package.conf.d/directory-1.3.7.1.conf
+@@ -31,6 +31,6 @@ depends:
+     Win32-2.12.0.1 base-4.17.1.0 filepath-1.4.2.2 time-1.12.2
+ 
+ haddock-interfaces:
+-    ${pkgroot}/../../doc/html/libraries/directory-1.3.7.1\directory.haddock
++    ${pkgroot}/../doc/html/libraries/directory-1.3.7.1\directory.haddock
+ 
+-haddock-html:         ${pkgroot}/../../doc/html/libraries/directory-1.3.7.1
++haddock-html:         ${pkgroot}/../doc/html/libraries/directory-1.3.7.1
+--- lib/package.conf.d/exceptions-0.10.5.conf
++++ lib/package.conf.d/exceptions-0.10.5.conf
+@@ -28,6 +28,6 @@ depends:
+     transformers-0.5.6.2
+ 
+ haddock-interfaces:
+-    ${pkgroot}/../../doc/html/libraries/exceptions-0.10.5\exceptions.haddock
++    ${pkgroot}/../doc/html/libraries/exceptions-0.10.5\exceptions.haddock
+ 
+-haddock-html:         ${pkgroot}/../../doc/html/libraries/exceptions-0.10.5
++haddock-html:         ${pkgroot}/../doc/html/libraries/exceptions-0.10.5
+--- lib/package.conf.d/filepath-1.4.2.2.conf
++++ lib/package.conf.d/filepath-1.4.2.2.conf
+@@ -33,6 +33,6 @@ data-dir:             ${pkgroot}\x86_64-windows-ghc-9.4.5\filepath-1.4.2.2
+ hs-libraries:         HSfilepath-1.4.2.2
+ depends:              base-4.17.1.0
+ haddock-interfaces:
+-    ${pkgroot}/../../doc/html/libraries/filepath-1.4.2.2\filepath.haddock
++    ${pkgroot}/../doc/html/libraries/filepath-1.4.2.2\filepath.haddock
+ 
+-haddock-html:         ${pkgroot}/../../doc/html/libraries/filepath-1.4.2.2
++haddock-html:         ${pkgroot}/../doc/html/libraries/filepath-1.4.2.2
+--- lib/package.conf.d/ghc-9.4.5.conf
++++ lib/package.conf.d/ghc-9.4.5.conf
+@@ -265,5 +265,5 @@ depends:
+     ghc-heap-9.4.5 ghci-9.4.5 hpc-0.6.1.0 process-1.6.16.0 stm-2.5.1.0
+     template-haskell-2.19.0.0 time-1.12.2 transformers-0.5.6.2
+ 
+-haddock-interfaces:   ${pkgroot}/../../doc/html/libraries/ghc-9.4.5\ghc.haddock
+-haddock-html:         ${pkgroot}/../../doc/html/libraries/ghc-9.4.5
++haddock-interfaces:   ${pkgroot}/../doc/html/libraries/ghc-9.4.5\ghc.haddock
++haddock-html:         ${pkgroot}/../doc/html/libraries/ghc-9.4.5
+--- lib/package.conf.d/ghc-bignum-1.3.conf
++++ lib/package.conf.d/ghc-bignum-1.3.conf
+@@ -28,6 +28,6 @@ hs-libraries:         HSghc-bignum-1.3
+ include-dirs:         ${pkgroot}\x86_64-windows-ghc-9.4.5\ghc-bignum-1.3\include
+ depends:              ghc-prim-0.9.0
+ haddock-interfaces:
+-    ${pkgroot}/../../doc/html/libraries/ghc-bignum-1.3\ghc-bignum.haddock
++    ${pkgroot}/../doc/html/libraries/ghc-bignum-1.3\ghc-bignum.haddock
+ 
+-haddock-html:         ${pkgroot}/../../doc/html/libraries/ghc-bignum-1.3
++haddock-html:         ${pkgroot}/../doc/html/libraries/ghc-bignum-1.3
+--- lib/package.conf.d/ghc-boot-9.4.5.conf
++++ lib/package.conf.d/ghc-boot-9.4.5.conf
+@@ -45,6 +45,6 @@ depends:
+     ghc-boot-th-9.4.5
+ 
+ haddock-interfaces:
+-    ${pkgroot}/../../doc/html/libraries/ghc-boot-9.4.5\ghc-boot.haddock
++    ${pkgroot}/../doc/html/libraries/ghc-boot-9.4.5\ghc-boot.haddock
+ 
+-haddock-html:         ${pkgroot}/../../doc/html/libraries/ghc-boot-9.4.5
++haddock-html:         ${pkgroot}/../doc/html/libraries/ghc-boot-9.4.5
+--- lib/package.conf.d/ghc-boot-th-9.4.5.conf
++++ lib/package.conf.d/ghc-boot-th-9.4.5.conf
+@@ -30,6 +30,6 @@ data-dir:             ${pkgroot}\x86_64-windows-ghc-9.4.5\ghc-boot-th-9.4.5
+ hs-libraries:         HSghc-boot-th-9.4.5
+ depends:              base-4.17.1.0
+ haddock-interfaces:
+-    ${pkgroot}/../../doc/html/libraries/ghc-boot-th-9.4.5\ghc-boot-th.haddock
++    ${pkgroot}/../doc/html/libraries/ghc-boot-th-9.4.5\ghc-boot-th.haddock
+ 
+-haddock-html:         ${pkgroot}/../../doc/html/libraries/ghc-boot-th-9.4.5
++haddock-html:         ${pkgroot}/../doc/html/libraries/ghc-boot-th-9.4.5
+--- lib/package.conf.d/ghc-compact-0.1.0.0.conf
++++ lib/package.conf.d/ghc-compact-0.1.0.0.conf
+@@ -31,6 +31,6 @@ data-dir:             ${pkgroot}\x86_64-windows-ghc-9.4.5\ghc-compact-0.1.0.0
+ hs-libraries:         HSghc-compact-0.1.0.0
+ depends:              base-4.17.1.0 bytestring-0.11.4.0 ghc-prim-0.9.0
+ haddock-interfaces:
+-    ${pkgroot}/../../doc/html/libraries/ghc-compact-0.1.0.0\ghc-compact.haddock
++    ${pkgroot}/../doc/html/libraries/ghc-compact-0.1.0.0\ghc-compact.haddock
+ 
+-haddock-html:         ${pkgroot}/../../doc/html/libraries/ghc-compact-0.1.0.0
++haddock-html:         ${pkgroot}/../doc/html/libraries/ghc-compact-0.1.0.0
+--- lib/package.conf.d/ghc-heap-9.4.5.conf
++++ lib/package.conf.d/ghc-heap-9.4.5.conf
+@@ -33,6 +33,6 @@ depends:
+     base-4.17.1.0 containers-0.6.7 ghc-prim-0.9.0 rts-1.0.2
+ 
+ haddock-interfaces:
+-    ${pkgroot}/../../doc/html/libraries/ghc-heap-9.4.5\ghc-heap.haddock
++    ${pkgroot}/../doc/html/libraries/ghc-heap-9.4.5\ghc-heap.haddock
+ 
+-haddock-html:         ${pkgroot}/../../doc/html/libraries/ghc-heap-9.4.5
++haddock-html:         ${pkgroot}/../doc/html/libraries/ghc-heap-9.4.5
+--- lib/package.conf.d/ghc-prim-0.9.0.conf
++++ lib/package.conf.d/ghc-prim-0.9.0.conf
+@@ -25,6 +25,6 @@ hs-libraries:         HSghc-prim-0.9.0
+ extra-libraries:      user32 mingw32 ucrt
+ depends:              rts-1.0.2
+ haddock-interfaces:
+-    ${pkgroot}/../../doc/html/libraries/ghc-prim-0.9.0\ghc-prim.haddock
++    ${pkgroot}/../doc/html/libraries/ghc-prim-0.9.0\ghc-prim.haddock
+ 
+-haddock-html:         ${pkgroot}/../../doc/html/libraries/ghc-prim-0.9.0
++haddock-html:         ${pkgroot}/../doc/html/libraries/ghc-prim-0.9.0
+--- lib/package.conf.d/ghci-9.4.5.conf
++++ lib/package.conf.d/ghci-9.4.5.conf
+@@ -31,5 +31,5 @@ depends:
+     ghc-heap-9.4.5 ghc-prim-0.9.0 rts-1.0.2 template-haskell-2.19.0.0
+     transformers-0.5.6.2
+ 
+-haddock-interfaces:   ${pkgroot}/../../doc/html/libraries/ghci-9.4.5\ghci.haddock
+-haddock-html:         ${pkgroot}/../../doc/html/libraries/ghci-9.4.5
++haddock-interfaces:   ${pkgroot}/../doc/html/libraries/ghci-9.4.5\ghci.haddock
++haddock-html:         ${pkgroot}/../doc/html/libraries/ghci-9.4.5
+--- lib/package.conf.d/haskeline-0.8.2.conf
++++ lib/package.conf.d/haskeline-0.8.2.conf
+@@ -57,6 +57,6 @@ depends:
+     process-1.6.16.0 stm-2.5.1.0 transformers-0.5.6.2
+ 
+ haddock-interfaces:
+-    ${pkgroot}/../../doc/html/libraries/haskeline-0.8.2\haskeline.haddock
++    ${pkgroot}/../doc/html/libraries/haskeline-0.8.2\haskeline.haddock
+ 
+-haddock-html:         ${pkgroot}/../../doc/html/libraries/haskeline-0.8.2
++haddock-html:         ${pkgroot}/../doc/html/libraries/haskeline-0.8.2
+--- lib/package.conf.d/hpc-0.6.1.0.conf
++++ lib/package.conf.d/hpc-0.6.1.0.conf
+@@ -28,5 +28,5 @@ depends:
+     base-4.17.1.0 containers-0.6.7 deepseq-1.4.8.0 directory-1.3.7.1
+     filepath-1.4.2.2 time-1.12.2
+ 
+-haddock-interfaces:   ${pkgroot}/../../doc/html/libraries/hpc-0.6.1.0\hpc.haddock
+-haddock-html:         ${pkgroot}/../../doc/html/libraries/hpc-0.6.1.0
++haddock-interfaces:   ${pkgroot}/../doc/html/libraries/hpc-0.6.1.0\hpc.haddock
++haddock-html:         ${pkgroot}/../doc/html/libraries/hpc-0.6.1.0
+--- lib/package.conf.d/integer-gmp-1.1.conf
++++ lib/package.conf.d/integer-gmp-1.1.conf
+@@ -29,6 +29,6 @@ data-dir:             ${pkgroot}\x86_64-windows-ghc-9.4.5\integer-gmp-1.1
+ hs-libraries:         HSinteger-gmp-1.1
+ depends:              base-4.17.1.0 ghc-bignum-1.3 ghc-prim-0.9.0
+ haddock-interfaces:
+-    ${pkgroot}/../../doc/html/libraries/integer-gmp-1.1\integer-gmp.haddock
++    ${pkgroot}/../doc/html/libraries/integer-gmp-1.1\integer-gmp.haddock
+ 
+-haddock-html:         ${pkgroot}/../../doc/html/libraries/integer-gmp-1.1
++haddock-html:         ${pkgroot}/../doc/html/libraries/integer-gmp-1.1
+--- lib/package.conf.d/libiserv-9.4.5.conf
++++ lib/package.conf.d/libiserv-9.4.5.conf
+@@ -27,6 +27,6 @@ depends:
+     deepseq-1.4.8.0 ghci-9.4.5
+ 
+ haddock-interfaces:
+-    ${pkgroot}/../../doc/html/libraries/libiserv-9.4.5\libiserv.haddock
++    ${pkgroot}/../doc/html/libraries/libiserv-9.4.5\libiserv.haddock
+ 
+-haddock-html:         ${pkgroot}/../../doc/html/libraries/libiserv-9.4.5
++haddock-html:         ${pkgroot}/../doc/html/libraries/libiserv-9.4.5
+--- lib/package.conf.d/mtl-2.2.2.conf
++++ lib/package.conf.d/mtl-2.2.2.conf
+@@ -36,5 +36,5 @@ dynamic-library-dirs: ${pkgroot}\x86_64-windows-ghc-9.4.5
+ data-dir:             ${pkgroot}\x86_64-windows-ghc-9.4.5\mtl-2.2.2
+ hs-libraries:         HSmtl-2.2.2
+ depends:              base-4.17.1.0 transformers-0.5.6.2
+-haddock-interfaces:   ${pkgroot}/../../doc/html/libraries/mtl-2.2.2\mtl.haddock
+-haddock-html:         ${pkgroot}/../../doc/html/libraries/mtl-2.2.2
++haddock-interfaces:   ${pkgroot}/../doc/html/libraries/mtl-2.2.2\mtl.haddock
++haddock-html:         ${pkgroot}/../doc/html/libraries/mtl-2.2.2
+--- lib/package.conf.d/parsec-3.1.16.1.conf
++++ lib/package.conf.d/parsec-3.1.16.1.conf
+@@ -55,6 +55,6 @@ depends:
+     base-4.17.1.0 bytestring-0.11.4.0 mtl-2.2.2 text-2.0.2
+ 
+ haddock-interfaces:
+-    ${pkgroot}/../../doc/html/libraries/parsec-3.1.16.1\parsec.haddock
++    ${pkgroot}/../doc/html/libraries/parsec-3.1.16.1\parsec.haddock
+ 
+-haddock-html:         ${pkgroot}/../../doc/html/libraries/parsec-3.1.16.1
++haddock-html:         ${pkgroot}/../doc/html/libraries/parsec-3.1.16.1
+--- lib/package.conf.d/pretty-1.1.3.6.conf
++++ lib/package.conf.d/pretty-1.1.3.6.conf
+@@ -33,6 +33,6 @@ data-dir:             ${pkgroot}\x86_64-windows-ghc-9.4.5\pretty-1.1.3.6
+ hs-libraries:         HSpretty-1.1.3.6
+ depends:              base-4.17.1.0 deepseq-1.4.8.0 ghc-prim-0.9.0
+ haddock-interfaces:
+-    ${pkgroot}/../../doc/html/libraries/pretty-1.1.3.6\pretty.haddock
++    ${pkgroot}/../doc/html/libraries/pretty-1.1.3.6\pretty.haddock
+ 
+-haddock-html:         ${pkgroot}/../../doc/html/libraries/pretty-1.1.3.6
++haddock-html:         ${pkgroot}/../doc/html/libraries/pretty-1.1.3.6
+--- lib/package.conf.d/process-1.6.16.0.conf
++++ lib/package.conf.d/process-1.6.16.0.conf
+@@ -35,6 +35,6 @@ depends:
+     filepath-1.4.2.2
+ 
+ haddock-interfaces:
+-    ${pkgroot}/../../doc/html/libraries/process-1.6.16.0\process.haddock
++    ${pkgroot}/../doc/html/libraries/process-1.6.16.0\process.haddock
+ 
+-haddock-html:         ${pkgroot}/../../doc/html/libraries/process-1.6.16.0
++haddock-html:         ${pkgroot}/../doc/html/libraries/process-1.6.16.0
+--- lib/package.conf.d/rts-1.0.2.conf
++++ lib/package.conf.d/rts-1.0.2.conf
+@@ -79,5 +79,5 @@ ld-options:
+     "-Wl,-u,base_GHCziStackziCloneStack_StackSnapshot_closure"
+     "-Wl,-u,base_GHCziEventziWindows_processRemoteCompletion_closure"
+ 
+-haddock-interfaces:   ${pkgroot}/../../doc/html/libraries/rts-1.0.2\rts.haddock
+-haddock-html:         ${pkgroot}/../../doc/html/libraries/rts-1.0.2
++haddock-interfaces:   ${pkgroot}/../doc/html/libraries/rts-1.0.2\rts.haddock
++haddock-html:         ${pkgroot}/../doc/html/libraries/rts-1.0.2
+--- lib/package.conf.d/stm-2.5.1.0.conf
++++ lib/package.conf.d/stm-2.5.1.0.conf
+@@ -34,5 +34,5 @@ dynamic-library-dirs: ${pkgroot}\x86_64-windows-ghc-9.4.5
+ data-dir:             ${pkgroot}\x86_64-windows-ghc-9.4.5\stm-2.5.1.0
+ hs-libraries:         HSstm-2.5.1.0
+ depends:              array-0.5.4.0 base-4.17.1.0
+-haddock-interfaces:   ${pkgroot}/../../doc/html/libraries/stm-2.5.1.0\stm.haddock
+-haddock-html:         ${pkgroot}/../../doc/html/libraries/stm-2.5.1.0
++haddock-interfaces:   ${pkgroot}/../doc/html/libraries/stm-2.5.1.0\stm.haddock
++haddock-html:         ${pkgroot}/../doc/html/libraries/stm-2.5.1.0
+--- lib/package.conf.d/template-haskell-2.19.0.0.conf
++++ lib/package.conf.d/template-haskell-2.19.0.0.conf
+@@ -42,7 +42,7 @@ depends:
+     base-4.17.1.0 ghc-boot-th-9.4.5 ghc-prim-0.9.0 pretty-1.1.3.6
+ 
+ haddock-interfaces:
+-    ${pkgroot}/../../doc/html/libraries/template-haskell-2.19.0.0\template-haskell.haddock
++    ${pkgroot}/../doc/html/libraries/template-haskell-2.19.0.0\template-haskell.haddock
+ 
+ haddock-html:
+-    ${pkgroot}/../../doc/html/libraries/template-haskell-2.19.0.0
++    ${pkgroot}/../doc/html/libraries/template-haskell-2.19.0.0
+--- lib/package.conf.d/text-2.0.2.conf
++++ lib/package.conf.d/text-2.0.2.conf
+@@ -84,5 +84,5 @@ depends:
+     array-0.5.4.0 base-4.17.1.0 binary-0.8.9.1 bytestring-0.11.4.0
+     deepseq-1.4.8.0 ghc-prim-0.9.0 template-haskell-2.19.0.0
+ 
+-haddock-interfaces:   ${pkgroot}/../../doc/html/libraries/text-2.0.2\text.haddock
+-haddock-html:         ${pkgroot}/../../doc/html/libraries/text-2.0.2
++haddock-interfaces:   ${pkgroot}/../doc/html/libraries/text-2.0.2\text.haddock
++haddock-html:         ${pkgroot}/../doc/html/libraries/text-2.0.2
+--- lib/package.conf.d/time-1.12.2.conf
++++ lib/package.conf.d/time-1.12.2.conf
+@@ -52,6 +52,6 @@ hs-libraries:         HStime-1.12.2
+ include-dirs:         ${pkgroot}\x86_64-windows-ghc-9.4.5\time-1.12.2\include
+ depends:              Win32-2.12.0.1 base-4.17.1.0 deepseq-1.4.8.0
+ haddock-interfaces:
+-    ${pkgroot}/../../doc/html/libraries/time-1.12.2\time.haddock
++    ${pkgroot}/../doc/html/libraries/time-1.12.2\time.haddock
+ 
+-haddock-html:         ${pkgroot}/../../doc/html/libraries/time-1.12.2
++haddock-html:         ${pkgroot}/../doc/html/libraries/time-1.12.2
+--- lib/package.conf.d/transformers-0.5.6.2.conf
++++ lib/package.conf.d/transformers-0.5.6.2.conf
+@@ -56,6 +56,6 @@ data-dir:             ${pkgroot}\x86_64-windows-ghc-9.4.5\transformers-0.5.6.2
+ hs-libraries:         HStransformers-0.5.6.2
+ depends:              base-4.17.1.0
+ haddock-interfaces:
+-    ${pkgroot}/../../doc/html/libraries/transformers-0.5.6.2\transformers.haddock
++    ${pkgroot}/../doc/html/libraries/transformers-0.5.6.2\transformers.haddock
+ 
+-haddock-html:         ${pkgroot}/../../doc/html/libraries/transformers-0.5.6.2
++haddock-html:         ${pkgroot}/../doc/html/libraries/transformers-0.5.6.2
+--- lib/package.conf.d/xhtml-3000.2.2.1.conf
++++ lib/package.conf.d/xhtml-3000.2.2.1.conf
+@@ -38,6 +38,6 @@ data-dir:             ${pkgroot}\x86_64-windows-ghc-9.4.5\xhtml-3000.2.2.1
+ hs-libraries:         HSxhtml-3000.2.2.1
+ depends:              base-4.17.1.0
+ haddock-interfaces:
+-    ${pkgroot}/../../doc/html/libraries/xhtml-3000.2.2.1\xhtml.haddock
++    ${pkgroot}/../doc/html/libraries/xhtml-3000.2.2.1\xhtml.haddock
+ 
+-haddock-html:         ${pkgroot}/../../doc/html/libraries/xhtml-3000.2.2.1
++haddock-html:         ${pkgroot}/../doc/html/libraries/xhtml-3000.2.2.1

--- a/haskell/assets/ghc_9_6_1_win.patch
+++ b/haskell/assets/ghc_9_6_1_win.patch
@@ -1,0 +1,379 @@
+--- lib/package.conf.d/Cabal-3.10.1.0.conf
++++ lib/package.conf.d/Cabal-3.10.1.0.conf
+@@ -256,6 +256,6 @@ depends:
+     transformers-0.6.1.0
+ 
+ haddock-interfaces:
+-    ${pkgroot}/../../doc/html/libraries/Cabal-3.10.1.0\Cabal.haddock
++    ${pkgroot}/../doc/html/libraries/Cabal-3.10.1.0\Cabal.haddock
+ 
+-haddock-html:         ${pkgroot}/../../doc/html/libraries/Cabal-3.10.1.0
++haddock-html:         ${pkgroot}/../doc/html/libraries/Cabal-3.10.1.0
+--- lib/package.conf.d/Cabal-syntax-3.10.1.0.conf
++++ lib/package.conf.d/Cabal-syntax-3.10.1.0.conf
+@@ -117,6 +117,6 @@ depends:
+     pretty-1.1.3.6 text-2.0.2 time-1.12.2 transformers-0.6.1.0
+ 
+ haddock-interfaces:
+-    ${pkgroot}/../../doc/html/libraries/Cabal-syntax-3.10.1.0\Cabal-syntax.haddock
++    ${pkgroot}/../doc/html/libraries/Cabal-syntax-3.10.1.0\Cabal-syntax.haddock
+ 
+-haddock-html:         ${pkgroot}/../../doc/html/libraries/Cabal-syntax-3.10.1.0
++haddock-html:         ${pkgroot}/../doc/html/libraries/Cabal-syntax-3.10.1.0
+--- lib/package.conf.d/Win32-2.13.3.0.conf
++++ lib/package.conf.d/Win32-2.13.3.0.conf
+@@ -79,6 +79,6 @@ includes:
+ 
+ depends:              base-4.18.0.0 filepath-1.4.100.1
+ haddock-interfaces:
+-    ${pkgroot}/../../doc/html/libraries/Win32-2.13.3.0\Win32.haddock
++    ${pkgroot}/../doc/html/libraries/Win32-2.13.3.0\Win32.haddock
+ 
+-haddock-html:         ${pkgroot}/../../doc/html/libraries/Win32-2.13.3.0
++haddock-html:         ${pkgroot}/../doc/html/libraries/Win32-2.13.3.0
+--- lib/package.conf.d/array-0.5.5.0.conf
++++ lib/package.conf.d/array-0.5.5.0.conf
+@@ -31,6 +31,6 @@ data-dir:             ${pkgroot}\x86_64-windows-ghc-9.6.1\array-0.5.5.0
+ hs-libraries:         HSarray-0.5.5.0
+ depends:              base-4.18.0.0
+ haddock-interfaces:
+-    ${pkgroot}/../../doc/html/libraries/array-0.5.5.0\array.haddock
++    ${pkgroot}/../doc/html/libraries/array-0.5.5.0\array.haddock
+ 
+-haddock-html:         ${pkgroot}/../../doc/html/libraries/array-0.5.5.0
++haddock-html:         ${pkgroot}/../doc/html/libraries/array-0.5.5.0
+--- lib/package.conf.d/base-4.18.0.0.conf
++++ lib/package.conf.d/base-4.18.0.0.conf
+@@ -125,6 +125,6 @@ include-dirs:         ${pkgroot}\x86_64-windows-ghc-9.6.1\base-4.18.0.0\include
+ includes:             HsBase.h
+ depends:              ghc-bignum-1.3 ghc-prim-0.10.0 rts-1.0.2
+ haddock-interfaces:
+-    ${pkgroot}/../../doc/html/libraries/base-4.18.0.0\base.haddock
++    ${pkgroot}/../doc/html/libraries/base-4.18.0.0\base.haddock
+ 
+-haddock-html:         ${pkgroot}/../../doc/html/libraries/base-4.18.0.0
++haddock-html:         ${pkgroot}/../doc/html/libraries/base-4.18.0.0
+--- lib/package.conf.d/binary-0.8.9.1.conf
++++ lib/package.conf.d/binary-0.8.9.1.conf
+@@ -42,6 +42,6 @@ depends:
+     array-0.5.5.0 base-4.18.0.0 bytestring-0.11.4.0 containers-0.6.7
+ 
+ haddock-interfaces:
+-    ${pkgroot}/../../doc/html/libraries/binary-0.8.9.1\binary.haddock
++    ${pkgroot}/../doc/html/libraries/binary-0.8.9.1\binary.haddock
+ 
+-haddock-html:         ${pkgroot}/../../doc/html/libraries/binary-0.8.9.1
++haddock-html:         ${pkgroot}/../doc/html/libraries/binary-0.8.9.1
+--- lib/package.conf.d/bytestring-0.11.4.0.conf
++++ lib/package.conf.d/bytestring-0.11.4.0.conf
+@@ -100,6 +100,6 @@ depends:
+     template-haskell-2.20.0.0
+ 
+ haddock-interfaces:
+-    ${pkgroot}/../../doc/html/libraries/bytestring-0.11.4.0\bytestring.haddock
++    ${pkgroot}/../doc/html/libraries/bytestring-0.11.4.0\bytestring.haddock
+ 
+-haddock-html:         ${pkgroot}/../../doc/html/libraries/bytestring-0.11.4.0
++haddock-html:         ${pkgroot}/../doc/html/libraries/bytestring-0.11.4.0
+--- lib/package.conf.d/containers-0.6.7.conf
++++ lib/package.conf.d/containers-0.6.7.conf
+@@ -55,6 +55,6 @@ depends:
+     template-haskell-2.20.0.0
+ 
+ haddock-interfaces:
+-    ${pkgroot}/../../doc/html/libraries/containers-0.6.7\containers.haddock
++    ${pkgroot}/../doc/html/libraries/containers-0.6.7\containers.haddock
+ 
+-haddock-html:         ${pkgroot}/../../doc/html/libraries/containers-0.6.7
++haddock-html:         ${pkgroot}/../doc/html/libraries/containers-0.6.7
+--- lib/package.conf.d/deepseq-1.4.8.1.conf
++++ lib/package.conf.d/deepseq-1.4.8.1.conf
+@@ -34,6 +34,6 @@ data-dir:             ${pkgroot}\x86_64-windows-ghc-9.6.1\deepseq-1.4.8.1
+ hs-libraries:         HSdeepseq-1.4.8.1
+ depends:              array-0.5.5.0 base-4.18.0.0 ghc-prim-0.10.0
+ haddock-interfaces:
+-    ${pkgroot}/../../doc/html/libraries/deepseq-1.4.8.1\deepseq.haddock
++    ${pkgroot}/../doc/html/libraries/deepseq-1.4.8.1\deepseq.haddock
+ 
+-haddock-html:         ${pkgroot}/../../doc/html/libraries/deepseq-1.4.8.1
++haddock-html:         ${pkgroot}/../doc/html/libraries/deepseq-1.4.8.1
+--- lib/package.conf.d/directory-1.3.8.1.conf
++++ lib/package.conf.d/directory-1.3.8.1.conf
+@@ -35,6 +35,6 @@ depends:
+     Win32-2.13.3.0 base-4.18.0.0 filepath-1.4.100.1 time-1.12.2
+ 
+ haddock-interfaces:
+-    ${pkgroot}/../../doc/html/libraries/directory-1.3.8.1\directory.haddock
++    ${pkgroot}/../doc/html/libraries/directory-1.3.8.1\directory.haddock
+ 
+-haddock-html:         ${pkgroot}/../../doc/html/libraries/directory-1.3.8.1
++haddock-html:         ${pkgroot}/../doc/html/libraries/directory-1.3.8.1
+--- lib/package.conf.d/exceptions-0.10.7.conf
++++ lib/package.conf.d/exceptions-0.10.7.conf
+@@ -29,6 +29,6 @@ depends:
+     transformers-0.6.1.0
+ 
+ haddock-interfaces:
+-    ${pkgroot}/../../doc/html/libraries/exceptions-0.10.7\exceptions.haddock
++    ${pkgroot}/../doc/html/libraries/exceptions-0.10.7\exceptions.haddock
+ 
+-haddock-html:         ${pkgroot}/../../doc/html/libraries/exceptions-0.10.7
++haddock-html:         ${pkgroot}/../doc/html/libraries/exceptions-0.10.7
+--- lib/package.conf.d/filepath-1.4.100.1.conf
++++ lib/package.conf.d/filepath-1.4.100.1.conf
+@@ -59,6 +59,6 @@ depends:
+     template-haskell-2.20.0.0
+ 
+ haddock-interfaces:
+-    ${pkgroot}/../../doc/html/libraries/filepath-1.4.100.1\filepath.haddock
++    ${pkgroot}/../doc/html/libraries/filepath-1.4.100.1\filepath.haddock
+ 
+-haddock-html:         ${pkgroot}/../../doc/html/libraries/filepath-1.4.100.1
++haddock-html:         ${pkgroot}/../doc/html/libraries/filepath-1.4.100.1
+--- lib/package.conf.d/ghc-9.6.1.conf
++++ lib/package.conf.d/ghc-9.6.1.conf
+@@ -304,5 +304,5 @@ depends:
+     process-1.6.17.0 stm-2.5.1.0 template-haskell-2.20.0.0 time-1.12.2
+     transformers-0.6.1.0
+ 
+-haddock-interfaces:   ${pkgroot}/../../doc/html/libraries/ghc-9.6.1\ghc.haddock
+-haddock-html:         ${pkgroot}/../../doc/html/libraries/ghc-9.6.1
++haddock-interfaces:   ${pkgroot}/../doc/html/libraries/ghc-9.6.1\ghc.haddock
++haddock-html:         ${pkgroot}/../doc/html/libraries/ghc-9.6.1
+--- lib/package.conf.d/ghc-bignum-1.3.conf
++++ lib/package.conf.d/ghc-bignum-1.3.conf
+@@ -29,6 +29,6 @@ hs-libraries:         HSghc-bignum-1.3
+ include-dirs:         ${pkgroot}\x86_64-windows-ghc-9.6.1\ghc-bignum-1.3\include
+ depends:              ghc-prim-0.10.0
+ haddock-interfaces:
+-    ${pkgroot}/../../doc/html/libraries/ghc-bignum-1.3\ghc-bignum.haddock
++    ${pkgroot}/../doc/html/libraries/ghc-bignum-1.3\ghc-bignum.haddock
+ 
+-haddock-html:         ${pkgroot}/../../doc/html/libraries/ghc-bignum-1.3
++haddock-html:         ${pkgroot}/../doc/html/libraries/ghc-bignum-1.3
+--- lib/package.conf.d/ghc-boot-9.6.1.conf
++++ lib/package.conf.d/ghc-boot-9.6.1.conf
+@@ -46,6 +46,6 @@ depends:
+     ghc-boot-th-9.6.1
+ 
+ haddock-interfaces:
+-    ${pkgroot}/../../doc/html/libraries/ghc-boot-9.6.1\ghc-boot.haddock
++    ${pkgroot}/../doc/html/libraries/ghc-boot-9.6.1\ghc-boot.haddock
+ 
+-haddock-html:         ${pkgroot}/../../doc/html/libraries/ghc-boot-9.6.1
++haddock-html:         ${pkgroot}/../doc/html/libraries/ghc-boot-9.6.1
+--- lib/package.conf.d/ghc-boot-th-9.6.1.conf
++++ lib/package.conf.d/ghc-boot-th-9.6.1.conf
+@@ -31,6 +31,6 @@ data-dir:             ${pkgroot}\x86_64-windows-ghc-9.6.1\ghc-boot-th-9.6.1
+ hs-libraries:         HSghc-boot-th-9.6.1
+ depends:              base-4.18.0.0
+ haddock-interfaces:
+-    ${pkgroot}/../../doc/html/libraries/ghc-boot-th-9.6.1\ghc-boot-th.haddock
++    ${pkgroot}/../doc/html/libraries/ghc-boot-th-9.6.1\ghc-boot-th.haddock
+ 
+-haddock-html:         ${pkgroot}/../../doc/html/libraries/ghc-boot-th-9.6.1
++haddock-html:         ${pkgroot}/../doc/html/libraries/ghc-boot-th-9.6.1
+--- lib/package.conf.d/ghc-compact-0.1.0.0.conf
++++ lib/package.conf.d/ghc-compact-0.1.0.0.conf
+@@ -32,6 +32,6 @@ data-dir:             ${pkgroot}\x86_64-windows-ghc-9.6.1\ghc-compact-0.1.0.0
+ hs-libraries:         HSghc-compact-0.1.0.0
+ depends:              base-4.18.0.0 bytestring-0.11.4.0 ghc-prim-0.10.0
+ haddock-interfaces:
+-    ${pkgroot}/../../doc/html/libraries/ghc-compact-0.1.0.0\ghc-compact.haddock
++    ${pkgroot}/../doc/html/libraries/ghc-compact-0.1.0.0\ghc-compact.haddock
+ 
+-haddock-html:         ${pkgroot}/../../doc/html/libraries/ghc-compact-0.1.0.0
++haddock-html:         ${pkgroot}/../doc/html/libraries/ghc-compact-0.1.0.0
+--- lib/package.conf.d/ghc-heap-9.6.1.conf
++++ lib/package.conf.d/ghc-heap-9.6.1.conf
+@@ -34,6 +34,6 @@ depends:
+     base-4.18.0.0 containers-0.6.7 ghc-prim-0.10.0 rts-1.0.2
+ 
+ haddock-interfaces:
+-    ${pkgroot}/../../doc/html/libraries/ghc-heap-9.6.1\ghc-heap.haddock
++    ${pkgroot}/../doc/html/libraries/ghc-heap-9.6.1\ghc-heap.haddock
+ 
+-haddock-html:         ${pkgroot}/../../doc/html/libraries/ghc-heap-9.6.1
++haddock-html:         ${pkgroot}/../doc/html/libraries/ghc-heap-9.6.1
+--- lib/package.conf.d/ghc-prim-0.10.0.conf
++++ lib/package.conf.d/ghc-prim-0.10.0.conf
+@@ -30,6 +30,6 @@ hs-libraries:         HSghc-prim-0.10.0
+ extra-libraries:      user32 mingw32 ucrt
+ depends:              rts-1.0.2
+ haddock-interfaces:
+-    ${pkgroot}/../../doc/html/libraries/ghc-prim-0.10.0\ghc-prim.haddock
++    ${pkgroot}/../doc/html/libraries/ghc-prim-0.10.0\ghc-prim.haddock
+ 
+-haddock-html:         ${pkgroot}/../../doc/html/libraries/ghc-prim-0.10.0
++haddock-html:         ${pkgroot}/../doc/html/libraries/ghc-prim-0.10.0
+--- lib/package.conf.d/ghci-9.6.1.conf
++++ lib/package.conf.d/ghci-9.6.1.conf
+@@ -32,5 +32,5 @@ depends:
+     ghc-heap-9.6.1 ghc-prim-0.10.0 rts-1.0.2 template-haskell-2.20.0.0
+     transformers-0.6.1.0
+ 
+-haddock-interfaces:   ${pkgroot}/../../doc/html/libraries/ghci-9.6.1\ghci.haddock
+-haddock-html:         ${pkgroot}/../../doc/html/libraries/ghci-9.6.1
++haddock-interfaces:   ${pkgroot}/../doc/html/libraries/ghci-9.6.1\ghci.haddock
++haddock-html:         ${pkgroot}/../doc/html/libraries/ghci-9.6.1
+--- lib/package.conf.d/haskeline-0.8.2.1.conf
++++ lib/package.conf.d/haskeline-0.8.2.1.conf
+@@ -60,6 +60,6 @@ depends:
+     process-1.6.17.0 stm-2.5.1.0 transformers-0.6.1.0
+ 
+ haddock-interfaces:
+-    ${pkgroot}/../../doc/html/libraries/haskeline-0.8.2.1\haskeline.haddock
++    ${pkgroot}/../doc/html/libraries/haskeline-0.8.2.1\haskeline.haddock
+ 
+-haddock-html:         ${pkgroot}/../../doc/html/libraries/haskeline-0.8.2.1
++haddock-html:         ${pkgroot}/../doc/html/libraries/haskeline-0.8.2.1
+--- lib/package.conf.d/hpc-0.6.2.0.conf
++++ lib/package.conf.d/hpc-0.6.2.0.conf
+@@ -29,5 +29,5 @@ depends:
+     base-4.18.0.0 containers-0.6.7 deepseq-1.4.8.1 directory-1.3.8.1
+     filepath-1.4.100.1 time-1.12.2
+ 
+-haddock-interfaces:   ${pkgroot}/../../doc/html/libraries/hpc-0.6.2.0\hpc.haddock
+-haddock-html:         ${pkgroot}/../../doc/html/libraries/hpc-0.6.2.0
++haddock-interfaces:   ${pkgroot}/../doc/html/libraries/hpc-0.6.2.0\hpc.haddock
++haddock-html:         ${pkgroot}/../doc/html/libraries/hpc-0.6.2.0
+--- lib/package.conf.d/integer-gmp-1.1.conf
++++ lib/package.conf.d/integer-gmp-1.1.conf
+@@ -30,6 +30,6 @@ data-dir:             ${pkgroot}\x86_64-windows-ghc-9.6.1\integer-gmp-1.1
+ hs-libraries:         HSinteger-gmp-1.1
+ depends:              base-4.18.0.0 ghc-bignum-1.3 ghc-prim-0.10.0
+ haddock-interfaces:
+-    ${pkgroot}/../../doc/html/libraries/integer-gmp-1.1\integer-gmp.haddock
++    ${pkgroot}/../doc/html/libraries/integer-gmp-1.1\integer-gmp.haddock
+ 
+-haddock-html:         ${pkgroot}/../../doc/html/libraries/integer-gmp-1.1
++haddock-html:         ${pkgroot}/../doc/html/libraries/integer-gmp-1.1
+--- lib/package.conf.d/libiserv-9.6.1.conf
++++ lib/package.conf.d/libiserv-9.6.1.conf
+@@ -28,6 +28,6 @@ depends:
+     deepseq-1.4.8.1 ghci-9.6.1
+ 
+ haddock-interfaces:
+-    ${pkgroot}/../../doc/html/libraries/libiserv-9.6.1\libiserv.haddock
++    ${pkgroot}/../doc/html/libraries/libiserv-9.6.1\libiserv.haddock
+ 
+-haddock-html:         ${pkgroot}/../../doc/html/libraries/libiserv-9.6.1
++haddock-html:         ${pkgroot}/../doc/html/libraries/libiserv-9.6.1
+--- lib/package.conf.d/mtl-2.3.1.conf
++++ lib/package.conf.d/mtl-2.3.1.conf
+@@ -41,5 +41,5 @@ dynamic-library-dirs: ${pkgroot}\x86_64-windows-ghc-9.6.1
+ data-dir:             ${pkgroot}\x86_64-windows-ghc-9.6.1\mtl-2.3.1
+ hs-libraries:         HSmtl-2.3.1
+ depends:              base-4.18.0.0 transformers-0.6.1.0
+-haddock-interfaces:   ${pkgroot}/../../doc/html/libraries/mtl-2.3.1\mtl.haddock
+-haddock-html:         ${pkgroot}/../../doc/html/libraries/mtl-2.3.1
++haddock-interfaces:   ${pkgroot}/../doc/html/libraries/mtl-2.3.1\mtl.haddock
++haddock-html:         ${pkgroot}/../doc/html/libraries/mtl-2.3.1
+--- lib/package.conf.d/parsec-3.1.16.1.conf
++++ lib/package.conf.d/parsec-3.1.16.1.conf
+@@ -56,6 +56,6 @@ depends:
+     base-4.18.0.0 bytestring-0.11.4.0 mtl-2.3.1 text-2.0.2
+ 
+ haddock-interfaces:
+-    ${pkgroot}/../../doc/html/libraries/parsec-3.1.16.1\parsec.haddock
++    ${pkgroot}/../doc/html/libraries/parsec-3.1.16.1\parsec.haddock
+ 
+-haddock-html:         ${pkgroot}/../../doc/html/libraries/parsec-3.1.16.1
++haddock-html:         ${pkgroot}/../doc/html/libraries/parsec-3.1.16.1
+--- lib/package.conf.d/pretty-1.1.3.6.conf
++++ lib/package.conf.d/pretty-1.1.3.6.conf
+@@ -34,6 +34,6 @@ data-dir:             ${pkgroot}\x86_64-windows-ghc-9.6.1\pretty-1.1.3.6
+ hs-libraries:         HSpretty-1.1.3.6
+ depends:              base-4.18.0.0 deepseq-1.4.8.1 ghc-prim-0.10.0
+ haddock-interfaces:
+-    ${pkgroot}/../../doc/html/libraries/pretty-1.1.3.6\pretty.haddock
++    ${pkgroot}/../doc/html/libraries/pretty-1.1.3.6\pretty.haddock
+ 
+-haddock-html:         ${pkgroot}/../../doc/html/libraries/pretty-1.1.3.6
++haddock-html:         ${pkgroot}/../doc/html/libraries/pretty-1.1.3.6
+--- lib/package.conf.d/process-1.6.17.0.conf
++++ lib/package.conf.d/process-1.6.17.0.conf
+@@ -36,6 +36,6 @@ depends:
+     filepath-1.4.100.1
+ 
+ haddock-interfaces:
+-    ${pkgroot}/../../doc/html/libraries/process-1.6.17.0\process.haddock
++    ${pkgroot}/../doc/html/libraries/process-1.6.17.0\process.haddock
+ 
+-haddock-html:         ${pkgroot}/../../doc/html/libraries/process-1.6.17.0
++haddock-html:         ${pkgroot}/../doc/html/libraries/process-1.6.17.0
+--- lib/package.conf.d/rts-1.0.2.conf
++++ lib/package.conf.d/rts-1.0.2.conf
+@@ -80,5 +80,5 @@ ld-options:
+     "-Wl,-u,base_GHCziStackziCloneStack_StackSnapshot_closure"
+     "-Wl,-u,base_GHCziEventziWindows_processRemoteCompletion_closure"
+ 
+-haddock-interfaces:   ${pkgroot}/../../doc/html/libraries/rts-1.0.2\rts.haddock
+-haddock-html:         ${pkgroot}/../../doc/html/libraries/rts-1.0.2
++haddock-interfaces:   ${pkgroot}/../doc/html/libraries/rts-1.0.2\rts.haddock
++haddock-html:         ${pkgroot}/../doc/html/libraries/rts-1.0.2
+--- lib/package.conf.d/stm-2.5.1.0.conf
++++ lib/package.conf.d/stm-2.5.1.0.conf
+@@ -35,5 +35,5 @@ dynamic-library-dirs: ${pkgroot}\x86_64-windows-ghc-9.6.1
+ data-dir:             ${pkgroot}\x86_64-windows-ghc-9.6.1\stm-2.5.1.0
+ hs-libraries:         HSstm-2.5.1.0
+ depends:              array-0.5.5.0 base-4.18.0.0
+-haddock-interfaces:   ${pkgroot}/../../doc/html/libraries/stm-2.5.1.0\stm.haddock
+-haddock-html:         ${pkgroot}/../../doc/html/libraries/stm-2.5.1.0
++haddock-interfaces:   ${pkgroot}/../doc/html/libraries/stm-2.5.1.0\stm.haddock
++haddock-html:         ${pkgroot}/../doc/html/libraries/stm-2.5.1.0
+--- lib/package.conf.d/template-haskell-2.20.0.0.conf
++++ lib/package.conf.d/template-haskell-2.20.0.0.conf
+@@ -45,7 +45,7 @@ depends:
+     base-4.18.0.0 ghc-boot-th-9.6.1 ghc-prim-0.10.0 pretty-1.1.3.6
+ 
+ haddock-interfaces:
+-    ${pkgroot}/../../doc/html/libraries/template-haskell-2.20.0.0\template-haskell.haddock
++    ${pkgroot}/../doc/html/libraries/template-haskell-2.20.0.0\template-haskell.haddock
+ 
+ haddock-html:
+-    ${pkgroot}/../../doc/html/libraries/template-haskell-2.20.0.0
++    ${pkgroot}/../doc/html/libraries/template-haskell-2.20.0.0
+--- lib/package.conf.d/text-2.0.2.conf
++++ lib/package.conf.d/text-2.0.2.conf
+@@ -86,5 +86,5 @@ depends:
+     array-0.5.5.0 base-4.18.0.0 binary-0.8.9.1 bytestring-0.11.4.0
+     deepseq-1.4.8.1 ghc-prim-0.10.0 template-haskell-2.20.0.0
+ 
+-haddock-interfaces:   ${pkgroot}/../../doc/html/libraries/text-2.0.2\text.haddock
+-haddock-html:         ${pkgroot}/../../doc/html/libraries/text-2.0.2
++haddock-interfaces:   ${pkgroot}/../doc/html/libraries/text-2.0.2\text.haddock
++haddock-html:         ${pkgroot}/../doc/html/libraries/text-2.0.2
+--- lib/package.conf.d/time-1.12.2.conf
++++ lib/package.conf.d/time-1.12.2.conf
+@@ -53,6 +53,6 @@ hs-libraries:         HStime-1.12.2
+ include-dirs:         ${pkgroot}\x86_64-windows-ghc-9.6.1\time-1.12.2\include
+ depends:              Win32-2.13.3.0 base-4.18.0.0 deepseq-1.4.8.1
+ haddock-interfaces:
+-    ${pkgroot}/../../doc/html/libraries/time-1.12.2\time.haddock
++    ${pkgroot}/../doc/html/libraries/time-1.12.2\time.haddock
+ 
+-haddock-html:         ${pkgroot}/../../doc/html/libraries/time-1.12.2
++haddock-html:         ${pkgroot}/../doc/html/libraries/time-1.12.2
+--- lib/package.conf.d/transformers-0.6.1.0.conf
++++ lib/package.conf.d/transformers-0.6.1.0.conf
+@@ -56,6 +56,6 @@ data-dir:             ${pkgroot}\x86_64-windows-ghc-9.6.1\transformers-0.6.1.0
+ hs-libraries:         HStransformers-0.6.1.0
+ depends:              base-4.18.0.0
+ haddock-interfaces:
+-    ${pkgroot}/../../doc/html/libraries/transformers-0.6.1.0\transformers.haddock
++    ${pkgroot}/../doc/html/libraries/transformers-0.6.1.0\transformers.haddock
+ 
+-haddock-html:         ${pkgroot}/../../doc/html/libraries/transformers-0.6.1.0
++haddock-html:         ${pkgroot}/../doc/html/libraries/transformers-0.6.1.0
+--- lib/package.conf.d/xhtml-3000.2.2.1.conf
++++ lib/package.conf.d/xhtml-3000.2.2.1.conf
+@@ -39,6 +39,6 @@ data-dir:             ${pkgroot}\x86_64-windows-ghc-9.6.1\xhtml-3000.2.2.1
+ hs-libraries:         HSxhtml-3000.2.2.1
+ depends:              base-4.18.0.0
+ haddock-interfaces:
+-    ${pkgroot}/../../doc/html/libraries/xhtml-3000.2.2.1\xhtml.haddock
++    ${pkgroot}/../doc/html/libraries/xhtml-3000.2.2.1\xhtml.haddock
+ 
+-haddock-html:         ${pkgroot}/../../doc/html/libraries/xhtml-3000.2.2.1
++haddock-html:         ${pkgroot}/../doc/html/libraries/xhtml-3000.2.2.1

--- a/haskell/cc_toolchain_config.bzl
+++ b/haskell/cc_toolchain_config.bzl
@@ -31,7 +31,7 @@ def _impl(ctx):
         ),
         tool_path(
             name = "gcc",
-            path = "mingw/bin/gcc",
+            path = "mingw/bin/clang" if ctx.attr.is_clang else "mingw/bin/gcc",
         ),
         tool_path(
             name = "gcov",
@@ -102,6 +102,8 @@ def _impl(ctx):
 
 cc_toolchain_config = rule(
     implementation = _impl,
-    attrs = {},
+    attrs = {
+        "is_clang": attr.bool(default = False, mandatory = False),
+    },
     provides = [CcToolchainConfigInfo],
 )

--- a/haskell/gen_ghc_bindist.py
+++ b/haskell/gen_ghc_bindist.py
@@ -16,6 +16,10 @@ from distutils.version import StrictVersion
 # `ignore_prefixes` is the prefix of files to ignore
 # `ignore_suffixes` is the suffix of files to ignore
 VERSIONS = [
+    { "version": "9.6.1",
+      "ignore_suffixes": [".bz2", ".lz", ".zip"] },
+    { "version": "9.4.5",
+      "ignore_suffixes": [".bz2", ".lz", ".zip"] },
     { "version": "9.2.5",
       "ignore_suffixes": [".bz2", ".lz", ".zip"] },
     { "version": "9.2.4",

--- a/haskell/ghc.BUILD.tpl
+++ b/haskell/ghc.BUILD.tpl
@@ -65,4 +65,4 @@ cc_toolchain(
     toolchain_identifier = "ghc_windows_mingw64",
 )
 
-cc_toolchain_config(name = "ghc_windows_mingw64_config")
+cc_toolchain_config(name = "ghc_windows_mingw64_config", is_clang=%{is_clang})

--- a/haskell/ghc_bindist.bzl
+++ b/haskell/ghc_bindist.bzl
@@ -407,6 +407,8 @@ def ghc_bindist(
             "9.2.3": ["@rules_haskell//haskell:assets/ghc_9_2_3_win.patch"],
             "9.2.4": ["@rules_haskell//haskell:assets/ghc_9_2_4_win.patch"],
             "9.2.5": ["@rules_haskell//haskell:assets/ghc_9_2_5_win.patch"],
+            "9.4.5": ["@rules_haskell//haskell:assets/ghc_9_4_5_win.patch"],
+            "9.6.1": ["@rules_haskell//haskell:assets/ghc_9_6_1_win.patch"],
         }.get(version)
 
     if target == "darwin_amd64":

--- a/haskell/ghc_bindist.bzl
+++ b/haskell/ghc_bindist.bzl
@@ -215,6 +215,9 @@ rm -f
         cabalopts = ctx.attr.cabalopts,
         locale = repr(locale),
     )
+
+    is_clang = ctx.path(paths.join(unpack_dir, "mingw", "bin", "clang.exe")).exists
+
     ctx.template(
         "BUILD",
         filepaths["@rules_haskell//haskell:ghc.BUILD.tpl"],
@@ -222,6 +225,7 @@ rm -f
             "%{toolchain_libraries}": toolchain_libraries,
             "%{toolchain}": toolchain,
             "%{docdir}": docdir,
+            "%{is_clang}": str(is_clang),
         },
         executable = False,
     )

--- a/haskell/ghc_bindist.bzl
+++ b/haskell/ghc_bindist.bzl
@@ -126,7 +126,10 @@ def _ghc_bindist_impl(ctx):
         # tools! This means that sed -i always takes an argument.
 
         if is_hadrian_dist:
-            make_args = ["-E", "RelocatableBuild := YES"]
+            ctx.file(paths.join(unpack_dir, "relocatable.mk"), content = """
+RelocatableBuild := YES
+include Makefile""")
+            make_args = ["-f", "relocatable.mk"]
         else:
             make_args = []
 

--- a/haskell/ghc_bindist.bzl
+++ b/haskell/ghc_bindist.bzl
@@ -76,6 +76,8 @@ def _ghc_bindist_impl(ctx):
             stripPrefix += "-{}-unknown-mingw32".format(arch_suffix)
         elif os == "darwin" and version_tuple >= (9, 0, 2):
             stripPrefix += "-{}-apple-darwin".format(arch_suffix)
+        elif os == "linux" and version_tuple >= (9, 4, 1):
+            stripPrefix += "-{}-unknown-linux".format(arch_suffix)
 
     ctx.download_and_extract(
         url = url,

--- a/haskell/ghc_bindist.bzl
+++ b/haskell/ghc_bindist.bzl
@@ -193,7 +193,7 @@ rm -f
     docdir = "doc"
     if GHC_BINDIST_DOCDIR.get(version) != None and GHC_BINDIST_DOCDIR[version].get(target) != None:
         docdir = GHC_BINDIST_DOCDIR[version][target]
-    elif os == "windows" and version_tuple >= (9, 0, 1):
+    elif os == "windows" and version_tuple >= (9, 0, 1) and version_tuple < (9, 4, 1):
         docdir = "docs"
 
     toolchain_libraries = pkgdb_to_bzl(ctx, filepaths, libdir)["file_content"]

--- a/haskell/private/ghc_bindist_generated.bzl
+++ b/haskell/private/ghc_bindist_generated.bzl
@@ -274,9 +274,57 @@ GHC_BINDIST = \
                 "https://downloads.haskell.org/~ghc/9.2.5/ghc-9.2.5-x86_64-deb9-linux.tar.xz",
                 "2d115b7258751f0e4481e35b5953ca3c7870e8ec9ce68f1d32fc014ddc29b2a5",
             ),
+            "linux_arm64": (
+                "https://downloads.haskell.org/~ghc/9.2.5/ghc-9.2.5-aarch64-deb10-linux.tar.xz",
+                "29c0735ada90cdbf7e4a227dee08f18d74e33ec05d7c681e4ef95b8aa13104b3",
+            ),
             "windows_amd64": (
                 "https://downloads.haskell.org/~ghc/9.2.5/ghc-9.2.5-x86_64-unknown-mingw32.tar.xz",
                 "a6815804606ef2d99250078d5c1315b74bb5718d8f15a629f211bcd37bad07c3",
+            ),
+        },
+        "9.4.5": {
+            "darwin_amd64": (
+                "https://downloads.haskell.org/~ghc/9.4.5/ghc-9.4.5-x86_64-apple-darwin.tar.xz",
+                "f8cf9bb725120c25fac909834c79786ac646c97dc3cd69a1ef0b734b489d6709",
+            ),
+            "darwin_arm64": (
+                "https://downloads.haskell.org/~ghc/9.4.5/ghc-9.4.5-aarch64-apple-darwin.tar.xz",
+                "edd28a261f4d608be59000fb4c4a4d37b2cc825e6d46aded6612661de7d066a0",
+            ),
+            "linux_amd64": (
+                "https://downloads.haskell.org/~ghc/9.4.5/ghc-9.4.5-x86_64-deb9-linux.tar.xz",
+                "7508314c884c69738e93eb69b919d965e83c444830ae53c5991818f8414634be",
+            ),
+            "linux_arm64": (
+                "https://downloads.haskell.org/~ghc/9.4.5/ghc-9.4.5-aarch64-deb10-linux.tar.xz",
+                "ecf16ec503e739e727174b29e5acbe4cf0c54737dd4d5eda046e09323f9ee248",
+            ),
+            "windows_amd64": (
+                "https://downloads.haskell.org/~ghc/9.4.5/ghc-9.4.5-x86_64-unknown-mingw32.tar.xz",
+                "1b65ccb99b5e0bc6ad535b58323b023c61a675e0c3a0d53b82f819e55a7dd8d7",
+            ),
+        },
+        "9.6.1": {
+            "darwin_amd64": (
+                "https://downloads.haskell.org/~ghc/9.6.1/ghc-9.6.1-x86_64-apple-darwin.tar.xz",
+                "3dcca5e83795b5b7c0af636216dc2ef9c40c70fb368bc7feb2a74921c81445ff",
+            ),
+            "darwin_arm64": (
+                "https://downloads.haskell.org/~ghc/9.6.1/ghc-9.6.1-aarch64-apple-darwin.tar.xz",
+                "1729e8cec960879c620917d935a673e54197fa2ee87c62e45c44fad2e522960a",
+            ),
+            "linux_amd64": (
+                "https://downloads.haskell.org/~ghc/9.6.1/ghc-9.6.1-x86_64-deb9-linux.tar.xz",
+                "3c727e93a82ff039fbedd6645518859849130a0fc93b7181cd69a41800aa639c",
+            ),
+            "linux_arm64": (
+                "https://downloads.haskell.org/~ghc/9.6.1/ghc-9.6.1-aarch64-deb10-linux.tar.xz",
+                "0fd57fdc9e7b9c0850350492deea1c00016d751c89c11478cfe6b6038da0c6db",
+            ),
+            "windows_amd64": (
+                "https://downloads.haskell.org/~ghc/9.6.1/ghc-9.6.1-x86_64-unknown-mingw32.tar.xz",
+                "6121a889839d8b409f082169365bbfb6ed9e6a1f6ff0531d577ef7c2a9a417fb",
             ),
         },
     }


### PR DESCRIPTION
This adds GHC bindists for the latest stable GHC releases for 9.4 and 9.6. Fixes #1889 

Notable changes are that starting with GHC 9.6.1 the bindist packages are packaged with Hadrian and thus are relocatable without patching the scripts in `bin`.

Note that the test-patches workflow has been run for these successfully, except for GHC 9.4.5 on Windows. See https://github.com/tweag/rules_haskell/issues/1892  For the time being, until this gets resolved, I have excluded this version from the `test-ghc-patches` workflow.