### PR TITLE
Fix using the single threaded RTS lib

### DIFF
--- a/haskell/private/pkgdb_to_bzl.py
+++ b/haskell/private/pkgdb_to_bzl.py
@@ -100,7 +100,7 @@ def hs_library_pattern(name, mode = "static", profiling = False):
     # See https://gitlab.haskell.org/ghc/ghc/wikis/commentary/rts/config#rts-configurations
     configs = ["_p"] if profiling else [""]
     # Special case HSrts or Cffi - include both libXYZ and libXYZ_thr.
-    if name == "HSrts" or name == "Cffi":
+    if name == "HSrts" or name.startswith("HSrts-") or name == "Cffi":
         configs = [
             prefix + config
             for config in configs

--- a/haskell/toolchain.bzl
+++ b/haskell/toolchain.bzl
@@ -250,6 +250,15 @@ def _haskell_toolchain_libraries(ctx, libraries):
                     if len(ext_components) == 2 and ext_components[0] == "so":
                         libs[libname]["dynamic"] = lib
                 else:
+                    # with GHC >= 9.4.1 the rts library has a version number
+                    # included in the name.
+                    # for handling single-threaded and threading variants below,
+                    # we normalize the name and strip the version number
+                    if libname.startswith("HSrts-"):
+                        idx = libname.find("_")
+                        suffix = libname[idx:] if idx > 0 else ""
+                        libname = "HSrts" + suffix
+
                     libs[libname] = {"dynamic": lib}
             for lib in target[HaskellImportHack].static_libraries.to_list():
                 name = get_static_hs_lib_name(with_profiling, lib)

--- a/haskell/toolchain.bzl
+++ b/haskell/toolchain.bzl
@@ -262,6 +262,16 @@ def _haskell_toolchain_libraries(ctx, libraries):
                     libs[libname] = {"dynamic": lib}
             for lib in target[HaskellImportHack].static_libraries.to_list():
                 name = get_static_hs_lib_name(with_profiling, lib)
+
+                # with GHC >= 9.4.1 the rts library has a version number
+                # included in the name.
+                # for handling single-threaded and threading variants below,
+                # we normalize the name and strip the version number
+                if name.startswith("HSrts-"):
+                    idx = name.find("_")
+                    suffix = name[idx:] if idx > 0 else ""
+                    name = "HSrts" + suffix
+
                 entry = libs.get(name, {})
                 entry["static"] = lib
                 libs[name] = entry


### PR DESCRIPTION
Since GHC 9.4.1, the rts package has `hs-libraries: HSrts-1.0.2 Cffi` in its package config.

We have special handling for HSrts (and Cffi) but that fails due to the name change.

This caused the build on Bazel CI to fail since the single threaded rts library
was symlinked into the solib directory instead of the multi threaded variant:

```
libHSrts-1.0.2_thr-ghc9.4.6.so: cannot open shared object file: No such file or directory
```

Fixes #2188

----

Note: Bazel CI is green on this branch: https://buildkite.com/bazel/rules-haskell-haskell/builds/2032
