### PR TITLE
Retry uploading build events more often

### DIFF
--- a/.bazelrc.common
+++ b/.bazelrc.common
@@ -64,6 +64,10 @@ build:ci-common --experimental_repository_cache_hardlinks
 
 # Use a remote cache during CI
 build:ci-windows-bindist --bes_upload_mode=wait_for_upload_complete --bes_timeout=60s
+# On Github CI for Windows, we see intermittent connection failures to BuildBuddy
+# (see https://github.com/buildbuddy-io/buildbuddy/issues/4467)
+# increase the retries as a workaround.
+build:ci-windows-bindist --experimental_build_event_upload_max_retries=256
 build:remote-cache --remote_cache=grpcs://remote.buildbuddy.io
 build:ci-common --remote_timeout=3600
 # Avoid failures of the form `deadline exceeded after 14999958197ns DEADLINE_EXCEEDED`.

--- a/.bazelrc.common
+++ b/.bazelrc.common
@@ -63,7 +63,7 @@ build:ci-common --repository_cache=~/repo-cache/
 build:ci-common --experimental_repository_cache_hardlinks
 
 # Use a remote cache during CI
-build:ci-windows-bindist --bes_upload_mode=wait_for_upload_complete --bes_timeout=60s
+build:ci-windows-bindist --bes_upload_mode=wait_for_upload_complete --bes_timeout=600s
 # On Github CI for Windows, we see intermittent connection failures to BuildBuddy
 # (see https://github.com/buildbuddy-io/buildbuddy/issues/4467)
 # increase the retries as a workaround.

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -199,3 +199,25 @@ jobs:
           # NOTE keep in sync with tests/RunTests.hs
           bazel run @stackage-pinning-test-unpinned//:pin
           bazel build @stackage-pinning-test//:hspec
+
+      - name: Collect Logs
+        id: collect_logs
+        if: failure()
+        shell: bash
+        run: |
+          mkdir -p logs
+          if [[ ${{ matrix.module }} == 'rules_haskell_tests' ]]; then
+             dir=rules_haskell_tests
+          else
+             dir=.
+          fi
+          export PATH=$HOME/bazel:$PATH
+          base=$( cd "$dir" ; bazel info output_base )
+          find "$base" -mindepth 1 -maxdepth 1 -name "java*.log.*" -print0 | xargs -0rI % cp % logs/
+
+      - name: Upload Logs
+        if: ${{ failure() && steps.collect_logs.conclusion == 'success' }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: Logs ${{ matrix.os }} ${{ matrix.module }} ${{ matrix.bzlmod }}
+          path: logs


### PR DESCRIPTION
This change retries event upload 256 times on Windows (default is 4).

This remedies an issue (https://github.com/buildbuddy-io/buildbuddy/issues/4467) where the build would fail eventually because the connections to the remote get closed intermittently.

Since we were seeing this mainly for PRs started from forks (where the BuildBuddy API secret is not set), deliberately opened from my fork.

---

Still no dice. Two jobs fail with a timeout error:
```
ERROR: The Build Event Protocol upload timed out. com.google.common.util.concurrent.TimeoutFuture$TimeoutFutureException: Timed out: NonCancellationPropagatingFuture@57251f74[status=PENDING, info=[delegate=[SettableFuture@12279bf4[status=PENDING]]]]
```