### PR TITLE
Do not skip worker on Windows

### DIFF
--- a/.bazelrc.common
+++ b/.bazelrc.common
@@ -51,6 +51,9 @@ build:ci --bes_backend=grpcs://remote.buildbuddy.io
 
 common:ci-common --color=no
 
+common:ci-common --nolegacy_important_outputs
+build:ci-common --experimental_remote_cache_compression
+
 build:ci-common --loading_phase_threads=1
 build:ci-common --verbose_failures
 # Make sure we don't rely on the names of convenience symlinks because those

--- a/tools/worker/BUILD.bazel
+++ b/tools/worker/BUILD.bazel
@@ -3,8 +3,6 @@ load("@rules_haskell//haskell:cabal.bzl", "haskell_cabal_binary")
 haskell_cabal_binary(
     name = "bin",
     srcs = glob(["**"]),
-    # Requires more recent GHC version than we use on Windows.
-    tags = ["dont_test_on_windows"],
     visibility = ["//visibility:public"],
     deps = [
         "@rules_haskell_worker_dependencies//:base",


### PR DESCRIPTION
It had been skipped because of an old GHC version on Windows, but this should be recent enough now.

This reverts commit 45340b1.

Also add some of the suggested Bazel flags by BuildBuddy. Apparently, this helps getting successful Windows CI builds.

depends on #1928 