### PR TITLE
cabal: Honor LOCALE_ARCHIVE settings when building cabal targets

### DIFF
--- a/haskell/cabal.bzl
+++ b/haskell/cabal.bzl
@@ -387,6 +387,9 @@ def _prepare_cabal_inputs(
     if extra_ldflags_file:
         input_files.append(extra_ldflags_file)
 
+    if hs.toolchain.locale_archive:
+        input_files.append(hs.toolchain.locale_archive)
+
     inputs = depset(
         input_files,
         transitive = [

--- a/haskell/private/cabal_wrapper.py
+++ b/haskell/private/cabal_wrapper.py
@@ -100,6 +100,8 @@ os.environ["RULES_HASKELL_GHC_PATH"] = canonicalize_path(os.getenv("RULES_HASKEL
 os.environ["RULES_HASKELL_GHC_PKG_PATH"] = canonicalize_path(os.getenv("RULES_HASKELL_GHC_PKG_PATH", ""))
 os.environ["RULES_HASKELL_LIBDIR_PATH"] = canonicalize_path(os.getenv("RULES_HASKELL_LIBDIR_PATH", ""))
 os.environ["RULES_HASKELL_DOCDIR_PATH"] = canonicalize_path(os.getenv("RULES_HASKELL_DOCDIR_PATH", ""))
+if "LOCALE_ARCHIVE" in os.environ:
+    os.environ["LOCALE_ARCHIVE"] = canonicalize_path(os.getenv("LOCALE_ARCHIVE"))
 
 component = json_args["component"]
 name = json_args["pkg_name"]


### PR DESCRIPTION
LOCALE_ARCHIVE is a nixpkgs/nixos setting to help glibc find the correct `locale-archive` file. A recent change has made setting this mandatory for newer nixpkgs snapshots. This setting wasn't being honored for `haskell_cabal_library` and `haskell_cabal_binary`. Pass it through for these targets. Also fix `cabal_wrapper.py` to make the path absolute before changing directories.