### PR TITLE
Preliminary changes for bzlmod

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -24,7 +24,7 @@ test --test_env=LANG=C.UTF-8 --test_env=LOCALE_ARCHIVE
 # ------------------------------
 build:linux-nixpkgs --config=nixpkgs
 build:macos-nixpkgs --config=nixpkgs
-build:nixpkgs --host_platform=@io_tweag_rules_nixpkgs//nixpkgs/platforms:host
+build:nixpkgs --host_platform=@rules_nixpkgs_core//platforms:host
 
 # Build and Test Filters
 # ----------------------

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -20,7 +20,6 @@ load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 bazel_skylib_workspace()
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-load("@rules_haskell//haskell:cabal.bzl", "stack_snapshot")
 
 http_archive(
     name = "rules_proto",

--- a/docs/pandoc/BUILD.bazel
+++ b/docs/pandoc/BUILD.bazel
@@ -16,7 +16,7 @@ toolchain(
     name = "nixpkgs",
     exec_compatible_with = [
         "@platforms//cpu:x86_64",
-        "@io_tweag_rules_nixpkgs//nixpkgs/constraints:support_nix",
+        "@rules_nixpkgs_core//constraints:support_nix",
     ] + (["@platforms//os:linux"] if is_linux else ["@platforms//os:macos"]),
     toolchain = "@nixpkgs_pandoc//:pandoc_toolchain",
     toolchain_type = ":toolchain_type",

--- a/docs/pandoc/pandoc.bzl
+++ b/docs/pandoc/pandoc.bzl
@@ -1,5 +1,5 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-load("@io_tweag_rules_nixpkgs//nixpkgs:nixpkgs.bzl", "nixpkgs_package")
+load("@rules_nixpkgs_core//:nixpkgs.bzl", "nixpkgs_package")
 
 def _pandoc_toolchain_impl(ctx):
     return [platform_common.ToolchainInfo(

--- a/haskell/BUILD.bazel
+++ b/haskell/BUILD.bazel
@@ -95,6 +95,7 @@ bzl_library(
         "@bazel_skylib//lib:collections",
         "@bazel_skylib//lib:dicts",
         "@bazel_skylib//lib:paths",
+        "@bazel_skylib//lib:sets",
         "@bazel_skylib//lib:shell",
         "@bazel_skylib//lib:versions",
         "@rules_nixpkgs_core//:nixpkgs",

--- a/haskell/BUILD.bazel
+++ b/haskell/BUILD.bazel
@@ -97,7 +97,8 @@ bzl_library(
         "@bazel_skylib//lib:paths",
         "@bazel_skylib//lib:shell",
         "@bazel_skylib//lib:versions",
-        "@io_tweag_rules_nixpkgs//nixpkgs",
+        "@rules_nixpkgs_core//:nixpkgs",
+        "@rules_nixpkgs_posix//:posix",
         "@rules_sh//sh:posix",
     ],
 )

--- a/haskell/asterius/asterius_dependencies.bzl
+++ b/haskell/asterius/asterius_dependencies.bzl
@@ -130,10 +130,10 @@ node_toolchain(
 toolchain(
     name = "node_nixpkgs_toolchain",
     exec_compatible_with = [
-        "@io_tweag_rules_nixpkgs//nixpkgs/constraints:support_nix",
+        "@rules_nixpkgs_core//constraints:support_nix"
     ],
     target_compatible_with = [
-        "@io_tweag_rules_nixpkgs//nixpkgs/constraints:support_nix",
+        "@rules_nixpkgs_core//constraints:support_nix"
     ],
     toolchain = ":node_nixpkgs",
     toolchain_type = "@rules_nodejs//nodejs:toolchain_type",

--- a/haskell/cabal_wrapper.bzl
+++ b/haskell/cabal_wrapper.bzl
@@ -10,8 +10,5 @@ def cabal_wrapper(name, **kwargs):
         srcs_version = "PY3",
         python_version = "PY3",
         imports = ["private"],
-        deps = [
-            "@bazel_tools//tools/python/runfiles",
-        ],
         **kwargs
     )

--- a/haskell/nixpkgs.bzl
+++ b/haskell/nixpkgs.bzl
@@ -1,8 +1,11 @@
 """Workspace rules (Nixpkgs)"""
 
 load(
-    "@io_tweag_rules_nixpkgs//nixpkgs:nixpkgs.bzl",
+    "@rules_nixpkgs_core//:nixpkgs.bzl",
     "nixpkgs_package",
+)
+load(
+    "@rules_nixpkgs_posix//:posix.bzl",
     "nixpkgs_sh_posix_configure",
 )
 load("@bazel_tools//tools/cpp:lib_cc_configure.bzl", "get_cpu_value")
@@ -160,7 +163,7 @@ def _ghc_nixpkgs_toolchain_impl(repository_ctx):
         target_constraints = repository_ctx.attr.target_constraints
         exec_constraints = list(repository_ctx.attr.exec_constraints)
 
-    exec_constraints.append("@io_tweag_rules_nixpkgs//nixpkgs/constraints:support_nix")
+    exec_constraints.append("@rules_nixpkgs_core//constraints:support_nix")
 
     repository_ctx.file(
         "BUILD",

--- a/haskell/nixpkgs.bzl
+++ b/haskell/nixpkgs.bzl
@@ -348,6 +348,7 @@ def haskell_register_ghc_nixpkgs(
         sh_posix_nixpkgs_kwargs["packages"] = sh_posix_attributes
     nixpkgs_sh_posix_configure(
         name = nixpkgs_sh_posix_repo_name,
+        register = register,
         **sh_posix_nixpkgs_kwargs
     )
 

--- a/haskell/platforms/BUILD.bazel
+++ b/haskell/platforms/BUILD.bazel
@@ -13,20 +13,20 @@ declare_config_settings()
 
 alias(
     name = "nixpkgs",
-    actual = "@io_tweag_rules_nixpkgs//nixpkgs/constraints:support_nix",
+    actual = "@rules_nixpkgs_core//constraints:support_nix",
     visibility = ["//visibility:public"],
 )
 
 alias(
     name = "linux_x86_64_nixpkgs",
-    actual = "@io_tweag_rules_nixpkgs//nixpkgs/platforms:host",
+    actual = "@rules_nixpkgs_core//platforms:host",
     deprecation = "Use @io_tweag_rules_nixpkgs//nixpkgs/platforms:host instead.",
     visibility = ["//visibility:public"],
 )
 
 alias(
     name = "darwin_x86_64_nixpkgs",
-    actual = "@io_tweag_rules_nixpkgs//nixpkgs/platforms:host",
+    actual = "@rules_nixpkgs_core//platforms:host",
     deprecation = "Use @io_tweag_rules_nixpkgs//nixpkgs/platforms:host instead.",
     visibility = ["//visibility:public"],
 )

--- a/haskell/private/cc_wrapper.bzl
+++ b/haskell/private/cc_wrapper.bzl
@@ -110,7 +110,7 @@ def cc_wrapper(name, **kwargs):
         python_version = "PY3",
         main = name + ".py",
         deps = [
-            "@bazel_tools//tools/python/runfiles",
+            "@rules_python//python/runfiles",
         ],
         **kwargs
     )

--- a/haskell/private/cc_wrapper.py.tpl
+++ b/haskell/private/cc_wrapper.py.tpl
@@ -68,7 +68,7 @@ used to avoid command line length limitations.
 
 """
 
-from bazel_tools.tools.python.runfiles import runfiles as bazel_runfiles
+from python.runfiles import runfiles as bazel_runfiles
 from contextlib import contextmanager
 from collections import deque
 import glob

--- a/haskell/repositories.bzl
+++ b/haskell/repositories.bzl
@@ -49,9 +49,9 @@ def rules_haskell_dependencies():
     maybe(
         http_archive,
         name = "rules_python",
-        sha256 = "48a838a6e1983e4884b26812b2c748a35ad284fd339eb8e2a6f3adf95307fbcd",
-        strip_prefix = "rules_python-0.16.2",
-        url = "https://github.com/bazelbuild/rules_python/archive/refs/tags/0.16.2.tar.gz",
+        sha256 = "94750828b18044533e98a129003b6a68001204038dc4749f40b195b24c38f49f",
+        strip_prefix = "rules_python-0.21.0",
+        url = "https://github.com/bazelbuild/rules_python/releases/download/0.21.0/rules_python-0.21.0.tar.gz",
     )
 
     maybe(

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -39,7 +39,7 @@ package(default_testonly = 1)
 config_setting(
     name = "nix",
     constraint_values = [
-        "@io_tweag_rules_nixpkgs//nixpkgs/constraints:support_nix",
+        "@rules_nixpkgs_core//constraints:support_nix",
     ],
 )
 

--- a/tests/cc_haskell_import/BUILD.bazel
+++ b/tests/cc_haskell_import/BUILD.bazel
@@ -72,7 +72,9 @@ py_binary(
         "requires_threaded_rts",
     ],
     visibility = ["//tests:__subpackages__"],
-    deps = ["@bazel_tools//tools/python/runfiles"],
+    deps = [
+        "@rules_python//python/runfiles",
+    ],
 )
 
 filegroup(

--- a/tests/cc_haskell_import/python_add_one.py
+++ b/tests/cc_haskell_import/python_add_one.py
@@ -1,6 +1,6 @@
 import os
 import ctypes
-from bazel_tools.tools.python.runfiles import runfiles
+from python.runfiles import runfiles
 import subprocess
 
 r = runfiles.Create()

--- a/tests/inline_tests.bzl
+++ b/tests/inline_tests.bzl
@@ -65,7 +65,7 @@ def sh_inline_test(name, script, **kwargs):
     )
 
 python_runfiles_boilerplate = """
-from bazel_tools.tools.python.runfiles import runfiles
+from python.runfiles import runfiles
 r = runfiles.Create()
 """
 
@@ -86,6 +86,6 @@ def py_inline_test(name, script, **kwargs):
         name = name,
         srcs = [script_name] + srcs,
         main = script_name,
-        deps = ["@bazel_tools//tools/python/runfiles"] + deps,
+        deps = ["@rules_python//python/runfiles"] + deps,
         **kwargs
     )

--- a/tests/integration_testing/BUILD.bazel
+++ b/tests/integration_testing/BUILD.bazel
@@ -10,6 +10,7 @@ haskell_library(
         "//tests/hackage:filepath",
         "//tests/hackage:process",
         "//tests/hackage:text",
+        "@rules_haskell//tools/runfiles",
         "@stackage//:hspec",
         "@stackage//:hspec-core",
     ],

--- a/tests/integration_testing/dependencies.bzl
+++ b/tests/integration_testing/dependencies.bzl
@@ -1,4 +1,4 @@
-load("@io_tweag_rules_nixpkgs//nixpkgs:nixpkgs.bzl", "nixpkgs_package")
+load("@rules_nixpkgs_core//:nixpkgs.bzl", "nixpkgs_package")
 load("@contrib_rules_bazel_integration_test//bazel_integration_test:defs.bzl", "bazel_binaries")
 load(
     "//haskell:private/versions.bzl",

--- a/tests/stack-snapshot-deps/BUILD.bazel
+++ b/tests/stack-snapshot-deps/BUILD.bazel
@@ -2,7 +2,6 @@ load(
     "@rules_haskell//haskell:defs.bzl",
     "haskell_test",
 )
-load("@io_bazel_rules_go//go/tools/bazel_testing:def.bzl", "go_bazel_test")
 load("//tests/integration_testing:rules_haskell_integration_test.bzl", "rules_haskell_integration_test")
 
 package(default_testonly = 1)

--- a/tests/stackage_zlib_runpath/BUILD.bazel
+++ b/tests/stackage_zlib_runpath/BUILD.bazel
@@ -77,7 +77,7 @@ py_inline_test(
         ":libz_soname",
     ],
     script = """\
-from bazel_tools.tools.python.runfiles import runfiles as bazel_runfiles
+from python.runfiles import runfiles as bazel_runfiles
 import itertools
 import os
 import platform


### PR DESCRIPTION
This PR contains some fixes and changes needed to support bzlmod.
Most notably:

- It updates rules_python to use its `runfiles` library which now support bzlmod (instead of the [deprecated](https://github.com/bazelbuild/bazel/blob/master/tools/python/BUILD.tools#L1-L7C8) one from bazel_tools).
- It uses the new names of the `rules_nixpkgs` repositories inside the rules_haskell one. This is because repositories like `rules_nixpkgs_core` and `rules_nixpkgs_python` are modules which are meant to be used in bzlmod, but `io_tweag_rules_nixpkgs` is not.
- Make use of the runfiles library in `IntegrationTesting.hs`, to not hardcode the names of external repository folders (which change with bzlmod).