### PR TITLE
Buildifier fix

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -25,7 +25,7 @@ jobs:
         with:
           path: ~/repo-cache
           key: repo-cache-${{ runner.os }}-nixpkgs-${{ env.cache-version }}
-      - uses: cachix/install-nix-action@v21
+      - uses: cachix/install-nix-action@v22
         with:
           nix_path: nixpkgs=./nixpkgs/default.nix
           extra_nix_config: |
@@ -91,7 +91,7 @@ jobs:
         with:
           path: ~/repo-cache
           key: repo-cache-${{ runner.os }}-nixpkgs-${{ env.cache-version }}
-      - uses: cachix/install-nix-action@v21
+      - uses: cachix/install-nix-action@v22
         with:
           nix_path: nixpkgs=./nixpkgs/default.nix
           extra_nix_config: |

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -14,6 +14,8 @@ exports_files(
         "BUILD.bazel",
         "WORKSPACE",
         "constants.bzl",
+        "non_module_dev_deps.bzl",
+        "non_module_dev_deps_2.bzl",
     ],
     visibility = ["//buildifier:__pkg__"],
 )

--- a/buildifier/BUILD.bazel
+++ b/buildifier/BUILD.bazel
@@ -9,7 +9,6 @@ buildifier(
     name = "buildifier",
     exclude_patterns = buildifier_exclude_patterns,
     mode = "check",
-    tags = ["manual"],
 )
 
 # Run this to fix the errors in BUILD files.
@@ -17,7 +16,6 @@ buildifier(
     name = "buildifier-fix",
     exclude_patterns = buildifier_exclude_patterns,
     mode = "fix",
-    tags = ["manual"],
     verbose = True,
 )
 
@@ -27,13 +25,11 @@ buildifier_test(
         "//:BUILD.bazel",
         "//:WORKSPACE",
         "//:constants.bzl",
-        "//:non_module_deps.bzl",
         "//:non_module_dev_deps.bzl",
         "//:non_module_dev_deps_2.bzl",
         "//buildifier:all_files",
         "//debug/linking_utils:all_files",
         "//docs:all_files",
-        "//extensions:all_files",
         "//haskell:all_files",
         "//nixpkgs:all_files",
         "//rule_info:all_files",
@@ -46,7 +42,6 @@ buildifier_test(
     mode = "diff",
     tags = [
         "dont_test_on_windows",
-        "manual",
     ],
 )
 

--- a/rules_haskell_tests/WORKSPACE
+++ b/rules_haskell_tests/WORKSPACE
@@ -190,4 +190,3 @@ bind(
     name = "python_headers",
     actual = "@com_google_protobuf//util/python:python_headers",
 )
-

--- a/rules_haskell_tests/buildifier/BUILD.bazel
+++ b/rules_haskell_tests/buildifier/BUILD.bazel
@@ -4,14 +4,12 @@ load("@com_github_bazelbuild_buildtools//buildifier:def.bzl", "buildifier", "bui
 buildifier(
     name = "buildifier",
     mode = "check",
-    tags = ["manual"],
 )
 
 # Run this to fix the errors in BUILD files.
 buildifier(
     name = "buildifier-fix",
     mode = "fix",
-    tags = ["manual"],
     verbose = True,
 )
 
@@ -29,7 +27,6 @@ buildifier_test(
     mode = "diff",
     tags = [
         "dont_test_on_windows",
-        "manual",
     ],
 )
 


### PR DESCRIPTION
- This PR reactivates the buildifier tests in the CI and fixes some errors in the buildifier setup.
   I had set the buildifier targets to manual locally because buildifier does not work yet with bzlmod on NixOS (https://github.com/bazelbuild/bazel-gazelle/issues/1469) and accidentally committed the change.

- The nix setup in the CI was failing because of the following [issue](https://github.com/cachix/install-nix-action/issues/183) (for instance [here](https://github.com/tweag/rules_haskell/actions/runs/5311656797/jobs/9615156106#step:4:334)) so the install-nix-action was updated to 22.
