### PR TITLE
Add legacy _cc_toolchain attribute to protoc rule

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -13,11 +13,13 @@ tasks:
       - "sudo apt -y update && sudo apt -y install libgmp-dev"
     build_flags:
       - "--config=ci-common"
-      - "--build_tag_filters=-requires_nix,-requires_lz4,-requires_shellcheck,-requires_threaded_rts,-dont_test_with_bindist,-dont_test_on_bazelci,-integration"
+      - "--config=linux-bindist"
+      - "--build_tag_filters=-dont_test_on_bazelci,-integration"
     build_targets:
       - "//tests/..."
     test_flags:
       - "--config=ci-common"
-      - "--test_tag_filters=-requires_nix,-requires_lz4,-requires_shellcheck,-requires_threaded_rts,-dont_test_with_bindist,-dont_test_on_bazelci,-integration"
+      - "--config=linux-bindist"
+      - "--test_tag_filters=-dont_test_on_bazelci,-integration"
     test_targets:
       - "//tests/..."

--- a/tests/protoc.bzl
+++ b/tests/protoc.bzl
@@ -35,6 +35,11 @@ _protoc_wrapper = rule(
     implementation = _protoc_wrapper_impl,
     attrs = {
         "_protoc": attr.label(executable = True, cfg = "exec", default = "@com_google_protobuf//:protoc"),
+        "_cc_toolchain": attr.label(
+            default = Label(
+                "@rules_cc//cc:current_cc_toolchain",
+            ),
+        ),
     },
     toolchains = use_cc_toolchain(),
 )


### PR DESCRIPTION
This makes using a CC toolchain work if toolchain resolution is disabled.

Fixes #1963

:heavy_check_mark:  Bazel CI: https://buildkite.com/bazel/rules-haskell-haskell/builds/1698#_

Note, this also uses the `linux-bindist` config for Bazel's CI now, which enables toolchain resolution and strict action env.

:heavy_check_mark: Bazel CI: https://buildkite.com/bazel/rules-haskell-haskell/builds/1699#_