### PR TITLE
Support for --incompatible_disable_starlark_host_transitions

### DIFF
--- a/haskell/c2hs.bzl
+++ b/haskell/c2hs.bzl
@@ -175,7 +175,7 @@ _c2hs_toolchain = rule(
             mandatory = True,
             allow_single_file = True,
             executable = True,
-            cfg = "host",
+            cfg = "exec",
         ),
     },
 )

--- a/haskell/cabal.bzl
+++ b/haskell/cabal.bzl
@@ -701,7 +701,7 @@ haskell_cabal_library = rule(
             Flags to pass to Haskell compiler, in addition to those defined the cabal file. Subject to Make variable substitution.""",
         ),
         "tools": attr.label_list(
-            cfg = "host",
+            cfg = "exec",
             allow_files = True,
             doc = """Tool dependencies. They are built using the host configuration, since
             the tools are executed as part of the build.""",
@@ -719,12 +719,12 @@ haskell_cabal_library = rule(
         ),
         "_cabal_wrapper": attr.label(
             executable = True,
-            cfg = "host",
+            cfg = "exec",
             default = Label("@rules_haskell//haskell:cabal_wrapper"),
         ),
         "_runghc": attr.label(
             executable = True,
-            cfg = "host",
+            cfg = "exec",
             default = Label("@rules_haskell//haskell:runghc"),
         ),
         "_cc_toolchain": attr.label(
@@ -940,7 +940,7 @@ haskell_cabal_binary = rule(
             Flags to pass to Haskell compiler, in addition to those defined the cabal file. Subject to Make variable substitution.""",
         ),
         "tools": attr.label_list(
-            cfg = "host",
+            cfg = "exec",
             allow_files = True,
             doc = """Tool dependencies. They are built using the host configuration, since
             the tools are executed as part of the build.""",
@@ -958,12 +958,12 @@ haskell_cabal_binary = rule(
         ),
         "_cabal_wrapper": attr.label(
             executable = True,
-            cfg = "host",
+            cfg = "exec",
             default = Label("@rules_haskell//haskell:cabal_wrapper"),
         ),
         "_runghc": attr.label(
             executable = True,
-            cfg = "host",
+            cfg = "exec",
             default = Label("@rules_haskell//haskell:runghc"),
         ),
         "_cc_toolchain": attr.label(

--- a/haskell/defs.bzl
+++ b/haskell/defs.bzl
@@ -76,7 +76,7 @@ _haskell_common_attrs = {
         aspects = [haskell_cc_libraries_aspect],
     ),
     "tools": attr.label_list(
-        cfg = "host",
+        cfg = "exec",
         allow_files = True,
     ),
     "_ghci_script": attr.label(
@@ -89,7 +89,7 @@ _haskell_common_attrs = {
     ),
     "_version_macros": attr.label(
         executable = True,
-        cfg = "host",
+        cfg = "exec",
         default = Label("@rules_haskell//haskell:version_macros"),
     ),
     "_cc_toolchain": attr.label(
@@ -97,13 +97,13 @@ _haskell_common_attrs = {
     ),
     "_ghc_wrapper": attr.label(
         executable = True,
-        cfg = "host",
+        cfg = "exec",
         default = Label("@rules_haskell//haskell:ghc_wrapper"),
     ),
     "worker": attr.label(
         default = None,
         executable = True,
-        cfg = "host",
+        cfg = "exec",
     ),
 }
 
@@ -686,7 +686,7 @@ haskell_import = rule(
         "haddock_html": attr.label(allow_single_file = True),
         "_version_macros": attr.label(
             executable = True,
-            cfg = "host",
+            cfg = "exec",
             default = Label("@rules_haskell//haskell:version_macros"),
         ),
     },

--- a/haskell/doctest.bzl
+++ b/haskell/doctest.bzl
@@ -28,7 +28,7 @@ _doctest_toolchain = rule(
     attrs = {
         "doctest": attr.label(
             doc = "Doctest executable",
-            cfg = "host",
+            cfg = "exec",
             executable = True,
             allow_single_file = True,
             mandatory = True,

--- a/haskell/experimental/defs.bzl
+++ b/haskell/experimental/defs.bzl
@@ -33,7 +33,7 @@ _haskell_module = rule(
             aspects = [haskell_cc_libraries_aspect],
         ),
         "tools": attr.label_list(
-            cfg = "host",
+            cfg = "exec",
             allow_files = True,
         ),
         "_cc_toolchain": attr.label(
@@ -41,7 +41,7 @@ _haskell_module = rule(
         ),
         "_ghc_wrapper": attr.label(
             executable = True,
-            cfg = "host",
+            cfg = "exec",
             default = Label("@rules_haskell//haskell:ghc_wrapper"),
         ),
         # TODO[AH] Suppport worker

--- a/haskell/plugins.bzl
+++ b/haskell/plugins.bzl
@@ -30,7 +30,7 @@ ghc_plugin = rule(
             doc = "Plugin options.",
         ),
         "tools": attr.label_list(
-            cfg = "host",
+            cfg = "exec",
             doc = "Tools needed by the plugin when enabled.",
         ),
     },

--- a/haskell/protobuf.bzl
+++ b/haskell/protobuf.bzl
@@ -285,7 +285,7 @@ _haskell_proto_aspect = aspect(
         ),
         "_ghc_wrapper": attr.label(
             executable = True,
-            cfg = "host",
+            cfg = "exec",
             default = Label("@rules_haskell//haskell:ghc_wrapper"),
         ),
     },
@@ -367,13 +367,13 @@ _protobuf_toolchain = rule(
     attrs = {
         "protoc": attr.label(
             executable = True,
-            cfg = "host",
+            cfg = "exec",
             allow_single_file = True,
             mandatory = True,
         ),
         "plugin": attr.label(
             executable = True,
-            cfg = "host",
+            cfg = "exec",
             allow_single_file = True,
             mandatory = True,
         ),

--- a/haskell/repositories.bzl
+++ b/haskell/repositories.bzl
@@ -141,6 +141,19 @@ def rules_haskell_dependencies():
 
     rules_haskell_dependencies_bzlmod()
 
+    # For --incompatible_disable_starlark_host_transitions support (default in bazel 7)
+    # Temporarily overrides the rules_licence that comes with bazel to workaround
+    # https://github.com/bazelbuild/bazel/issues/17032#issuecomment-1548459728
+    maybe(
+        http_archive,
+        name = "rules_license",
+        sha256 = "4531deccb913639c30e5c7512a054d5d875698daeb75d8cf90f284375fe7c360",
+        urls = [
+            "https://mirror.bazel.build/github.com/bazelbuild/rules_license/releases/download/0.0.7/rules_license-0.0.7.tar.gz",
+            "https://github.com/bazelbuild/rules_license/releases/download/0.0.7/rules_license-0.0.7.tar.gz",
+        ],
+    )
+
 def haskell_repositories():
     """Alias for rules_haskell_dependencies
 

--- a/haskell/toolchain.bzl
+++ b/haskell/toolchain.bzl
@@ -370,13 +370,13 @@ common_attrs = {
     ),
     "asterius_binaries": attr.label(),
     "_cc_wrapper": attr.label(
-        cfg = "host",
+        cfg = "exec",
         default = Label("@rules_haskell//haskell:cc_wrapper"),
         executable = True,
     ),
     "_protoc": attr.label(
         executable = True,
-        cfg = "host",
+        cfg = "exec",
         default = Label("@com_google_protobuf//:protoc"),
     ),
     "_rule_info_proto": attr.label(

--- a/non_module_dev_deps.bzl
+++ b/non_module_dev_deps.bzl
@@ -90,9 +90,9 @@ haskell_cabal_library(
     # no modules are provided at the moment for buildifier
     http_archive(
         name = "com_github_bazelbuild_buildtools",
-        sha256 = "614c84128ddb86aab4e1f25ba2e027d32fd5c6da302ae30685b9d7973b13da1b",
-        strip_prefix = "buildtools-4.2.3",
-        urls = ["https://github.com/bazelbuild/buildtools/archive/4.2.3.tar.gz"],
+        sha256 = "977a0bd4593c8d4c8f45e056d181c35e48aa01ad4f8090bdb84f78dca42f47dc",
+        strip_prefix = "buildtools-6.1.2",
+        urls = ["https://github.com/bazelbuild/buildtools/archive/v6.1.2.tar.gz"],
     )
 
     nixpkgs_local_repository(

--- a/rules_haskell_tests/non_module_deps.bzl
+++ b/rules_haskell_tests/non_module_deps.bzl
@@ -70,9 +70,9 @@ def repositories(*, bzlmod):
     # no modules are provided at the moment for buildifier
     http_archive(
         name = "com_github_bazelbuild_buildtools",
-        sha256 = "614c84128ddb86aab4e1f25ba2e027d32fd5c6da302ae30685b9d7973b13da1b",
-        strip_prefix = "buildtools-4.2.3",
-        urls = ["https://github.com/bazelbuild/buildtools/archive/4.2.3.tar.gz"],
+        sha256 = "977a0bd4593c8d4c8f45e056d181c35e48aa01ad4f8090bdb84f78dca42f47dc",
+        strip_prefix = "buildtools-6.1.2",
+        urls = ["https://github.com/bazelbuild/buildtools/archive/v6.1.2.tar.gz"],
     )
 
     http_archive(


### PR DESCRIPTION
Depends on #1908

This PR addressed #1846 by replacing the deprecated `cfg = "host"` syntax by `cfg = "exec"`, and updating some dependencies to a compatible version.

This was tested with bazel 6 (see [this branch](https://github.com/tweag/rules_haskell/compare/ylecornec/incompatible_disable_starlark_host_transitions...ylecornec/incompatible_disable_starlark_host_transitions_tests)) in This [CI run](https://github.com/tweag/rules_haskell/actions/runs/5312966243) by enabling the `--incompatible_disable_starlark_host_transitions` flag (this flag is not available on bazel 5).

Note: Updating `rules_go` is also needed to support `--incompatible_disable_starlark_host_transitions` but this requires updating the version of bazel used by the CI. So it will be part of the update to bazel 6.