### PR TITLE
Hide `--registry` flags behind a config

### DIFF
--- a/.bazelrc.bzlmod
+++ b/.bazelrc.bzlmod
@@ -3,4 +3,5 @@ common --noenable_bzlmod
 
 common:bzlmod --enable_bzlmod
 # Note, have to use /// to make Bazel not crash on Windows
-common --registry=file:///%workspace%/registry --registry=https://bcr.bazel.build
+common:common --registry=file:///%workspace%/registry --registry=https://bcr.bazel.build
+

--- a/.bazelrc.common
+++ b/.bazelrc.common
@@ -3,6 +3,9 @@
 # Global Configuration
 # --------------------
 
+# enable common config by default (needed for renovate to ignore the file: registry)
+common --config common
+
 # Force TLS 1.2. With TLS 1.3, we run into the following error on Darwin.
 # > No subject alternative DNS name matching github-releases.githubusercontent.com found.
 # It looks like this is a result of SNI being broken on TLS 1.3 which results

--- a/examples/.bazelrc.bzlmod
+++ b/examples/.bazelrc.bzlmod
@@ -1,2 +1,2 @@
 common:bzlmod --enable_bzlmod
-common --registry=file://%workspace%/../registry --registry=https://bcr.bazel.build
+common:common --registry=file://%workspace%/../registry --registry=https://bcr.bazel.build

--- a/rules_haskell_nix/.bazelrc.bzlmod
+++ b/rules_haskell_nix/.bazelrc.bzlmod
@@ -1,4 +1,4 @@
 common:bzlmod --enable_bzlmod
 
 # Note, have to use /// to make Bazel not crash on Windows
-common --registry=file:///%workspace%/../registry --registry=https://bcr.bazel.build
+common:common --registry=file:///%workspace%/../registry --registry=https://bcr.bazel.build

--- a/rules_haskell_tests/.bazelrc.bzlmod
+++ b/rules_haskell_tests/.bazelrc.bzlmod
@@ -4,4 +4,4 @@ common --noenable_bzlmod
 common:bzlmod --enable_bzlmod
 
 # Note, have to use /// to make Bazel not crash on Windows
-common --registry=file:///%workspace%/../registry --registry=https://bcr.bazel.build
+common:common --registry=file:///%workspace%/../registry --registry=https://bcr.bazel.build

--- a/tutorial/.bazelrc.bzlmod
+++ b/tutorial/.bazelrc.bzlmod
@@ -1,2 +1,2 @@
 common:bzlmod --enable_bzlmod
-common --registry=file://%workspace%/../registry --registry=https://bcr.bazel.build
+common:common --registry=file://%workspace%/../registry --registry=https://bcr.bazel.build


### PR DESCRIPTION
Renovate scans for registry URLs in .bazelrc files and tries to use all of them, but it does not support file: URLs and fails:
```
WARN: Host error (repository=tweag/rules_haskell)
       "hostType": "bazel",
       "packageName": "rules_haskell",
       "err": {
         "name": "UnsupportedProtocolError",
         "code": "ERR_UNSUPPORTED_PROTOCOL",
         "message": "Unsupported protocol \"file:\"",
         "stack": "UnsupportedProtocolError: Unsupported protocol \"file:\"\n    at normalizeArguments (/opt/containerbase/tools/renovate/37.49.3/node_modules/got/dist/source/core/index.js:521:23)\n    at got (/opt/containerbase/tools/renovate/37.49.3/node_modules/got/dist/source/create.js:112:39)\n    at gotTask (/opt/containerbase/tools/renovate/37.49.3/node_modules/renovate/lib/util/http/index.ts:96:27)\n    at httpTask (/opt/containerbase/tools/renovate/37.49.3/node_modules/renovate/lib/util/http/index.ts:208:16)\n    at Http.request (/opt/containerbase/tools/renovate/37.49.3/node_modules/renovate/lib/util/http/index.ts:225:20)\n    at Http.requestJson (/opt/containerbase/tools/renovate/37.49.3/node_modules/renovate/lib/util/http/index.ts:290:28)\n    at Http.getJson (/opt/containerbase/tools/renovate/37.49.3/node_modules/renovate/lib/util/http/index.ts:351:17)\n    at BazelDatasource.getReleases (/opt/containerbase/tools/renovate/37.49.3/node_modules/renovate/lib/modules/datasource/bazel/index.ts:44:50)\n    at callback (/opt/containerbase/tools/renovate/37.49.3/node_modules/renovate/lib/util/decorator/index.ts:55:34)\n    at /opt/containerbase/tools/renovate/37.49.3/node_modules/renovate/lib/util/cache/package/decorator.ts:119:24\n    at getRegistryReleases (/opt/containerbase/tools/renovate/37.49.3/node_modules/renovate/lib/modules/datasource/index.ts:77:15)\n    at huntRegistries (/opt/containerbase/tools/renovate/37.49.3/node_modules/renovate/lib/modules/datasource/index.ts:118:13)\n    at fetchReleases (/opt/containerbase/tools/renovate/37.49.3/node_modules/renovate/lib/modules/datasource/index.ts:291:15)",
         "options": {
```
However, it ignores any `--registry` values associated with a configuration.

So introduce a `common` configuration which is always enabled, but causes renovate to skip the `--registry` values.