### PR TITLE
try Ignoring unhandled paths in `path_to_label`

### DIFF
--- a/haskell/private/pkgdb_to_bzl.py
+++ b/haskell/private/pkgdb_to_bzl.py
@@ -222,10 +222,12 @@ for conf in glob.glob(os.path.join(package_conf_dir, '*.conf')):
                     "/".join([path_to_label(include_dir, pkgroot, output), header])
                     for include_dir in pkg.include_dirs
                     for header in match_glob(resolve(include_dir, pkgroot), "**/*.h")
+                    if path_to_label(include_dir, pkgroot, output)
                 ],
                 includes = [
                     "/".join([repo_dir, path_to_label(include_dir, pkgroot, output)])
                     for include_dir in pkg.include_dirs
+                    if path_to_label(include_dir, pkgroot, output)
                 ],
                 static_libraries = [
                     "/".join([path_to_label(library_dir, pkgroot, output), library])
@@ -233,6 +235,7 @@ for conf in glob.glob(os.path.join(package_conf_dir, '*.conf')):
                     for pattern in hs_library_pattern(hs_library, mode = "static", profiling = False)
                     for library_dir in pkg.library_dirs
                     for library in match_glob(resolve(library_dir, pkgroot), pattern)
+                    if path_to_label(library_dir, pkgroot, output)
                 ],
                 static_profiling_libraries = [
                     "/".join([path_to_label(library_dir, pkgroot, output), library])
@@ -240,6 +243,7 @@ for conf in glob.glob(os.path.join(package_conf_dir, '*.conf')):
                     for pattern in hs_library_pattern(hs_library, mode = "static", profiling = True)
                     for library_dir in pkg.library_dirs
                     for library in match_glob(resolve(library_dir, pkgroot), pattern)
+                    if path_to_label(library_dir, pkgroot, output)
                 ],
                 shared_libraries = [
                     "/".join([path_to_label(dynamic_library_dir, pkgroot, output), library])
@@ -247,6 +251,7 @@ for conf in glob.glob(os.path.join(package_conf_dir, '*.conf')):
                     for pattern in hs_library_pattern(hs_library, mode = "dynamic", profiling = False)
                     for dynamic_library_dir in set(pkg.dynamic_library_dirs + pkg.library_dirs)
                     for library in match_glob(resolve(dynamic_library_dir, pkgroot), pattern)
+                    if path_to_label(dynamic_library_dir, pkgroot, output)
                 ],
                 haddock_html = repr(haddock_html),
                 haddock_interfaces = repr(haddock_interfaces),


### PR DESCRIPTION
This is an attempt to fix the following issue on the bcr pull request.
https://buildkite.com/bazel/bcr-presubmit/builds/3569#018d83b1-1c78-4b51-a6b2-9c6055208279/268-305

However I did no manage to reproduce the problem yet.