### PR TITLE
Upgrade rules_cc, platforms and aspect_rules_js to fix Bazel CI HEAD

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -51,7 +51,7 @@ bazel_dep(
 
 bazel_dep(
     name = "aspect_rules_js",
-    version = "1.27.1",
+    version = "1.31.0",
 )
 
 bazel_dep(

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -26,7 +26,7 @@ bazel_dep(
 
 bazel_dep(
     name = "rules_cc",
-    version = "0.0.6",
+    version = "0.0.8",
 )
 
 bazel_dep(

--- a/haskell/private/versions.bzl
+++ b/haskell/private/versions.bzl
@@ -14,8 +14,8 @@
 # because every bazel version tested requires a lot of space on CI
 # See https://github.com/tweag/rules_haskell/pull/1781#issuecomment-1187640454
 SUPPORTED_BAZEL_VERSIONS = [
-    "5.0.0",
     "5.2.0",
+    "5.4.1",
     "6.2.0",
 ]
 

--- a/haskell/repositories.bzl
+++ b/haskell/repositories.bzl
@@ -135,9 +135,9 @@ def rules_haskell_dependencies():
     maybe(
         http_archive,
         name = "aspect_rules_js",
-        sha256 = "2a1e5d4400e2b49f6d36785aa894412670a0babfe7054e733b6a8f23c1b41e26",
-        strip_prefix = "rules_js-1.23.1",
-        url = "https://github.com/aspect-build/rules_js/releases/download/v1.23.1/rules_js-v1.23.1.tar.gz",
+        sha256 = "7b2a4d1d264e105eae49a27e2e78065b23e2e45724df2251eacdd317e95bfdfd",
+        strip_prefix = "rules_js-1.31.0",
+        url = "https://github.com/aspect-build/rules_js/releases/download/v1.31.0/rules_js-v1.31.0.tar.gz",
     )
 
     rules_haskell_dependencies_bzlmod()

--- a/haskell/repositories.bzl
+++ b/haskell/repositories.bzl
@@ -46,10 +46,10 @@ def rules_haskell_dependencies():
         http_archive,
         name = "platforms",
         urls = [
-            "https://mirror.bazel.build/github.com/bazelbuild/platforms/releases/download/0.0.6/platforms-0.0.6.tar.gz",
-            "https://github.com/bazelbuild/platforms/releases/download/0.0.6/platforms-0.0.6.tar.gz",
+            "https://mirror.bazel.build/github.com/bazelbuild/platforms/releases/download/0.0.7/platforms-0.0.7.tar.gz",
+            "https://github.com/bazelbuild/platforms/releases/download/0.0.7/platforms-0.0.7.tar.gz",
         ],
-        sha256 = "5308fc1d8865406a49427ba24a9ab53087f17f5266a7aabbfc28823f3916e1ca",
+        sha256 = "3a561c99e7bdbe9173aa653fd579fe849f1d8d67395780ab4770b1f381431d51",
     )
 
     maybe(

--- a/haskell/repositories.bzl
+++ b/haskell/repositories.bzl
@@ -65,8 +65,9 @@ def rules_haskell_dependencies():
     maybe(
         http_archive,
         name = "rules_cc",
-        urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.0.1/rules_cc-0.0.1.tar.gz"],
-        sha256 = "4dccbfd22c0def164c8f47458bd50e0c7148f3d92002cdb459c2a96a68498241",
+        urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.0.7/rules_cc-0.0.7.tar.gz"],
+        sha256 = "eb389b5b74862a3d310ee9d6c63348388223b384ae4423ff0fd286fcd123942d",
+        strip_prefix = "rules_cc-0.0.7",
     )
 
     maybe(

--- a/rules_haskell_tests/MODULE.bazel
+++ b/rules_haskell_tests/MODULE.bazel
@@ -85,7 +85,7 @@ bazel_dep(
 
 bazel_dep(
     name = "aspect_rules_js",
-    version = "1.23.0",
+    version = "1.31.0",
 )
 
 bazel_dep(

--- a/rules_haskell_tests/MODULE.bazel
+++ b/rules_haskell_tests/MODULE.bazel
@@ -60,7 +60,7 @@ bazel_dep(
 
 bazel_dep(
     name = "rules_cc",
-    version = "0.0.6",
+    version = "0.0.8",
 )
 
 bazel_dep(

--- a/rules_haskell_tests/MODULE.bazel
+++ b/rules_haskell_tests/MODULE.bazel
@@ -136,8 +136,8 @@ use_repo(
     "toolchains_libraries",
     "zlib.dev",
     "bazel_5",
-    "build_bazel_bazel_5_0_0",
     "build_bazel_bazel_5_2_0",
+    "build_bazel_bazel_5_4_1",
     "build_bazel_bazel_6_2_0",
     "bazel_6",
 )

--- a/start
+++ b/start
@@ -10,7 +10,7 @@ set -eu
 GHC_VERSION=${GHC_VERSION:="9.2.5"}
 
 readonly MIN_BAZEL_MAJOR=5
-readonly MIN_BAZEL_MINOR=0
+readonly MIN_BAZEL_MINOR=2
 
 readonly MAX_BAZEL_MAJOR=6
 readonly MAX_BAZEL_MINOR=2


### PR DESCRIPTION
Fixes #1937

Fixes https://github.com/tweag/rules_haskell/issues/1904

Tested for Bazel HEAD on Bazel CI here: https://buildkite.com/bazel/rules-haskell-haskell/builds/1643#018a1d07-1278-4a4f-a64e-a618fefc3580

FTR, upgrading rules_cc induces bumping the Bazel version since `use_cpp_toolchain` was added in Bazel 5.1.0. I have opted to upgrade to Bazel 5.2 instead, since that was an existing version we integration tested on CI.