### PR TITLE
Add GHC 9.8 to update-ghc workflow

### DIFF
--- a/.github/update-ghc.py
+++ b/.github/update-ghc.py
@@ -93,8 +93,7 @@ def main():
             gen_script = gen.read()
 
             added_version = replace.sub(
-                rf"""\g<indent>{{ "version": { repr(latest_release) },
-\g<indent>  "ignore_suffixes": [".bz2", ".lz", ".zip"] }},
+                rf"""\g<indent>{{ "version": "{ latest_release }" }},
 \g<0>""",
                 gen_script,
                 count=1,

--- a/.github/update-ghc.py
+++ b/.github/update-ghc.py
@@ -78,43 +78,23 @@ def main():
 
         print("found update:", latest_release, file=sys.stderr)
 
-        replace = re.compile(
-            r'^(?P<indent>\s+)\{\s*"version"\s*:\s*"'
-            + re.escape(GHC_MAJOR_MINOR + "."),
-            re.MULTILINE,
-        )
+        print(" 1. modify haskell/private/ghc_bindist_generated.json", file=sys.stderr)
 
-        print(" 1. modify haskell/gen_ghc_bindist.py", file=sys.stderr)
+        bindists[latest_release] = {}
 
-        gen_script_path = SCRIPT_PATH.parent.parent.joinpath(
-            "haskell/gen_ghc_bindist.py"
-        )
-        with open(gen_script_path, "r+") as gen:
-            gen_script = gen.read()
+        bindist_json.truncate(0)
+        bindist_json.seek(0)
+        json.dump(bindists, bindist_json)
 
-            added_version = replace.sub(
-                rf"""\g<indent>{{ "version": "{ latest_release }" }},
-\g<0>""",
-                gen_script,
-                count=1,
-            )
+    gen_script_path = SCRIPT_PATH.parent.parent.joinpath("haskell/gen_ghc_bindist.py")
 
-            if added_version is gen_script:
-                sys.exit(
-                    f"could not add new version {latest_release} using regex {replace}"
-                )
+    print(" 2. call haskell/gen_ghc_bindist.py", file=sys.stderr)
 
-            gen.truncate(0)
-            gen.seek(0)
-            gen.write(added_version)
+    check_call([sys.executable, "haskell/gen_ghc_bindist.py"])
 
-        print(" 2. call haskell/gen_ghc_bindist.py", file=sys.stderr)
-
-        check_call([sys.executable, "haskell/gen_ghc_bindist.py"])
-
-        if "GITHUB_OUTPUT" in os.environ:
-            with open(os.environ["GITHUB_OUTPUT"], "a") as output:
-                print(f"latest={ latest_release }", file=output)
+    if "GITHUB_OUTPUT" in os.environ:
+        with open(os.environ["GITHUB_OUTPUT"], "a") as output:
+            print(f"latest={ latest_release }", file=output)
 
 
 if __name__ == "__main__":

--- a/.github/workflows/update-ghc.yaml
+++ b/.github/workflows/update-ghc.yaml
@@ -18,6 +18,8 @@ jobs:
           - '9.6'
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: master
       - uses: cachix/install-nix-action@v23
         with:
           nix_path: nixpkgs=nixpkgs/default.nix

--- a/.github/workflows/update-ghc.yaml
+++ b/.github/workflows/update-ghc.yaml
@@ -16,6 +16,7 @@ jobs:
           - '9.2'
           - '9.4'
           - '9.6'
+          - '9.8'
     steps:
       - uses: actions/checkout@v4
         with:

--- a/haskell/gen_ghc_bindist.py
+++ b/haskell/gen_ghc_bindist.py
@@ -14,38 +14,21 @@ from distutils.version import StrictVersion
 # `version` is the version number
 # `distribution_version` is a corrected name
 # (sometimes bindists have errors and are updated by new bindists)
-# `ignore_prefixes` is the prefix of files to ignore
-# `ignore_suffixes` is the suffix of files to ignore
 VERSIONS = [
-    { "version": '9.6.3',
-      "ignore_suffixes": [".bz2", ".lz", ".zip"] },
-    { "version": "9.6.2",
-      "ignore_suffixes": [".bz2", ".lz", ".zip"] },
-    { "version": "9.6.1",
-      "ignore_suffixes": [".bz2", ".lz", ".zip"] },
-    { "version": '9.4.6',
-      "ignore_suffixes": [".bz2", ".lz", ".zip"] },
-    { "version": '9.4.7',
-      "ignore_suffixes": [".bz2", ".lz", ".zip"] },
-    { "version": "9.4.5",
-      "ignore_suffixes": [".bz2", ".lz", ".zip"] },
-    { "version": '9.2.8',
-      "ignore_suffixes": [".bz2", ".lz", ".zip"] },
-    { "version": "9.2.5",
-      "ignore_suffixes": [".bz2", ".lz", ".zip"] },
-    { "version": "9.2.4",
-      "ignore_suffixes": [".bz2", ".lz", ".zip"] },
-    { "version": "9.2.3",
-      "ignore_suffixes": [".bz2", ".lz", ".zip"] },
-    { "version": "9.2.1",
-      "ignore_suffixes": [".bz2", ".lz", ".zip"] },
-    { "version": "9.0.2",
-      "ignore_prefixes": ["ghc-9.0.2a"],
-      "ignore_suffixes": [".bz2", ".lz", ".zip"] },
-    { "version": "9.0.1",
-      "ignore_suffixes": [".bz2", ".lz", ".zip"] },
-    { "version": "8.10.7",
-      "ignore_suffixes": [".bz2", ".lz", ".zip"] },
+    { "version": "9.6.3" },
+    { "version": "9.6.2" },
+    { "version": "9.6.1" },
+    { "version": "9.4.7" },
+    { "version": "9.4.6" },
+    { "version": "9.4.5" },
+    { "version": "9.2.8" },
+    { "version": "9.2.5" },
+    { "version": "9.2.4" },
+    { "version": "9.2.3" },
+    { "version": "9.2.1" },
+    { "version": "9.0.2" },
+    { "version": "9.0.1" },
+    { "version": "8.10.7" },
     { "version": "8.10.4" },
     { "version": "8.10.3" },
     { "version": "8.8.4" },
@@ -91,30 +74,21 @@ def link_for_sha256_file(version):
 # Parses the tarball hashsum file for a distribution version.
 def parse_sha256_file(content, version, url):
     res = {}
-    errs = []
+
+    prefix = "ghc-{ver}-".format(ver = version.get("distribution_version", version['version']))
+    suffix = ".tar.xz"
+
     for line in content:
         # f5763983a26dedd88b65a0b17267359a3981b83a642569b26334423f684f8b8c  ./ghc-8.4.3-i386-deb8-linux.tar.xz
         (hash, file_) = line.decode().strip().split("  ./")
-        prefix = "ghc-{ver}-".format(ver = version.get("distribution_version", version['version']))
-        suffix = ".tar.xz"
-
-        # filter ignored files
-        if   any([file_.startswith(p) for p in version.get("ignore_prefixes", [])]) \
-          or any([file_.endswith(s)   for s in version.get("ignore_suffixes", [])]):
-            continue
 
         if file_.startswith(prefix) and file_.endswith(suffix):
             # i386-deb8-linux
             name = file_[len(prefix):-len(suffix)]
             res[name] = hash
-        else:
-            errs.append("Can't parse the sha256 field for {ver}: {entry}".format(
-                ver = version['version'], entry = line.strip()))
 
-    if errs:
-        eprint("Errors parsing file at " + url + ". Either fix or ignore the lines (ignore_suffixes/ignore_prefixes).")
-        for e in errs:
-            eprint(e)
+    if not res:
+        eprint(f"Errors parsing file at {url}. Could not find entries for {prefix}…{suffix}")
         exit(1)
 
     return res

--- a/haskell/gen_ghc_bindist.py
+++ b/haskell/gen_ghc_bindist.py
@@ -11,34 +11,35 @@ from urllib.request import urlopen
 from distutils.version import StrictVersion
 
 # All GHC versions we generate.
-# `version` is the version number
-# `distribution_version` is a corrected name
-# (sometimes bindists have errors and are updated by new bindists)
 VERSIONS = [
-    { "version": "9.6.3" },
-    { "version": "9.6.2" },
-    { "version": "9.6.1" },
-    { "version": "9.4.7" },
-    { "version": "9.4.6" },
-    { "version": "9.4.5" },
-    { "version": "9.2.8" },
-    { "version": "9.2.5" },
-    { "version": "9.2.4" },
-    { "version": "9.2.3" },
-    { "version": "9.2.1" },
-    { "version": "9.0.2" },
-    { "version": "9.0.1" },
-    { "version": "8.10.7" },
-    { "version": "8.10.4" },
-    { "version": "8.10.3" },
-    { "version": "8.8.4" },
-    { "version": "8.6.5" },
-    { "version": "8.4.4" },
-    { "version": "8.4.3" },
-    { "version": "8.4.2" },
-    { "version": "8.4.1" },
-    { "version": "8.2.2" },
+    "9.6.3",
+    "9.6.2",
+    "9.6.1",
+    "9.4.7",
+    "9.4.6",
+    "9.4.5",
+    "9.2.8",
+    "9.2.5",
+    "9.2.4",
+    "9.2.3",
+    "9.2.1",
+    "9.0.2",
+    "9.0.1",
+    "8.10.7",
+    "8.10.4",
+    "8.10.3",
+    "8.8.4",
+    "8.6.5",
+    "8.4.4",
+    "8.4.3",
+    "8.4.2",
+    "8.4.1",
+    "8.2.2",
 ]
+
+# Sometimes bindists have errors and are updated by new bindists.
+# This dict is used to keep a version -> corrected_version mapping.
+VERSIONS_CORRECTED = {}
 
 # All architectures we generate.
 # bazel: bazel name
@@ -75,7 +76,7 @@ def link_for_sha256_file(version):
 def parse_sha256_file(content, version, url):
     res = {}
 
-    prefix = "ghc-{ver}-".format(ver = version.get("distribution_version", version['version']))
+    prefix = "ghc-{ver}-".format(ver=VERSIONS_CORRECTED.get(version, version))
     suffix = ".tar.xz"
 
     for line in content:
@@ -108,14 +109,14 @@ if __name__ == "__main__":
     # grab : { version: { arch: sha256 } }
     grab = {}
     for ver in VERSIONS:
-        eprint("fetching " + ver['version'])
-        url = link_for_sha256_file(ver['version'])
+        eprint("fetching " + ver)
+        url = link_for_sha256_file(ver)
         res = urlopen(url)
         if res.getcode() != 200:
             eprint("download of {} failed with status {}".format(url, res.getcode()))
             sys.exit(1)
         else:
-            grab[ver['version']] = parse_sha256_file(res, ver, url)
+            grab[ver] = parse_sha256_file(res, ver, url)
 
     # check whether any version is missing arches we need
     # errs : { version: set(missing_arches) }


### PR DESCRIPTION
GHC 9.8.1 has been released a few weeks ago. This PR enables updates to the generated bindist file for this stable release too.

* Simplify and refactor the `gen_ghc_bindist.py` script to keep the GHC versions we generate entries for in the same place.
  These are now just stored in `ghc_bindist_generated.json` file.
* Add `9.8` to the `ghc` matrix variable to keep it updated