### PR TITLE
Use macos-12 instead of macos-11

### DIFF
--- a/.github/workflows/patch-test.yaml
+++ b/.github/workflows/patch-test.yaml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-11, windows-latest]
+        os: [ubuntu-latest, macos-12, windows-latest]
         ghc-version: ${{ fromJSON(needs.find-ghc-version.outputs.ghc-matrix) }}
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
As announced by Github [1], macos-11 runners were scheduled for removal on 6/28/2024.

[1]: https://github.blog/changelog/2024-05-20-actions-upcoming-changes-to-github-hosted-macos-runners/
