### PR TITLE
fix: write remote cache auth to `.bazelrc.auth` for Format & Lint job

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -23,7 +23,7 @@ jobs:
       - uses: tweag/configure-bazel-remote-cache-auth@v0
         with:
           buildbuddy_api_key: ${{ secrets.BUILDBUDDY_API_KEY }}
-          bazelrc_path: .bazelrc.local
+          bazelrc_path: .bazelrc.auth
       - name: Configure
         run: |
           # Avoid failures of the form `deadline exceeded after 14999958197ns DEADLINE_EXCEEDED`.


### PR DESCRIPTION
Related to https://github.com/tweag/scalable-builds-group/issues/107.