### PR TITLE
chore: configure OS-specific variables in `.bazelrc`

### DIFF
--- a/.bazelrc.common
+++ b/.bazelrc.common
@@ -23,6 +23,19 @@ common --incompatible_disallow_empty_glob=true
 # as LOCALE_ARCHIVE We also need to setup an utf8 locale
 test --test_env=LANG=C.UTF-8 --test_env=LOCALE_ARCHIVE
 
+# Enable automatic OS-specific config (e.g. build:linux, build:macos, build:windows).
+common --enable_platform_specific_config
+
+# MacOS Configuration
+# -------------------
+# do not use Xcode on macOS
+common:macos --repo_env=BAZEL_USE_CPP_ONLY_TOOLCHAIN=1
+
+# Windows Configuration
+# ---------------------
+# prevent auto-detection of system compilers on Windows
+common:windows --repo_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
+
 # Platform / Toolchain Selection
 # ------------------------------
 build:linux-nixpkgs --config=nixpkgs

--- a/.bcr/rules_haskell/presubmit.yml
+++ b/.bcr/rules_haskell/presubmit.yml
@@ -11,8 +11,6 @@ tasks:
   verify_targets:
     name: Verify build targets
     platform: ${{ platform }}
-    environment:
-      BAZEL_USE_CPP_ONLY_TOOLCHAIN: '1'
     shell_commands:
     - |
       if apt --version >/dev/null 2>/dev/null; then
@@ -22,7 +20,6 @@ tasks:
     batch_commands:
     # enforce certificate update
     - 'powershell -Command "Invoke-WebRequest -Uri https://hackage.haskell.org/root.json -OutFile out.json"'
-    - set BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
     build_flags:
       - '--incompatible_enable_cc_toolchain_resolution'
     build_targets:

--- a/.github/workflows/patch-test.yaml
+++ b/.github/workflows/patch-test.yaml
@@ -72,7 +72,6 @@ jobs:
         shell: bash
         run: |
           export PATH=$HOME/bazel:$PATH
-          [[ ${{ runner.os }} == macOS ]] && export BAZEL_USE_CPP_ONLY_TOOLCHAIN=1
           export GHC_VERSION=${{ matrix.ghc-version }}
           cd rules_haskell_tests
           ./tests/run-start-script.sh --use-bindists

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -157,10 +157,6 @@ jobs:
           - ghc: 9.6.2
             os: windows-latest
     env:
-      # prevent auto-detection of system compilers on Windows
-      BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN: ${{ matrix.os == 'windows-latest' && 1 || 0 }}
-      # do not use Xcode on macOS
-      BAZEL_USE_CPP_ONLY_TOOLCHAIN: ${{ matrix.os == 'macos-latest' && 1 || 0 }}
       GHC_VERSION: ${{ matrix.ghc }}
     runs-on: ${{ matrix.os }}
     steps:

--- a/README.md
+++ b/README.md
@@ -76,9 +76,6 @@ If you are on NixOS, this is the only way to set up your project,
 because the GHC toolchain provisioned through binary distributions
 cannot be executed on NixOS.
 
-If you are on macOS, you will have to set the environment variable
-`BAZEL_USE_CPP_ONLY_TOOLCHAIN = 1`, so that Bazel picks the correct C compiler.
-
 [bazel-cli-commands]: https://docs.bazel.build/versions/master/command-line-reference.html#commands
 [nixpkgs]: https://nixos.org/nixpkgs/
 
