### PR TITLE
Add GHC 9.12 to update-ghc workflow

### DIFF
--- a/.github/workflows/update-ghc.yaml
+++ b/.github/workflows/update-ghc.yaml
@@ -17,6 +17,7 @@ jobs:
           - '9.6'
           - '9.8'
           - '9.10'
+          - '9.12'
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
GHC 9.12.1 has been released on 16th Dec 2024

https://www.haskell.org/ghc/blog/20241216-ghc-9.12.1-released.html