### PR TITLE
Make `find_python` work with Windows App aliases

### DIFF
--- a/haskell/private/workspace_utils.bzl
+++ b/haskell/private/workspace_utils.bzl
@@ -32,15 +32,24 @@ def _as_string(v):
         return repr(v)
 
 def find_python(repository_ctx):
-    python = repository_ctx.which("python3")
-    if not python:
-        python = repository_ctx.which("python")
-        if not python:
-            fail("There is no Python in PATH. Please install Python >= 3.3.")
-        result = execute_or_fail_loudly(repository_ctx, [python, "--version"])
-        if not result.stdout.startswith("Python 3"):
-            fail("rules_haskell requires Python >= 3.3. (found {})".format(result.stdout))
-    return python
+    python_version_script = "import sys; v=sys.version_info; print(v.major, v.minor, v.micro, sys.executable)"
+
+    ret = repository_ctx.execute(["python3", "-c", python_version_script])
+
+    if ret.return_code != 0:
+        ret = repository_ctx.execute(["python", "-c", python_version_script])
+
+    if ret.return_code != 0:
+        fail("There is no Python in PATH. Please install Python >= 3.3.")
+
+    tokens = ret.stdout.split("\n")[0].split(" ", 3)
+
+    py_version = [int(c) for c in tokens[0:3]]
+
+    if py_version < [3, 3]:
+        fail("rules_haskell requires Python >= 3.3. (found {})".format(".".join(tokens[0:3])))
+
+    return tokens[-1].replace("\\", "/").rstrip("\r")
 
 def resolve_labels(repository_ctx, labels):
     """


### PR DESCRIPTION
On recent Windows systems, installing Python makes the python executable available in the `PATH` but uses a special kind of reparse point which resolves the real executable via a registry lookup.

These reparse points are not supported by the JVM and checking if the file exists will return false.

So, although the file can be executed by running "python" it cannot be found using `repository_ctx.which`.

This change just executes `python3` or `python` and uses the executable information from Python directly instead of doing a `PATH` lookup.