### PR TITLE
Cleanup: remove deprecated options and targets

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -10,8 +10,41 @@ env:
   cache-version: 0
 
 jobs:
+  lint:
+    name: Format & Lint
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}-lint
+      cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Configure
+        env:
+          BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
+        run: |
+          # Avoid failures of the form `deadline exceeded after 14999958197ns DEADLINE_EXCEEDED`.
+          # See https://github.com/tweag/rules_haskell/issues/1498 and https://github.com/tweag/rules_haskell/pull/1692.
+          [[ ${{ runner.os }} == Linux ]] && sudo sysctl -w net.ipv4.tcp_keepalive_time=60
+          if [ -z "$BUILDBUDDY_API_KEY" ]; then
+              cache_setting='--noremote_upload_local_results'
+          else
+              cache_setting="--remote_header=x-buildbuddy-api-key=$BUILDBUDDY_API_KEY"
+          fi
+          cat >.bazelrc.local <<EOF
+          common --config=ci
+          build $cache_setting
+          EOF
+          cat >~/.netrc <<EOF
+          machine api.github.com
+                  password ${{ secrets.GITHUB_TOKEN }}
+          EOF
+      - run: |
+          bazelisk test buildifier:buildifier_test
+
   test-nixpkgs:
     name: Build & Test - Nixpkgs
+    needs:
+      - lint
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.os }}-${{ matrix.module }}-${{ matrix.bzlmod }}-${{ matrix.ghc }}-nixpkgs
       cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
@@ -115,6 +148,8 @@ jobs:
 
   test-bindist:
     name: Build & Test - bindist
+    needs:
+      - lint
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.os }}-${{ matrix.module }}-${{ matrix.bzlmod }}-${{ matrix.ghc }}-bindist
       cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 ### Removed
 
 * remove `compiler_flags` option which was deprecated since 0.14 from macros and rules
+* remove `<name>-repl` aliases for repl targets introduced in 0.7
 
 ## [0.17] 2023-10-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 * remove `compiler_flags` option which was deprecated since 0.14 from macros and rules
 * remove `<name>-repl` aliases for repl targets introduced in 0.7
+* remove deprecated nixpkgs platform aliases introduced in 0.13
 
 ## [0.17] 2023-10-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## Unreleased
+
+### Removed
+
+* remove `compiler_flags` option which was deprecated since 0.14 from macros and rules
+
 ## [0.17] 2023-10-19
 
 [0.17]: https://github.com/tweag/rules_haskell/compare/v0.16...v0.17

--- a/buildifier/BUILD.bazel
+++ b/buildifier/BUILD.bazel
@@ -45,6 +45,7 @@ buildifier_test(
     mode = "diff",
     tags = [
         "dont_test_on_windows",
+        "manual",
     ],
 )
 

--- a/buildifier/BUILD.bazel
+++ b/buildifier/BUILD.bazel
@@ -4,10 +4,17 @@ buildifier_exclude_patterns = [
     "./vendor/**",
 ]
 
+_lint_warnings = [
+    "load",
+    "unused-variable",
+]
+
 # Run this to fix the errors in BUILD files.
 buildifier(
     name = "buildifier",
     exclude_patterns = buildifier_exclude_patterns,
+    lint_mode = "fix",
+    lint_warnings = _lint_warnings,
     verbose = True,
 )
 
@@ -33,6 +40,8 @@ buildifier_test(
         "@examples//:all_files",
         "@tutorial//:all_files",
     ],
