### PR TITLE
fix `use_stack` documentation

### DIFF
--- a/haskell/cabal.bzl
+++ b/haskell/cabal.bzl
@@ -2746,7 +2746,8 @@ def use_stack(stack):
     Globally override the `stack` version used by all instances of `stack_snapshot`.
     WARNING: This should only be used in the top-level repository.
 
-    Example:
+    ### Examples
+    ```
     # WORKSPACE
 
     # Order is important! Placing `use_stack()` after any occurrence of `stack_snapshot`
@@ -2758,13 +2759,16 @@ def use_stack(stack):
         stack = "@y_stack:stack",
         # ...
     )
+    ```
 
-    # BUILD
+    ```
+    # BUILD.bazel
     haskell_binary(
         # ...
         # targets in `x` will be built using `x_stack`, NOT `y_stack`
         deps = ["@x//:all"],
     )
+    ```
     """
     if native.existing_rule("rules_haskell_stack"):
         fail("`rules_haskell_stack` already defined. call `use_stack()` before `stack_snapshot()` in `WORKSPACE`")


### PR DESCRIPTION
closes https://github.com/tweag/rules_haskell/issues/1759.

Here is a screenshot.
![Screenshot 2024-02-14 at 22-43-13 Cabal packages](https://github.com/tweag/rules_haskell/assets/30812734/601c01a9-704c-4fc5-b5e3-0e61d2749233)