@@ -226,14 +223,6 @@ en_US.iso88591
 en_US.utf8
 POSIX
 ```
-
-### MacOS: Error: DEVELOPER_DIR not set.
-
-Make sure to set the following environment variable:
-```
-export BAZEL_USE_CPP_ONLY_TOOLCHAIN=1
-```
-This ensures that Bazel picks the correct C compiler.
 
 ### Windows: Incorrect `cc_toolchain` used
 

--- a/rules_haskell_tests/shell.nix
+++ b/rules_haskell_tests/shell.nix
@@ -2,11 +2,6 @@
 
 with pkgs;
 mkShell {
-  # XXX: hack for macosX, this flags disable bazel usage of xcode
-  # Note: this is set even for linux so any regression introduced by this flag
-  # will be catched earlier
-  # See: https://github.com/bazelbuild/bazel/issues/4231
-  BAZEL_USE_CPP_ONLY_TOOLCHAIN = 1;
   TMPDIR = "/tmp";
 
   GHC_VERSION = ghcVersion;

--- a/rules_haskell_tests/tests/integration_testing/IntegrationTesting.hs
+++ b/rules_haskell_tests/tests/integration_testing/IntegrationTesting.hs
@@ -78,6 +78,9 @@ generateBazelRc dir = do
 \ build:linux-bindist --incompatible_enable_cc_toolchain_resolution \n\
 \ build:macos-bindist --incompatible_enable_cc_toolchain_resolution \n\
 \ build:windows-bindist --incompatible_enable_cc_toolchain_resolution \n\
+\ common --enable_platform_specific_config \n\
+\ common:macos --repo_env=BAZEL_USE_CPP_ONLY_TOOLCHAIN=1 \n\
+\ common:windows --repo_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1 \n\
 \ ")
 
 setupWorkspace :: IO (String, String)

--- a/rules_haskell_tests/tests/integration_testing/rules_haskell_integration_test.bzl
+++ b/rules_haskell_tests/tests/integration_testing/rules_haskell_integration_test.bzl
@@ -1,4 +1,4 @@
-load(":haskell_bazel_integration_test.bzl", "haskell_bazel_integration_test")
+load("@os_info//:os_info.bzl", "is_nix_shell", "is_windows")
 load(
     "@rules_bazel_integration_test//bazel_integration_test:defs.bzl",
     "integration_test_utils",
@@ -9,7 +9,7 @@ load(
     "SUPPORTED_NIXPKGS_BAZEL_PACKAGES",
 )
 load("//tests/integration_testing:dependencies.bzl", "nixpkgs_bazel_label")
-load("@os_info//:os_info.bzl", "is_nix_shell", "is_windows")
+load(":haskell_bazel_integration_test.bzl", "haskell_bazel_integration_test")
 
 def rules_haskell_integration_test(
         name,
@@ -43,7 +43,6 @@ def rules_haskell_integration_test(
                 "//tests:nix": [],
                 "//conditions:default": ["@platforms//:incompatible"],
             }),
-            additional_env_inherit = ["BAZEL_USE_CPP_ONLY_TOOLCHAIN"],
             **kwargs
         )
     elif not is_windows:
@@ -58,6 +57,5 @@ def rules_haskell_integration_test(
                 "//tests:nix": ["@platforms//:incompatible"],
                 "//conditions:default": [],
             }),
-            additional_env_inherit = ["BAZEL_USE_CPP_ONLY_TOOLCHAIN"],
             **kwargs
         )

--- a/shell.nix
+++ b/shell.nix
@@ -9,11 +9,6 @@ let
     writeScriptBin "security" ''exec /usr/bin/security "$@"'';
 in
 mkShell {
-  # XXX: hack for macosX, this flags disable bazel usage of xcode
-  # Note: this is set even for linux so any regression introduced by this flag
-  # will be catched earlier
-  # See: https://github.com/bazelbuild/bazel/issues/4231
-  BAZEL_USE_CPP_ONLY_TOOLCHAIN = 1;
   TMPDIR = "/tmp";
 
   GHC_VERSION = ghcVersion;

--- a/start
+++ b/start
@@ -443,6 +443,19 @@ common --enable_bzlmod=$BZLMOD
 # Should become the default in bazel 7
 build --incompatible_enable_cc_toolchain_resolution
 
+# Enable automatic OS-specific config (e.g. build:linux, build:macos, build:windows).
+common --enable_platform_specific_config
+
+# MacOS Configuration
+# -------------------
+# do not use Xcode on macOS
+common:macos --repo_env=BAZEL_USE_CPP_ONLY_TOOLCHAIN=1
+
+# Windows Configuration
+# ---------------------
+# prevent auto-detection of system compilers on Windows
+common:windows --repo_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
+
 EOF
 
 if [ "${MODE}" = "nix" ]; then


### PR DESCRIPTION
- Add `--enable_platform_specific_config` to `.bazelrc.common`.
- Move MacOS- and Windows-specific environment variables to `.bazelrc.common` under their OS config names.
- Update code that generates bazelrc files for integration tests to include the new entries.

Related to https://github.com/tweag/rules_haskell/issues/2099.