### PR TITLE
Cancel running workflows for the same branch/tag automatically

### DIFF
--- a/.github/workflows/patch-test.yaml
+++ b/.github/workflows/patch-test.yaml
@@ -22,6 +22,9 @@ jobs:
         name: Extract from gen_ghc_bindist
         run: python .github/extract_from_ghc_bindist.py
   test-ghc-patches:
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.os }}-${{ matrix.ghc-version }}
+      cancel-in-progress: true
     name: Test GHC patches
     needs: find-ghc-version
     strategy:

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -12,6 +12,9 @@ env:
 jobs:
   test-nixpkgs:
     name: Build & Test - Nixpkgs
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.os }}-${{ matrix.module }}-${{ matrix.bzlmod }}-nixpkgs
+      cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
     strategy:
       fail-fast: false
       matrix:
@@ -107,6 +110,9 @@ jobs:
 
   test-bindist:
     name: Build & Test - bindist
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.os }}-${{ matrix.module }}-${{ matrix.bzlmod }}-${{ matrix.ghc }}-bindist
+      cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
If you push an update to a branch, we stop running the workflows to save some resources.

See an example for a workflow with cancelled jobs here: https://github.com/tweag/rules_haskell/actions/runs/6587444125?pr=1993  (it was cancelled after I force pushed a commit)