### PR TITLE
coverage: persist .tix and .mix into TEST_UNDECLARED_OUTPUTS_DIR

### DIFF
--- a/haskell/private/coverage_wrapper.sh.tpl
+++ b/haskell/private/coverage_wrapper.sh.tpl
@@ -74,6 +74,23 @@ done
 
 # run the test binary, and then generate the report
 $binary_path "$@" > /dev/null 2>&1
+
+# Persist the coverage inputs (.tix + the .mix dirs) into the test's
+# undeclared outputs. Bazel keeps these as a stable per-target artifact
+# under bazel-testlogs/<target>/test.outputs/, so the lcov post-processor
+# (scripts/coverage.sh) reads complete, deterministic per-target data.
+# Without this the .tix lives ONLY in the ephemeral sandbox, which
+# Bazel's sandbox-stash pool evicts once there are many tests — silently
+# under-counting coverage (a gate that can falter is worse than none).
+if [ -n "${TEST_UNDECLARED_OUTPUTS_DIR:-}" ] && [ -f "$tix_file_path" ]; then
+  cp "$tix_file_path" "$TEST_UNDECLARED_OUTPUTS_DIR/" 2>/dev/null || true
+  mkdir -p "$TEST_UNDECLARED_OUTPUTS_DIR/mix"
+  for _hd in "${hpc_dir_args[@]}"; do
+    _d="${_hd#--hpcdir=}"
+    [ -d "$_d" ] && cp -r "$_d" "$TEST_UNDECLARED_OUTPUTS_DIR/mix/" 2>/dev/null || true
+  done
+fi
+
 $hpc_path report "$tix_file_path" "${hpc_dir_args[@]}" "${hpc_exclude_args[@]}" \
   --srcdir "." --srcdir "$package_path" > __hpc_coverage_report
 

--- a/haskell/private/coverage_wrapper.sh.tpl
+++ b/haskell/private/coverage_wrapper.sh.tpl
@@ -83,11 +83,13 @@ $binary_path "$@" > /dev/null 2>&1
 # Bazel's sandbox-stash pool evicts once there are many tests — silently
 # under-counting coverage (a gate that can falter is worse than none).
 if [ -n "${TEST_UNDECLARED_OUTPUTS_DIR:-}" ] && [ -f "$tix_file_path" ]; then
-  cp "$tix_file_path" "$TEST_UNDECLARED_OUTPUTS_DIR/" 2>/dev/null || true
+  cp "$tix_file_path" "$TEST_UNDECLARED_OUTPUTS_DIR/" || echo "coverage: warning: could not persist tix $tix_file_path" >&2
   mkdir -p "$TEST_UNDECLARED_OUTPUTS_DIR/mix"
   for _hd in "${hpc_dir_args[@]}"; do
     _d="${_hd#--hpcdir=}"
-    [ -d "$_d" ] && cp -r "$_d" "$TEST_UNDECLARED_OUTPUTS_DIR/mix/" 2>/dev/null || true
+    if [ -d "$_d" ]; then
+      cp -r "$_d" "$TEST_UNDECLARED_OUTPUTS_DIR/mix/" || echo "coverage: warning: could not persist mixdir $_d" >&2
+    fi
   done
 fi
 


### PR DESCRIPTION
**Problem**

The coverage wrapper runs `hpc report` but leaves the generated `.tix` in the ephemeral test sandbox. Tooling that post-processes coverage (e.g. HPC→lcov for a coverage service) then has to scrape Bazel's sandbox-stash pool, which evicts `.tix` files once a suite grows large — silently under-counting coverage.

**Fix**

When `TEST_UNDECLARED_OUTPUTS_DIR` is set, copy each test's `.tix` and its `.mix` dirs into it, so Bazel preserves them as a stable per-target artifact under `bazel-testlogs/<target>/test.outputs/`. No behavior change when the variable is unset (non-coverage runs).

**Why upstream**

Generic + low-risk: a guarded copy gated on `TEST_UNDECLARED_OUTPUTS_DIR`, touching only coverage runs. Anyone post-processing HPC output across a large suite hits the eviction.

**Verification**

The insert sits between the test run and `hpc report`; the report path is unchanged. Carried in a downstream fork where it makes large-suite HPC→lcov scoring complete and stable.
