### PR TITLE
improve testing and linting experience for newcomers

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -98,7 +98,6 @@ jobs:
           common --enable_bzlmod=${{ matrix.bzlmod }}
           EOF
           cp .bazelrc.local rules_haskell_nix
-          cp .bazelrc.local rules_haskell_tests
       - name: Build & test - rules_haskell
         if: matrix.module == 'rules_haskell'
         uses: tweag/run-nix-shell@v0
@@ -208,7 +207,6 @@ jobs:
           $bzlmod_cache_silo_key
           common --enable_bzlmod=${{ matrix.bzlmod }}
           EOF
-          cp .bazelrc.local rules_haskell_tests
       - name: Build & test - rules_haskell
         if: matrix.module == 'rules_haskell'
         shell: bash

--- a/README.md
+++ b/README.md
@@ -352,20 +352,20 @@ on every development system (`python`, `ghc`, `go`, …).
 To build and run tests locally, execute:
 
 ```
-$ bazel test //... && cd rules_haskell_tests && bazel test //...
+$ (bazel test //... && cd rules_haskell_tests && bazel test //...)
 ```
 
 Starlark code in this project is formatted according to the output of
 [buildifier]. You can check that the formatting is correct using:
 
 ```
-$ bazel run //buildifier && cd rules_haskell_tests && bazel run //buildifier
+$ (bazel run //buildifier && cd rules_haskell_tests && bazel run //buildifier)
 ```
 
 If tests fail then run the following to fix the formatting:
 
 ```
-$ git rebase --exec "bazel run //buildifier:buildifier-fix && cd rules_haskell_tests && bazel run //buildifier:buildifier-fix" <first commit>
+$ (git rebase --exec "bazel run //buildifier:buildifier-fix && cd rules_haskell_tests && bazel run //buildifier:buildifier-fix" <first commit>)
 ```
 
 where `<first commit>` is the first commit in your pull request.

--- a/rules_haskell_tests/.bazelrc.local
+++ b/rules_haskell_tests/.bazelrc.local
@@ -1,0 +1,1 @@
+../.bazelrc.local


### PR DESCRIPTION
added a `.bazelrc.local` symbolic link to `rules_haskell_tests` following the example of https://github.com/tweag/rules_haskell/pull/750 and in reaction to https://github.com/tweag/rules_haskell/pull/2122#issuecomment-1944652674.

`(bazel test //... && cd rules_haskell_tests && bazel test //...)` and `(bazel run //buildifier && cd rules_haskell_tests && bazel run //buildifier)` run successfully now in a freshly cloned repository after `echo "build --config=linux-nixpkgs" >> .bazelrc.local`.

using round brackets around the bash commands will restore the current working directory afterwards.