### PR TITLE
fix: shutdown Bazel before executing `run-tests`

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -139,6 +139,8 @@ jobs:
               ./tests/run-start-script.sh --use-nix --with-bzlmod=${{ matrix.bzlmod }}
             fi
             bazel build //tests:run-tests
+            # Shutdown Bazel to free up memory
+            bazel shutdown
             ./bazel-ci-bin/tests/run-tests
             bazel coverage //...
 

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -130,6 +130,9 @@ jobs:
           options: ${{ env.NIX_SHELL_ARGS }}
           run: |
             set -euo pipefail
+            # DEBUG BEGIN
+            set -x
+            # DEBUG END
             cd rules_haskell_tests
             # XXX run start script `--with-bzlmod=true` when supported
             if ! ${{ matrix.bzlmod }}; then

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -130,9 +130,6 @@ jobs:
           options: ${{ env.NIX_SHELL_ARGS }}
           run: |
             set -euo pipefail
-            # DEBUG BEGIN
-            set -x
-            # DEBUG END
             cd rules_haskell_tests
             # XXX run start script `--with-bzlmod=true` when supported
             if ! ${{ matrix.bzlmod }}; then
@@ -140,6 +137,7 @@ jobs:
             fi
             bazel build //tests:run-tests
             # Shutdown Bazel to free up memory
+            # https://github.com/tweag/rules_haskell/issues/2089.
             bazel shutdown
             ./bazel-ci-bin/tests/run-tests
             bazel coverage //...

--- a/tools/os_info.bzl
+++ b/tools/os_info.bzl
@@ -15,7 +15,6 @@ def _os_info_impl(repository_ctx):
     known_cpu_values = [
         "aarch64",
         "darwin",
-        "darwin_x86_64",
         "darwin_arm64",
         "darwin_x86_64",
         "k8",

--- a/tools/os_info.bzl
+++ b/tools/os_info.bzl
@@ -15,6 +15,7 @@ def _os_info_impl(repository_ctx):
     known_cpu_values = [
         "aarch64",
         "darwin",
+        "darwin_x86_64",
         "darwin_arm64",
         "darwin_x86_64",
         "k8",


### PR DESCRIPTION
The `run-tests` can fail with out-of-memory errors (e.g. `Exit Code: ExitFailure (-9)`). We shutdown Bazel from the previous step to alleviate some of the memory pressure.

Related to #2089.