### PR TITLE
Set asterius tests to manual

### DIFF
--- a/rules_haskell_tests/tests/asterius/asterius_tests_utils.bzl
+++ b/rules_haskell_tests/tests/asterius/asterius_tests_utils.bzl
@@ -6,7 +6,7 @@ load(
     "asterius_webpack",
 )
 
-tags = ["dont_test_on_windows", "dont_test_on_darwin", "skip_profiling", "dont_test_on_bazel_lt_4"]
+tags = ["dont_test_on_windows", "dont_test_on_darwin", "skip_profiling", "dont_test_on_bazel_lt_4", "manual"]
 
 def asterius_test_macro(
         dep_label,


### PR DESCRIPTION
Asterius has been [deprecated](https://github.com/tweag/asterius) for a while so we do not need to maintain these tests anymore.

At first sight, it looks like they might be responsible for https://github.com/tweag/rules_haskell/issues/2181,
so making them manual may solve this issue until we remove them.