### PR TITLE
Fix error when include dirs do not exist

### DIFF
--- a/haskell/private/pkgdb_to_bzl.bzl
+++ b/haskell/private/pkgdb_to_bzl.bzl
@@ -19,6 +19,9 @@ def pkgdb_to_bzl(repository_ctx, paths, libdir):
     ])
     if result.return_code:
         fail("Error executing pkgdb_to_bzl.py: {stderr}".format(stderr = result.stderr))
+    elif result.stderr:
+        # print any warnings from pkgdb_to_bzl.py
+        print(result.stderr)
 
     result_dict = json.decode(result.stdout)
 

--- a/haskell/private/pkgdb_to_bzl.py
+++ b/haskell/private/pkgdb_to_bzl.py
@@ -50,6 +50,11 @@ def resolve(path, pkgroot):
     else:
         return path
 
+
+def join_paths(paths):
+    return ["/".join(ps) for ps in paths if not None in ps]
+
+
 symlinks = {}
 
 def path_to_label(path, pkgroot, output=None):
@@ -218,36 +223,36 @@ for conf in glob.glob(os.path.join(package_conf_dir, '*.conf')):
                 name = pkg.name,
                 id = pkg.id,
                 version = pkg.version,
-                hdrs = [
-                    "/".join([path_to_label(include_dir, pkgroot, output), header])
+                hdrs = join_paths([
+                    [path_to_label(include_dir, pkgroot, output), header]
                     for include_dir in pkg.include_dirs
                     for header in match_glob(resolve(include_dir, pkgroot), "**/*.h")
-                ],
-                includes = [
-                    "/".join([repo_dir, path_to_label(include_dir, pkgroot, output)])
+                ]),
+                includes = join_paths([
+                    [repo_dir, path_to_label(include_dir, pkgroot, output)]
                     for include_dir in pkg.include_dirs
-                ],
-                static_libraries = [
-                    "/".join([path_to_label(library_dir, pkgroot, output), library])
+                ]),
+                static_libraries = join_paths([
+                    [path_to_label(library_dir, pkgroot, output), library]
                     for hs_library in pkg.hs_libraries
                     for pattern in hs_library_pattern(hs_library, mode = "static", profiling = False)
                     for library_dir in pkg.library_dirs
                     for library in match_glob(resolve(library_dir, pkgroot), pattern)
-                ],
-                static_profiling_libraries = [
-                    "/".join([path_to_label(library_dir, pkgroot, output), library])
+                ]),
+                static_profiling_libraries = join_paths([
+                    [path_to_label(library_dir, pkgroot, output), library]
                     for hs_library in pkg.hs_libraries
                     for pattern in hs_library_pattern(hs_library, mode = "static", profiling = True)
                     for library_dir in pkg.library_dirs
                     for library in match_glob(resolve(library_dir, pkgroot), pattern)
-                ],
-                shared_libraries = [
-                    "/".join([path_to_label(dynamic_library_dir, pkgroot, output), library])
+                ]),
+                shared_libraries = join_paths([
+                    [path_to_label(dynamic_library_dir, pkgroot, output), library]
                     for hs_library in pkg.hs_libraries
                     for pattern in hs_library_pattern(hs_library, mode = "dynamic", profiling = False)
                     for dynamic_library_dir in set(pkg.dynamic_library_dirs + pkg.library_dirs)
                     for library in match_glob(resolve(dynamic_library_dir, pkgroot), pattern)
-                ],
+                ]),
                 haddock_html = repr(haddock_html),
                 haddock_interfaces = repr(haddock_interfaces),
                 deps = pkg.depends,


### PR DESCRIPTION
When converting the pkgdb to JSON for consumption in starlark, the `pkgdb_to_bzl.py` script might fail if config files list directories that don't exist:

```
ERROR: An error occurred during the fetch of repository 'rules_haskell_ghc_nixpkgs_haskell_toolchain':
   Traceback (most recent call last):
	File "/private/var/tmp/_bazel_runner/11ad2da2a0847baf09d91bfe3a37fb9a/external/rules_haskell/haskell/nixpkgs.bzl", line 69, column 39, in _ghc_nixpkgs_haskell_toolchain_impl
		toolchain_libraries = pkgdb_to_bzl(repository_ctx, paths, "lib/{}".format(ghc_name))["file_content"]
	File "/private/var/tmp/_bazel_runner/11ad2da2a0847baf09d91bfe3a37fb9a/external/rules_haskell/haskell/private/pkgdb_to_bzl.bzl", line 21, column 13, in pkgdb_to_bzl
		fail("Error executing pkgdb_to_bzl.py: {stderr}".format(stderr = result.stderr))
Error in fail: Error executing pkgdb_to_bzl.py: WARN: could not handle /usr/local/opt/icu4c/include
Traceback (most recent call last):
  File "/private/var/tmp/_bazel_runner/11ad2da2a0847baf09d91bfe3a37fb9a/external/rules_haskell/haskell/private/pkgdb_to_bzl.py", line 226, in <module>
    includes = [
               ^
  File "/private/var/tmp/_bazel_runner/11ad2da2a0847baf09d91bfe3a37fb9a/external/rules_haskell/haskell/private/pkgdb_to_bzl.py", line 227, in <listcomp>
    "/".join([repo_dir, path_to_label(include_dir, pkgroot, output)])
TypeError: sequence item 1: expected str instance, NoneType found
```

- Skip non-existent paths in pkgdb_to_bzl.py script
- Show warnings from pkgdb_to_bzl.py script

Close https://github.com/tweag/rules_haskell/pull/2118