### PR TITLE
Update rules_nixpkgs to latest HEAD

### DIFF
--- a/haskell/repositories.bzl
+++ b/haskell/repositories.bzl
@@ -9,8 +9,8 @@ load(
 )
 load(":private/ghc_ci.bzl", "ghc_default_version")
 
-_rules_nixpkgs_version = "0c1f8f5470c7f292b7620762e224f53d837929d3"
-_rules_nixpkgs_sha256 = "9e3898a33c5f21f634aa9e2d45620e7c4b6d54d16d473571a891193bbd4725ca"
+_rules_nixpkgs_version = "7e627d76ba65d6c42586fc265e46bd370672b4eb"
+_rules_nixpkgs_sha256 = "714a0bec45d23bfc23604de5d292a68f6e12272b303fb7bf33567d2878f52612"
 
 _rules_sh_version = "v0.3.0"
 _rules_sh_sha256 = "d668bb32f112ead69c58bde2cae62f6b8acefe759a8c95a2d80ff6a85af5ac5e"
@@ -106,7 +106,7 @@ def rules_haskell_dependencies():
             sha256 = _rules_nixpkgs_sha256,
         )
 
-        # requiered by rules_nixpkgs
+        # required by rules_nixpkgs
         http_archive(
             name = "rules_nodejs",
             sha256 = "08337d4fffc78f7fe648a93be12ea2fc4e8eb9795a4e6aa48595b66b34555626",

--- a/registry/modules/rules_nixpkgs_cc/0.9.0/source.json
+++ b/registry/modules/rules_nixpkgs_cc/0.9.0/source.json
@@ -1,5 +1,5 @@
 {
-    "integrity" : "sha256-njiYozxfIfY0qp4tRWIOfEttVNFtRzVxqJEZO71HJco",
-    "strip_prefix" : "rules_nixpkgs-0c1f8f5470c7f292b7620762e224f53d837929d3/toolchains/cc",
-    "url": "https://github.com/tweag/rules_nixpkgs/archive/0c1f8f5470c7f292b7620762e224f53d837929d3.tar.gz"
+    "integrity" : "sha256-cUoL7EXSO/wjYE3l0pKmj24SJyswP7e/M1Z9KHj1JhI=",
+    "strip_prefix" : "rules_nixpkgs-7e627d76ba65d6c42586fc265e46bd370672b4eb/toolchains/cc",
+    "url": "https://github.com/tweag/rules_nixpkgs/archive/7e627d76ba65d6c42586fc265e46bd370672b4eb.tar.gz"
 }

--- a/registry/modules/rules_nixpkgs_core/0.9.0/source.json
+++ b/registry/modules/rules_nixpkgs_core/0.9.0/source.json
@@ -1,6 +1,6 @@
 {
-    "integrity" : "sha256-njiYozxfIfY0qp4tRWIOfEttVNFtRzVxqJEZO71HJco",
-    "strip_prefix" : "rules_nixpkgs-0c1f8f5470c7f292b7620762e224f53d837929d3/core",
-    "url": "https://github.com/tweag/rules_nixpkgs/archive/0c1f8f5470c7f292b7620762e224f53d837929d3.tar.gz"
+    "integrity" : "sha256-cUoL7EXSO/wjYE3l0pKmj24SJyswP7e/M1Z9KHj1JhI=",
+    "strip_prefix" : "rules_nixpkgs-7e627d76ba65d6c42586fc265e46bd370672b4eb/core",
+    "url": "https://github.com/tweag/rules_nixpkgs/archive/7e627d76ba65d6c42586fc265e46bd370672b4eb.tar.gz"
 }
 

--- a/registry/modules/rules_nixpkgs_go/0.9.0/source.json
+++ b/registry/modules/rules_nixpkgs_go/0.9.0/source.json
@@ -1,5 +1,5 @@
 {
-    "integrity" : "sha256-njiYozxfIfY0qp4tRWIOfEttVNFtRzVxqJEZO71HJco",
-    "strip_prefix" : "rules_nixpkgs-0c1f8f5470c7f292b7620762e224f53d837929d3/toolchains/go",
-    "url": "https://github.com/tweag/rules_nixpkgs/archive/0c1f8f5470c7f292b7620762e224f53d837929d3.tar.gz"
+    "integrity" : "sha256-cUoL7EXSO/wjYE3l0pKmj24SJyswP7e/M1Z9KHj1JhI=",
+    "strip_prefix" : "rules_nixpkgs-7e627d76ba65d6c42586fc265e46bd370672b4eb/toolchains/go",
+    "url": "https://github.com/tweag/rules_nixpkgs/archive/7e627d76ba65d6c42586fc265e46bd370672b4eb.tar.gz"
 }

--- a/registry/modules/rules_nixpkgs_java/0.9.0/source.json
+++ b/registry/modules/rules_nixpkgs_java/0.9.0/source.json
@@ -1,6 +1,6 @@
 {
-    "integrity" : "sha256-njiYozxfIfY0qp4tRWIOfEttVNFtRzVxqJEZO71HJco",
-    "strip_prefix" : "rules_nixpkgs-0c1f8f5470c7f292b7620762e224f53d837929d3/toolchains/java",
-    "url": "https://github.com/tweag/rules_nixpkgs/archive/0c1f8f5470c7f292b7620762e224f53d837929d3.tar.gz"
+    "integrity" : "sha256-cUoL7EXSO/wjYE3l0pKmj24SJyswP7e/M1Z9KHj1JhI=",
+    "strip_prefix" : "rules_nixpkgs-7e627d76ba65d6c42586fc265e46bd370672b4eb/toolchains/java",
+    "url": "https://github.com/tweag/rules_nixpkgs/archive/7e627d76ba65d6c42586fc265e46bd370672b4eb.tar.gz"
 }
 

--- a/registry/modules/rules_nixpkgs_nodejs/0.9.0/source.json
+++ b/registry/modules/rules_nixpkgs_nodejs/0.9.0/source.json
@@ -1,6 +1,6 @@
 {
-    "integrity" : "sha256-njiYozxfIfY0qp4tRWIOfEttVNFtRzVxqJEZO71HJco",
-    "strip_prefix" : "rules_nixpkgs-0c1f8f5470c7f292b7620762e224f53d837929d3/toolchains/nodejs",
-    "url": "https://github.com/tweag/rules_nixpkgs/archive/0c1f8f5470c7f292b7620762e224f53d837929d3.tar.gz"
+    "integrity" : "sha256-cUoL7EXSO/wjYE3l0pKmj24SJyswP7e/M1Z9KHj1JhI=",
+    "strip_prefix" : "rules_nixpkgs-7e627d76ba65d6c42586fc265e46bd370672b4eb/toolchains/nodejs",
+    "url": "https://github.com/tweag/rules_nixpkgs/archive/7e627d76ba65d6c42586fc265e46bd370672b4eb.tar.gz"
 }
 

--- a/registry/modules/rules_nixpkgs_posix/0.9.0/source.json
+++ b/registry/modules/rules_nixpkgs_posix/0.9.0/source.json
@@ -1,6 +1,6 @@
 {
-    "integrity" : "sha256-njiYozxfIfY0qp4tRWIOfEttVNFtRzVxqJEZO71HJco",
-    "strip_prefix" : "rules_nixpkgs-0c1f8f5470c7f292b7620762e224f53d837929d3/toolchains/posix",
-    "url": "https://github.com/tweag/rules_nixpkgs/archive/0c1f8f5470c7f292b7620762e224f53d837929d3.tar.gz"
+    "integrity" : "sha256-cUoL7EXSO/wjYE3l0pKmj24SJyswP7e/M1Z9KHj1JhI=",
+    "strip_prefix" : "rules_nixpkgs-7e627d76ba65d6c42586fc265e46bd370672b4eb/toolchains/posix",
+    "url": "https://github.com/tweag/rules_nixpkgs/archive/7e627d76ba65d6c42586fc265e46bd370672b4eb.tar.gz"
 }
 

--- a/registry/modules/rules_nixpkgs_python/0.9.0/source.json
+++ b/registry/modules/rules_nixpkgs_python/0.9.0/source.json
@@ -1,6 +1,6 @@
 {
-    "integrity" : "sha256-njiYozxfIfY0qp4tRWIOfEttVNFtRzVxqJEZO71HJco",
-    "strip_prefix" : "rules_nixpkgs-0c1f8f5470c7f292b7620762e224f53d837929d3/toolchains/python",
-    "url": "https://github.com/tweag/rules_nixpkgs/archive/0c1f8f5470c7f292b7620762e224f53d837929d3.tar.gz"
+    "integrity" : "sha256-cUoL7EXSO/wjYE3l0pKmj24SJyswP7e/M1Z9KHj1JhI=",
+    "strip_prefix" : "rules_nixpkgs-7e627d76ba65d6c42586fc265e46bd370672b4eb/toolchains/python",
+    "url": "https://github.com/tweag/rules_nixpkgs/archive/7e627d76ba65d6c42586fc265e46bd370672b4eb.tar.gz"
 }
 

--- a/registry/modules/rules_nixpkgs_rust/0.9.0/source.json
+++ b/registry/modules/rules_nixpkgs_rust/0.9.0/source.json
@@ -1,6 +1,6 @@
 {
-    "integrity" : "sha256-njiYozxfIfY0qp4tRWIOfEttVNFtRzVxqJEZO71HJco",
-    "strip_prefix" : "rules_nixpkgs-0c1f8f5470c7f292b7620762e224f53d837929d3/toolchains/rust",
-    "url": "https://github.com/tweag/rules_nixpkgs/archive/0c1f8f5470c7f292b7620762e224f53d837929d3.tar.gz"
+    "integrity" : "sha256-cUoL7EXSO/wjYE3l0pKmj24SJyswP7e/M1Z9KHj1JhI=",
+    "strip_prefix" : "rules_nixpkgs-7e627d76ba65d6c42586fc265e46bd370672b4eb/toolchains/rust",
+    "url": "https://github.com/tweag/rules_nixpkgs/archive/7e627d76ba65d6c42586fc265e46bd370672b4eb.tar.gz"
 }
 


### PR DESCRIPTION
This fixes a problem with the latest upstream Bazel as reported [here][1], incorporating the fix from https://github.com/tweag/rules_nixpkgs/pull/418

[1]: https://github.com/bazelbuild/continuous-integration/issues/1737