### PR TITLE
Fail with an error when non-root modules use specific package tag attrs

### DIFF
--- a/extensions/stack_snapshot.bzl
+++ b/extensions/stack_snapshot.bzl
@@ -142,6 +142,15 @@ def _assert_unique_tag(tags, tag_name, module):
             ),
         )
 
+def _assert_no_root_package_attrs(module, package_tag):
+    msg = """Non-root module "{module_name}~{module_version}" tried to use attr "{attr}" which is only valid for root modules."""
+    if package_tag.setup_deps:
+        fail(msg.format(module_name = module.name, module_version = module.version, attr = "setup_deps"))
+    if package_tag.flags:
+        fail(msg.format(module_name = module.name, module_version = module.version, attr = "flags"))
+    if package_tag.vendored:
+        fail(msg.format(module_name = module.name, module_version = module.version, attr = "vendored"))
+
 def _add_packages(conf, module, root_or_rules_haskell):
     """Read the `package` tags from `module` and add the configuration to `conf`"""
     packages_in_module = sets.make()
@@ -184,6 +193,9 @@ def _add_packages(conf, module, root_or_rules_haskell):
                 conf.flags[package_name] = package_tag.flags
             if package_tag.vendored:
                 conf.vendored_packages[package_name] = package_tag.vendored
+        else:
+            _assert_no_root_package_attrs(module, package_tag)
+
 
 def _stack_snapshot_impl(mctx):
     root_module = None

--- a/extensions/stack_snapshot.bzl
+++ b/extensions/stack_snapshot.bzl
@@ -196,6 +196,32 @@ def _add_packages(conf, module, root_or_rules_haskell):
         else:
             _assert_no_root_package_attrs(module, package_tag)
 
+def _assert_non_rules_haskell_tags(module):
+    msg = """Non-root module "{module_name}~{module_version}" tried to use the "{tag}" tag which is only valid for root modules (and rules_haskell)."""
+
+    if module.tags.snapshot:
+        fail(msg.format(module_name = module.name, module_version = module.version, tag = "snapshot"))
+
+def _assert_no_root_tags(module):
+    msg = """Non-root module "{module_name}~{module_version}" tried to use the "{tag}" tag which is only valid for root modules."""
+
+    if module.tags.stack_snapshot_json:
+        fail(msg.format(module_name = module.name, module_version = module.version, tag = "stack_snapshot_json"))
+
+    if module.tags.verbose:
+        fail(msg.format(module_name = module.name, module_version = module.version, tag = "verbose"))
+
+    if module.tags.netrc:
+        fail(msg.format(module_name = module.name, module_version = module.version, tag = "netrc"))
+
+    if module.tags.tools:
+        fail(msg.format(module_name = module.name, module_version = module.version, tag = "tools"))
+
+    if module.tags.stack:
+        fail(msg.format(module_name = module.name, module_version = module.version, tag = "stack"))
+
+    if module.tags.haddock:
+        fail(msg.format(module_name = module.name, module_version = module.version, tag = "haddock"))
 
 def _stack_snapshot_impl(mctx):
     root_module = None
@@ -218,6 +244,8 @@ def _stack_snapshot_impl(mctx):
                         kwargs["local_snapshot"] = snapshot_tag.local_snapshot
                     if snapshot_tag.name:
                         kwargs["snapshot_tag"] = snapshot_tag.name
+        else:
+            _assert_non_rules_haskell_tags(module)
         if module == root_module:
             for stack_snapshot_json_tag in module.tags.stack_snapshot_json:
                 # If the os list is empty (the default value), the file is compatible with all OSs.
@@ -255,6 +283,8 @@ def _stack_snapshot_impl(mctx):
                 _assert_unique_tag(module.tags.haddock, "haddock", module)
                 haddock_tag = module.tags.haddock[0]
                 kwargs["haddock"] = haddock_tag.label
+        else:
+            _assert_no_root_tags(module)
 
     packages_conf = struct(
         configured_packages = sets.make(),


### PR DESCRIPTION
According to comments https://github.com/tweag/rules_haskell/pull/1917#discussion_r1247942790 and https://github.com/tweag/rules_haskell/pull/1917#discussion_r1247946582

Round out #1899