### PR TITLE
Cleanup and fix CI jobs for Darwin

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -43,7 +43,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-12]
         module: [rules_haskell, rules_haskell_nix, rules_haskell_tests]
         bzlmod: [true, false]
         ghc:
@@ -139,7 +139,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-12, windows-latest]
         module: [rules_haskell, rules_haskell_tests]
         bzlmod: [true, false]
         ghc:

--- a/haskell/haddock.bzl
+++ b/haskell/haddock.bzl
@@ -89,16 +89,13 @@ def _haskell_doc_aspect_impl(target, ctx):
     html_dir = ctx.actions.declare_directory(html_dir_raw)
     haddock_file = ctx.actions.declare_file(_get_haddock_path(package_id))
 
-    # XXX Haddock really wants a version number, so invent one from
-    # thin air. See https://github.com/haskell/haddock/issues/898.
-    if target[HaskellLibraryInfo].version:
-        version = target[HaskellLibraryInfo].version
-    else:
-        version = "0"
-
     args = ctx.actions.args()
     args.add("--package-name={0}".format(package_id))
-    args.add("--package-version={0}".format(version))
+
+    if target[HaskellLibraryInfo].version:
+        version = target[HaskellLibraryInfo].version
+        args.add("--package-version={0}".format(version))
+
     args.add_all([
         "-D",
         haddock_file.path,


### PR DESCRIPTION
- Do not invent version number
- Use macos-12 runner images

This fixes the failing CI jobs for Darwin because of the roll-out of switching macos-latest to macos-14 arm64.

--- 

Currently, the CI bindist job for GHC 9.8.1 for rules_haskell_test fails with:
```
Error in fail: rule @//tests/haddock:haddock generates 
["haddock/array-0.5.6.0-ded9", "haddock/base-4.19.0.0-e537", "haddock/deepseq-1.5.0.0-5710", "haddock/ghc-bignum-1.3-b85e", "haddock/ghc-boot-th-9.8.1-29c5", "haddock/ghc-prim-0.11.0-2de8", "haddock/index", "haddock/pretty-1.1.3.6-913b", "haddock/template-haskell-2.21.0.0-4479", "haddock/testsZShaddockZShaddock-lib-a", "haddock/testsZShaddockZShaddock-lib-b", "haddock/testsZShaddockZShaddock-lib-deep"] 

not

 ["haddock/array-0.5.6.0-256c", "haddock/base-4.19.0.0-d6d2", "haddock/deepseq-1.5.0.0-c140", "haddock/ghc-bignum-1.3-93be", "haddock/ghc-boot-th-9.8.1-5d14", "haddock/ghc-prim-0.11.0-5379", "haddock/index", "haddock/pretty-1.1.3.6-eec0", "haddock/template-haskell-2.21.0.0-be6e", "haddock/testsZShaddockZShaddock-lib-a", "haddock/testsZShaddockZShaddock-lib-b", "haddock/testsZShaddockZShaddock-lib-deep"]
```
This also happens for all the renovate PRs.

I'll update the expeted values, but @aherrmann  / @ylecornec do you have an idea why the suffix (is this the package id?) of the haskell_haddock outputs changed?
