### PR TITLE
Only use GHC_VERSION if rules_haskell{,_test} is the root module

### DIFF
--- a/extensions/ghc_version.bzl
+++ b/extensions/ghc_version.bzl
@@ -14,9 +14,9 @@ load(
 )
 
 def _ghc_default_version_impl(mctx):
-    root_module = mctx.modules[0].name
+    root_module = mctx.modules[0]
 
-    if root_module in ["rules_haskell", "rules_haskell_tests"]:
+    if root_module.is_root and root_module.name in ["rules_haskell", "rules_haskell_tests"]:
         _ghc_version(name = "rules_haskell_ghc_version")
     else:
         _ghc_default_version(name = "rules_haskell_ghc_version")


### PR DESCRIPTION
module_ctx.modules only contains the modules that use the extension, if the root module does not use it, the first module in that list is not the root module.

Fixes #1967