### PR TITLE
pre bzlmod refactoring

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,5 +1,3 @@
-load("@com_github_bazelbuild_buildtools//buildifier:def.bzl", "buildifier", "buildifier_test")
-
 exports_files(["start"])
 
 exports_files(
@@ -11,9 +9,14 @@ exports_files(
     visibility = ["//tests/shellcheck:__pkg__"],
 )
 
-buildifier_exclude_patterns = [
-    "./vendor/**",
-]
+exports_files(
+    [
+        "BUILD.bazel",
+        "WORKSPACE",
+        "constants.bzl",
+    ],
+    visibility = ["//buildifier:__pkg__"],
+)
 
 filegroup(
     name = "distribution",
@@ -35,40 +38,4 @@ filegroup(
         "//vendor/bazel_json/lib:all_files",
     ],
     visibility = ["//visibility:public"],
-)
-
-# Run this to check for errors in BUILD files.
-buildifier(
-    name = "buildifier",
-    exclude_patterns = buildifier_exclude_patterns,
-    mode = "check",
-)
-
-# Run this to fix the errors in BUILD files.
-buildifier(
-    name = "buildifier-fix",
-    exclude_patterns = buildifier_exclude_patterns,
-    mode = "fix",
-    verbose = True,
-)
-
-buildifier_test(
-    name = "buildifier_test",
-    srcs = [
-        "BUILD.bazel",
-        "WORKSPACE",
-        "constants.bzl",
-        "//debug/linking_utils:all_files",
-        "//docs:all_files",
-        "//haskell:all_files",
-        "//nixpkgs:all_files",
-        "//rule_info:all_files",
-        "//tests:all_files",
-        "//tools:all_files",
-        "@examples-arm//:all_files",
-        "@examples//:all_files",
-        "@tutorial//:all_files",
-    ],
-    mode = "diff",
-    tags = ["dont_test_on_windows"],
 )

--- a/README.md
+++ b/README.md
@@ -342,20 +342,20 @@ on every development system (`python`, `ghc`, `go`, …).
 To build and run tests locally, execute:
 
 ```
-$ bazel test //...
+$ bazel test //... && cd rules_haskell_tests && bazel test //...
 ```
 
 Starlark code in this project is formatted according to the output of
 [buildifier]. You can check that the formatting is correct using:
 
 ```
-$ bazel run //:buildifier
+$ bazel run //buildifier && cd rules_haskell_tests && bazel run //buildifier
 ```
 
 If tests fail then run the following to fix the formatting:
 
 ```
-$ git rebase --exec "bazel run //:buildifier-fix" <first commit>
+$ git rebase --exec "bazel run //buildifier:buildifier-fix && cd rules_haskell_tests && bazel run //buildifier:buildifier-fix" <first commit>
 ```
 
 where `<first commit>` is the first commit in your pull request.

--- a/buildifier/BUILD.bazel
+++ b/buildifier/BUILD.bazel
@@ -1,0 +1,58 @@
+load("@com_github_bazelbuild_buildtools//buildifier:def.bzl", "buildifier", "buildifier_test")
+
+buildifier_exclude_patterns = [
+    "./vendor/**",
+]
+
+# Run this to check for errors in BUILD files.
+buildifier(
+    name = "buildifier",
+    exclude_patterns = buildifier_exclude_patterns,
+    mode = "check",
+    tags = ["manual"],
+)
+
+# Run this to fix the errors in BUILD files.
+buildifier(
+    name = "buildifier-fix",
+    exclude_patterns = buildifier_exclude_patterns,
+    mode = "fix",
+    tags = ["manual"],
+    verbose = True,
+)
+
+buildifier_test(
+    name = "buildifier_test",
+    srcs = [
+        "//:BUILD.bazel",
+        "//:WORKSPACE",
+        "//:constants.bzl",
+        "//:non_module_deps.bzl",
+        "//:non_module_dev_deps.bzl",
+        "//:non_module_dev_deps_2.bzl",
+        "//buildifier:all_files",
+        "//debug/linking_utils:all_files",
+        "//docs:all_files",
+        "//extensions:all_files",
+        "//haskell:all_files",
+        "//nixpkgs:all_files",
+        "//rule_info:all_files",
+        "//tests:all_files",
+        "//tools:all_files",
+        "@examples-arm//:all_files",
+        "@examples//:all_files",
+        "@tutorial//:all_files",
+    ],
+    mode = "diff",
+    tags = [
+        "dont_test_on_windows",
+        "manual",
+    ],
+)
+
+filegroup(
+    name = "all_files",
+    testonly = True,
+    srcs = glob(["**"]),
+    visibility = ["//visibility:public"],
+)

--- a/rules_haskell_tests/BUILD.bazel
+++ b/rules_haskell_tests/BUILD.bazel
@@ -1,25 +1,10 @@
-load("@com_github_bazelbuild_buildtools//buildifier:def.bzl", "buildifier", "buildifier_test")
-
-# Run this to check for errors in BUILD files.
-buildifier(
-    name = "buildifier",
-    mode = "check",
-)
-
-# Run this to fix the errors in BUILD files.
-buildifier(
-    name = "buildifier-fix",
-    mode = "fix",
-    verbose = True,
-)
-
-buildifier_test(
-    name = "buildifier_test",
-    srcs = [
+exports_files(
+    [
         "BUILD.bazel",
         "WORKSPACE",
-        "//tests:all_files",
+        "non_module_deps.bzl",
+        "non_module_deps_1.bzl",
+        "non_module_deps_2.bzl",
     ],
-    mode = "diff",
-    tags = ["dont_test_on_windows"],
+    visibility = ["//buildifier:__pkg__"],
 )

--- a/rules_haskell_tests/WORKSPACE
+++ b/rules_haskell_tests/WORKSPACE
@@ -96,6 +96,21 @@ load("non_module_deps_2.bzl", repositories_2 = "repositories")
 
 repositories_2(bzlmod = False)
 
+load(
+    "@rules_haskell//haskell/asterius:repositories.bzl",
+    "asterius_dependencies_bindist",
+    "asterius_dependencies_nix",
+)
+load(
+    "@rules_nixpkgs_core//:nixpkgs.bzl",
+    "nixpkgs_package",
+)
+
+asterius_dependencies_nix(
+    nix_repository = "@nixpkgs_default",
+    nixpkgs_package_rule = nixpkgs_package,
+) if is_nix_shell else asterius_dependencies_bindist()
+
 load("@rules_haskell_npm//:repositories.bzl", "npm_repositories")
 
 npm_repositories()
@@ -115,6 +130,15 @@ jvm_maven_import_external(
     artifact_sha256 = "28aad0602a5eea97e9cfed3a7c5f2934cd5afefdb7f7c1d871bb07985453ea6e",
     licenses = ["notice"],
     server_urls = ["https://repo.maven.apache.org/maven2"],
+)
+
+http_archive(
+    name = "io_bazel_stardoc",
+    sha256 = "3fd8fec4ddec3c670bd810904e2e33170bedfe12f90adf943508184be458c8bb",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/stardoc/releases/download/0.5.3/stardoc-0.5.3.tar.gz",
+        "https://github.com/bazelbuild/stardoc/releases/download/0.5.3/stardoc-0.5.3.tar.gz",
+    ],
 )
 
 load("@io_bazel_stardoc//:setup.bzl", "stardoc_repositories")
@@ -166,3 +190,4 @@ bind(
     name = "python_headers",
     actual = "@com_google_protobuf//util/python:python_headers",
 )
+

--- a/rules_haskell_tests/buildifier/BUILD.bazel
+++ b/rules_haskell_tests/buildifier/BUILD.bazel
@@ -1,0 +1,41 @@
+load("@com_github_bazelbuild_buildtools//buildifier:def.bzl", "buildifier", "buildifier_test")
+
+# Run this to check for errors in BUILD files.
+buildifier(
+    name = "buildifier",
+    mode = "check",
+    tags = ["manual"],
+)
+
+# Run this to fix the errors in BUILD files.
+buildifier(
+    name = "buildifier-fix",
+    mode = "fix",
+    tags = ["manual"],
+    verbose = True,
+)
+
+buildifier_test(
+    name = "buildifier_test",
+    srcs = [
+        "//:BUILD.bazel",
+        "//:WORKSPACE",
+        "//:non_module_deps.bzl",
+        "//:non_module_deps_1.bzl",
+        "//:non_module_deps_2.bzl",
+        "//buildifier:all_files",
+        "//tests:all_files",
+    ],
+    mode = "diff",
+    tags = [
+        "dont_test_on_windows",
+        "manual",
+    ],
+)
+
+filegroup(
+    name = "all_files",
+    testonly = True,
+    srcs = glob(["**"]),
+    visibility = ["//visibility:public"],
+)

--- a/rules_haskell_tests/non_module_deps.bzl
+++ b/rules_haskell_tests/non_module_deps.bzl
@@ -111,16 +111,6 @@ cc_library(
         ],
     )
 
-    # Does not support bzlmod yet
-    http_archive(
-        name = "io_bazel_stardoc",
-        sha256 = "3fd8fec4ddec3c670bd810904e2e33170bedfe12f90adf943508184be458c8bb",
-        urls = [
-            "https://mirror.bazel.build/github.com/bazelbuild/stardoc/releases/download/0.5.3/stardoc-0.5.3.tar.gz",
-            "https://github.com/bazelbuild/stardoc/releases/download/0.5.3/stardoc-0.5.3.tar.gz",
-        ],
-    )
-
 def _non_module_deps_impl(_ctx):
     repositories(bzlmod = True)
 

--- a/rules_haskell_tests/non_module_deps_1.bzl
+++ b/rules_haskell_tests/non_module_deps_1.bzl
@@ -8,11 +8,9 @@ load(
 load("@rules_nixpkgs_python//:python.bzl", "nixpkgs_python_configure")
 load("@rules_nixpkgs_go//:go.bzl", "nixpkgs_go_configure")
 load("@rules_nixpkgs_cc//:cc.bzl", "nixpkgs_cc_configure")
-load("@os_info//:os_info.bzl", "is_linux", "is_nix_shell", "is_windows")
+load("@os_info//:os_info.bzl", "is_linux", "is_windows")
 load(
     "@rules_haskell//haskell/asterius:repositories.bzl",
-    "asterius_dependencies_bindist",
-    "asterius_dependencies_nix",
     "rules_haskell_asterius_toolchains",
     "toolchain_libraries",
 )
@@ -104,12 +102,6 @@ filegroup(
         repository = "@nixpkgs_default",
         register = not bzlmod,
     )
-
-    asterius_dependencies_nix(
-        nix_repository = "@nixpkgs_default",
-        nixpkgs_package_rule = nixpkgs_package,
-        register = not bzlmod,
-    ) if is_nix_shell else asterius_dependencies_bindist(register = not bzlmod)
 
     rules_haskell_asterius_toolchains(
         cabalopts = test_cabalopts,


### PR DESCRIPTION
Depends on #1903

This PR contains some more refactoring in preparation for bzlmod.
- 84be61104a59502998bcc722375bfad0066d6c65 adds a `rules_haskell_dependencies_bzlmod` function that only contains dependencies that are not available as modules. So their definition is shared between bzlmod and workspace modes.
- f5d8e9fdece4b1fe1fc1de7d9254187256edf2f8 moves dependencies that are not used by bzlmod after all, from `non_module_deps` files directly to the WORKSPACE file.
- Because buildifier is a development dependency of rules_haskell, buildifier targets should not be in the same package as public ones. So they are moved to dedicated `buildifier` packages.