### PR TITLE
CI: Explicitely list build and test tag filters in presubmit.yml

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -14,12 +14,12 @@ tasks:
     build_flags:
       - "--config=ci-common"
       - "--config=linux-bindist"
-      - "--build_tag_filters=-dont_test_on_bazelci,-integration"
+      - "--build_tag_filters=-requires_nix,-requires_lz4,-requires_shellcheck,-requires_threaded_rts,-dont_test_with_bindist,-dont_test_on_bazelci,-integration"
     build_targets:
       - "//tests/..."
     test_flags:
       - "--config=ci-common"
       - "--config=linux-bindist"
-      - "--test_tag_filters=-dont_test_on_bazelci,-integration"
+      - "--test_tag_filters=-requires_nix,-requires_lz4,-requires_shellcheck,-requires_threaded_rts,-dont_test_with_bindist,-dont_test_on_bazelci,-integration"
     test_targets:
       - "//tests/..."


### PR DESCRIPTION
From https://buildkite.com/bazel/rules-haskell-haskell/builds/1738#018b35dc-49e9-4388-94d7-aee9e942b871
```
(00:23:04) INFO: Found applicable config definition build:linux-bindist in file /workdir/.bazelrc.common: --build_tag_filters -requires_nix,-requires_lz4,-requires_shellcheck,-requires_threaded_rts,-dont_test_with_bindist --test_tag_filters -requires_nix,-requires_lz4,-requires_shellcheck,-requires_threaded_rts,-dont_test_with_bindist --experimental_strict_action_env --incompatible_enable_cc_toolchain_resolution

(00:23:04) INFO: Current date is 2023-10-16

(00:25:27) INFO: From Testing //tests/shellcheck:netlify-install:

==================== Test output for //tests/shellcheck:netlify-install:

/var/lib/buildkite-agent/.cache/bazel/_bazel_buildkite-agent/ec321eb2cc2d0f8f91b676b6d4c66c29/sandbox/linux-sandbox/205/execroot/rules_haskell/bazel-out/k8-fastbuild/bin/tests/shellcheck/netlify-install.runfiles/rules_haskell/tests/shellcheck/netlify-install: line 21: shellcheck: command not found

================================================================================

==================== Test output for //tests/shellcheck:netlify-install:

/var/lib/buildkite-agent/.cache/bazel/_bazel_buildkite-agent/ec321eb2cc2d0f8f91b676b6d4c66c29/sandbox/linux-sandbox/216/execroot/rules_haskell/bazel-out/k8-fastbuild/bin/tests/shellcheck/netlify-install.runfiles/rules_haskell/tests/shellcheck/netlify-install: 
line 21: shellcheck: command not found

================================================================================

==================== Test output for //tests/shellcheck:netlify-install:

/var/lib/buildkite-agent/.cache/bazel/_bazel_buildkite-agent/ec321eb2cc2d0f8f91b676b6d4c66c29/sandbox/linux-sandbox/237/execroot/rules_haskell/bazel-out/k8-fastbuild/bin/tests/shellcheck/netlify-install.runfiles/rules_haskell/tests/shellcheck/netlify-
install: line 21: shellcheck: command not found

================================================================================

```

This problem was introduced in https://github.com/tweag/rules_haskell/pull/1966/commits/e59659a1da7424d29281f3c100c42b11c4acaa8a.

Unfortunately, these flags are not accumulated, so we cannot rely on a base config in a .bazelrc and have to repeat the flags from `linux-bindist` config.

See https://github.com/bazelbuild/bazel/issues/7322

:heavy_check_mark: https://buildkite.com/bazel/rules-haskell-haskell/builds/1741#018b37c9-3f20-4b10-ad21-9c3aa3b463b8

Once merged, this should update the last green commit for rules_haskell on buildkite, and also make rules_haskell work again for Bazel@HEAD (see https://github.com/tweag/rules_haskell/issues/1972)