### PR TITLE
unify `rules_haskell_tests/.bazelrc*` files

### DIFF
--- a/rules_haskell_tests/.bazelrc
+++ b/rules_haskell_tests/.bazelrc
@@ -1,6 +1,1 @@
-import %workspace%/../.bazelrc.common
-import %workspace%/.bazelrc.bzlmod
-
-# User Configuration
-# ------------------
-try-import %workspace%/.bazelrc.local
+../.bazelrc

--- a/rules_haskell_tests/.bazelrc.common
+++ b/rules_haskell_tests/.bazelrc.common
@@ -1,0 +1,1 @@
+../.bazelrc.common


### PR DESCRIPTION
unify `.bazelrc*` files and `rules_haskell_tests/.bazelrc* files` via symbolic links following the example of https://github.com/tweag/rules_haskell/pull/750.