### PR TITLE
Update presubmit.yml for the BCR

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -7,21 +7,31 @@ matrix:
   # disable Windows for now, it fails with
   # "this rule is missing dependency declarations for the following files ..."
   #- windows
+  bazel:
+  - 6.x
 tasks:
   verify_targets:
     name: Verify build targets
     platform: ${{ platform }}
+    bazel: ${{ bazel }}
     shell_commands:
     - |
       if apt --version >/dev/null 2>/dev/null; then
         sudo apt update
         sudo apt install --no-install-recommends -yy libtinfo5 libgmp-dev
       fi
+    - |
+      if xcodebuild -version; then
+        # Setup xcode because GHC bindists expect the following directory on mac:
+        # /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/ffi
+        xcodebuild -runFirstLaunch
+      fi
     batch_commands:
     # enforce certificate update
     - 'powershell -Command "Invoke-WebRequest -Uri https://hackage.haskell.org/root.json -OutFile out.json"'
     build_flags:
       - '--incompatible_enable_cc_toolchain_resolution'
+      - '--repo_env=BAZEL_USE_CPP_ONLY_TOOLCHAIN=1'
     build_targets:
     - '@rules_haskell//haskell/...'
     - '@rules_haskell//tools/...'

--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -9,7 +9,7 @@ about: Steps to work through in order to publish a new release
 - [ ] Create and checkout a new release preparation branch, named
       `release-<major>.<minor>`.
 - [ ] If the minimal Bazel version has changed:
-  - [ ] update it in [the `start` script][start], in [`haskell/private/versions.bzl`][versions], and in [the `README`][readme]
+  - [ ] update it in [the `start` script][start], in [`haskell/private/versions.bzl`][versions], in [the `README`][readme] and in `presubmit.yml` files from the `.bcr` folder
   - [ ] add a note about this change to the [`CHANGELOG`][changelog]
 - [ ] Remove any feature that is still too experimental to go into a
       release, by cherry-picking reverts (or by manually deleting the


### PR DESCRIPTION
This PR updates the presubmit.yml for the BRC after it was modified a bit in the following [PR](
https://github.com/bazelbuild/bazel-central-registry/pull/1447).

In the end calling `xcodebuild -runFirstLaunch` installed the required library on the macos arm64 runner (IIUC `code-select --install` requires a desktop environment).
