### PR TITLE
chore: join all CI jobs

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -39,8 +39,6 @@ jobs:
 
   test-nixpkgs:
     name: Build & Test - Nixpkgs
-    needs:
-      - lint
     strategy:
       fail-fast: false
       matrix:
@@ -52,6 +50,7 @@ jobs:
           - 9.4.6
         exclude:
           - module: rules_haskell_nix
+
             bzlmod: false
           # TODO: in a MODULE.bazel file we declare version specific dependencies, would need to use stack snapshot json
           #       and stack config per GHC version
@@ -130,8 +129,6 @@ jobs:
 
   test-bindist:
     name: Build & Test - bindist
-    needs:
-      - lint
     strategy:
       fail-fast: false
       matrix:
@@ -254,3 +251,15 @@ jobs:
         with:
           name: Logs ${{ matrix.os }} ${{ matrix.module }} ${{ matrix.bzlmod }}
           path: logs
+
+  all_ci_tests:
+    runs-on: ubuntu-latest
+    needs:
+      - lint
+      - test-nixpkgs
+      - test-bindist
+    if: ${{ always() }}
+    steps:
+      - uses: cgrindel/gha_join_jobs@794a2d117251f22607f1aab937d3fd3eaaf9a2f5 # v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- Introduce `cgrindel/gha_join_jobs` to ensure all CI jobs are green.
- Remove dependency between unrelated jobs.