### PR TITLE
Fix Update GHC workflow

### DIFF
--- a/.github/workflows/update-ghc.yaml
+++ b/.github/workflows/update-ghc.yaml
@@ -2,9 +2,8 @@ name: Update GHC
 on:
   schedule:
     # run weekly on Thursday
-    - cron:  '0 15 * * THU'
+    - cron: '0 15 * * THU'
   workflow_dispatch: # allows manual triggering
-
 jobs:
   update_ghc:
     name: GHC ${{ matrix.ghc }} Update
@@ -27,7 +26,9 @@ jobs:
           nix_path: nixpkgs=nixpkgs/default.nix
       - name: Fetch updates
         id: ghc_update
-        run: nix shell 'nixpkgs#bazel-buildtools' 'nixpkgs#python3' --command python .github/update-ghc.py ${{ matrix.ghc }}
+        run: |-
+          nix-shell -p 'bazel-buildtools' 'python3.withPackages (ps: [ps.packaging])' --run \
+            'python .github/update-ghc.py ${{ matrix.ghc }}'
       - name: Create Pull Request
         if: steps.ghc_update.outputs.latest != ''
         uses: peter-evans/create-pull-request@v7

--- a/haskell/gen_ghc_bindist.py
+++ b/haskell/gen_ghc_bindist.py
@@ -8,7 +8,7 @@ import os
 import json
 import sys
 from urllib.request import urlopen
-from distutils.version import StrictVersion
+from packaging.version import Version
 
 # Sometimes bindists have errors and are updated by new bindists.
 # This dict is used to keep a version -> corrected_version mapping.
@@ -158,7 +158,7 @@ if __name__ == "__main__":
 
         ghc_versions = {
             version: ghc_bindists[version]
-            for version in sorted(ghc_bindists.keys(), key=StrictVersion)
+            for version in sorted(ghc_bindists.keys(), key=Version)
         }
 
         json_file.truncate(0)


### PR DESCRIPTION
The workflow failed for a few weeks because of an error:
```
 Traceback (most recent call last):
  File "/home/runner/work/rules_haskell/rules_haskell/haskell/gen_ghc_bindist.py", line 11, in <module>
    from distutils.version import StrictVersion
ModuleNotFoundError: No module named 'distutils'
```

The `distutils` module is deprecated since Python 3.10 and has been removed in Python 3.12 now.

Apparently, this workflow is using Python 3.12 since the `nixpkgs` registry entry by default refers to
"github:NixOS/nixpkgs/nixpkgs-unstable".

This change uses the `packaging.version` module instead, switching to `nix-shell` to make use of the
nixpkgs revision that is configured in `nixpkgs/default.nix` and to provide the `packaging` pip package.
