### PR TITLE
Actually run in bzlmod mode on CI

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,2 +1,6 @@
 import %workspace%/.bazelrc.common
 import %workspace%/.bazelrc.bzlmod
+
+# User Configuration
+# ------------------
+try-import %workspace%/.bazelrc.local

--- a/.bazelrc.bzlmod
+++ b/.bazelrc.bzlmod
@@ -3,4 +3,4 @@ common --noenable_bzlmod
 
 common:bzlmod --enable_bzlmod
 # Note, have to use /// to make Bazel not crash on Windows
-common:bzlmod --registry=file:///%workspace%/registry --registry=https://bcr.bazel.build
+common --registry=file:///%workspace%/registry --registry=https://bcr.bazel.build

--- a/.bazelrc.bzlmod
+++ b/.bazelrc.bzlmod
@@ -2,4 +2,5 @@
 common --noenable_bzlmod
 
 common:bzlmod --enable_bzlmod
-common:bzlmod --registry=file:%workspace%/registry --registry=https://bcr.bazel.build
+# Note, have to use /// to make Bazel not crash on Windows
+common:bzlmod --registry=file:///%workspace%/registry --registry=https://bcr.bazel.build

--- a/.bazelrc.common
+++ b/.bazelrc.common
@@ -136,7 +136,3 @@ build:windows-bindist --proto_compiler @rules_haskell//tests:protoc.cmd
 # This flag will become the default in bazel 7
 # https://github.com/bazelbuild/bazel/issues/17032
 build --incompatible_disable_starlark_host_transitions
-
-# User Configuration
-# ------------------
-try-import %workspace%/.bazelrc.local

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -204,6 +204,8 @@ jobs:
         run: |
           [[ ${{ runner.os }} == macOS ]] && export BAZEL_USE_CPP_ONLY_TOOLCHAIN=1
           if [[ ${{ runner.os }} == Windows ]]; then
+            # prevent auto-detection of system compilers
+            export BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
             # On Windows `//...` expands to `/...`.
             bazel test ///...
           else
@@ -218,6 +220,8 @@ jobs:
           [[ ${{ runner.os }} == macOS ]] && export BAZEL_USE_CPP_ONLY_TOOLCHAIN=1
           ./tests/run-start-script.sh --use-bindists
           if [[ ${{ runner.os }} == Windows ]]; then
+            # prevent auto-detection of system compilers
+            export BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
             # On Windows `//...` expands to `/...`.
             bazel test ///...
           else

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -27,6 +27,10 @@ jobs:
         exclude:
           - module: rules_haskell_nix
             bzlmod: false
+          # TODO: in a MODULE.bazel file we declare version specific dependencies, would need to use stack snapshot json
+          #       and stack config per GHC version
+          - ghc: 9.4.5
+            bzlmod: true
     runs-on: ${{ matrix.os }}
     steps:
       - if: ${{ matrix.os == 'ubuntu-latest' }}
@@ -120,6 +124,11 @@ jobs:
         ghc:
           - 9.2.5
           - 9.4.5
+        exclude:
+          # TODO: in a MODULE.bazel file we declare version specific dependencies, would need to use stack snapshot json
+          #       and stack config per GHC version
+          - ghc: 9.4.5
+            bzlmod: true
     env:
       GHC_VERSION: ${{ matrix.ghc }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -20,13 +20,13 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-11]
         module: [rules_haskell, rules_haskell_nix, rules_haskell_tests]
-        bzlmod: [bzlmod, workspace]
+        bzlmod: [true, false]
         ghc:
           - 9.2.5
           - 9.4.5
         exclude:
           - module: rules_haskell_nix
-            bzlmod: workspace
+            bzlmod: false
     runs-on: ${{ matrix.os }}
     steps:
       - if: ${{ matrix.os == 'ubuntu-latest' }}
@@ -62,16 +62,11 @@ jobs:
           else
               cache_setting="--remote_header=x-buildbuddy-api-key=$BUILDBUDDY_API_KEY"
           fi
