### PR TITLE
Use the same nixpkgs revision on CI

### DIFF
--- a/rules_haskell_tests/tests/run-start-script.sh
+++ b/rules_haskell_tests/tests/run-start-script.sh
@@ -15,6 +15,32 @@ mkdir $workdir
 cd $workdir
 cp "$rules_haskell_dir/.bazelversion" .
 
+function getattr_value() {
+    local nix_file="$rules_haskell_dir/nixpkgs/default.nix"
+    while IFS=$' \t;' read -r key eq value rest ; do
+        if [ "$key" == "$1" ] && [ "$eq" == '=' ]; then
+            value="${value%\"}"
+            value="${value#\"}"
+
+            echo "$value"
+            return
+        fi
+    done < "$nix_file"
+    echo "could not lookup ${1} in $nix_file" >&2
+    exit 1
+}
+
+function have() {
+    command -v "$1" &> /dev/null
+}
+
+if have nix; then
+    NIXPKGS_REVISION=$( getattr_value "rev" )
+    NIXPKGS_HASH=$( nix hash to-sri "$(getattr_value "sha256")" )
+fi
+
+export NIXPKGS_REVISION NIXPKGS_HASH
+
 # specify version for bazelisk via `USE_BAZEL_VERSION`, since it does not read the .bazelversion when there is no WORKSPACE file
 USE_BAZEL_VERSION=$( cat .bazelversion )
 export USE_BAZEL_VERSION

--- a/rules_haskell_tests/tests/run-start-script.sh
+++ b/rules_haskell_tests/tests/run-start-script.sh
@@ -36,7 +36,9 @@ function have() {
 
 if have nix; then
     NIXPKGS_REVISION=$( getattr_value "rev" )
-    NIXPKGS_HASH=$( nix hash to-sri "$(getattr_value "sha256")" )
+    # N.B. the sha256 hash attribute given to `builtins.fetchTarball` is computed after unpacking
+    #      the archive, it is not the hash of the downloaded artifact
+    #NIXPKGS_HASH=$( nix hash to-sri "$(getattr_value "sha256")" )
 fi
 
 export NIXPKGS_REVISION NIXPKGS_HASH

--- a/start
+++ b/start
@@ -126,15 +126,22 @@ have () {
 check_bazel_version () {
     if ! have bazel; then
         # shellcheck disable=SC2016
-        stderr 'Warning: cannot find `bazel` executable in $PATH'
+        stderr 'Warning: cannot find `bazel` executable in $PATH (skipping version check)'
         return
     fi
-    actual_raw=$(bazel version | grep -E '^Build label:' | grep -Eo '[0-9.]+')
+    if ! actual_raw=$(bazel version | grep -E '^Build label:' | grep -Eo '[0-9.]+'); then
+        stderr 'Warning: cannot determine bazel version (skipping version check)'
+        return
+    fi
 
     # shellcheck disable=SC2034
-    IFS=. read -r actual_major actual_minor actual_patch <<-EOF
+    if ! IFS=. read -r actual_major actual_minor actual_patch <<-EOF
 	${actual_raw}
 	EOF
+    then
+        stderr "Warning: cannot parse version from bazel output (skipping version check)"
+        return
+    fi
 
     expected_min="${MIN_BAZEL_MAJOR}.${MIN_BAZEL_MINOR}.0"
     expected_max="${MAX_BAZEL_MAJOR}.${MAX_BAZEL_MINOR}.x"

--- a/start
+++ b/start
@@ -119,7 +119,16 @@ check_files_dont_exist () {
     done
 }
 
+have () {
+    command -v "$1" > /dev/null 2>&1
+}
+
 check_bazel_version () {
+    if ! have bazel; then
+        # shellcheck disable=SC2016
+        stderr 'Warning: cannot find `bazel` executable in $PATH'
+        return
+    fi
     actual_raw=$(bazel version | grep -E '^Build label:' | grep -Eo '[0-9.]+')
 
     # shellcheck disable=SC2034

--- a/start
+++ b/start
@@ -9,6 +9,8 @@ set -eu
 # we use the default version (currently "9.4.6").
 GHC_VERSION=${GHC_VERSION:="9.4.6"}
 
+NIXPKGS_REVISION=${NIXPKGS_REVISION:-nixos-24.05}
+
 readonly MIN_BAZEL_MAJOR=6
 readonly MIN_BAZEL_MINOR=0
 
@@ -328,7 +330,8 @@ EOF
 		# https://github.com/tweag/rules_nixpkgs/blob/master/README.md
 		nixpkgs_git_repository(
 		    name = "nixpkgs",
-		    revision = "nixos-24.05",
+		    revision = "${NIXPKGS_REVISION}",${NIXPKGS_HASH:+
+		    integrity = \"$NIXPKGS_HASH\",}
 		)
 
 		nixpkgs_cc_configure(


### PR DESCRIPTION
This avoids pulling down a different ghc version for the example project created by the `start` script than is used for the tests on CI.

Even worse, I noticed that we were building ghc 9.4.6 on CI just for running the `start` script on macOS:
```
Analyzing: target //:example (39 packages loaded, 140 targets configured)
this path will be fetched (0.03 MiB download, 0.11 MiB unpacked):
  /nix/store/pcz77230xr6xr27i44gy2c7qiy2arbk2-zlib-1.3.1-dev
copying path '/nix/store/pcz77230xr6xr27i44gy2c7qiy2arbk2-zlib-1.3.1-dev' from 'https://cache.iog.io/'...
/nix/store/pcz77230xr6xr27i44gy2c7qiy2arbk2-zlib-1.3.1-dev
Analyzing: target //:example (39 packages loaded, 140 targets configured)
warning: unknown setting 'always-allow-substitutes'
Analyzing: target //:example (39 packages loaded, 140 targets configured)
this derivation will be built:
  /nix/store/x7wkr642fsv89c5922imznd2nca88dsa-ghc-9.4.6.drv
```
(see https://github.com/tweag/rules_haskell/actions/runs/12140138249/job/33849261707?pr=2269#step:12:575)