### PR TITLE
Do not depend on system tools on Darwin

### DIFF
--- a/haskell/private/cc_wrapper.bzl
+++ b/haskell/private/cc_wrapper.bzl
@@ -1,3 +1,4 @@
+load("@bazel_skylib//lib:paths.bzl", "paths")
 load("@rules_cc//cc:action_names.bzl", "ACTION_NAMES")
 load("@rules_cc//cc:find_cc_toolchain.bzl", "find_cc_toolchain", "use_cc_toolchain")
 load("@rules_python//python:defs.bzl", "py_binary")
@@ -46,6 +47,10 @@ def _cc_wrapper_impl(ctx):
         feature_configuration = feature_configuration,
         action_name = ACTION_NAMES.c_compile,
     )
+    ar = cc_common.get_tool_for_action(
+        feature_configuration = feature_configuration,
+        action_name = ACTION_NAMES.cpp_link_static_library,
+    )
     cc_wrapper = ctx.actions.declare_file(ctx.label.name)
     ctx.actions.expand_template(
         template = ctx.file.template,
@@ -56,6 +61,7 @@ def _cc_wrapper_impl(ctx):
             "{:cpu:}": cc_toolchain.cpu,
             "{:workspace:}": ctx.workspace_name,
             "{:platform:}": ctx.attr.platform,
+            "{:bindir:}": paths.dirname(ar),
         },
     )
     return [DefaultInfo(

--- a/haskell/private/cc_wrapper.py.tpl
+++ b/haskell/private/cc_wrapper.py.tpl
@@ -931,12 +931,16 @@ def darwin_rewrite_load_commands(rewrites, output):
     if args:
         subprocess.check_call([INSTALL_NAME_TOOL] + args + [output])
         # Resign the binary after patching it.
+        # Fall back to /usr/bin/codesign if the `CODESIGN` executable is not available
+        # (this might happen when using a default cc toolchain from a nix shell on Darwin instead
+        #  of using a nixpkgs_cc_configure'd toolchain).
+        codesign = CODESIGN if os.access(CODESIGN, os.X_OK) else "/usr/bin/codesign"
         # This is necessary on MacOS Monterey on M1.
         # The moving back and forth is necessary because the OS caches the signature.
         # See this note from nixpkgs for reference:
         # https://github.com/NixOS/nixpkgs/blob/5855ff74f511423e3e2646248598b3ffff229223/pkgs/os-specific/darwin/signing-utils/utils.sh#L1-L6
         os.rename(output, f"{output}.resign")
-        subprocess.check_call([CODESIGN] + ["-f", "-s", "-"] + [f"{output}.resign"], env = {'CODESIGN_ALLOCATE': CODESIGN_ALLOCATE})
+        subprocess.check_call([codesign] + ["-f", "-s", "-"] + [f"{output}.resign"], env = {'CODESIGN_ALLOCATE': CODESIGN_ALLOCATE})
         os.rename(f"{output}.resign", output)
 
 

--- a/haskell/private/cc_wrapper.py.tpl
+++ b/haskell/private/cc_wrapper.py.tpl
@@ -83,9 +83,10 @@ WORKSPACE = "{:workspace:}"
 CC = os.environ.get("CC_WRAPPER_CC_PATH", "{:cc:}")
 PLATFORM = os.environ.get("CC_WRAPPER_PLATFORM", "{:platform:}")
 CPU = os.environ.get("CC_WRAPPER_CPU", "{:cpu:}")
-INSTALL_NAME_TOOL = "/usr/bin/install_name_tool"
-CODESIGN = "/usr/bin/codesign"
-OTOOL = "/usr/bin/otool"
+INSTALL_NAME_TOOL = "{:bindir:}/install_name_tool"
+CODESIGN = "{:bindir:}/codesign"
+CODESIGN_ALLOCATE = "{:bindir:}/codesign_allocate"
+OTOOL = "{:bindir:}/otool"
 
 
 def main():
@@ -935,7 +936,7 @@ def darwin_rewrite_load_commands(rewrites, output):
         # See this note from nixpkgs for reference:
         # https://github.com/NixOS/nixpkgs/blob/5855ff74f511423e3e2646248598b3ffff229223/pkgs/os-specific/darwin/signing-utils/utils.sh#L1-L6
         os.rename(output, f"{output}.resign")
-        subprocess.check_call([CODESIGN] + ["-f", "-s", "-"] + [f"{output}.resign"])
+        subprocess.check_call([CODESIGN] + ["-f", "-s", "-"] + [f"{output}.resign"], env = {'CODESIGN_ALLOCATE': CODESIGN_ALLOCATE})
         os.rename(f"{output}.resign", output)
 
 

--- a/haskell/private/cc_wrapper.py.tpl
+++ b/haskell/private/cc_wrapper.py.tpl
@@ -934,13 +934,15 @@ def darwin_rewrite_load_commands(rewrites, output):
         # Fall back to /usr/bin/codesign if the `CODESIGN` executable is not available
         # (this might happen when using a default cc toolchain from a nix shell on Darwin instead
         #  of using a nixpkgs_cc_configure'd toolchain).
+        # Do the same for codesign_allocate.
         codesign = CODESIGN if os.access(CODESIGN, os.X_OK) else "/usr/bin/codesign"
+        codesign_allocate = CODESIGN_ALLOCATE if os.access(CODESIGN_ALLOCATE, os.X_OK) else "/usr/bin/codesign_allocate"
         # This is necessary on MacOS Monterey on M1.
         # The moving back and forth is necessary because the OS caches the signature.
         # See this note from nixpkgs for reference:
         # https://github.com/NixOS/nixpkgs/blob/5855ff74f511423e3e2646248598b3ffff229223/pkgs/os-specific/darwin/signing-utils/utils.sh#L1-L6
         os.rename(output, f"{output}.resign")
-        subprocess.check_call([codesign] + ["-f", "-s", "-"] + [f"{output}.resign"], env = {'CODESIGN_ALLOCATE': CODESIGN_ALLOCATE})
+        subprocess.check_call([codesign] + ["-f", "-s", "-"] + [f"{output}.resign"], env = {'CODESIGN_ALLOCATE': codesign_allocate})
         os.rename(f"{output}.resign", output)
 
 


### PR DESCRIPTION
Our cc wrapper was always using the system tools from a fixed location on Darwin, which is not hermetic
(and can lead to problems when using nixpkgs) and requires the Xcode command line tools to be installed.

Apply the same heuristic as for the otool and install_name tool for the haskell toolchain and assume
the tools are available at the same location as the `ar` binary.

Depends on https://github.com/tweag/rules_nixpkgs/pull/479 and depends on #2119 