### PR TITLE
Make static linking of haskell_cabal_binary explicit

### DIFF
--- a/haskell/cabal.bzl
+++ b/haskell/cabal.bzl
@@ -2136,7 +2136,7 @@ haskell_cabal_binary(
     setup_deps = {setup_deps},
     tools = {tools},
     visibility = ["@{workspace}-exe//{name}:__pkg__"],
-    cabalopts = ["--ghc-option=-w", "--ghc-option=-optF=-w"],
+    cabalopts = ["--ghc-option=-w", "--ghc-option=-optF=-w", "--ghc-option=-static"],
     verbose = {verbose},
 )
 """.format(


### PR DESCRIPTION
The runtime dependency resolution for `haskell_cabal_binary` doesn't currently support dynamically linked haskell libraries, and expects executables built by `haskell_cabal_binary` to be statically linked to haskell dependencies. Make that explicit by an option to cabal.

Related to #2147 