### PR TITLE
fix: shutdown Bazel before executing `run-tests`

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -136,6 +136,9 @@ jobs:
               ./tests/run-start-script.sh --use-nix --with-bzlmod=${{ matrix.bzlmod }}
             fi
             bazel build //tests:run-tests
+            # Shutdown Bazel to free up memory
+            # https://github.com/tweag/rules_haskell/issues/2089.
+            bazel shutdown
             ./bazel-ci-bin/tests/run-tests
             bazel coverage //...
 


### PR DESCRIPTION
The `run-tests` can fail with out-of-memory errors (e.g. `Exit Code: ExitFailure (-9)`). We shutdown Bazel from the previous step to alleviate some of the memory pressure.

Related to #2089.