+    lint_mode = "warn",
+    lint_warnings = _lint_warnings,
     mode = "diff",
     tags = [
         "dont_test_on_windows",

--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@io_bazel_stardoc//stardoc:stardoc.bzl", "stardoc")
 load("@rules_python//python:defs.bzl", "py_binary")
 load("@rules_haskell//docs/pandoc:pandoc.bzl", "set_site_end_location")
@@ -34,6 +35,17 @@ libraries = [
     "c2hs",
 ]
 
+# moved here so that //haskell is not dependent upon rules_nixpkgs_*
+bzl_library(
+    name = "haskell_nix",
+    srcs = ["//haskell:nixpkgs.bzl"],
+    deps = [
+        "//haskell",
+        "@rules_nixpkgs_core//:nixpkgs",
+        "@rules_nixpkgs_posix//:posix",
+    ],
+)
+
 [
     (
         # Extract API documentation metadata to generate navigation and index.
@@ -47,7 +59,10 @@ libraries = [
             provider_template = ":templates/metadata/provider.vm",
             rule_template = ":templates/metadata/rule.vm",
             tags = ["dont_test_on_windows"],
-            deps = ["//haskell"],
+            deps = [
+                ":haskell_nix",
+                "//haskell",
+            ],
         ),
         # Generate markdown API documentation.
         stardoc(
@@ -60,7 +75,10 @@ libraries = [
             provider_template = ":templates/markdown/provider.vm",
             rule_template = ":templates/markdown/rule.vm",
             tags = ["dont_test_on_windows"],
-            deps = ["//haskell"],
+            deps = [
+                ":haskell_nix",
+                "//haskell",
+            ],
         ),
         # Convert markdown to html.
         genrule(

--- a/docs/haskell.rst
+++ b/docs/haskell.rst
@@ -239,7 +239,7 @@ a single ``BUILD.bazel`` as follows::
   haskell_binary(
       name = "demorgan",
       srcs = ["Main.hs"],
-      compiler_flags = ["-threaded"],
+      ghcopts = ["-threaded"],
       deps = [":base", ":booleans"],
   )
 
@@ -317,7 +317,7 @@ And at the ``main/BUILD.bazel`` file::
   haskell_binary(
       name = "demorgan",
       srcs = ["Main.hs"],
-      compiler_flags = ["-threaded"],
+      ghcopts = ["-threaded"],
       deps = [":base", "//lib:booleans"],
   )
 

--- a/examples/WORKSPACE
+++ b/examples/WORKSPACE
@@ -10,7 +10,6 @@ local_repository(
     path = "arm",
 )
 
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@rules_haskell//haskell:repositories.bzl", "rules_haskell_dependencies")
 
 rules_haskell_dependencies()

--- a/extensions/rules_haskell_dependencies.bzl
+++ b/extensions/rules_haskell_dependencies.bzl
@@ -7,7 +7,7 @@ load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 load("@rules_haskell//tools:os_info.bzl", "os_info")
 load("@rules_haskell_ghc_version//:ghc_version.bzl", "GHC_VERSION")
 
-def repositories(*, bzlmod):
+def repositories(*, bzlmod):  # @unused
     rules_haskell_dependencies_bzlmod()
 
     # Some helpers for platform-dependent configuration

--- a/haskell/BUILD.bazel
+++ b/haskell/BUILD.bazel
@@ -100,8 +100,6 @@ bzl_library(
         "@bazel_skylib//lib:shell",
         "@bazel_skylib//lib:versions",
         "@bazel_skylib//rules:expand_template",
-        "@rules_nixpkgs_core//:nixpkgs",
-        "@rules_nixpkgs_posix//:posix",
         "@rules_sh//sh:posix",
     ],
 )

--- a/haskell/asterius/defs.bzl
+++ b/haskell/asterius/defs.bzl
@@ -47,7 +47,7 @@ asterius_toolchain = rule(
 # select the asterius platform.
 # We also set the asterius_targets_browser back to it's default value
 # as it in not needed anymore.
-def _asterius_transition_impl(settings, attr):
+def _asterius_transition_impl(_settings, _attr):
     return {
         "//command_line_option:platforms": "@rules_haskell//haskell/asterius:asterius_platform",
         "@rules_haskell_asterius_build_setting//:asterius_targets_browser": False,
@@ -64,7 +64,7 @@ _asterius_transition = transition(
 
 # ahc_dist targets used by asterius_webpack rules must be configured for the browser.
 # We use the following transition for this purpose.
-def _set_ahc_dist_browser_target_impl(settings, attr):
+def _set_ahc_dist_browser_target_impl(_settings, _attr):
     return {"@rules_haskell_asterius_build_setting//:asterius_targets_browser": True}
 
 _set_ahc_dist_browser_target = transition(

--- a/haskell/asterius/repositories.bzl
+++ b/haskell/asterius/repositories.bzl
@@ -3,10 +3,8 @@ load(
     "//haskell:private/workspace_utils.bzl",
     "define_rule",
     "execute_or_fail_loudly",
-    "find_python",
     "resolve_labels",
 )
-load("//haskell:private/validate_attrs.bzl", "check_deprecated_attribute_usage")
 load(
     "//haskell:private/pkgdb_to_bzl.bzl",
     "pkgdb_to_bzl",

--- a/haskell/asterius/repositories.bzl
+++ b/haskell/asterius/repositories.bzl
@@ -279,7 +279,7 @@ def rules_haskell_asterius_toolchains(
         version = AHC_DEFAULT_VERSION,
         ghcopts = [],
         cabalopts = [],
-        repl_ghci_args = [],
+        repl_ghci_args = [],  # @unused
         locale = None,
         register = True):
     """

--- a/haskell/cabal.bzl
+++ b/haskell/cabal.bzl
@@ -93,7 +93,7 @@ def _chop_version(name):
     """Remove any version component from the given package name."""
     return name.rpartition("-")[0]
 
-def _find_cabal(hs, srcs):
+def _find_cabal(srcs):
     """Check that a .cabal file exists. Choose the root one."""
     cabal = None
     for f in srcs:
@@ -207,7 +207,7 @@ def _prepare_cabal_inputs(
         verbose,
         transitive_haddocks,
         generate_paths_module,
-        is_library = False,
+        is_library = False,  # @unused
         dynamic_file = None):
     """Compute Cabal wrapper, arguments, inputs."""
     with_profiling = is_profiling_enabled(hs)
@@ -460,7 +460,7 @@ def _haskell_cabal_library_impl(ctx):
     if ctx.attr.compiler_flags:
         fail("ERROR: `compiler_flags` attribute was removed. Use `cabalopts` with `--ghc-option` instead.")
 
-    cabal = _find_cabal(hs, ctx.files.srcs)
+    cabal = _find_cabal(ctx.files.srcs)
     setup = _find_setup(hs, cabal, ctx.files.srcs)
     package_database = hs.actions.declare_file(
         "_install/{}.conf.d/package.cache".format(package_id),
@@ -803,11 +803,11 @@ def _haskell_cabal_binary_impl(ctx):
     posix = ctx.toolchains["@rules_sh//sh/posix:toolchain_type"]
 
     exe_name = ctx.attr.exe_name if ctx.attr.exe_name else hs.label.name
-    user_cabalopts = _expand_make_variables("cabalopts", ctx, ctx.attr.cabalopts)
+    user_cabalopts = _expand_make_variables("cabalopts", ctx, ctx.atOBtr.cabalopts)
     if ctx.attr.compiler_flags:
         fail("ERROR: `compiler_flags` attribute was removed. Use `cabalopts` with `--ghc-option` instead.")
 
-    cabal = _find_cabal(hs, ctx.files.srcs)
+    cabal = _find_cabal(ctx.files.srcs)
     setup = _find_setup(hs, cabal, ctx.files.srcs)
     package_database = hs.actions.declare_file(
         "_install/{}.conf.d/package.cache".format(hs.label.name),
@@ -1394,7 +1394,7 @@ def _pin_packages(repository_ctx, resolved):
     hashes_url = "https://raw.githubusercontent.com/commercialhaskell/all-cabal-hashes/" + hashes_commit
 
     resolved = dict(**resolved)
-    for (name, spec) in resolved.items():
+    for (_name, spec) in resolved.items():
         # Determine package sha256
         if spec["location"]["type"] == "hackage":
             # stack does not expose sha256, see https://github.com/commercialhaskell/stack/issues/5274
@@ -2432,7 +2432,7 @@ def stack_snapshot(
         tools = [],
         components = {},
         components_dependencies = {},
-        stack_update = None,
+        stack_update = None,  # @unused
         verbose = False,
         netrc = "",
         toolchain_libraries = None,

--- a/haskell/cabal.bzl
+++ b/haskell/cabal.bzl
@@ -20,7 +20,6 @@ load(
     "relative_rpath_prefix",
     "truly_relativize",
 )
-load(":private/set.bzl", "set")
 load("@bazel_skylib//lib:sets.bzl", "sets")
 load(":private/validate_attrs.bzl", "typecheck_stackage_extradeps")
 load(":haddock.bzl", "generate_unified_haddock_info")
@@ -803,7 +802,7 @@ def _haskell_cabal_binary_impl(ctx):
     posix = ctx.toolchains["@rules_sh//sh/posix:toolchain_type"]
 
     exe_name = ctx.attr.exe_name if ctx.attr.exe_name else hs.label.name
-    user_cabalopts = _expand_make_variables("cabalopts", ctx, ctx.atOBtr.cabalopts)
+    user_cabalopts = _expand_make_variables("cabalopts", ctx, ctx.attr.cabalopts)
     if ctx.attr.compiler_flags:
         fail("ERROR: `compiler_flags` attribute was removed. Use `cabalopts` with `--ghc-option` instead.")
 

--- a/haskell/cabal.bzl
+++ b/haskell/cabal.bzl
@@ -458,11 +458,8 @@ def _haskell_cabal_library_impl(ctx):
 
     user_cabalopts = _expand_make_variables("cabalopts", ctx, ctx.attr.cabalopts)
     if ctx.attr.compiler_flags:
-        print("WARNING: compiler_flags attribute is deprecated. Use cabalopts instead.")
-        user_cabalopts.extend([
-            "--ghc-option=" + opt
-            for opt in _expand_make_variables("compiler_flags", ctx, ctx.attr.compiler_flags)
-        ])
+        fail("ERROR: `compiler_flags` attribute was removed. Use `cabalopts` with `--ghc-option` instead.")
+
     cabal = _find_cabal(hs, ctx.files.srcs)
     setup = _find_setup(hs, cabal, ctx.files.srcs)
     package_database = hs.actions.declare_file(
@@ -696,7 +693,7 @@ haskell_cabal_library = rule(
             """,
         ),
         "compiler_flags": attr.string_list(
-            doc = """DEPRECATED. Use `cabalopts` with `--ghc-option` instead.
+            doc = """REMOVED. Use `cabalopts` with `--ghc-option` instead.
 
             Flags to pass to Haskell compiler, in addition to those defined the cabal file. Subject to Make variable substitution.""",
         ),
@@ -808,11 +805,8 @@ def _haskell_cabal_binary_impl(ctx):
     exe_name = ctx.attr.exe_name if ctx.attr.exe_name else hs.label.name
     user_cabalopts = _expand_make_variables("cabalopts", ctx, ctx.attr.cabalopts)
     if ctx.attr.compiler_flags:
-        print("WARNING: compiler_flags attribute is deprecated. Use cabalopts instead.")
-        user_cabalopts.extend([
-            "--ghc-option=" + opt
-            for opt in _expand_make_variables("compiler_flags", ctx, ctx.attr.compiler_flags)
-        ])
+        fail("ERROR: `compiler_flags` attribute was removed. Use `cabalopts` with `--ghc-option` instead.")
+
     cabal = _find_cabal(hs, ctx.files.srcs)
     setup = _find_setup(hs, cabal, ctx.files.srcs)
     package_database = hs.actions.declare_file(

--- a/haskell/defs.bzl
+++ b/haskell/defs.bzl
@@ -351,13 +351,6 @@ def haskell_binary(
     )
 
     repl_kwargs = make_repl_kwargs(["testonly", "tags"], kwargs)
-    native.alias(
-        # XXX Temporary backwards compatibility hack. Remove eventually.
-        # See https://github.com/tweag/rules_haskell/pull/460.
-        name = "%s-repl" % name,
-        actual = "%s@repl" % name,
-        **repl_kwargs
-    )
     haskell_repl(
         name = "%s@repl" % name,
         deps = [name],
@@ -510,14 +503,6 @@ def haskell_test(
     )
 
     repl_kwargs = make_repl_kwargs(["tags"], kwargs)
-    native.alias(
-        # XXX Temporary backwards compatibility hack. Remove eventually.
-        # See https://github.com/tweag/rules_haskell/pull/460.
-        name = "%s-repl" % name,
-        actual = "%s@repl" % name,
-        testonly = kwargs.get("testonly", True),
-        **repl_kwargs
-    )
     haskell_repl(
         name = "%s@repl" % name,
         deps = [name],
@@ -644,13 +629,6 @@ def haskell_library(
     )
 
     repl_kwargs = make_repl_kwargs(["testonly", "tags"], kwargs)
-    native.alias(
-        # XXX Temporary backwards compatibility hack. Remove eventually.
-        # See https://github.com/tweag/rules_haskell/pull/460.
-        name = "%s-repl" % name,
-        actual = "%s@repl" % name,
-        **repl_kwargs
-    )
     haskell_repl(
         name = "%s@repl" % name,
         deps = [name],

--- a/haskell/defs.bzl
+++ b/haskell/defs.bzl
@@ -32,10 +32,6 @@ load(
     _ghc_plugin = "ghc_plugin",
 )
 load(
-    "//haskell:providers.bzl",
-    "HaskellLibraryInfo",
-)
-load(
     "//haskell/experimental:providers.bzl",
     "HaskellModuleInfo",
 )

--- a/haskell/defs.bzl
+++ b/haskell/defs.bzl
@@ -536,7 +536,6 @@ def haskell_library(
         narrowed_deps = [],
         modules = [],
         data = [],
-        compiler_flags = [],
         ghcopts = [],
         repl_ghci_args = [],
         runcompile_flags = [],

--- a/haskell/defs.bzl
+++ b/haskell/defs.bzl
@@ -32,10 +32,6 @@ load(
     _ghc_plugin = "ghc_plugin",
 )
 load(
-    ":private/validate_attrs.bzl",
-    "check_deprecated_attribute_usage",
-)
-load(
     "//haskell:providers.bzl",
     "HaskellLibraryInfo",
 )
@@ -224,14 +220,6 @@ _haskell_library = rule(
 )
 
 def _haskell_worker_wrapper(rule_type, **kwargs):
-    kwargs["ghcopts"] = check_deprecated_attribute_usage(
-        old_attr_name = "compiler_flags",
-        old_attr_value = kwargs["compiler_flags"],
-        new_attr_name = "ghcopts",
-        new_attr_value = kwargs["ghcopts"],
-    )
-    kwargs.pop("compiler_flags")
-
     defaults = dict(
         worker = select({
             "@rules_haskell//haskell:use_worker": Label("@rules_haskell//tools/worker:bin"),
@@ -255,7 +243,6 @@ def haskell_binary(
         deps = [],
         narrowed_deps = [],
         data = [],
-        compiler_flags = [],
         ghcopts = [],
         repl_ghci_args = [],
         runcompile_flags = [],
@@ -323,7 +310,6 @@ def haskell_binary(
       modules: List of extra haskell_module() dependencies to be linked into this binary.
           Note: This attribute is experimental and not ready for production, yet.
       data: See [Bazel documentation](https://docs.bazel.build/versions/master/be/common-definitions.html#common.data).,
-      compiler_flags: DEPRECATED. Use new name ghcopts.
       ghcopts: Flags to pass to Haskell compiler. Subject to Make variable substitution.
       repl_ghci_args: Arbitrary extra arguments to pass to GHCi. This extends `ghcopts` and `repl_ghci_args` from the toolchain. Subject to Make variable substitution.,
       runcompile_flags: Arbitrary extra arguments to pass to runghc. This extends `ghcopts` and `repl_ghci_args` from the toolchain. Subject to Make variable substitution.
@@ -337,6 +323,10 @@ def haskell_binary(
       version: Executable version. If this is specified, CPP version macros will be generated for this build.
       **kwargs: Common rule attributes. See [Bazel documentation](https://docs.bazel.build/versions/master/be/common-definitions.html#common-attributes).
     """
+
+    if "compiler_flags" in kwargs:
+        fail("`compiler_flags` argument was removed, use `ghcopts` instead")
+
     _haskell_worker_wrapper(
         "binary",
         name = name,
@@ -346,7 +336,6 @@ def haskell_binary(
         deps = deps,
         narrowed_deps = narrowed_deps,
         data = data,
-        compiler_flags = compiler_flags,
         ghcopts = ghcopts,
         repl_ghci_args = repl_ghci_args,
         runcompile_flags = runcompile_flags,
@@ -406,7 +395,6 @@ def haskell_test(
         deps = [],
         narrowed_deps = [],
         data = [],
-        compiler_flags = [],
         ghcopts = [],
         repl_ghci_args = [],
         runcompile_flags = [],
@@ -464,7 +452,6 @@ def haskell_test(
       modules: List of extra haskell_module() dependencies to be linked into this test.
           Note: This attribute is experimental and not ready for production, yet.
       data: See [Bazel documentation](https://docs.bazel.build/versions/master/be/common-definitions.html#common.data).,
-      compiler_flags: DEPRECATED. Use new name ghcopts.
       ghcopts: Flags to pass to Haskell compiler. Subject to Make variable substitution.
       repl_ghci_args: Arbitrary extra arguments to pass to GHCi. This extends `ghcopts` and `repl_ghci_args` from the toolchain. Subject to Make variable substitution.,
       runcompile_flags: Arbitrary extra arguments to pass to runghc. This extends `ghcopts` and `repl_ghci_args` from the toolchain. Subject to Make variable substitution.
@@ -491,6 +478,9 @@ def haskell_test(
           Note, this attribute may leave experimental status depending on the outcome of https://github.com/bazelbuild/bazel/issues/7763.
       **kwargs: Common rule attributes. See [Bazel documentation](https://docs.bazel.build/versions/master/be/common-definitions.html#common-attributes).
     """
+    if "compiler_flags" in kwargs:
+        fail("`compiler_flags` argument was removed, use `ghcopts` instead")
+
     _haskell_worker_wrapper(
         "test",
         name = name,
@@ -500,7 +490,6 @@ def haskell_test(
         deps = deps,
         narrowed_deps = narrowed_deps,
         data = data,
-        compiler_flags = compiler_flags,
         ghcopts = ghcopts,
         repl_ghci_args = repl_ghci_args,
         runcompile_flags = runcompile_flags,
@@ -607,7 +596,6 @@ def haskell_library(
       modules: List of extra haskell_module() dependencies to be linked into this library.
           Note: This attribute is experimental and not ready for production, yet.
       data: See [Bazel documentation](https://docs.bazel.build/versions/master/be/common-definitions.html#common.data).,
-      compiler_flags: DEPRECATED. Use new name ghcopts.
       ghcopts: Flags to pass to Haskell compiler. Subject to Make variable substitution.
       repl_ghci_args: Arbitrary extra arguments to pass to GHCi. This extends `ghcopts` and `repl_ghci_args` from the toolchain. Subject to Make variable substitution.,
       runcompile_flags: Arbitrary extra arguments to pass to runghc. This extends `ghcopts` and `repl_ghci_args` from the toolchain. Subject to Make variable substitution.
@@ -626,6 +614,9 @@ def haskell_library(
         originally defined as a Cabal package, or which is a dependency of a Cabal package. If this is specified, CPP version macro will be generated.
       **kwargs: Common rule attributes. See [Bazel documentation](https://docs.bazel.build/versions/master/be/common-definitions.html#common-attributes).
     """
+    if "compiler_flags" in kwargs:
+        fail("`compiler_flags` argument was removed, use `ghcopts` instead")
+
     _haskell_worker_wrapper(
         "library",
         name = name,
@@ -637,7 +628,6 @@ def haskell_library(
         narrowed_deps = narrowed_deps,
         modules = modules,
         data = data,
-        compiler_flags = compiler_flags,
         ghcopts = ghcopts,
         repl_ghci_args = repl_ghci_args,
         runcompile_flags = runcompile_flags,

--- a/haskell/doctest.bzl
+++ b/haskell/doctest.bzl
@@ -4,7 +4,6 @@ load("@bazel_skylib//lib:dicts.bzl", "dicts")
 load("@rules_cc//cc:find_cc_toolchain.bzl", "use_cc_toolchain")
 load(":cc.bzl", "cc_interop_info", "ghc_cc_program_args")
 load(":private/context.bzl", "haskell_context", "render_env")
-load(":private/set.bzl", "set")
 load("@bazel_skylib//lib:sets.bzl", "sets")
 load(
     "@rules_haskell//haskell:providers.bzl",

--- a/haskell/doctest.bzl
+++ b/haskell/doctest.bzl
@@ -87,7 +87,6 @@ def _haskell_doctest_single(target, ctx):
         return []
 
     hs = haskell_context(ctx, ctx.attr)
-    posix = ctx.toolchains["@rules_sh//sh/posix:toolchain_type"]
 
     hs_info = target[HaskellInfo]
     cc_info = target[CcInfo]

--- a/haskell/experimental/BUILD.bazel
+++ b/haskell/experimental/BUILD.bazel
@@ -1,5 +1,3 @@
-load("@bazel_skylib//rules:common_settings.bzl", "string_setting")
-
 # for bzl_library() in //haskell:BUILD.bazel
 exports_files([
     "providers.bzl",

--- a/haskell/experimental/defs.bzl
+++ b/haskell/experimental/defs.bzl
@@ -65,7 +65,7 @@ def haskell_module(
         ghcopts = [],
         plugins = [],
         tools = [],
-        worker = None,
+        worker = None,  # @unused
         **kwargs):
     """Declare a module and its dependencies on other modules.
 

--- a/haskell/experimental/defs.bzl
+++ b/haskell/experimental/defs.bzl
@@ -1,7 +1,6 @@
 """Experimental Haskell rules"""
 
 load("@rules_cc//cc:find_cc_toolchain.bzl", "use_cc_toolchain")
-load("//haskell/experimental:providers.bzl", "HaskellModuleInfo")
 load(
     "//haskell/experimental/private:module.bzl",
     _haskell_module_impl = "haskell_module_impl",

--- a/haskell/experimental/private/module.bzl
+++ b/haskell/experimental/private/module.bzl
@@ -97,7 +97,7 @@ def _build_haskell_module(
         ctx,
         hs,
         cc,
-        posix,
+        posix,  # @unused
         dep_info,
         narrowed_deps_info,
         package_name,

--- a/haskell/experimental/private/module.bzl
+++ b/haskell/experimental/private/module.bzl
@@ -10,10 +10,6 @@ load(
     "expand_make_variables",
     "haskell_library_expand_make_variables",
 )
-load(
-    "//haskell:private/mode.bzl",
-    "is_profiling_enabled",
-)
 load("//haskell:private/pkg_id.bzl", "pkg_id")
 load(
     "//haskell:private/packages.bzl",
@@ -24,7 +20,6 @@ load(
     "//haskell:private/plugins.bzl",
     "resolve_plugin_tools",
 )
-load("//haskell:private/set.bzl", "set")
 load(
     "//haskell:providers.bzl",
     "GhcPluginInfo",

--- a/haskell/ghc_bindist.bzl
+++ b/haskell/ghc_bindist.bzl
@@ -446,7 +446,6 @@ def ghc_bindist(
     Args:
       name: A unique name for the repository.
       version: The desired GHC version.
-      compiler_flags: [see rules_haskell_toolchains](toolchain.html#rules_haskell_toolchains-compiler_flags)
       ghcopts: [see rules_haskell_toolchains](toolchain.html#rules_haskell_toolchains-ghcopts)
       haddock_flags: [see rules_haskell_toolchains](toolchain.html#rules_haskell_toolchains-haddock_flags)
       repl_ghci_args: [see rules_haskell_toolchains](toolchain.html#rules_haskell_toolchains-repl_ghci_args)
@@ -454,12 +453,8 @@ def ghc_bindist(
       locale: [see rules_haskell_toolchains](toolchain.html#rules_haskell_toolchains-locale)
       register: Whether to register the toolchains (must be set to False if bzlmod is enabled)
     """
-    ghcopts = check_deprecated_attribute_usage(
-        old_attr_name = "compiler_flags",
-        old_attr_value = compiler_flags,
-        new_attr_name = "ghcopts",
-        new_attr_value = ghcopts,
-    )
+    if compiler_flags:
+        fail("`compiler_flags` argument was removed, use `ghcopts` instead")
 
     bindist_name = name
     toolchain_name = "{}-toolchain".format(name)
@@ -525,7 +520,7 @@ _GHC_AVAILABLE_TARGETS = [
 
 def haskell_register_ghc_bindists(
         version = None,
-        compiler_flags = None,
+        compiler_flags = None,  # TODO remove
         ghcopts = None,
         haddock_flags = None,
         repl_ghci_args = None,
@@ -539,7 +534,6 @@ def haskell_register_ghc_bindists(
 
     Args:
       version: [see rules_haskell_toolchains](toolchain.html#rules_haskell_toolchains-version)
-      compiler_flags: [see rules_haskell_toolchains](toolchain.html#rules_haskell_toolchains-compiler_flags)
       ghcopts: [see rules_haskell_toolchains](toolchain.html#rules_haskell_toolchains-ghcopts)
       haddock_flags: [see rules_haskell_toolchains](toolchain.html#rules_haskell_toolchains-haddock_flags)
       repl_ghci_args: [see rules_haskell_toolchains](toolchain.html#rules_haskell_toolchains-repl_ghci_args)
@@ -548,6 +542,9 @@ def haskell_register_ghc_bindists(
       register: Whether to register the toolchains (must be set to False if bzlmod is enabled)
       targets: A list of target platforms to generate bindists for, e.g. `["linux_amd64", "windows_amd64"]` (default: all)
     """
+    if compiler_flags:
+        fail("`compiler_flags` argument was removed, use `ghcopts` instead")
+
     version = version or _GHC_DEFAULT_VERSION
 
     for target in targets:

--- a/haskell/ghc_bindist.bzl
+++ b/haskell/ghc_bindist.bzl
@@ -17,7 +17,6 @@ load(
     "find_python",
     "resolve_labels",
 )
-load(":private/validate_attrs.bzl", "check_deprecated_attribute_usage")
 load("//haskell:ghc.bzl", "DEFAULT_GHC_VERSION")
 
 _GHC_DEFAULT_VERSION = DEFAULT_GHC_VERSION
@@ -458,8 +457,6 @@ def ghc_bindist(
 
     bindist_name = name
     toolchain_name = "{}-toolchain".format(name)
-
-    version_tuple = _split_version(version)
 
     patches = None
     if target == "windows_amd64":

--- a/haskell/haddock.bzl
+++ b/haskell/haddock.bzl
@@ -1,6 +1,5 @@
 """Haddock support"""
 
-load("@bazel_skylib//lib:dicts.bzl", "dicts")
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load("@bazel_skylib//lib:shell.bzl", "shell")
 load(
@@ -16,8 +15,6 @@ load(
     "haskell_cc_libraries_aspect",
 )
 load(":private/context.bzl", "haskell_context", "render_env")
-load(":private/set.bzl", "set")
-load("@bazel_skylib//lib:sets.bzl", "sets")
 
 def generate_unified_haddock_info(this_package_id, this_package_haddock, this_package_html, deps):
     """Collapse dependencies into a single `HaddockInfo`.

--- a/haskell/platforms/BUILD.bazel
+++ b/haskell/platforms/BUILD.bazel
@@ -11,26 +11,6 @@ load(":list.bzl", "declare_config_settings")
 
 declare_config_settings()
 
-alias(
-    name = "nixpkgs",
-    actual = "@rules_nixpkgs_core//constraints:support_nix",
-    visibility = ["//visibility:public"],
-)
-
-alias(
-    name = "linux_x86_64_nixpkgs",
-    actual = "@rules_nixpkgs_core//platforms:host",
-    deprecation = "Use @rules_nixpkgs_core//platforms:host instead.",
-    visibility = ["//visibility:public"],
-)
-
-alias(
-    name = "darwin_x86_64_nixpkgs",
-    actual = "@rules_nixpkgs_core//platforms:host",
-    deprecation = "Use @rules_nixpkgs_core//platforms:host instead.",
-    visibility = ["//visibility:public"],
-)
-
 bzl_library(
     name = "platforms",
     srcs = ["list.bzl"],

--- a/haskell/private/actions/compile.bzl
+++ b/haskell/private/actions/compile.bzl
@@ -7,16 +7,9 @@ load(
 )
 load("@bazel_skylib//lib:dicts.bzl", "dicts")
 load("@bazel_skylib//lib:paths.bzl", "paths")
-load(
-    ":private/path_utils.bzl",
-    "declare_compiled",
-    "target_unique_name",
-)
 load(":private/pkg_id.bzl", "pkg_id")
-load(":private/version_macros.bzl", "version_macro_includes")
 load(
     ":providers.bzl",
-    "HaskellLibraryInfo",
     "all_dependencies_package_ids",
 )
 load(
@@ -24,9 +17,7 @@ load(
     "get_ghci_library_files",
     "link_libraries",
 )
-load(":private/set.bzl", "set")
 load("@bazel_skylib//lib:sets.bzl", "sets")
-load("//haskell/experimental:providers.bzl", "HaskellModuleInfo")
 load(
     ":private/actions/process_hsc_file.bzl",
     "preprocess_hsc_flags_and_inputs",
@@ -347,7 +338,7 @@ def compile_binary(
         hs,
         cc,
         java,
-        posix,
+        posix,  # @unused
         dep_info,
         plugin_dep_info,
         srcs,
@@ -380,7 +371,6 @@ def compile_binary(
         hs,
         cc,
         java,
-        posix,
         dep_info,
         plugin_dep_info,
         srcs,
@@ -442,7 +432,7 @@ def compile_library(
         hs,
         cc,
         java,
-        posix,
+        posix,  # @unused
         dep_info,
         plugin_dep_info,
         srcs,
@@ -477,7 +467,6 @@ def compile_library(
         hs,
         cc,
         java,
-        posix,
         dep_info,
         plugin_dep_info,
         srcs,

--- a/haskell/private/actions/compile.bzl
+++ b/haskell/private/actions/compile.bzl
@@ -37,7 +37,6 @@ def _compilation_defaults(
         hs,
         cc,
         java,
-        posix,
         dep_info,
         plugin_dep_info,
         srcs,

--- a/haskell/private/actions/info.bzl
+++ b/haskell/private/actions/info.bzl
@@ -58,7 +58,7 @@ def _filter_package_env(flags):
     # groups will be responsible for setting the right GHC flags themselves,
     # based on the fields of haskell.LibraryInfo.
     result = []
-    for i in flags:
+    for _i in flags:
         if not flags:
             break
         if flags[0] == "-package-env":
@@ -146,7 +146,7 @@ def compile_info_output_groups(
         hs,
         cc,
         c,
-        posix,
+        _posix,
         runfiles):
     """Output groups for compiling a Haskell target.
 

--- a/haskell/private/actions/info.bzl
+++ b/haskell/private/actions/info.bzl
@@ -1,13 +1,7 @@
 """Defines output groups that are consumed by tools such as 'hrepl'."""
 
-load("@bazel_skylib//lib:dicts.bzl", "dicts")
 load("@bazel_skylib//lib:paths.bzl", "paths")
-load(":providers.bzl", "all_package_ids")
 load(":private/cc_libraries.bzl", "get_ghci_library_files")
-load(
-    ":private/path_utils.bzl",
-    "get_lib_name",
-)
 
 def write_proto_file(hs, output_name, proto_type, content):
     """Write an encoded .proto file.
@@ -146,7 +140,7 @@ def compile_info_output_groups(
         hs,
         cc,
         c,
-        _posix,
+        posix,  # @unused
         runfiles):
     """Output groups for compiling a Haskell target.
 

--- a/haskell/private/actions/link.bzl
+++ b/haskell/private/actions/link.bzl
@@ -285,7 +285,7 @@ def _so_extension(hs):
     """
     return "dylib" if hs.toolchain.is_darwin else "so"
 
-def link_library_static(hs, cc, object_files, my_pkg_id, with_profiling, libdir = ""):
+def link_library_static(hs, cc, _posix, _dep_info, object_files, my_pkg_id, with_profiling, libdir = ""):
     """Link a static library for the package using given object files.
 
     Returns:

--- a/haskell/private/actions/link.bzl
+++ b/haskell/private/actions/link.bzl
@@ -285,7 +285,7 @@ def _so_extension(hs):
     """
     return "dylib" if hs.toolchain.is_darwin else "so"
 
-def link_library_static(hs, cc, posix, dep_info, object_files, my_pkg_id, with_profiling, libdir = ""):
+def link_library_static(hs, cc, object_files, my_pkg_id, with_profiling, libdir = ""):
     """Link a static library for the package using given object files.
 
     Returns:

--- a/haskell/private/actions/package.bzl
+++ b/haskell/private/actions/package.bzl
@@ -47,7 +47,6 @@ def package(
         hs,
         cc,
         posix,
-        dep_info,
         with_shared,
         exposed_modules,
         other_modules,

--- a/haskell/private/actions/package.bzl
+++ b/haskell/private/actions/package.bzl
@@ -2,10 +2,9 @@
 
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load(":private/packages.bzl", "ghc_pkg_recache", "write_package_conf")
-load(":private/path_utils.bzl", "get_lib_name", "rel_to_pkgroot", "target_unique_name")
+load(":private/path_utils.bzl", "get_lib_name")
 load(":private/pkg_id.bzl", "pkg_id")
 load(":private/cc_libraries.bzl", "get_library_files")
-load("//haskell/experimental:providers.bzl", "HaskellModuleInfo")
 
 def _get_extra_libraries(hs, cc, with_shared, dynamic = False):
     """Get directories and library names for extra library dependencies.
@@ -47,6 +46,7 @@ def package(
         hs,
         cc,
         posix,
+        dep_info,  # @unused
         with_shared,
         exposed_modules,
         other_modules,

--- a/haskell/private/actions/process_hsc_file.bzl
+++ b/haskell/private/actions/process_hsc_file.bzl
@@ -3,7 +3,6 @@
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load(":private/version_macros.bzl", "version_macro_includes")
 load(":private/path_utils.bzl", "declare_compiled")
-load(":private/set.bzl", "set")
 load("@bazel_skylib//lib:sets.bzl", "sets")
 
 def process_hsc_file(hs, cc, hsc_flags, hsc_inputs, hsc_file):

--- a/haskell/private/actions/runghc.bzl
+++ b/haskell/private/actions/runghc.bzl
@@ -1,15 +1,10 @@
 """runghc support"""
 
-load(":private/context.bzl", "render_env")
 load(":private/packages.bzl", "expose_packages", "pkg_info_to_compile_flags")
 load(
     ":private/path_utils.bzl",
     "ln",
     "target_unique_name",
-)
-load(
-    ":private/set.bzl",
-    "set",
 )
 load(
     ":private/cc_libraries.bzl",

--- a/haskell/private/cc_libraries.bzl
+++ b/haskell/private/cc_libraries.bzl
@@ -306,7 +306,6 @@ def extend_HaskellCcLibrariesInfo(
     Returns:
       HaskellCcLibrariesInfo
     """
-    hs = ctx.toolchains["@rules_haskell//haskell:toolchain"]
     posix = ctx.toolchains["@rules_sh//sh/posix:toolchain_type"]
     libraries = dict(cc_libraries_info.libraries)
 
@@ -354,9 +353,6 @@ def _haskell_cc_libraries_aspect_impl(target, ctx):
         # To work around this we instead generate HaskellCcLibrariesInfo within
         # _haskell_proto_aspect and bundle it in HaskellProtobufInfo.
         return target[HaskellProtobufInfo].cc_libraries_info
-
-    hs = ctx.toolchains["@rules_haskell//haskell:toolchain"]
-    posix = ctx.toolchains["@rules_sh//sh/posix:toolchain_type"]
 
     cc_libraries_info = merge_HaskellCcLibrariesInfo(infos = [
         dep[HaskellCcLibrariesInfo]

--- a/haskell/private/context.bzl
+++ b/haskell/private/context.bzl
@@ -1,7 +1,7 @@
 """Derived context with Haskell-specific fields and methods"""
 
 load("@bazel_skylib//lib:paths.bzl", "paths")
-load("//haskell:providers.bzl", "HaskellLibraryInfo", "all_dependencies_package_ids")
+load("//haskell:providers.bzl", "all_dependencies_package_ids")
 load(":private/path_utils.bzl", "join_path_list")
 
 HaskellContext = provider()

--- a/haskell/private/haskell_impl.bzl
+++ b/haskell/private/haskell_impl.bzl
@@ -9,7 +9,6 @@ load(
     "HaskellInfo",
     "HaskellLibraryInfo",
     "HaskellToolchainLibraryInfo",
-    "all_dependencies_package_ids",
 )
 load(":cc.bzl", "cc_interop_info")
 load(
@@ -40,7 +39,6 @@ load(
     "get_lib_extension",
     "get_static_hs_lib_name",
     "infer_main_module",
-    "ln",
     "match_label",
     "parse_pattern",
 )
@@ -54,7 +52,6 @@ load("@bazel_skylib//lib:paths.bzl", "paths")
 load("@bazel_skylib//lib:collections.bzl", "collections")
 load("@bazel_skylib//lib:shell.bzl", "shell")
 load("@rules_cc//cc:find_cc_toolchain.bzl", "find_cc_toolchain")
-load("//haskell/experimental:providers.bzl", "HaskellModuleInfo")
 load("//haskell/experimental/private:module.bzl", "build_haskell_modules", "get_module_path_from_target")
 
 # Note [Empty Libraries]

--- a/haskell/private/haskell_impl.bzl
+++ b/haskell/private/haskell_impl.bzl
@@ -101,7 +101,7 @@ def haskell_test_impl(ctx):
 def haskell_binary_impl(ctx):
     return _haskell_binary_common_impl(ctx, is_test = False)
 
-def _should_inspect_coverage(ctx, hs, is_test):
+def _should_inspect_coverage(_ctx, hs, is_test):
     return hs.coverage_enabled and is_test
 
 def _coverage_enabled_for_target(coverage_source_patterns, label):
@@ -573,7 +573,7 @@ def haskell_library_impl(ctx):
     else:
         dynamic_library = None
 
-    conf_file, cache_file = package(
+    _, cache_file = package(
         hs,
         cc,
         posix,
@@ -586,7 +586,7 @@ def haskell_library_impl(ctx):
     )
 
     empty_libs_dir = "empty_libs"
-    conf_file_empty, cache_file_empty = package(
+    _, cache_file_empty = package(
         hs,
         cc,
         posix,
@@ -858,7 +858,6 @@ def haskell_toolchain_libraries_impl(ctx):
         target = libraries[package]
 
         # Construct CcInfo
-        additional_link_inputs = []
         if with_profiling:
             # GHC does not provide dynamic profiling mode libraries. The dynamic
             # libraries that are available are missing profiling symbols, that

--- a/haskell/private/list.bzl
+++ b/haskell/private/list.bzl
@@ -1,6 +1,5 @@
 """Helper functions on lists."""
 
-load(":private/set.bzl", "set")
 load("@bazel_skylib//lib:sets.bzl", "sets")
 
 def _dedup_on(f, list_):

--- a/haskell/private/path_utils.bzl
+++ b/haskell/private/path_utils.bzl
@@ -1,7 +1,6 @@
 """Utilities for module and path manipulations."""
 
 load("@bazel_skylib//lib:paths.bzl", "paths")
-load("@bazel_skylib//lib:sets.bzl", "sets")
 
 def is_haskell_extension(extension):
     """Whether the given extension defines a Haskell source file."""

--- a/haskell/private/version_macros.bzl
+++ b/haskell/private/version_macros.bzl
@@ -1,4 +1,3 @@
-load(":private/set.bzl", "set")
 load("@bazel_skylib//lib:sets.bzl", "sets")
 
 def generate_version_macros(ctx, pkg_name, version):

--- a/haskell/private/workspace_utils.bzl
+++ b/haskell/private/workspace_utils.bzl
@@ -1,5 +1,3 @@
-load("@bazel_tools//tools/cpp:lib_cc_configure.bzl", "get_cpu_value")
-
 def execute_or_fail_loudly(
         repository_ctx,
         arguments,

--- a/haskell/protobuf.bzl
+++ b/haskell/protobuf.bzl
@@ -8,13 +8,11 @@ load("@bazel_skylib//lib:paths.bzl", "paths")
 load(
     ":providers.bzl",
     "HaddockInfo",
-    "HaskellCcLibrariesInfo",
     "HaskellInfo",
     "HaskellLibraryInfo",
     "HaskellProtobufInfo",
 )
-load("@rules_cc//cc:find_cc_toolchain.bzl", "find_cc_toolchain", "use_cc_toolchain")
-load(":private/pkg_id.bzl", "pkg_id")
+load("@rules_cc//cc:find_cc_toolchain.bzl", "use_cc_toolchain")
 load(
     ":private/cc_libraries.bzl",
     "deps_HaskellCcLibrariesInfo",

--- a/haskell/protobuf.bzl
+++ b/haskell/protobuf.bzl
@@ -217,7 +217,7 @@ def _haskell_proto_aspect_impl(target, ctx):
     # TODO this pattern match is very brittle. Let's not do this. The
     # order should match the order in the return value expression in
     # haskell_library_impl().
-    [hs_info, cc_info, coverage_info, default_info, library_info, output_groups] = _haskell_library_impl(patched_ctx)
+    [hs_info, cc_info, _coverage_info, default_info, library_info, output_groups] = _haskell_library_impl(patched_ctx)
 
     # Build haddock informations
     transitive_html = {}
@@ -236,8 +236,8 @@ def _haskell_proto_aspect_impl(target, ctx):
     # See bug https://github.com/tweag/rules_haskell/issues/1030
     # We instead declare empty documentation directories / file
     haddock_files = []
-    html_dir = None
 
+    #html_dir = None
     #transitive_html.update({package_id: html_dir})
     transitive_haddocks.update({package_id: haddock_files})
 

--- a/haskell/repl.bzl
+++ b/haskell/repl.bzl
@@ -1,6 +1,5 @@
 """Multi target Haskell REPL."""
 
-load("@bazel_skylib//lib:dicts.bzl", "dicts")
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load("@bazel_skylib//lib:shell.bzl", "shell")
 load("@rules_cc//cc:find_cc_toolchain.bzl", "find_cc_toolchain", "use_cc_toolchain")
@@ -33,7 +32,6 @@ load(
 )
 load(":private/java.bzl", "java_interop_info")
 load(":private/set.bzl", "set")
-load("@bazel_skylib//lib:sets.bzl", "sets")
 
 HaskellReplLoadInfo = provider(
     doc = """Haskell REPL target information.

--- a/haskell/repositories.bzl
+++ b/haskell/repositories.bzl
@@ -1,6 +1,5 @@
 """Workspace rules (repositories)"""
 
-load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 load(

--- a/haskell/toolchain.bzl
+++ b/haskell/toolchain.bzl
@@ -431,7 +431,6 @@ def haskell_toolchain(
         tools,
         libraries,
         asterius_binaries = None,
-        compiler_flags = [],
         ghcopts = [],
         repl_ghci_args = [],
         haddock_flags = [],
@@ -482,7 +481,6 @@ def haskell_toolchain(
       asterius_binaries: An optional filegroup containing asterius binaries.
         If present the toolchain will target WebAssembly and only use binaries from `tools` if needed to complete the toolchain.
       ghcopts: A collection of flags that will be passed to GHC on every invocation.
-      compiler_flags: DEPRECATED. Use new name ghcopts.
       repl_ghci_args: A collection of flags that will be passed to GHCI on repl invocation. It extends the `ghcopts` collection.\\
         Flags set here have precedance over `ghcopts`.
       haddock_flags: A collection of flags that will be passed to haddock.
@@ -496,13 +494,10 @@ def haskell_toolchain(
       **kwargs: Common rule attributes. See [Bazel documentation](https://docs.bazel.build/versions/master/be/common-definitions.html#common-attributes).
 
     """
+    if "compiler_flags" in kwargs:
+        fail("`compiler_flags` argument was removed, use `ghcopts` instead")
+
     corrected_ghci_args = repl_ghci_args + ["-no-user-package-db"]
-    ghcopts = check_deprecated_attribute_usage(
-        old_attr_name = "compiler_flags",
-        old_attr_value = compiler_flags,
-        new_attr_name = "ghcopts",
-        new_attr_value = ghcopts,
-    )
 
     toolchain_rule = _ahc_haskell_toolchain if asterius_binaries else _haskell_toolchain
     toolchain_rule(
@@ -537,7 +532,7 @@ def haskell_toolchain(
 
 def rules_haskell_toolchains(
         version = None,
-        compiler_flags = None,
+        compiler_flags = None,  # TODO remove
         ghcopts = None,
         haddock_flags = None,
         repl_ghci_args = None,
@@ -557,13 +552,14 @@ def rules_haskell_toolchains(
       version: The desired GHC version
       locale: Locale that will be set during compiler
         invocations. Default: C.UTF-8 (en_US.UTF-8 on MacOS)
-      compiler_flags: DEPRECATED. Use new name ghcopts.
       ghcopts: A collection of flags that will be passed to GHC on every invocation.
 
     """
+    if compiler_flags:
+        fail("`compiler_flags` argument was removed, use `ghcopts` instead")
+
     haskell_register_ghc_bindists(
         version = version,
-        compiler_flags = compiler_flags,
         ghcopts = ghcopts,
         haddock_flags = haddock_flags,
         repl_ghci_args = repl_ghci_args,

--- a/haskell/toolchain.bzl
+++ b/haskell/toolchain.bzl
@@ -18,7 +18,6 @@ load(
 )
 load(":private/actions/package.bzl", "package")
 load(":cc.bzl", "ghc_cc_program_args")
-load(":private/validate_attrs.bzl", "check_deprecated_attribute_usage")
 load(":private/context.bzl", "append_to_path")
 load(
     "//haskell/asterius:asterius_config.bzl",

--- a/rules_haskell_nix/BUILD.bazel
+++ b/rules_haskell_nix/BUILD.bazel
@@ -21,3 +21,10 @@ buildifier_test(
     ],
     verbose = True,
 )
+
+sh_test(
+    name = "nix_smoke_test",
+    size = "medium",
+    srcs = ["nix_test.sh"],
+    tags = ["external"],
+)

--- a/rules_haskell_nix/BUILD.bazel
+++ b/rules_haskell_nix/BUILD.bazel
@@ -17,6 +17,7 @@ buildifier_test(
     buildifier = "@buildifier//:buildifier",
     tags = [
         "dont_test_on_windows",
+        "manual",
     ],
     verbose = True,
 )

--- a/rules_haskell_nix/nix_test.sh
+++ b/rules_haskell_nix/nix_test.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+export XDG_CACHE_HOME=${TMPDIR}
+
+exec nix run -I nixpkgs=../nixpkgs 'nixpkgs#cowsay' -- hello, rules_haskell_nix

--- a/rules_haskell_nix/nixpkgs.bzl
+++ b/rules_haskell_nix/nixpkgs.bzl
@@ -19,7 +19,6 @@ load(
     "execute_or_fail_loudly",
     "resolve_labels",
 )
-load("@rules_haskell//haskell:private/validate_attrs.bzl", "check_deprecated_attribute_usage")
 
 def check_ghc_version(repository_ctx):
     ghc_name = "ghc-{}".format(repository_ctx.attr.version)

--- a/rules_haskell_nix/nixpkgs.bzl
+++ b/rules_haskell_nix/nixpkgs.bzl
@@ -365,7 +365,6 @@ def haskell_register_ghc_nixpkgs(
         required in order to use statically-linked Haskell libraries with GHCi
         and Template Haskell.
       fully_static_link: True if and only if fully-statically-linked binaries are to be built.
-      compiler_flags: DEPRECADED. Use new name ghcopts.
       ghcopts: A collection of flags that will be passed to GHC
       compiler_flags_select: temporary workaround to pass conditional arguments.
         See https://github.com/bazelbuild/bazel/issues/9199 for details.
@@ -382,6 +381,9 @@ def haskell_register_ghc_nixpkgs(
         Passed to [nixpkgs_sh_posix_configure](https://github.com/tweag/rules_nixpkgs#nixpkgs_sh_posix_configure).
       register: Whether to register the toolchain (must be set to False if bzlmod is enabled)
     """
+    if compiler_flags:
+        fail("`compiler_flags` argument was removed, use `ghcopts` instead")
+
     nixpkgs_ghc_repo_name = "{}_ghc_nixpkgs".format(name)
     nixpkgs_sh_posix_repo_name = "{}_sh_posix_nixpkgs".format(name)
 
@@ -412,13 +414,6 @@ def haskell_register_ghc_nixpkgs(
         name = nixpkgs_sh_posix_repo_name,
         register = register,
         **sh_posix_nixpkgs_kwargs
-    )
-
-    ghcopts = check_deprecated_attribute_usage(
-        old_attr_name = "compiler_flags",
-        old_attr_value = compiler_flags,
-        new_attr_name = "ghcopts",
-        new_attr_value = ghcopts,
     )
 
     register_ghc_from_nixpkgs_package(

--- a/rules_haskell_tests/MODULE.bazel
+++ b/rules_haskell_tests/MODULE.bazel
@@ -222,13 +222,6 @@ go_deps.module(
 use_repo(
     go_deps,
     "com_github_gogo_protobuf",
-    "com_github_golang_mock",
-    "com_github_golang_protobuf",
-    "org_golang_google_genproto",
-    "org_golang_google_grpc",
-    "org_golang_google_protobuf",
-    "org_golang_x_net",
-    "org_golang_x_tools",
 )
 
 # Java dependencies for the //tests/java_classpath test

--- a/rules_haskell_tests/buildifier/BUILD.bazel
+++ b/rules_haskell_tests/buildifier/BUILD.bazel
@@ -30,6 +30,7 @@ buildifier_test(
     mode = "diff",
     tags = [
         "dont_test_on_windows",
+        "manual",
     ],
 )
 

--- a/rules_haskell_tests/buildifier/BUILD.bazel
+++ b/rules_haskell_tests/buildifier/BUILD.bazel
@@ -1,14 +1,8 @@
 load("@com_github_bazelbuild_buildtools//buildifier:def.bzl", "buildifier", "buildifier_test")
 
-# Run this to check for errors in BUILD files.
-buildifier(
-    name = "buildifier",
-    mode = "check",
-)
-
 # Run this to fix the errors in BUILD files.
 buildifier(
-    name = "buildifier-fix",
+    name = "buildifier",
     mode = "fix",
     verbose = True,
 )

--- a/rules_haskell_tests/non_module_deps.bzl
+++ b/rules_haskell_tests/non_module_deps.bzl
@@ -24,7 +24,7 @@ starlarkified_local_repository = repository_rule(
     },
 )
 
-def repositories(*, bzlmod):
+def repositories(*, bzlmod):  # @unused
     # Some helpers for platform-dependent configuration
     os_info(name = "os_info")
 

--- a/rules_haskell_tests/non_module_deps_2.bzl
+++ b/rules_haskell_tests/non_module_deps_2.bzl
@@ -22,7 +22,7 @@ _empty_repo = repository_rule(
     },
 )
 
-def repositories(*, bzlmod):
+def repositories(*, bzlmod):  # @unused
     # In a separate repo because not all platforms support zlib.
     stack_snapshot(
         name = "stackage-zlib",
@@ -217,7 +217,7 @@ haskell_cabal_library(
             error_msg = "The stackage_asterius-unpinned repository should only be used on linux",
         )
 
-def _non_module_deps_2_impl(ctx):
+def _non_module_deps_2_impl(_ctx):
     repositories(bzlmod = True)
 
 non_module_deps_2 = module_extension(

--- a/rules_haskell_tests/tests/binary-with-compiler-flags/BUILD.bazel
+++ b/rules_haskell_tests/tests/binary-with-compiler-flags/BUILD.bazel
@@ -9,8 +9,8 @@ haskell_test(
     name = "binary-with-compiler-flags",
     srcs = ["Main.hs"],
     # Flags that require -threaded, which we should get from the toolchain's
-    # compiler_flags. Include spaces to validate proper quoting:
-    compiler_flags = [
+    # ghcopts. Include spaces to validate proper quoting:
+    ghcopts = [
         "-with-rtsopts=-N2 -qg -I0 -n2m -A128m",
         "-XLambdaCase",
     ],

--- a/rules_haskell_tests/tests/binary-with-data/BUILD.bazel
+++ b/rules_haskell_tests/tests/binary-with-data/BUILD.bazel
@@ -8,9 +8,9 @@ package(default_testonly = 1)
 haskell_test(
     name = "bin1",
     srcs = ["bin1.hs"],
-    compiler_flags = ['-DBIN1_INPUT="$(rootpath bin1-input)"'],
     # Regular file input:
     data = ["bin1-input"],
+    ghcopts = ['-DBIN1_INPUT="$(rootpath bin1-input)"'],
     visibility = ["//visibility:public"],
     deps = [
         "//tests/hackage:base",

--- a/rules_haskell_tests/tests/binary-with-plugin/BUILD.bazel
+++ b/rules_haskell_tests/tests/binary-with-plugin/BUILD.bazel
@@ -64,7 +64,7 @@ haskell_test(
 haskell_test(
     name = "binary-with-plugin2",
     srcs = ["main2.hs"],
-    compiler_flags = ["-fplugin=Plugin"],
+    ghcopts = ["-fplugin=Plugin"],
     non_default_plugins = [":plugin2"],
     tags = ["skip_profiling"],
     visibility = ["//visibility:public"],

--- a/rules_haskell_tests/tests/cpp_macro_conflict/BUILD.bazel
+++ b/rules_haskell_tests/tests/cpp_macro_conflict/BUILD.bazel
@@ -18,7 +18,7 @@ haskell_library(
 haskell_test(
     name = "macro_conflict",
     srcs = ["Main.hs"],
-    compiler_flags = [
+    ghcopts = [
         "-XCPP",
         "-Werror",
     ] + select({

--- a/rules_haskell_tests/tests/extra-source-files/BUILD.bazel
+++ b/rules_haskell_tests/tests/extra-source-files/BUILD.bazel
@@ -35,13 +35,13 @@ haskell_test(
         "FooTH.hs",
         "Main.hs",
     ],
-    # Test that the linker can also see the extra_srcs.
-    compiler_flags = ["-optl-Wl,@tests/extra-source-files/ld-options.txt"],
     extra_srcs = [
         "file.txt",
         "Foo.hs",  # Test "Multiple entries with same key" in expand_location
         "ld-options.txt",
     ],
+    # Test that the linker can also see the extra_srcs.
+    ghcopts = ["-optl-Wl,@tests/extra-source-files/ld-options.txt"],
     tags = [
         # ld on darwin does not support response files.
         "dont_test_on_darwin_with_bindist",

--- a/rules_haskell_tests/tests/haddock/BUILD.bazel
+++ b/rules_haskell_tests/tests/haddock/BUILD.bazel
@@ -22,7 +22,7 @@ haskell_library(
         "LibA/A.hs",
         "header.h",
     ],
-    compiler_flags = ["-I."],
+    ghcopts = ["-I."],
     tags = ["requires_dynamic"],
     deps = [
         ":haddock-lib-deep",

--- a/rules_haskell_tests/tests/haskell_cabal_datafiles/compare_other_cabal_functions/BUILD.bazel
+++ b/rules_haskell_tests/tests/haskell_cabal_datafiles/compare_other_cabal_functions/BUILD.bazel
@@ -5,17 +5,6 @@
 # have the same behavior as cabal's one.
 #
 
-load(
-    "@rules_haskell//haskell:cabal.bzl",
-    "haskell_cabal_binary",
-    "haskell_cabal_library",
-)
-load(
-    "@rules_haskell//haskell:defs.bzl",
-    "haskell_binary",
-    "haskell_test",
-    "haskell_toolchain_library",
-)
 load("@os_info//:os_info.bzl", "is_windows")
 
 sh_test(

--- a/rules_haskell_tests/tests/haskell_cabal_datafiles/compare_other_cabal_functions/without_generate_paths_module/BUILD.bazel
+++ b/rules_haskell_tests/tests/haskell_cabal_datafiles/compare_other_cabal_functions/without_generate_paths_module/BUILD.bazel
@@ -7,7 +7,6 @@ load(
     "haskell_binary",
     "haskell_toolchain_library",
 )
-load("@rules_haskell_ghc_version//:ghc_version.bzl", "GHC_VERSION")
 
 package(default_testonly = 1)
 

--- a/rules_haskell_tests/tests/haskell_cabal_datafiles/haskell_cabal_binary_with_datafiles/BUILD.bazel
+++ b/rules_haskell_tests/tests/haskell_cabal_datafiles/haskell_cabal_binary_with_datafiles/BUILD.bazel
@@ -1,16 +1,11 @@
 # Check that we manage to access the runfile while using the generate_paths_module attribute of haskell_cabal_binary
 
-load("@bazel_skylib//rules:diff_test.bzl", "diff_test")
-load("@rules_cc//cc:defs.bzl", "cc_library")
 load(
     "@rules_haskell//haskell:cabal.bzl",
     "haskell_cabal_binary",
-    "haskell_cabal_library",
 )
 load(
     "@rules_haskell//haskell:defs.bzl",
-    "haskell_binary",
-    "haskell_test",
     "haskell_toolchain_library",
 )
 load("@os_info//:os_info.bzl", "is_windows")

--- a/rules_haskell_tests/tests/haskell_cabal_datafiles/haskell_cabal_library_with_datafiles/BUILD.bazel
+++ b/rules_haskell_tests/tests/haskell_cabal_datafiles/haskell_cabal_library_with_datafiles/BUILD.bazel
@@ -1,7 +1,5 @@
 # Check that we manage to access the runfile while using the generate_paths_module attribute of haskell_cabal_library
 
-load("@bazel_skylib//rules:diff_test.bzl", "diff_test")
-load("@rules_cc//cc:defs.bzl", "cc_library")
 load(
     "@rules_haskell//haskell:cabal.bzl",
     "haskell_cabal_binary",
@@ -9,7 +7,6 @@ load(
 )
 load(
     "@rules_haskell//haskell:defs.bzl",
-    "haskell_binary",
     "haskell_test",
     "haskell_toolchain_library",
 )

--- a/rules_haskell_tests/tests/haskell_cabal_datafiles/other_binary/haskell_cabal_library_datafiles_2/BUILD.bazel
+++ b/rules_haskell_tests/tests/haskell_cabal_datafiles/other_binary/haskell_cabal_library_datafiles_2/BUILD.bazel
@@ -1,12 +1,6 @@
 # tests that a haskell binary from another package can access
 # datafiles of it's cabal_library dependencY
 
-load("@rules_cc//cc:defs.bzl", "cc_library")
-load(
-    "@rules_haskell//haskell:cabal.bzl",
-    "haskell_cabal_binary",
-    "haskell_cabal_library",
-)
 load(
     "@rules_haskell//haskell:defs.bzl",
     "haskell_binary",

--- a/rules_haskell_tests/tests/haskell_module/repl/haskell_module_repl_cross_library_deps_test/WORKSPACE
+++ b/rules_haskell_tests/tests/haskell_module/repl/haskell_module_repl_cross_library_deps_test/WORKSPACE
@@ -1,5 +1,3 @@
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-
 local_repository(
     name = "rules_haskell",
     path = "../rules_haskell",

--- a/rules_haskell_tests/tests/haskell_module/repl/haskell_module_repl_test/WORKSPACE
+++ b/rules_haskell_tests/tests/haskell_module/repl/haskell_module_repl_test/WORKSPACE
@@ -1,5 +1,3 @@
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-
 local_repository(
     name = "rules_haskell",
     path = "../rules_haskell",

--- a/rules_haskell_tests/tests/haskell_module/tools/BUILD.bazel
+++ b/rules_haskell_tests/tests/haskell_module/tools/BUILD.bazel
@@ -1,7 +1,6 @@
 load(
     "@rules_haskell//haskell:defs.bzl",
     "haskell_binary",
-    "haskell_test",
 )
 load("@rules_haskell//haskell/experimental:defs.bzl", "haskell_module")
 

--- a/rules_haskell_tests/tests/haskell_proto_simple/BUILD.bazel
+++ b/rules_haskell_tests/tests/haskell_proto_simple/BUILD.bazel
@@ -6,7 +6,6 @@ load("@rules_haskell//haskell:defs.bzl", "haskell_library")
 load(
     "@rules_haskell//haskell:protobuf.bzl",
     "haskell_proto_library",
-    "haskell_proto_toolchain",
 )
 
 proto_library(

--- a/rules_haskell_tests/tests/library-external-workspace/repo/BUILD.bazel
+++ b/rules_haskell_tests/tests/library-external-workspace/repo/BUILD.bazel
@@ -1,7 +1,6 @@
 load(
     "@rules_haskell//haskell:defs.bzl",
     "haskell_library",
-    "haskell_test",
     "haskell_toolchain_library",
 )
 load("@rules_haskell//haskell/experimental:defs.bzl", "haskell_module")

--- a/rules_haskell_tests/tests/library-linkstatic-flag/get_library_files.bzl
+++ b/rules_haskell_tests/tests/library-linkstatic-flag/get_library_files.bzl
@@ -3,7 +3,6 @@ load(
     "HaskellInfo",
     "HaskellLibraryInfo",
 )
-load("@rules_haskell//haskell:private/set.bzl", "set")
 
 def _get_libraries_as_runfiles_impl(ctx):
     """Extract all library files from a haskell_library target

--- a/rules_haskell_tests/tests/recompilation/recompilation_workspace/WORKSPACE
+++ b/rules_haskell_tests/tests/recompilation/recompilation_workspace/WORKSPACE
@@ -1,5 +1,3 @@
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-
 local_repository(
     name = "rules_haskell",
     path = "%RULES_HASKELL_PATH%",
@@ -9,8 +7,6 @@ load("@rules_haskell//haskell:repositories.bzl", "rules_haskell_dependencies")
 load("@rules_haskell//tools:os_info.bzl", "os_info")
 
 os_info(name = "os_info")
-
-load("@os_info//:os_info.bzl", "is_windows")
 
 rules_haskell_dependencies()
 

--- a/rules_haskell_tests/tests/repl-flags/BUILD.bazel
+++ b/rules_haskell_tests/tests/repl-flags/BUILD.bazel
@@ -13,8 +13,8 @@ haskell_test(
     name = "compiler_flags",
     srcs = ["CompilerFlags.hs"],
 
-    # This also ensure that local `compiler_flags` does not override the `global ones`
-    compiler_flags = ["-XOverloadedStrings"],
+    # This also ensure that local `ghcopts` does not override the `global ones`
+    ghcopts = ["-XOverloadedStrings"],
     visibility = ["//visibility:public"],
     deps = [
         "//tests/hackage:base",

--- a/rules_haskell_tests/tests/repl-make-variables/BUILD.bazel
+++ b/rules_haskell_tests/tests/repl-make-variables/BUILD.bazel
@@ -4,13 +4,13 @@ package(default_testonly = 1)
 
 # Regression tests for https://github.com/tweag/rules_haskell/issues/1377
 
-# Test that make variable expension is performed on `compiler_flags` forwarded
+# Test that make variable expension is performed on `ghcopts` forwarded
 # to the REPL.
 haskell_test(
     name = "test-compiler-flags",
     srcs = ["Main.hs"],
-    compiler_flags = ['-DDATA="$(rootpath data.txt)"'],
     data = ["data.txt"],
+    ghcopts = ['-DDATA="$(rootpath data.txt)"'],
     visibility = ["//tests/asterius/repl-make-variables:__pkg__"],
     deps = [
         "//tests/hackage:base",

--- a/rules_haskell_tests/tests/repl-targets/BUILD.bazel
+++ b/rules_haskell_tests/tests/repl-targets/BUILD.bazel
@@ -1,7 +1,6 @@
 load("@rules_haskell//haskell:c2hs.bzl", "c2hs_library")
 load(
     "@rules_haskell//haskell:defs.bzl",
-    "haskell_binary",
     "haskell_library",
     "haskell_test",
 )

--- a/rules_haskell_tests/tests/repl-targets/hs_bin_repl_test/WORKSPACE
+++ b/rules_haskell_tests/tests/repl-targets/hs_bin_repl_test/WORKSPACE
@@ -3,7 +3,6 @@ local_repository(
     path = "%RULES_HASKELL_PATH%",
 )
 
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@rules_haskell//haskell:repositories.bzl", "rules_haskell_dependencies")
 
 rules_haskell_dependencies()

--- a/rules_haskell_tests/tests/repl-targets/hs_lib_repl_test/BUILD.bazel
+++ b/rules_haskell_tests/tests/repl-targets/hs_lib_repl_test/BUILD.bazel
@@ -2,7 +2,6 @@ load("@rules_haskell//haskell:c2hs.bzl", "c2hs_library", "c2hs_toolchain")
 load(
     "@rules_haskell//haskell:defs.bzl",
     "haskell_library",
-    "haskell_test",
 )
 load(
     "@rules_haskell//haskell:defs.bzl",

--- a/rules_haskell_tests/tests/sandwich/BUILD.bazel
+++ b/rules_haskell_tests/tests/sandwich/BUILD.bazel
@@ -15,7 +15,7 @@ cc_library(
 haskell_library(
     name = "testlib",
     srcs = ["Lib.hs"],
-    compiler_flags = [
+    ghcopts = [
         "-Wall",
         "-Werror",
     ],
@@ -28,7 +28,7 @@ haskell_library(
 haskell_test(
     name = "test",
     srcs = ["Main.hs"],
-    compiler_flags = [
+    ghcopts = [
         "-Wall",
         "-Werror",
     ],

--- a/tests/protoc.bzl
+++ b/tests/protoc.bzl
@@ -1,4 +1,3 @@
-load("@rules_python//python:py_binary.bzl", "py_binary")
 load("@rules_cc//cc:find_cc_toolchain.bzl", "find_cc_toolchain", "use_cc_toolchain")
 
 def _protoc_wrapper_impl(ctx):

--- a/tools/repositories.bzl
+++ b/tools/repositories.bzl
@@ -2,7 +2,6 @@
 
 load("@rules_haskell//haskell:cabal.bzl", "stack_snapshot")
 load("@rules_haskell_ghc_version//:ghc_version.bzl", "GHC_VERSION")
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
 
 def rules_haskell_worker_dependencies(**stack_kwargs):
     """

--- a/tutorial/WORKSPACE
+++ b/tutorial/WORKSPACE
@@ -5,7 +5,6 @@ local_repository(
     path = "..",
 )
 
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@rules_haskell//haskell:repositories.bzl", "rules_haskell_dependencies")
 
 rules_haskell_dependencies()


### PR DESCRIPTION
1. remove `compiler_flags` option (users will get an error message now telling them to use `ghcopts` instead, to ease the migration -- this error handling should be removed after the next version was released)
2. remove REPL alias introduced in #460
3. remove deprecated nixpkgs platform aliases
4. move nixpkgs bzl_library to //docs (in order to get rid of any references to rules_nixpkgs_* in the core rules_haskell module)
5. enable lint rules and remove unused variables and load statements
6. remove unneeded indirect repositories from rules_haskell_tests module (as reported by gazelle's go_deps extension)