-          if [ ${{ matrix.bzlmod }} == bzlmod ]; then
-              bzlmod_setting='common --config bzlmod'
-          else
-              bzlmod_setting=''
-          fi
           cat >.bazelrc.local <<EOF
           common --config=ci
           build --config=$BUILD_CONFIG
           build $cache_setting
-          $bzlmod_setting
+          common --enable_bzlmod=${{ matrix.bzlmod }}
           EOF
           cp .bazelrc.local rules_haskell_nix
           cp .bazelrc.local rules_haskell_tests
@@ -121,7 +116,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-11, windows-latest]
         module: [rules_haskell, rules_haskell_tests]
-        bzlmod: [bzlmod, workspace]
+        bzlmod: [true, false]
         ghc:
           - 9.2.5
           - 9.4.5
@@ -168,16 +163,15 @@ jobs:
           else
               cache_setting="--remote_header=x-buildbuddy-api-key=$BUILDBUDDY_API_KEY"
           fi
-          if [ ${{ matrix.bzlmod }} == bzlmod ]; then
-              bzlmod_setting='common --config bzlmod'
-          else
-              bzlmod_setting=''
-          fi
           if [[ ${{ runner.os }} == Windows ]]; then
               output_root_setting="startup --output_user_root=C:/_bzl"
               # On windows, we use a separate remote cache for bzlmod,
               # because the c dependency analysis is leaking absolute paths which are different
-              bzlmod_cache_silo_key="build --remote_default_exec_properties=bzlmod-cache-silo-key=${{ matrix.bzlmod }}"
+              if ${{ matrix.bzlmod }}; then
+                bzlmod_cache_silo_key='build --remote_default_exec_properties=bzlmod-cache-silo-key=bzlmod'
+              else
+                bzlmod_cache_silo_key='build --remote_default_exec_properties=bzlmod-cache-silo-key=workspace'
+              fi
           else
               output_root_setting=""
               bzlmod_cache_silo_key=""
@@ -188,7 +182,7 @@ jobs:
           build $cache_setting
           $output_root_setting
           $bzlmod_cache_silo_key
-          $bzlmod_setting
+          common --enable_bzlmod=${{ matrix.bzlmod }}
           EOF
           cp .bazelrc.local rules_haskell_tests
           cat >~/.netrc <<EOF

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -168,7 +168,7 @@ jobs:
           else
               cache_setting="--remote_header=x-buildbuddy-api-key=$BUILDBUDDY_API_KEY"
           fi
-          if [ ${{ matrix.bzlmod }} == bzlmod]; then
+          if [ ${{ matrix.bzlmod }} == bzlmod ]; then
               bzlmod_setting='common --config bzlmod'
           else
               bzlmod_setting=''

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -83,6 +83,7 @@ haskell_toolchains.bindists()
 use_repo(
     haskell_toolchains,
     "all_bindist_toolchains",
+    "rules_haskell_ghc_windows_amd64_cc_toolchain",
     "rules_haskell_python_local",
 )
 
