### PR TITLE
Add `haskell-gi-overloading` to empty packages blacklist

### DIFF
--- a/haskell/cabal.bzl
+++ b/haskell/cabal.bzl
@@ -135,9 +135,10 @@ _CABAL_TOOLS = ["alex", "c2hs", "cpphs", "doctest", "happy"]
 _EMPTY_PACKAGES_BLACKLIST = [
     "bytestring-builder",
     "fail",
+    "ghc-byteorder",
+    "haskell-gi-overloading",
     "mtl-compat",
     "nats",
-    "ghc-byteorder",
 ]
 
 def _cabal_tool_flag(tool):


### PR DESCRIPTION
Fixes #1752
