### PR TITLE
Make the flags passed to Stack match Cabal

### DIFF
--- a/haskell/cabal.bzl
+++ b/haskell/cabal.bzl
@@ -1307,10 +1307,12 @@ library
         ],
         "extra-deps": versioned_packages,
         "flags": {
-            pkg: {
-                flag[1:] if flag.startswith("-") else flag: not flag.startswith("-")
+            pkg: dict([
+                (flag[1:], True) if flag.startswith('+') else
+                (flag[1:], False) if flag.startswith('-') else
+                (flag, True)
                 for flag in flags
-            }
+            ])
             for (pkg, flags) in repository_ctx.attr.flags.items()
         },
     }).to_json()


### PR DESCRIPTION
Cabal uses '+' to enable a flag, and '-' to disable a flag. Stack builds a dictionary that has either 'flag: true', or 'flag: false'. The behavior before was passing inconsistent flags to the different tools. Have cabal.bzl handle all the flags that we could pass to cabal. This helps to aid people new to rules_haskell. It also allows negating a flag, which didn't work before.