### PR TITLE
Fix small issues with CI examples jobs

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -254,14 +254,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04, macos-13, macos-14, windows-latest]
+        os: [ubuntu-24.04, macos-13, macos-14, windows-2022]
         bzlmod: [true, false]
         bazel:
           - "6.x"
           - "7.x"
         exclude:
           # TODO(cb) add full support for Bazel 7
-          - os: windows-latest
+          - os: windows-2022
             bazel: "7.x"
     env:
       USE_BAZEL_VERSION: ${{ matrix.bazel }}

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -323,7 +323,7 @@ jobs:
         working-directory: examples
         run: |
           # Quote the package specifier so that it works on Windows
-          bazelisk build "//..."
+          bazelisk test "//..."
 
   all_ci_tests:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
- **CI: Use windows-2022 explicitly, instead of latest**
- **CI: Run tests in test step for examples**