@@ -95,6 +96,7 @@ register_toolchains(
 
 register_toolchains(
     "@all_bindist_toolchains//:all",
+    "@rules_haskell_ghc_windows_amd64_cc_toolchain//:all",
     "@rules_haskell_python_local//:toolchain",
 )
 

--- a/examples/.bazelrc.bzlmod
+++ b/examples/.bazelrc.bzlmod
@@ -1,2 +1,2 @@
-common:bzlmod --experimental_enable_bzlmod
-common:bzlmod --registry=file://%workspace%/../registry --registry=https://bcr.bazel.build
+common:bzlmod --enable_bzlmod
+common --registry=file://%workspace%/../registry --registry=https://bcr.bazel.build

--- a/rules_haskell_nix/.bazelrc
+++ b/rules_haskell_nix/.bazelrc
@@ -1,2 +1,6 @@
 import %workspace%/../.bazelrc.common
 import %workspace%/.bazelrc.bzlmod
+
+# User Configuration
+# ------------------
+try-import %workspace%/.bazelrc.local

--- a/rules_haskell_nix/.bazelrc.bzlmod
+++ b/rules_haskell_nix/.bazelrc.bzlmod
@@ -1,3 +1,4 @@
 common:bzlmod --enable_bzlmod
+
 # Note, have to use /// to make Bazel not crash on Windows
-common:bzlmod --registry=file:///%workspace%/../registry --registry=https://bcr.bazel.build
+common --registry=file:///%workspace%/../registry --registry=https://bcr.bazel.build

--- a/rules_haskell_nix/.bazelrc.bzlmod
+++ b/rules_haskell_nix/.bazelrc.bzlmod
@@ -1,2 +1,3 @@
 common:bzlmod --enable_bzlmod
-common:bzlmod --registry=file://%workspace%/../registry --registry=https://bcr.bazel.build
+# Note, have to use /// to make Bazel not crash on Windows
+common:bzlmod --registry=file:///%workspace%/../registry --registry=https://bcr.bazel.build

--- a/rules_haskell_tests/.bazelrc
+++ b/rules_haskell_tests/.bazelrc
@@ -1,2 +1,6 @@
 import %workspace%/../.bazelrc.common
 import %workspace%/.bazelrc.bzlmod
+
+# User Configuration
+# ------------------
+try-import %workspace%/.bazelrc.local

--- a/rules_haskell_tests/.bazelrc.bzlmod
+++ b/rules_haskell_tests/.bazelrc.bzlmod
@@ -2,4 +2,6 @@
 common --noenable_bzlmod
 
 common:bzlmod --enable_bzlmod
-common:bzlmod --registry=file:%workspace%/../registry --registry=https://bcr.bazel.build
+
+# Note, have to use /// to make Bazel not crash on Windows
+common:bzlmod --registry=file:///%workspace%/../registry --registry=https://bcr.bazel.build

--- a/rules_haskell_tests/.bazelrc.bzlmod
+++ b/rules_haskell_tests/.bazelrc.bzlmod
@@ -4,4 +4,4 @@ common --noenable_bzlmod
 common:bzlmod --enable_bzlmod
 
 # Note, have to use /// to make Bazel not crash on Windows
-common:bzlmod --registry=file:///%workspace%/../registry --registry=https://bcr.bazel.build
+common --registry=file:///%workspace%/../registry --registry=https://bcr.bazel.build

--- a/rules_haskell_tests/MODULE.bazel
+++ b/rules_haskell_tests/MODULE.bazel
@@ -387,7 +387,6 @@ stack_snapshot.package(
         "process",
         "profunctors",
         "proto-lens",
-        "proto-lens-runtime",
         "safe-exceptions",
         "streaming",
         "temporary",
@@ -410,13 +409,20 @@ stack_snapshot.package(
         setup_deps = ["@Cabal//:Cabal"],
     )
     for package in [
+        "bifunctors",
+        "call-stack",
         "c2hs",
         "doctest",
+        "HUnit",
         "happy",
         "hspec",
         "hspec-core",
         "hspec-discover",
         "hspec-expectations",
+        "proto-lens-runtime",
+        "quickcheck-io",
+        "transformers-compat",
+        "type-errors",
     ]
 ]
 

--- a/tutorial/.bazelrc.bzlmod
+++ b/tutorial/.bazelrc.bzlmod
@@ -1,2 +1,2 @@
-common:bzlmod --experimental_enable_bzlmod
-common:bzlmod --registry=file://%workspace%/../registry --registry=https://bcr.bazel.build
+common:bzlmod --enable_bzlmod
+common --registry=file://%workspace%/../registry --registry=https://bcr.bazel.build


### PR DESCRIPTION
I have noticed that we actually never ran rules_haskell_test in bzlmod mode on CI.

This was due to a missing space character in the inline bash script of the workflow.yml file which would always yield `false`.

Additionally, we need to ensure that we can actually override Bazel settings using `.bazelrc.local` file which we are using on CI.

Note, this PR disables CI jobs for GHC 9.4 with bzlmod for now. The reason is that we would need to find a way to read a different stack_snapshot and json file depending on the GHC version. This is tracked here: https://github.com/tweag/rules_haskell/issues/2006

For Windows, we need to work around a path problem passing when `file:%workspace%/registry` which is expanded to an invalid file: URI without a path component. See https://github.com/bazelbuild/bazel/issues/20015