### PR TITLE
Increase GHC bindist install timeout

### DIFF
--- a/haskell/ghc_bindist.bzl
+++ b/haskell/ghc_bindist.bzl
@@ -201,6 +201,8 @@ include Makefile""")
             # https://source.chromium.org/chromium/chromium/src/+/62848c8d298690e086e49a9832278ff56b6976b5.
             environment = {"ZERO_AR_DATE": "1"},
             working_directory = unpack_dir,
+            # use a big timeout because copying GHC is slow (1.5G)
+            timeout = 30 * 60,
         )
 
         if not is_hadrian_dist:

--- a/haskell/private/workspace_utils.bzl
+++ b/haskell/private/workspace_utils.bzl
@@ -2,13 +2,15 @@ def execute_or_fail_loudly(
         repository_ctx,
         arguments,
         environment = {},
-        working_directory = ""):
+        working_directory = "",
+        timeout = 600):
     """Execute the given command
 
     Fails if the command does not exit with exit-code 0.
 
     Args:
       arguments: List, the command line to execute.
+      timeout: The timeout for the command in seconds (default: 600).
 
     Returns:
       exec_result: The output of the command.
@@ -19,6 +21,7 @@ def execute_or_fail_loudly(
         environment = environment,
         quiet = True,
         working_directory = working_directory,
+        timeout = timeout,
     )
     if exec_result.return_code != 0:
         arguments = [_as_string(x) for x in arguments]


### PR DESCRIPTION
Fixes #2254 

This bumps the default timeout for installing the GHC bindist to 30 minutes. Because the GHC install is so big (1+ GB) the command can take a while to complete on some systems.